### PR TITLE
feat(factory): label settings by scope and match each control to its setting

### DIFF
--- a/.changeset/settings-controls-by-kind.md
+++ b/.changeset/settings-controls-by-kind.md
@@ -1,0 +1,17 @@
+---
+'@mastra/factory': patch
+---
+
+Settings controls now match what they set instead of every choice being the same row of buttons.
+
+**Thinking level** is a slider, not six buttons. Six buttons said "pick one of these"; a slider says what is actually true — the level is a ramp, so you drag the thumb along it. The track carries a dot per stop and fills up to the handle, and the colour turns to warning on the top two steps where the bill turns. The level is named to the left of the track in a fixed column, so "Off" and "Extra high" leave the track in the same place and nothing on the page shifts as you drag. The save only fires when you let go, so crossing the whole scale is one write, not five, and the write is optimistic: the thumb stays where you dropped it instead of the row greying out and snapping back. A per-mode row that follows the base level reads "Follows base" and grows a "Reset to base" button only once it has an override of its own. A refusal from the server puts the slider back and says why under the row that asked for it, rather than as a banner over the whole section. Arrow keys move it, and screen readers hear the level name rather than a number. One control at every width — the phone and desktop renderings are no longer two separate components.
+
+The per-mode rows moved next to the level they follow. They set deployment defaults, but they sat in your personal card beside the session thinking level, so "Follows base" pointed at a row that was neither the base nor on the same screen. Base and modes are now one group of their own, and the session-level row that used to sit beside them is labelled for what it really is: the level for chats opened from this factory, shared with everyone working in it. Saving no longer raises a toast per change — the control already shows the new value, and it holds the stop you dropped it on until the write lands instead of flicking back and forth once.
+
+On a deployment that refuses these writes — the defaults live in one settings file shared by everyone, so an authenticated deployment keeps them fixed — the rows now say so and render read-only, instead of letting you drag a slider that fails on release.
+
+**Theme** uses the shared theme toggle instead of a picker built here, so System, Light and Dark read and behave the same in the Factory as everywhere else in the product.
+
+**Completion sound** is a one-line select with a mute button tucked under its left edge, not four buttons: whether a run makes a sound and which sound it makes are two different questions. Muting swaps the icon and greys the select's label while keeping your sound, so unmuting returns to what you had. Nothing moves as you toggle, and the greyed-out select keeps its own background rather than turning translucent over the button behind it. Each pick plays, since a sound can only be judged by ear.
+
+**Observe attachments** was a hand-rolled copy of the shared button group; it now uses the shared one, so Auto/On/Off, Notifications and the tool-permission rows stay identical — those are alternatives, not a ramp, and keep the control that says so.

--- a/.changeset/settings-scope-badges.md
+++ b/.changeset/settings-scope-badges.md
@@ -1,0 +1,20 @@
+---
+'@mastra/factory': patch
+---
+
+Settings now say who each block applies to. Every section heading carries a scope label: **Personal** for your own account, chats and credentials, **Factory-wide** for what everyone working in this factory shares, **Org-wide** for what the whole organization shares such as custom providers and GitHub CLI tokens, and **Deployment-wide** for the handful of settings that live in the server's own settings file and reach every factory on it.
+
+Writing the labels turned up blocks that claimed the wrong owner, and those moved to where they belong:
+
+- **Thinking level, auto-approve tools, smart editing, notifications and the tool-permission rows** sat under Personal, but a settings page has no chat session of its own, so they all write the factory-level session that every member of the factory shares. They now read Factory-wide, and say plainly that auto-approve, smart editing and permissions reset when the server restarts.
+- **Base and per-mode thinking defaults** claimed Factory-wide while writing one settings file shared by every factory on the server. They are their own Deployment-wide block now, sitting together so a mode row that follows the base level shows the row it follows.
+- **GitHub and Linear issue syncing** claimed Factory-wide while storing one row per person. They read Personal, and say that teammates choose their own.
+- **Linear routing** is org-level config that happens to name a factory, so it reads Org-wide.
+- **"Create work items for new Slack threads"** sat in a Personal block on the Slack page while flipping a switch on the factory itself. It has its own Factory-wide block now, next to the per-account routing that really is personal.
+- **Model packs**: choosing your default pack is personal, but creating or removing one changes the list for the whole org, which the block now says.
+- **Factory skills** ship with the server and are identical on every factory, so they read Deployment-wide rather than implying this factory has its own.
+
+Where the same form exists at two scopes, the label becomes a switch instead of a second copy of the form, and switching slides the old content out and the new content in from the picked side, so the change is visible even when both scopes are configured alike:
+
+- **Provider access** switches between your own credentials and the org-wide ones (org admins only). The sign-in and API-key tabs moved up next to the heading, so the section leads with one row of controls instead of two. Each row shows one status and one action for the picked scope; from the personal view a provider you have no credential for reads "Covered by org" when the org already has one. Signing in or adding a key no longer asks who it is for; the switch already decided.
+- **Observational memory** switches between your interactive chats and Factory runs instead of stacking two identical forms.

--- a/mastracode/factory-ui/src/hooks/use-thinking.ts
+++ b/mastracode/factory-ui/src/hooks/use-thinking.ts
@@ -29,13 +29,34 @@ export interface UpdateThinkingArgs {
   modeDefaults?: Record<string, ThinkingLevelValue | null>;
 }
 
+function applyThinkingUpdates(config: ThinkingConfigInfo, args: UpdateThinkingArgs): ThinkingConfigInfo {
+  const modeDefaults = { ...config.modeDefaults };
+  for (const [mode, level] of Object.entries(args.modeDefaults ?? {})) {
+    if (level === null) delete modeDefaults[mode];
+    else modeDefaults[mode] = level;
+  }
+  return { ...config, globalDefault: args.globalDefault ?? config.globalDefault, modeDefaults };
+}
+
+/** Optimistic: the slider holds the dropped level, a rejection puts it back. */
 export function useUpdateThinkingMutation() {
   const { client } = useApiConfig();
   const queryClient = useQueryClient();
+  const key = queryKeys.thinkingConfig();
+
   return useMutation({
     mutationFn: (args: UpdateThinkingArgs) => client.put<UpdateThinkingConfigResponse>('/web/config/thinking', args),
+    onMutate: async args => {
+      await queryClient.cancelQueries({ queryKey: key, exact: true });
+      const previous = queryClient.getQueryData<ThinkingConfigInfo>(key);
+      if (previous) queryClient.setQueryData<ThinkingConfigInfo>(key, applyThinkingUpdates(previous, args));
+      return { previous };
+    },
+    onError: (_error, _args, context) => {
+      if (context?.previous) queryClient.setQueryData(key, context.previous);
+    },
     onSuccess: res =>
-      queryClient.setQueryData<ThinkingConfigInfo>(queryKeys.thinkingConfig(), prev =>
+      queryClient.setQueryData<ThinkingConfigInfo>(key, prev =>
         prev ? { ...prev, globalDefault: res.globalDefault, modeDefaults: res.modeDefaults } : prev,
       ),
   });

--- a/mastracode/factory-ui/src/hooks/use-thinking.ts
+++ b/mastracode/factory-ui/src/hooks/use-thinking.ts
@@ -45,6 +45,9 @@ export function useUpdateThinkingMutation() {
   const key = queryKeys.thinkingConfig();
 
   return useMutation({
+    // Base and per-mode rows write the same file: run them one at a time so a
+    // rollback restores the value before that write, not before its neighbour's.
+    scope: { id: 'thinking-config' },
     mutationFn: (args: UpdateThinkingArgs) => client.put<UpdateThinkingConfigResponse>('/web/config/thinking', args),
     onMutate: async args => {
       await queryClient.cancelQueries({ queryKey: key, exact: true });

--- a/mastracode/factory-ui/src/ui/domains/settings/components/AccountSettingsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/AccountSettingsSection.tsx
@@ -68,7 +68,7 @@ export function AccountSettingsSection() {
 
   if (auth.isPending) {
     return (
-      <SettingsSubsection title="Profile">
+      <SettingsSubsection scope="personal" title="Profile">
         <AccountSettingsSkeleton />
       </SettingsSubsection>
     );
@@ -96,7 +96,11 @@ export function AccountSettingsSection() {
 
   return (
     <div className="flex flex-col gap-8">
-      <SettingsSubsection title="Profile" description="Your signed-in identity for this MastraCode deployment.">
+      <SettingsSubsection
+        scope="personal"
+        title="Profile"
+        description="Your signed-in identity for this MastraCode deployment."
+      >
         <SettingsCard>
           <SettingsRow variant="factory" label="Name">
             <AccountValue>{user?.name ?? 'Not provided'}</AccountValue>
@@ -123,7 +127,7 @@ export function AccountSettingsSection() {
           )}
         </SettingsCard>
       </SettingsSubsection>
-      <SettingsSubsection title="Session">
+      <SettingsSubsection scope="personal" title="Session">
         <SettingsCard>
           <SettingsRow variant="factory" label="Log out" description="End your MastraCode session on this device.">
             <Button type="button" variant="outline" size="sm" aria-label="Log out of MastraCode" onClick={logOut}>

--- a/mastracode/factory-ui/src/ui/domains/settings/components/AddApiKeyDialog.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/AddApiKeyDialog.tsx
@@ -27,18 +27,25 @@ interface AddApiKeyDialogProps {
    * narrow a shared key.
    */
   defaultScope?: 'user' | 'org';
+  fixedScope?: 'user' | 'org';
   onClose: () => void;
 }
 
 /** Dialog for adding or updating a provider API key, with an org/user scope choice when auth is enabled. */
-export function AddApiKeyDialog({ provider, authEnabled, defaultScope = 'user', onClose }: AddApiKeyDialogProps) {
+export function AddApiKeyDialog({
+  provider,
+  authEnabled,
+  defaultScope = 'user',
+  fixedScope,
+  onClose,
+}: AddApiKeyDialogProps) {
   const displayName = providerDisplayName(provider.provider);
   const saveKeyMutation = useSaveProviderKey();
   const orgKeyAdminQuery = useOrgKeyAdminQuery();
   const canWriteOrgKey = !authEnabled || (orgKeyAdminQuery.data ?? true);
   const preferredScope = provider.source === 'stored-org' ? 'org' : defaultScope;
   const [keyDraft, setKeyDraft] = useState('');
-  const [scope, setScope] = useState<'user' | 'org'>(canWriteOrgKey ? preferredScope : 'user');
+  const [scope, setScope] = useState<'user' | 'org'>(fixedScope ?? (canWriteOrgKey ? preferredScope : 'user'));
 
   const error = saveKeyMutation.error instanceof Error ? saveKeyMutation.error.message : undefined;
   // A shared context wanted an org-wide key but this caller can't write one —
@@ -85,7 +92,7 @@ export function AddApiKeyDialog({ provider, authEnabled, defaultScope = 'user', 
               if (event.key === 'Escape') close();
             }}
           />
-          {authEnabled && (
+          {authEnabled && !fixedScope && (
             <div className="flex items-center justify-between gap-4">
               <Txt as="span" variant="ui-sm" className="text-icon4">
                 Who can use this key

--- a/mastracode/factory-ui/src/ui/domains/settings/components/FactoryManagementSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/FactoryManagementSection.tsx
@@ -20,7 +20,7 @@ export function FactoryManagementSection() {
   }
 
   return (
-    <SettingsSubsection title="Danger zone">
+    <SettingsSubsection scope="factory" title="Danger zone">
       <SettingsCard>
         <SettingsRow variant="factory" label={`Delete ${factory.name}`} description="Also unlinks its repositories.">
           <AlertDialog>

--- a/mastracode/factory-ui/src/ui/domains/settings/components/FactorySetupSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/FactorySetupSection.tsx
@@ -127,7 +127,11 @@ export function FactorySetupSection({ factory }: { factory: FactoryProject }) {
   if (rows.length === 0) return null;
 
   return (
-    <SettingsSubsection title="Sandbox" description="Shell commands each session runs in its own sandbox.">
+    <SettingsSubsection
+      scope="factory"
+      title="Sandbox"
+      description="Shell commands each session runs in its own sandbox."
+    >
       <div className="flex flex-col gap-4">
         {rows.map(row => (
           <RepositoryCommands

--- a/mastracode/factory-ui/src/ui/domains/settings/components/FactorySkillsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/FactorySkillsSection.tsx
@@ -82,8 +82,9 @@ export function FactorySkillsSection() {
 
   return (
     <SettingsSubsection
+      scope="deployment"
       title="Factory skills"
-      description="The built-in playbooks Factory agents follow when working your items. Expand a skill to read the exact instructions the agent receives."
+      description="The built-in playbooks Factory agents follow when working your items, shipped with the server and read-only. Expand a skill to read the exact instructions the agent receives."
     >
       {skillsQuery.isPending && (
         <Txt as="p" variant="ui-sm" role="status" className="text-icon3">

--- a/mastracode/factory-ui/src/ui/domains/settings/components/GithubPatBlock.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/GithubPatBlock.tsx
@@ -28,6 +28,7 @@ export function GithubPatBlock() {
 
   return (
     <SettingsSubsection
+      scope="org"
       title="GitHub CLI tokens"
       description="Classic PATs agents use for gh CLI commands in sandboxes. The token's account needs access to the linked repositories."
     >

--- a/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSection.tsx
@@ -38,8 +38,9 @@ interface SourceSectionProps {
 function GithubIntakeSection({ config, busy, update, slugs }: SourceSectionProps & { slugs: string[] }) {
   return (
     <SettingsSubsection
+      scope="personal"
       title="GitHub issues"
-      description="Open issues from the selected repositories. Pull requests always appear in Review."
+      description="Open issues from the repositories you select. Teammates choose their own. Pull requests always appear in Review."
     >
       <SettingsCard>
         <SettingsRow variant="factory" label="Sync GitHub issues">
@@ -112,7 +113,7 @@ function LinearIntakeSection({
       ? 'Connect a Linear workspace to sync its issues.'
       : reauthRequired
         ? 'Linear authorization expired. Reconnect to keep syncing issues.'
-        : 'Active issues from the selected projects.';
+        : 'Active issues from the projects you select. Teammates choose their own.';
 
   const action = !serverConfigured ? undefined : !connected ? (
     <Button size="sm" onClick={() => connectLinear(baseUrl)}>
@@ -134,7 +135,7 @@ function LinearIntakeSection({
   );
 
   return (
-    <SettingsSubsection title="Linear issues" description={description} action={action}>
+    <SettingsSubsection scope="personal" title="Linear issues" description={description} action={action}>
       <SettingsCard>
         <SettingsRow variant="factory" label="Sync Linear issues">
           <Switch
@@ -221,6 +222,7 @@ export function IntakeSection() {
       />
       {linearReady && routedProjectIds.length > 0 && (
         <SettingsSubsection
+          scope="org"
           title="Linear routing"
           description="Each selected project feeds one factory. Until a project is routed, its issues are not picked up."
         >

--- a/mastracode/factory-ui/src/ui/domains/settings/components/OMSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/OMSection.tsx
@@ -1,6 +1,4 @@
 import { Badge } from '@mastra/playground-ui/components/Badge';
-import { Button } from '@mastra/playground-ui/components/Button';
-import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
 import { Txt } from '@mastra/playground-ui/components/Txt';
@@ -15,6 +13,7 @@ import {
 import type { AvailableModelOption } from '../../../../hooks/useAvailableModels';
 import { SkeletonRows } from '../../../ui/SkeletonRows';
 import { ModelCombobox } from './ModelCombobox';
+import { Segmented } from './SettingsFields';
 
 type AttachmentChoice = 'auto' | 'on' | 'off';
 
@@ -23,6 +22,12 @@ function attachmentToChoice(value: 'auto' | boolean): AttachmentChoice {
   if (value === false) return 'off';
   return 'auto';
 }
+
+const ATTACHMENT_OPTIONS: { value: AttachmentChoice; label: string }[] = [
+  { value: 'auto', label: 'Auto' },
+  { value: 'on', label: 'On' },
+  { value: 'off', label: 'Off' },
+];
 
 function choiceToAttachment(choice: AttachmentChoice): 'auto' | boolean {
   if (choice === 'on') return true;
@@ -123,12 +128,6 @@ export function OMSection({
   }
 
   const attachmentChoice = attachmentToChoice(config?.observeAttachments ?? 'auto');
-  const attachmentOptions: { value: AttachmentChoice; label: string }[] = [
-    { value: 'auto', label: 'Auto' },
-    { value: 'on', label: 'On' },
-    { value: 'off', label: 'Off' },
-  ];
-
   return (
     <>
       {error && (
@@ -219,20 +218,13 @@ export function OMSection({
         label="Observe attachments"
         description="Whether attached files are included in observations"
       >
-        <ButtonsGroup spacing="close" role="group" aria-label="Observe attachments">
-          {attachmentOptions.map(option => (
-            <Button
-              key={option.value}
-              variant={attachmentChoice === option.value ? 'primary' : 'outline'}
-              size="sm"
-              aria-pressed={attachmentChoice === option.value}
-              disabled={busy || !config}
-              onClick={() => attachmentsMutation.mutate({ value: choiceToAttachment(option.value) })}
-            >
-              {option.label}
-            </Button>
-          ))}
-        </ButtonsGroup>
+        <Segmented
+          ariaLabel="Observe attachments"
+          value={attachmentChoice}
+          options={ATTACHMENT_OPTIONS}
+          disabled={busy || !config}
+          onChange={choice => attachmentsMutation.mutate({ value: choiceToAttachment(choice) })}
+        />
       </SettingsRow>
     </>
   );

--- a/mastracode/factory-ui/src/ui/domains/settings/components/ProviderAccessSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/ProviderAccessSection.tsx
@@ -130,7 +130,7 @@ export function ProviderAccessSection({ description }: { description?: string })
 
   // OAuth-capable providers usually accept API keys too, so the API-key tab
   // lists every provider, credentialed-first.
-  const apiKeyProviders = [...providers].sort((left, right) => {
+  const apiKeyProviders = providers.toSorted((left, right) => {
     const leftHas = credentialAt(left, scope) !== undefined;
     const rightHas = credentialAt(right, scope) !== undefined;
     if (leftHas !== rightHas) return leftHas ? -1 : 1;

--- a/mastracode/factory-ui/src/ui/domains/settings/components/ProviderAccessSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/ProviderAccessSection.tsx
@@ -1,17 +1,7 @@
 import { Badge } from '@mastra/playground-ui/components/Badge';
-import type { BadgeVariant } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
-import {
-  Dialog,
-  DialogBody,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@mastra/playground-ui/components/Dialog';
 import { Tab, TabContent, TabList, Tabs } from '@mastra/playground-ui/components/Tabs';
 import { toast } from '@mastra/playground-ui/components/Toaster';
 import { Txt } from '@mastra/playground-ui/components/Txt';
@@ -33,29 +23,14 @@ import { AddApiKeyDialog } from './AddApiKeyDialog';
 import { ProviderOAuthDialog } from './ProviderOAuthDialog';
 import { providerDisplayName } from './provider-display-name';
 import { SettingsCard } from './SettingsCard';
-import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
+import { ScopeSwap, useScopeControl } from './SettingsScope';
+import type { SettingsScope } from './SettingsScope';
+import { SettingsSubsection } from './SettingsSubsection';
 
-const SOURCE_LABEL: Record<ProviderInfo['source'], string> = {
-  oauth: 'Signed in',
-  'oauth-user': 'Signed in',
-  'oauth-org': 'Org sign-in',
-  stored: 'Key saved',
-  'stored-user': 'Personal key',
-  'stored-org': 'Org key',
-  env: 'From env',
-  none: 'Not set',
-};
+type CredentialScope = 'user' | 'org';
+type Credential = NonNullable<ProviderInfo['userCredential']>;
 
-const SOURCE_VARIANT: Record<ProviderInfo['source'], BadgeVariant> = {
-  oauth: 'green',
-  'oauth-user': 'green',
-  'oauth-org': 'blue',
-  stored: 'green',
-  'stored-user': 'green',
-  'stored-org': 'blue',
-  env: 'blue',
-  none: 'neutral',
-};
+const CREDENTIAL_LABEL: Record<Credential, string> = { oauth: 'Signed in', api_key: 'Key saved' };
 
 interface ActiveOAuthSession {
   provider: string;
@@ -67,103 +42,67 @@ function mutationErrorMessage(error: unknown, fallback: string): string {
 }
 
 /**
- * Credential source badge(s). When a personal credential shadows an org-wide
- * key, both badges render so it's clear a shared key also exists.
+ * Credential held at one scope. The legacy `source` field stands in for the
+ * per-scope fields in local mode and while /auth/me is still loading.
  */
-function SourceBadges({ provider }: { provider: ProviderInfo }) {
-  const shadowedOrg =
-    provider.orgKey === true && (provider.source === 'stored-user' || provider.source === 'oauth-user');
-  return (
-    <span className="flex items-center gap-1">
-      <Badge size="sm" variant={SOURCE_VARIANT[provider.source]}>
-        {SOURCE_LABEL[provider.source]}
+function credentialAt(provider: ProviderInfo, scope: CredentialScope): Credential | undefined {
+  if (scope === 'org') {
+    if (provider.orgCredential) return provider.orgCredential;
+    if (provider.source === 'oauth-org') return 'oauth';
+    if (provider.source === 'stored-org') return 'api_key';
+    return undefined;
+  }
+  if (provider.userCredential) return provider.userCredential;
+  if (provider.source === 'oauth' || provider.source === 'oauth-user') return 'oauth';
+  if (provider.source === 'stored' || provider.source === 'stored-user') return 'api_key';
+  return undefined;
+}
+
+interface RowScope {
+  scope: CredentialScope;
+  authEnabled: boolean;
+}
+
+function orgCoverage(provider: ProviderInfo, { scope, authEnabled }: RowScope): Credential | undefined {
+  return authEnabled && scope === 'user' ? credentialAt(provider, 'org') : undefined;
+}
+
+function StatusBadge({ provider, rowScope }: { provider: ProviderInfo; rowScope: RowScope }) {
+  const own = credentialAt(provider, rowScope.scope);
+  if (own) {
+    return (
+      <Badge size="sm" variant="green">
+        {CREDENTIAL_LABEL[own]}
       </Badge>
-      {shadowedOrg && (
-        <Badge size="sm" variant="blue">
-          {provider.orgCredential === 'oauth' ? 'Org sign-in' : 'Org key'}
-        </Badge>
-      )}
-    </span>
-  );
-}
-
-/**
- * Per-provider scope choice for org admins before starting an OAuth flow.
- * Scope is fixed at flow start (the server stores it on the login session),
- * so it has to be picked here rather than after authorization.
- */
-function OAuthScopeDialog({
-  provider,
-  signedInScopes,
-  onSelect,
-  onClose,
-}: {
-  provider: ProviderInfo;
-  /** Scopes that already have an OAuth credential; disabled in the picker. */
-  signedInScopes: Array<'user' | 'org'>;
-  onSelect: (scope: 'user' | 'org') => void;
-  onClose: () => void;
-}) {
-  const displayName = providerDisplayName(provider.provider);
-  const [scope, setScope] = useState<'user' | 'org'>(signedInScopes.includes('user') ? 'org' : 'user');
+    );
+  }
+  if (orgCoverage(provider, rowScope)) {
+    return (
+      <Badge size="sm" variant="blue">
+        Covered by org
+      </Badge>
+    );
+  }
+  if (provider.source === 'env') {
+    return (
+      <Badge size="sm" variant="blue">
+        From env
+      </Badge>
+    );
+  }
   return (
-    <Dialog open onOpenChange={open => !open && onClose()}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Sign in to {displayName}</DialogTitle>
-          <DialogDescription>Choose who can use this sign-in before authorizing.</DialogDescription>
-        </DialogHeader>
-        <DialogBody className="flex flex-col gap-4">
-          <div className="flex items-center justify-between gap-4">
-            <Txt as="span" variant="ui-sm" className="text-icon4">
-              Who can use this sign-in
-            </Txt>
-            <ButtonsGroup spacing="close" role="group" aria-label="Sign-in access">
-              {(
-                [
-                  { value: 'user', label: 'Just me' },
-                  { value: 'org', label: 'Everyone in org' },
-                ] as const
-              ).map(option => {
-                const alreadySignedIn = signedInScopes.includes(option.value);
-                return (
-                  <Button
-                    key={option.value}
-                    variant={scope === option.value ? 'primary' : 'outline'}
-                    size="sm"
-                    aria-pressed={scope === option.value}
-                    disabled={alreadySignedIn}
-                    title={alreadySignedIn ? 'Already signed in at this scope' : undefined}
-                    onClick={() => setScope(option.value)}
-                  >
-                    {option.label}
-                  </Button>
-                );
-              })}
-            </ButtonsGroup>
-          </div>
-          {scope === 'org' && (
-            <Txt as="p" variant="ui-sm" className="text-icon4" role="note">
-              Everyone in your organization will be able to run models through this {displayName} account.
-            </Txt>
-          )}
-        </DialogBody>
-        <DialogFooter>
-          <Button onClick={onClose}>Cancel</Button>
-          <Button variant="primary" onClick={() => onSelect(scope)}>
-            Continue
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <Badge size="sm" variant="neutral">
+      Not set
+    </Badge>
   );
 }
 
 /**
- * Provider credential management as a tabbed subsection of the Model settings
- * page: OAuth sign-in on one tab, API keys on the other.
+ * Provider credential management: OAuth sign-in on one tab, API keys on the
+ * other. The section's scope switch decides whether rows show and edit the
+ * caller's personal credentials or the org-wide ones (admins only).
  */
-export function ProviderAccessSection() {
+export function ProviderAccessSection({ description }: { description?: string }) {
   const providersQuery = useProvidersQuery();
   const authQuery = useFactoryAuth();
   const startOAuthMutation = useStartProviderOAuth();
@@ -172,13 +111,19 @@ export function ProviderAccessSection() {
   const removeKeyMutation = useRemoveProviderKey();
   const orgKeyAdminQuery = useOrgKeyAdminQuery();
   const [search, setSearch] = useState('');
-  const [scopeDialogProvider, setScopeDialogProvider] = useState<ProviderInfo>();
   const [startingProvider, setStartingProvider] = useState<string>();
   const [activeOAuth, setActiveOAuth] = useState<ActiveOAuthSession>();
   const [keyDialogProvider, setKeyDialogProvider] = useState<ProviderInfo>();
 
   const providers = providersQuery.data ?? [];
   const authEnabled = authQuery.data?.authEnabled === true;
+  const canWriteOrgKey = !authEnabled || (orgKeyAdminQuery.data ?? true);
+  const scopeOptions: SettingsScope[] = authEnabled && canWriteOrgKey ? ['personal', 'org'] : ['personal'];
+  const scopeControl = useScopeControl(scopeOptions);
+  const scope: CredentialScope = scopeControl.shown === 'org' ? 'org' : 'user';
+  const rowScope: RowScope = { scope, authEnabled };
+  const scopeArg = authEnabled ? { scope } : {};
+
   const oauthProviders = providers
     .filter(provider => provider.oauth?.supported === true)
     .sort((left, right) => left.provider.localeCompare(right.provider));
@@ -186,7 +131,9 @@ export function ProviderAccessSection() {
   // OAuth-capable providers usually accept API keys too, so the API-key tab
   // lists every provider, credentialed-first.
   const apiKeyProviders = [...providers].sort((left, right) => {
-    if ((left.source !== 'none') !== (right.source !== 'none')) return left.source !== 'none' ? -1 : 1;
+    const leftHas = credentialAt(left, scope) !== undefined;
+    const rightHas = credentialAt(right, scope) !== undefined;
+    if (leftHas !== rightHas) return leftHas ? -1 : 1;
     return left.provider.localeCompare(right.provider);
   });
   const query = search.trim().toLowerCase();
@@ -194,28 +141,14 @@ export function ProviderAccessSection() {
     ? apiKeyProviders.filter(provider => provider.provider.toLowerCase().includes(query))
     : apiKeyProviders;
 
-  const canWriteOrgKey = !authEnabled || (orgKeyAdminQuery.data ?? true);
-
-  // Per-scope OAuth status. Falls back to the legacy `source` field so rows
-  // stay correct in local mode and while /auth/me is still loading.
-  const oauthScopes = (provider: ProviderInfo): Array<'user' | 'org'> => {
-    const scopes: Array<'user' | 'org'> = [];
-    if (provider.userCredential === 'oauth' || provider.source === 'oauth' || provider.source === 'oauth-user') {
-      scopes.push('user');
-    }
-    if (provider.orgCredential === 'oauth' || provider.source === 'oauth-org') scopes.push('org');
-    return scopes;
-  };
-
-  const startOAuth = async (provider: ProviderInfo, scope: 'user' | 'org') => {
+  const startOAuth = async (provider: ProviderInfo) => {
     const modes = provider.oauth?.modes ?? [];
-    setScopeDialogProvider(undefined);
     setStartingProvider(provider.provider);
     try {
       const session = await startOAuthMutation.mutateAsync({
         provider: provider.provider,
         mode: modes.length === 1 ? modes[0] : undefined,
-        ...(authEnabled ? { scope } : {}),
+        ...scopeArg,
       });
       setActiveOAuth({ provider: provider.provider, session });
     } catch {
@@ -223,24 +156,6 @@ export function ProviderAccessSection() {
     } finally {
       setStartingProvider(undefined);
     }
-  };
-
-  // Org admins pick who the sign-in is for, per provider; everyone else signs
-  // in personally without an extra step.
-  const requestSignIn = (provider: ProviderInfo) => {
-    if (authEnabled && canWriteOrgKey) {
-      setScopeDialogProvider(provider);
-      return;
-    }
-    void startOAuth(provider, 'user');
-  };
-
-  // Sign in is offered whenever a scope the caller can write is still open:
-  // personal always, org only for admins.
-  const canSignIn = (provider: ProviderInfo) => {
-    const scopes = oauthScopes(provider);
-    if (!scopes.includes('user')) return true;
-    return authEnabled && canWriteOrgKey && !scopes.includes('org');
   };
 
   const closeOAuth = () => {
@@ -251,22 +166,16 @@ export function ProviderAccessSection() {
     }
   };
 
-  const signOut = (provider: ProviderInfo, scope: 'user' | 'org') => {
+  const signOut = (provider: ProviderInfo) => {
     signOutMutation.mutate(
-      {
-        provider: provider.provider,
-        ...(authEnabled ? { scope } : {}),
-      },
+      { provider: provider.provider, ...scopeArg },
       { onError: error => toast.error(mutationErrorMessage(error, 'Failed to sign out')) },
     );
   };
 
   const removeKey = (provider: ProviderInfo) => {
     removeKeyMutation.mutate(
-      {
-        provider: provider.provider,
-        ...(authEnabled ? { scope: provider.source === 'stored-org' ? 'org' : 'user' } : {}),
-      },
+      { provider: provider.provider, ...scopeArg },
       { onError: error => toast.error(mutationErrorMessage(error, 'Failed to remove API key')) },
     );
   };
@@ -280,160 +189,158 @@ export function ProviderAccessSection() {
   const error = requestError instanceof Error ? requestError.message : undefined;
 
   return (
-    <div className="flex flex-col gap-3">
-      {error && (
-        <Txt as="p" variant="ui-sm" className="text-notice-destructive-fg">
-          {error}
-        </Txt>
-      )}
+    <Tabs defaultTab="oauth">
+      <SettingsSubsection
+        title="Provider access"
+        description={description}
+        scope={scopeControl}
+        action={
+          <TabList variant="pill">
+            <Tab value="oauth">Sign in with a provider</Tab>
+            <Tab value="api-key">Connect with API key</Tab>
+          </TabList>
+        }
+      >
+        <div className="flex flex-col gap-3">
+          {error && (
+            <Txt as="p" variant="ui-sm" className="text-notice-destructive-fg">
+              {error}
+            </Txt>
+          )}
 
-      <Tabs defaultTab="oauth">
-        <TabList variant="pill">
-          <Tab value="oauth">Sign in with a provider</Tab>
-          <Tab value="api-key">Connect with API key</Tab>
-        </TabList>
+          <TabContent value="oauth" className="flex flex-col gap-3">
+            <ScopeSwap control={scopeControl}>
+              <SettingsCard>
+                {providersQuery.isPending ? (
+                  <div className="px-4 py-3">
+                    <SkeletonRows label="Loading providers" rows={3} rowClassName="h-9 w-full" />
+                  </div>
+                ) : oauthProviders.length === 0 ? (
+                  <Txt as="p" variant="ui-sm" className="text-icon3 px-4 py-3">
+                    No providers support sign in.
+                  </Txt>
+                ) : (
+                  oauthProviders.map(provider => {
+                    const displayName = providerDisplayName(provider.provider);
+                    const own = credentialAt(provider, scope);
+                    const signedIn = own === 'oauth';
+                    const covered = own !== undefined || orgCoverage(provider, rowScope) !== undefined;
+                    return (
+                      <SettingsRow key={provider.provider} variant="factory" label={displayName}>
+                        <span className="flex items-center gap-2">
+                          <StatusBadge provider={provider} rowScope={rowScope} />
+                          {signedIn ? (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              aria-label={
+                                scope === 'org'
+                                  ? `Sign out of ${displayName} for the org`
+                                  : `Sign out of ${displayName}`
+                              }
+                              disabled={isSigningOut(provider)}
+                              onClick={() => signOut(provider)}
+                            >
+                              {isSigningOut(provider) ? 'Signing out…' : 'Sign out'}
+                            </Button>
+                          ) : (
+                            <Button
+                              variant={covered ? 'outline' : 'primary'}
+                              size="sm"
+                              aria-label={`Sign in to ${displayName}`}
+                              disabled={startOAuthMutation.isPending}
+                              onClick={() => void startOAuth(provider)}
+                            >
+                              {startingProvider === provider.provider ? 'Starting…' : 'Sign in'}
+                            </Button>
+                          )}
+                        </span>
+                      </SettingsRow>
+                    );
+                  })
+                )}
+              </SettingsCard>
+            </ScopeSwap>
+          </TabContent>
 
-        <TabContent value="oauth" className="flex flex-col gap-3">
-          <SettingsCard>
-            {providersQuery.isPending ? (
-              <div className="px-4 py-3">
-                <SkeletonRows label="Loading providers" rows={3} rowClassName="h-9 w-full" />
-              </div>
-            ) : oauthProviders.length === 0 ? (
-              <Txt as="p" variant="ui-sm" className="text-icon3 px-4 py-3">
-                No providers support sign in.
-              </Txt>
-            ) : (
-              oauthProviders.map(provider => {
-                const displayName = providerDisplayName(provider.provider);
-                const scopes = oauthScopes(provider);
-                const showScopeLabels = scopes.length > 0 && authEnabled;
-                return (
-                  <SettingsRow key={provider.provider} variant="factory" label={displayName}>
-                    <span className="flex items-center gap-2">
-                      <SourceBadges provider={provider} />
-                      {scopes.map(scope => {
-                        // Removing the shared org sign-in is admin-only.
-                        if (scope === 'org' && !canWriteOrgKey) return null;
-                        const label = showScopeLabels ? (scope === 'org' ? 'Sign out org' : 'Sign out me') : 'Sign out';
-                        return (
+          <TabContent value="api-key" className="flex flex-col gap-3">
+            <div className="relative">
+              <Search size={14} className="text-icon3 pointer-events-none absolute top-1/2 left-3 -translate-y-1/2" />
+              <Input
+                type="text"
+                placeholder="Search providers to add an API key…"
+                value={search}
+                onChange={event => setSearch(event.target.value)}
+                aria-label="Search providers"
+                className="pl-8"
+              />
+            </div>
+
+            <ScopeSwap control={scopeControl}>
+              <SettingsCard className="max-h-[280px] overflow-y-auto">
+                {providersQuery.isPending ? (
+                  <div className="px-4 py-3">
+                    <SkeletonRows label="Loading providers" rows={3} rowClassName="h-9 w-full" />
+                  </div>
+                ) : results.length === 0 ? (
+                  <Txt as="p" variant="ui-sm" className="text-icon3 px-4 py-3">
+                    {query ? `No providers match “${search.trim()}”.` : 'No API key providers are available.'}
+                  </Txt>
+                ) : (
+                  results.map(provider => {
+                    const displayName = providerDisplayName(provider.provider);
+                    const storedKey = credentialAt(provider, scope) === 'api_key';
+                    return (
+                      <SettingsRow key={provider.provider} variant="factory" label={displayName}>
+                        <span className="flex items-center gap-2">
+                          <StatusBadge provider={provider} rowScope={rowScope} />
                           <Button
-                            key={scope}
-                            variant="outline"
                             size="sm"
-                            aria-label={
-                              scope === 'org' ? `Sign out of ${displayName} for the org` : `Sign out of ${displayName}`
-                            }
-                            disabled={isSigningOut(provider)}
-                            onClick={() => signOut(provider, scope)}
+                            aria-label={`${storedKey ? 'Update key' : 'Add API key'} for ${displayName}`}
+                            disabled={isRemoving(provider)}
+                            onClick={() => setKeyDialogProvider(provider)}
                           >
-                            {isSigningOut(provider) ? 'Signing out…' : label}
+                            {storedKey ? 'Update key' : 'Add API key'}
                           </Button>
-                        );
-                      })}
-                      {canSignIn(provider) && (
-                        <Button
-                          variant={scopes.length === 0 ? 'primary' : 'outline'}
-                          size="sm"
-                          aria-label={`Sign in to ${displayName}`}
-                          disabled={startOAuthMutation.isPending}
-                          onClick={() => requestSignIn(provider)}
-                        >
-                          {startingProvider === provider.provider ? 'Starting…' : 'Sign in'}
-                        </Button>
-                      )}
-                    </span>
-                  </SettingsRow>
-                );
-              })
-            )}
-          </SettingsCard>
-        </TabContent>
+                          {storedKey && (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              aria-label={`Remove key for ${displayName}`}
+                              disabled={isRemoving(provider)}
+                              onClick={() => removeKey(provider)}
+                            >
+                              {isRemoving(provider) ? 'Removing…' : 'Remove'}
+                            </Button>
+                          )}
+                        </span>
+                      </SettingsRow>
+                    );
+                  })
+                )}
+              </SettingsCard>
+            </ScopeSwap>
+          </TabContent>
 
-        <TabContent value="api-key" className="flex flex-col gap-3">
-          <div className="relative">
-            <Search size={14} className="text-icon3 pointer-events-none absolute top-1/2 left-3 -translate-y-1/2" />
-            <Input
-              type="text"
-              placeholder="Search providers to add an API key…"
-              value={search}
-              onChange={event => setSearch(event.target.value)}
-              aria-label="Search providers"
-              className="pl-8"
+          {keyDialogProvider && (
+            <AddApiKeyDialog
+              provider={keyDialogProvider}
+              authEnabled={authEnabled}
+              fixedScope={authEnabled ? scope : undefined}
+              onClose={() => setKeyDialogProvider(undefined)}
             />
-          </div>
+          )}
 
-          <SettingsCard className="max-h-[280px] overflow-y-auto">
-            {providersQuery.isPending ? (
-              <div className="px-4 py-3">
-                <SkeletonRows label="Loading providers" rows={3} rowClassName="h-9 w-full" />
-              </div>
-            ) : results.length === 0 ? (
-              <Txt as="p" variant="ui-sm" className="text-icon3 px-4 py-3">
-                {query ? `No providers match “${search.trim()}”.` : 'No API key providers are available.'}
-              </Txt>
-            ) : (
-              results.map(provider => {
-                const displayName = providerDisplayName(provider.provider);
-                const storedKey =
-                  provider.source === 'stored' || provider.source === 'stored-user' || provider.source === 'stored-org';
-                return (
-                  <SettingsRow key={provider.provider} variant="factory" label={displayName}>
-                    <span className="flex items-center gap-2">
-                      <SourceBadges provider={provider} />
-                      <Button
-                        size="sm"
-                        aria-label={`${storedKey ? 'Update key' : 'Add API key'} for ${displayName}`}
-                        disabled={isRemoving(provider)}
-                        onClick={() => setKeyDialogProvider(provider)}
-                      >
-                        {storedKey ? 'Update key' : 'Add API key'}
-                      </Button>
-                      {storedKey && (
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          aria-label={`Remove key for ${displayName}`}
-                          disabled={isRemoving(provider)}
-                          onClick={() => removeKey(provider)}
-                        >
-                          {isRemoving(provider) ? 'Removing…' : 'Remove'}
-                        </Button>
-                      )}
-                    </span>
-                  </SettingsRow>
-                );
-              })
-            )}
-          </SettingsCard>
-        </TabContent>
-      </Tabs>
-
-      {keyDialogProvider && (
-        <AddApiKeyDialog
-          provider={keyDialogProvider}
-          authEnabled={authEnabled}
-          onClose={() => setKeyDialogProvider(undefined)}
-        />
-      )}
-
-      {scopeDialogProvider && (
-        <OAuthScopeDialog
-          provider={scopeDialogProvider}
-          signedInScopes={oauthScopes(scopeDialogProvider)}
-          onSelect={scope => void startOAuth(scopeDialogProvider, scope)}
-          onClose={() => setScopeDialogProvider(undefined)}
-        />
-      )}
-
-      {activeOAuth && (
-        <ProviderOAuthDialog
-          provider={activeOAuth.provider}
-          session={activeOAuth.session}
-          onClose={closeOAuth}
-          onComplete={() => setActiveOAuth(undefined)}
-        />
-      )}
-    </div>
+          {activeOAuth && (
+            <ProviderOAuthDialog
+              provider={activeOAuth.provider}
+              session={activeOAuth.session}
+              onClose={closeOAuth}
+              onComplete={() => setActiveOAuth(undefined)}
+            />
+          )}
+        </div>
+      </SettingsSubsection>
+    </Tabs>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/settings/components/RepositoriesSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/RepositoriesSection.tsx
@@ -27,6 +27,7 @@ export function RepositoriesSection() {
   return (
     <div className="flex min-w-0 flex-col gap-8">
       <SettingsSubsection
+        scope="factory"
         title="Repositories"
         description={`Repositories ${activeFactory.name} can edit. What feeds the board is set under Work Intake.`}
         action={

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsFields.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsFields.tsx
@@ -11,7 +11,9 @@ import type { DoneSound } from '../services/doneSound';
 
 type ThinkingLevel = NonNullable<AgentControllerSessionSettings['thinkingLevel']>;
 
-export const THINKING_LEVELS: { value: ThinkingLevel; label: string }[] = [
+const AUDIBLE_SOUNDS = DONE_SOUND_OPTIONS.filter(option => option.value !== 'none');
+
+const THINKING_LEVELS: { value: ThinkingLevel; label: string }[] = [
   { value: 'off', label: 'Off' },
   { value: 'low', label: 'Low' },
   { value: 'medium', label: 'Medium' },
@@ -21,13 +23,13 @@ export const THINKING_LEVELS: { value: ThinkingLevel; label: string }[] = [
 ];
 
 interface ThinkingLevelPickerProps {
-  value: ThinkingLevel | null;
+  value?: ThinkingLevel;
   ariaLabel: string;
   disabled?: boolean;
-  /** When given, `value: null` means the row follows this level instead of setting its own. */
+  /** When given, an absent `value` means the row follows this level instead of setting its own. */
   inherited?: ThinkingLevel;
   /** Returning the write lets the thumb hold the dropped stop until it lands. */
-  onChange: (value: ThinkingLevel | null) => void | Promise<unknown>;
+  onChange: (value?: ThinkingLevel) => void | Promise<unknown>;
 }
 
 /**
@@ -37,26 +39,32 @@ interface ThinkingLevelPickerProps {
  * signal - muted at Off, plain through High, warning once the bill turns.
  */
 export function ThinkingLevelPicker({ value, ariaLabel, disabled, inherited, onChange }: ThinkingLevelPickerProps) {
-  const [dragged, setDragged] = useState<number | null>(null);
+  const [dragged, setDragged] = useState<number>();
+  const inFlight = useRef<number>(undefined);
   const last = THINKING_LEVELS.length - 1;
 
   const indexOf = (level: ThinkingLevel) => THINKING_LEVELS.findIndex(entry => entry.value === level);
-  const inheriting = value === null;
+  const inheriting = inherited !== undefined && value === undefined;
   const settled = indexOf(value ?? inherited ?? 'off');
   const shown = dragged ?? settled;
   const label = THINKING_LEVELS[shown]?.label ?? '';
   const tone = shown >= last - 1 ? 'text-warning1' : shown === 0 ? 'text-neutral2' : 'text-neutral5';
-  const valueText = `${label}${inheriting && dragged === null ? ' \u00b7 follows base' : ''}`;
+  const valueText = `${label}${inheriting && dragged === undefined ? ' \u00b7 follows base' : ''}`;
   const travelled = `calc(0.5rem + (100% - 1rem) * ${shown / last})`;
 
   // Holding the drop until the write settles: clearing it first shows the old
   // stop for a frame, then the new one — two jumps for one change.
   const commit = async () => {
-    if (dragged === null || dragged === settled) return setDragged(null);
+    const level = dragged === undefined ? undefined : THINKING_LEVELS[dragged];
+    if (!level || dragged === settled) return setDragged(undefined);
+    // Release and blur both ask to commit, and blur can land before the write does.
+    if (dragged === inFlight.current) return;
+    inFlight.current = dragged;
     try {
-      await onChange(THINKING_LEVELS[dragged]!.value);
+      await onChange(level.value);
     } finally {
-      setDragged(null);
+      inFlight.current = undefined;
+      setDragged(current => (current === dragged ? undefined : current));
     }
   };
 
@@ -67,7 +75,7 @@ export function ThinkingLevelPicker({ value, ariaLabel, disabled, inherited, onC
           (inheriting ? (
             <span className="text-neutral2 text-ui-xs">Follows base</span>
           ) : (
-            <Button variant="ghost" size="sm" disabled={disabled} onClick={() => onChange(null)}>
+            <Button variant="ghost" size="sm" disabled={disabled} onClick={() => onChange()}>
               Reset to base
             </Button>
           ))}
@@ -120,10 +128,15 @@ export function ThinkingLevelPicker({ value, ariaLabel, disabled, inherited, onC
   );
 }
 
+/** The mute button swaps the value for `none`, so the picker keeps the sound it has to come back to. */
 export function SoundPicker({ value, onChange }: { value: DoneSound; onChange: (value: DoneSound) => void }) {
-  const lastAudible = useRef<DoneSound>(value === 'none' ? 'chime' : value);
-  if (value !== 'none') lastAudible.current = value;
+  const [lastAudible, setLastAudible] = useState<DoneSound>(value === 'none' ? 'chime' : value);
   const muted = value === 'none';
+
+  const pick = (sound: DoneSound) => {
+    setLastAudible(sound);
+    onChange(sound);
+  };
 
   return (
     <div className="flex items-center">
@@ -137,12 +150,19 @@ export function SoundPicker({ value, onChange }: { value: DoneSound; onChange: (
           'transition-colors duration-150 motion-reduce:transition-none',
           'hover:text-neutral6 focus-visible:ring-neutral6/60 focus-visible:ring-2 focus-visible:outline-none',
         )}
-        onClick={() => onChange(muted ? lastAudible.current : 'none')}
+        onClick={() => onChange(muted ? lastAudible : 'none')}
       >
         {muted ? <VolumeXIcon aria-hidden className="size-4" /> : <Volume2Icon aria-hidden className="size-4" />}
       </button>
 
-      <Select value={lastAudible.current} disabled={muted} onValueChange={sound => onChange(sound as DoneSound)}>
+      <Select
+        value={lastAudible}
+        disabled={muted}
+        onValueChange={next => {
+          const picked = AUDIBLE_SOUNDS.find(option => option.value === next);
+          if (picked) pick(picked.value);
+        }}
+      >
         <SelectTrigger
           variant="outline"
           size="sm"
@@ -154,10 +174,10 @@ export function SoundPicker({ value, onChange }: { value: DoneSound; onChange: (
             muted && 'text-neutral1 hover:text-neutral1 border-border1/60 hover:bg-surface3 [&_svg]:opacity-25',
           )}
         >
-          {DONE_SOUND_OPTIONS.find(option => option.value === lastAudible.current)?.label}
+          {AUDIBLE_SOUNDS.find(option => option.value === lastAudible)?.label}
         </SelectTrigger>
         <SelectContent>
-          {DONE_SOUND_OPTIONS.filter(option => option.value !== 'none').map(option => (
+          {AUDIBLE_SOUNDS.map(option => (
             <SelectItem key={option.value} value={option.value}>
               {option.label}
             </SelectItem>

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsFields.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsFields.tsx
@@ -1,0 +1,197 @@
+import type { AgentControllerSessionSettings } from '@mastra/client-js';
+import { Button } from '@mastra/playground-ui/components/Button';
+import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@mastra/playground-ui/components/Select';
+import { cn } from '@mastra/playground-ui/utils/cn';
+import { Volume2Icon, VolumeXIcon } from 'lucide-react';
+import { useRef, useState } from 'react';
+
+import { DONE_SOUND_OPTIONS } from '../services/doneSound';
+import type { DoneSound } from '../services/doneSound';
+
+type ThinkingLevel = NonNullable<AgentControllerSessionSettings['thinkingLevel']>;
+
+export const THINKING_LEVELS: { value: ThinkingLevel; label: string }[] = [
+  { value: 'off', label: 'Off' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'xhigh', label: 'Extra high' },
+  { value: 'max', label: 'Max' },
+];
+
+interface ThinkingLevelPickerProps {
+  value: ThinkingLevel | null;
+  ariaLabel: string;
+  disabled?: boolean;
+  /** When given, `value: null` means the row follows this level instead of setting its own. */
+  inherited?: ThinkingLevel;
+  /** Returning the write lets the thumb hold the dropped stop until it lands. */
+  onChange: (value: ThinkingLevel | null) => void | Promise<unknown>;
+}
+
+/**
+ * A slider, because a thinking level is a ramp: drag the thumb along the stops,
+ * the fill shows how far up the scale it sits, and the level only commits on
+ * release so a drag across the whole scale is one save. Colour is the cost
+ * signal - muted at Off, plain through High, warning once the bill turns.
+ */
+export function ThinkingLevelPicker({ value, ariaLabel, disabled, inherited, onChange }: ThinkingLevelPickerProps) {
+  const [dragged, setDragged] = useState<number | null>(null);
+  const last = THINKING_LEVELS.length - 1;
+
+  const indexOf = (level: ThinkingLevel) => THINKING_LEVELS.findIndex(entry => entry.value === level);
+  const inheriting = value === null;
+  const settled = indexOf(value ?? inherited ?? 'off');
+  const shown = dragged ?? settled;
+  const label = THINKING_LEVELS[shown]?.label ?? '';
+  const tone = shown >= last - 1 ? 'text-warning1' : shown === 0 ? 'text-neutral2' : 'text-neutral5';
+  const valueText = `${label}${inheriting && dragged === null ? ' \u00b7 follows base' : ''}`;
+  const travelled = `calc(0.5rem + (100% - 1rem) * ${shown / last})`;
+
+  // Holding the drop until the write settles: clearing it first shows the old
+  // stop for a frame, then the new one — two jumps for one change.
+  const commit = async () => {
+    if (dragged === null || dragged === settled) return setDragged(null);
+    try {
+      await onChange(THINKING_LEVELS[dragged]!.value);
+    } finally {
+      setDragged(null);
+    }
+  };
+
+  return (
+    <div className={cn('flex items-center gap-2', tone, disabled && 'pointer-events-none opacity-50')}>
+      <span className="flex w-32 shrink-0 justify-end">
+        {inherited !== undefined &&
+          (inheriting ? (
+            <span className="text-neutral2 text-ui-xs">Follows base</span>
+          ) : (
+            <Button variant="ghost" size="sm" disabled={disabled} onClick={() => onChange(null)}>
+              Reset to base
+            </Button>
+          ))}
+      </span>
+
+      <span className="text-ui-sm w-20 shrink-0 text-right">{label}</span>
+
+      <span className="bg-surface4 relative flex h-7 w-36 items-center rounded-lg">
+        <span
+          aria-hidden
+          className="bg-surface6 absolute inset-y-0 left-0 rounded-lg"
+          style={{ width: `calc(${travelled} + 6px)` }}
+        />
+        <span aria-hidden className="pointer-events-none absolute inset-x-[6.5px] flex justify-between">
+          {THINKING_LEVELS.map(level => (
+            <span key={level.value} className="size-[3px] rounded-full bg-current/40" />
+          ))}
+        </span>
+        <span
+          aria-hidden
+          className="absolute h-4 w-[3px] -translate-x-1/2 rounded-full bg-current"
+          style={{ left: travelled }}
+        />
+        <input
+          type="range"
+          min={0}
+          max={last}
+          step={1}
+          value={shown}
+          aria-label={ariaLabel}
+          aria-valuetext={valueText}
+          disabled={disabled}
+          className={cn(
+            'focus-visible:ring-current/60 relative h-7 w-full cursor-pointer appearance-none rounded-lg',
+            'bg-transparent outline-none focus-visible:ring-2',
+            '[&::-webkit-slider-runnable-track]:h-7 [&::-webkit-slider-runnable-track]:bg-transparent',
+            '[&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none',
+            '[&::-webkit-slider-thumb]:bg-transparent',
+            '[&::-moz-range-thumb]:h-7 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:border-0',
+            '[&::-moz-range-thumb]:bg-transparent',
+          )}
+          onChange={event => setDragged(Number(event.target.value))}
+          onPointerUp={() => void commit()}
+          onPointerCancel={() => void commit()}
+          onKeyUp={() => void commit()}
+          onBlur={() => void commit()}
+        />
+      </span>
+    </div>
+  );
+}
+
+export function SoundPicker({ value, onChange }: { value: DoneSound; onChange: (value: DoneSound) => void }) {
+  const lastAudible = useRef<DoneSound>(value === 'none' ? 'chime' : value);
+  if (value !== 'none') lastAudible.current = value;
+  const muted = value === 'none';
+
+  return (
+    <div className="flex items-center">
+      <button
+        type="button"
+        role="switch"
+        aria-checked={!muted}
+        aria-label="Play a sound"
+        className={cn(
+          'bg-surface4 text-neutral3 -mr-6 flex h-7 items-center rounded-full py-1 pr-8 pl-2.5',
+          'transition-colors duration-150 motion-reduce:transition-none',
+          'hover:text-neutral6 focus-visible:ring-neutral6/60 focus-visible:ring-2 focus-visible:outline-none',
+        )}
+        onClick={() => onChange(muted ? lastAudible.current : 'none')}
+      >
+        {muted ? <VolumeXIcon aria-hidden className="size-4" /> : <Volume2Icon aria-hidden className="size-4" />}
+      </button>
+
+      <Select value={lastAudible.current} disabled={muted} onValueChange={sound => onChange(sound as DoneSound)}>
+        <SelectTrigger
+          variant="outline"
+          size="sm"
+          aria-label="Completion sound"
+          className={cn(
+            'bg-surface3 relative z-10 w-32',
+            // Opaque even when muted: the mute button is tucked underneath.
+            'disabled:opacity-100',
+            muted && 'text-neutral1 hover:text-neutral1 border-border1/60 hover:bg-surface3 [&_svg]:opacity-25',
+          )}
+        >
+          {DONE_SOUND_OPTIONS.find(option => option.value === lastAudible.current)?.label}
+        </SelectTrigger>
+        <SelectContent>
+          {DONE_SOUND_OPTIONS.filter(option => option.value !== 'none').map(option => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+interface SegmentedProps<T extends string> {
+  value: T;
+  options: { value: T; label: string }[];
+  ariaLabel: string;
+  disabled?: boolean;
+  onChange: (value: T) => void;
+}
+
+/** For choices that are alternatives rather than a ramp: policies, modes, delivery. */
+export function Segmented<T extends string>({ value, options, ariaLabel, disabled, onChange }: SegmentedProps<T>) {
+  return (
+    <ButtonsGroup spacing="close" role="group" aria-label={ariaLabel}>
+      {options.map(o => (
+        <Button
+          key={o.value}
+          variant={value === o.value ? 'primary' : 'outline'}
+          size="sm"
+          aria-pressed={value === o.value}
+          disabled={disabled}
+          onClick={() => onChange(o.value)}
+        >
+          {o.label}
+        </Button>
+      ))}
+    </ButtonsGroup>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.parts.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.parts.tsx
@@ -7,33 +7,22 @@ import type {
 } from '@mastra/client-js';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
-import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Switch } from '@mastra/playground-ui/components/Switch';
-import type { Theme } from '@mastra/playground-ui/components/ThemeProvider';
+import { ThemeToggle } from '@mastra/playground-ui/components/ThemeToggle';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { Check } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
-import { DONE_SOUND_OPTIONS, loadDoneSound, playDoneSound, saveDoneSound } from '../services/doneSound';
+import { loadDoneSound, playDoneSound, saveDoneSound } from '../services/doneSound';
 import type { DoneSound } from '../services/doneSound';
 import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
 import { SettingsCard } from './SettingsCard';
 import { SettingsSubsection } from './SettingsSubsection';
-import { Select, SelectContent, SelectItem, SelectTrigger } from '@mastra/playground-ui/components/Select';
+import { Segmented, SoundPicker, ThinkingLevelPicker } from './SettingsFields';
 
-type ThinkingLevel = NonNullable<AgentControllerSessionSettings['thinkingLevel']>;
 type NotificationMode = AgentControllerSessionSettings['notifications'];
-
-export const THINKING_LEVELS: { value: ThinkingLevel; label: string }[] = [
-  { value: 'off', label: 'Off' },
-  { value: 'low', label: 'Low' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'high', label: 'High' },
-  { value: 'xhigh', label: 'Extra high' },
-  { value: 'max', label: 'Max' },
-];
 const NOTIFICATION_MODES: { value: NotificationMode; label: string }[] = [
   { value: 'off', label: 'Off' },
   { value: 'bell', label: 'Bell' },
@@ -41,12 +30,7 @@ const NOTIFICATION_MODES: { value: NotificationMode; label: string }[] = [
   { value: 'both', label: 'Both' },
 ];
 
-interface GeneralSettingsProps {
-  theme: Theme;
-  onThemeChange: (theme: Theme) => void;
-}
-
-export function GeneralSettings({ theme, onThemeChange }: GeneralSettingsProps) {
+export function GeneralSettings() {
   const [doneSound, setDoneSound] = useState<DoneSound>(() => loadDoneSound());
   const changeDoneSound = (next: DoneSound) => {
     setDoneSound(next);
@@ -55,31 +39,17 @@ export function GeneralSettings({ theme, onThemeChange }: GeneralSettingsProps) 
     playDoneSound(next);
   };
   return (
-    <SettingsSubsection title="General">
+    <SettingsSubsection scope="personal" title="General" description="Stored in this browser.">
       <SettingsCard>
         <SettingsRow variant="factory" label="Theme" description="Color scheme for the interface">
-          <Segmented
-            ariaLabel="Theme"
-            value={theme}
-            options={[
-              { value: 'system', label: 'System' },
-              { value: 'light', label: 'Light' },
-              { value: 'dark', label: 'Dark' },
-            ]}
-            onChange={onThemeChange}
-          />
+          <ThemeToggle />
         </SettingsRow>
         <SettingsRow
           variant="factory"
           label="Completion sound"
           description="Played when an agent run finishes in a workspace"
         >
-          <Segmented
-            ariaLabel="Completion sound"
-            value={doneSound}
-            options={DONE_SOUND_OPTIONS}
-            onChange={changeDoneSound}
-          />
+          <SoundPicker value={doneSound} onChange={changeDoneSound} />
         </SettingsRow>
       </SettingsCard>
     </SettingsSubsection>
@@ -88,39 +58,29 @@ export function GeneralSettings({ theme, onThemeChange }: GeneralSettingsProps) 
 
 interface ModelSettingsProps {
   settings: AgentControllerSessionSettings | null;
-  updating: boolean;
-  onBehaviorChange: (updates: Partial<AgentControllerSessionSettings>) => void;
+  onBehaviorChange: (updates: Partial<AgentControllerSessionSettings>) => Promise<unknown>;
 }
 
-export function ModelSettings({ settings, updating, onBehaviorChange }: ModelSettingsProps) {
+export function ModelSettings({ settings, onBehaviorChange }: ModelSettingsProps) {
   return (
-    <SettingsRow variant="factory" label="Thinking level" description="Extended-reasoning budget for the agent">
-      <div className="w-full lg:hidden">
-        <SegmentedSelect
-          ariaLabel="Thinking level"
-          value={settings?.thinkingLevel ?? 'off'}
-          disabled={!settings || updating}
-          options={THINKING_LEVELS}
-          onChange={v => onBehaviorChange({ thinkingLevel: v })}
-        />
-      </div>
-      <div className="hidden lg:block">
-        <Segmented
-          ariaLabel="Thinking level"
-          value={settings?.thinkingLevel ?? 'off'}
-          disabled={!settings || updating}
-          options={THINKING_LEVELS}
-          onChange={v => onBehaviorChange({ thinkingLevel: v })}
-        />
-      </div>
+    <SettingsRow
+      variant="factory"
+      label="Thinking level"
+      description="Reasoning budget for your chats — overrides the Factory defaults"
+    >
+      <ThinkingLevelPicker
+        ariaLabel="Thinking level"
+        value={settings?.thinkingLevel ?? 'off'}
+        disabled={!settings}
+        onChange={level => onBehaviorChange({ thinkingLevel: level ?? 'off' })}
+      />
     </SettingsRow>
   );
 }
 
 interface BehaviorSettingsProps {
   settings: AgentControllerSessionSettings | null;
-  updating: boolean;
-  onBehaviorChange: (updates: Partial<AgentControllerSessionSettings>) => void;
+  onBehaviorChange: (updates: Partial<AgentControllerSessionSettings>) => Promise<unknown>;
   permissions: PermissionRules | null;
   pendingPermissionCategory: ToolCategory | null;
   setPermissionForCategory: (category: ToolCategory, policy: PermissionPolicy) => Promise<void>;
@@ -128,7 +88,6 @@ interface BehaviorSettingsProps {
 
 export function BehaviorSettings({
   settings,
-  updating,
   onBehaviorChange,
   permissions,
   pendingPermissionCategory,
@@ -137,13 +96,17 @@ export function BehaviorSettings({
   const notificationMode = settings?.notifications ?? 'off';
   return (
     <div className="flex flex-col gap-8">
-      <SettingsSubsection title="General">
+      <SettingsSubsection
+        scope="factory"
+        title="General"
+        description="Shared by everyone working in this Factory. Auto-approve and smart editing reset when the server restarts."
+      >
         <SettingsCard>
           <SettingsRow variant="factory" label="Auto-approve tools" description="Run tool calls without asking (YOLO)">
             <Toggle
               ariaLabel="Auto-approve tools"
               checked={!!settings?.yolo}
-              disabled={!settings || updating}
+              disabled={!settings}
               onChange={v => onBehaviorChange({ yolo: v })}
             />
           </SettingsRow>
@@ -151,7 +114,7 @@ export function BehaviorSettings({
             <Toggle
               ariaLabel="Smart editing"
               checked={!!settings?.smartEditing}
-              disabled={!settings || updating}
+              disabled={!settings}
               onChange={v => onBehaviorChange({ smartEditing: v })}
             />
           </SettingsRow>
@@ -159,7 +122,7 @@ export function BehaviorSettings({
             <Segmented
               ariaLabel="Notifications"
               value={notificationMode}
-              disabled={!settings || updating}
+              disabled={!settings}
               options={NOTIFICATION_MODES}
               onChange={v => onBehaviorChange({ notifications: v })}
             />
@@ -199,8 +162,9 @@ function PermissionsSection({
 
   return (
     <SettingsSubsection
+      scope="factory"
       title="Tool permissions"
-      description="“Allow” runs without asking, “Ask” prompts you, “Deny” blocks it. Auto-approve above sets every category to Allow."
+      description="“Allow” runs without asking, “Ask” prompts you, “Deny” blocks it. Auto-approve above sets every category to Allow. Shared by everyone working in this Factory, and reset when the server restarts."
     >
       <SettingsCard>
         {TOOL_CATEGORIES.map(({ value, label, hint }) => (
@@ -374,57 +338,6 @@ function ModelPicker({
         </div>
       )}
     </div>
-  );
-}
-
-interface SegmentedProps<T extends string> {
-  value: T;
-  options: { value: T; label: string }[];
-  ariaLabel: string;
-  disabled?: boolean;
-  onChange: (value: T) => void;
-}
-
-export function Segmented<T extends string>({ value, options, ariaLabel, disabled, onChange }: SegmentedProps<T>) {
-  return (
-    <ButtonsGroup spacing="close" role="group" aria-label={ariaLabel}>
-      {options.map(o => (
-        <Button
-          key={o.value}
-          variant={value === o.value ? 'primary' : 'outline'}
-          size="sm"
-          aria-pressed={value === o.value}
-          disabled={disabled}
-          onClick={() => onChange(o.value)}
-        >
-          {o.label}
-        </Button>
-      ))}
-    </ButtonsGroup>
-  );
-}
-
-/** Select rendering of the same choice — callers decide which variant shows at which breakpoint. */
-export function SegmentedSelect<T extends string>({
-  value,
-  options,
-  ariaLabel,
-  disabled,
-  onChange,
-}: SegmentedProps<T>) {
-  return (
-    <Select value={value} disabled={disabled} onValueChange={v => onChange(v as T)}>
-      <SelectTrigger variant="outline" size="sm" aria-label={ariaLabel} className="w-full">
-        {options.find(o => o.value === value)?.label ?? value}
-      </SelectTrigger>
-      <SelectContent>
-        {options.map(o => (
-          <SelectItem key={o.value} value={o.value}>
-            {o.label}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
   );
 }
 

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.parts.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.parts.tsx
@@ -1,19 +1,12 @@
 import type {
-  AgentControllerAvailableModel,
   AgentControllerSessionSettings,
   PermissionPolicy,
   PermissionRules,
   ToolCategory,
 } from '@mastra/client-js';
-import { Badge } from '@mastra/playground-ui/components/Badge';
-import { Button } from '@mastra/playground-ui/components/Button';
-import { Input } from '@mastra/playground-ui/components/Input';
 import { Switch } from '@mastra/playground-ui/components/Switch';
 import { ThemeToggle } from '@mastra/playground-ui/components/ThemeToggle';
-import { Txt } from '@mastra/playground-ui/components/Txt';
-import { cn } from '@mastra/playground-ui/utils/cn';
-import { Check } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 import { loadDoneSound, playDoneSound, saveDoneSound } from '../services/doneSound';
 import type { DoneSound } from '../services/doneSound';
@@ -156,10 +149,6 @@ function PermissionsSection({
   pendingPermissionCategory,
   setPermissionForCategory,
 }: Pick<BehaviorSettingsProps, 'permissions' | 'pendingPermissionCategory' | 'setPermissionForCategory'>) {
-  const update = async (category: ToolCategory, policy: PermissionPolicy) => {
-    await setPermissionForCategory(category, policy);
-  };
-
   return (
     <SettingsSubsection
       scope="factory"
@@ -174,170 +163,12 @@ function PermissionsSection({
               value={permissions?.categories?.[value] ?? 'ask'}
               disabled={!permissions || pendingPermissionCategory === value}
               options={PERMISSION_POLICIES}
-              onChange={policy => void update(value, policy)}
+              onChange={policy => void setPermissionForCategory(value, policy)}
             />
           </SettingsRow>
         ))}
       </SettingsCard>
     </SettingsSubsection>
-  );
-}
-
-function ModelPicker({
-  models,
-  currentModelId,
-  onModelChange,
-}: {
-  models: AgentControllerAvailableModel[];
-  currentModelId: string | null;
-  onModelChange: (id: string) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState('');
-  const [active, setActive] = useState(0);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const current = models.find(m => m.id === currentModelId);
-  const currentLabel = current ? `${current.provider} / ${current.modelName}` : (currentModelId ?? 'Select a model');
-
-  const q = query.trim().toLowerCase();
-  const matched = q
-    ? models.filter(
-        m =>
-          m.provider.toLowerCase().includes(q) ||
-          m.modelName.toLowerCase().includes(q) ||
-          m.id.toLowerCase().includes(q),
-      )
-    : models;
-  const filtered = [...matched].sort((a, b) => {
-    if (a.hasApiKey !== b.hasApiKey) return a.hasApiKey ? -1 : 1;
-    return a.id.localeCompare(b.id);
-  });
-
-  // Open/close is an event, not a synchronization: reset search state in the
-  // handlers that trigger it instead of reacting via effects.
-  const openPicker = () => {
-    setQuery('');
-    setActive(0);
-    setOpen(true);
-    requestAnimationFrame(() => inputRef.current?.focus());
-  };
-
-  const updateQuery = (next: string) => {
-    setQuery(next);
-    setActive(0);
-  };
-
-  useEffect(() => {
-    if (!open) return;
-    const onDocClick = (e: MouseEvent) => {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', onDocClick);
-    return () => document.removeEventListener('mousedown', onDocClick);
-  }, [open]);
-
-  const choose = (m: AgentControllerAvailableModel) => {
-    if (!m.hasApiKey) return;
-    onModelChange(m.id);
-    setOpen(false);
-  };
-
-  const onKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      setActive(a => Math.min(a + 1, filtered.length - 1));
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      setActive(a => Math.max(a - 1, 0));
-    } else if (e.key === 'Enter') {
-      e.preventDefault();
-      const m = filtered[active];
-      if (m) choose(m);
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      setOpen(false);
-    }
-  };
-
-  if (models.length === 0) {
-    return (
-      <Txt variant="ui-sm" className="text-icon3">
-        No models available.
-      </Txt>
-    );
-  }
-
-  return (
-    <div className="relative" ref={rootRef}>
-      <Button
-        variant="outline"
-        size="md"
-        className="w-full justify-between"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        onClick={() => (open ? setOpen(false) : openPicker())}
-      >
-        <span className="truncate">{currentLabel}</span>
-        <span aria-hidden>▾</span>
-      </Button>
-
-      {open && (
-        <div
-          className="border-border1/60 bg-surface3 shadow-dialog absolute z-50 mt-1 w-full rounded-lg border"
-          role="dialog"
-          aria-label="Choose a model"
-        >
-          <div className="border-border1/40 border-b p-2">
-            <Input
-              ref={inputRef}
-              placeholder="Search models or providers…"
-              value={query}
-              onChange={e => updateQuery(e.target.value)}
-              onKeyDown={onKeyDown}
-              aria-label="Search models"
-            />
-          </div>
-          <ul className="max-h-72 overflow-y-auto p-1" role="listbox" aria-label="Models">
-            {filtered.length === 0 && (
-              <li className="px-3 py-2">
-                <Txt variant="ui-sm" className="text-icon3">
-                  No models match “{query}”.
-                </Txt>
-              </li>
-            )}
-            {filtered.slice(0, 100).map((m, i) => (
-              <li key={m.id}>
-                <button
-                  type="button"
-                  role="option"
-                  aria-selected={m.id === currentModelId}
-                  className={cn(
-                    'flex w-full items-center justify-between gap-3 rounded-md px-3 py-2 text-left',
-                    i === active && 'bg-surface4',
-                    m.hasApiKey ? 'cursor-pointer' : 'cursor-not-allowed opacity-50',
-                  )}
-                  disabled={!m.hasApiKey}
-                  onMouseEnter={() => setActive(i)}
-                  onClick={() => choose(m)}
-                >
-                  <span className="flex min-w-0 flex-col gap-0.5">
-                    <Txt variant="ui-md" className="text-icon6 truncate">
-                      {m.modelName}
-                    </Txt>
-                    <Txt variant="ui-sm" className="text-icon3 truncate">
-                      {m.provider}
-                    </Txt>
-                  </span>
-                  {m.id === currentModelId ? <Check size={14} /> : m.hasApiKey ? null : <Badge>no key</Badge>}
-                </button>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-    </div>
   );
 }
 

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.tsx
@@ -1,5 +1,4 @@
 import type { AgentControllerSessionSettings } from '@mastra/client-js';
-import { useTheme } from '@mastra/playground-ui/components/ThemeProvider';
 import { useEffect } from 'react';
 import { Link, useLocation, useParams } from 'react-router';
 import { Brain } from 'lucide-react';
@@ -33,6 +32,8 @@ import { IntakeSection } from './IntakeSection';
 import { ModelPacksSection } from './ModelPacksSection';
 import { RepositoriesSection } from './RepositoriesSection';
 import { SettingsCard } from './SettingsCard';
+import { ScopeSwap, useScopeControl } from './SettingsScope';
+import type { SettingsScope } from './SettingsScope';
 import { SettingsSubsection } from './SettingsSubsection';
 import { OMSection } from './OMSection';
 import { BaseThinkingSection, ModeThinkingDefaultsSection } from './ThinkingDefaultsSection';
@@ -49,7 +50,6 @@ export function SettingsPanel() {
   const section = useSettingsSection();
   const { hash } = useLocation();
   const { factoryId } = useParams<{ factoryId: string }>();
-  const { theme, setTheme } = useTheme();
 
   // Deep links like `/settings/models#model-packs` scroll to the subsection.
   useEffect(() => {
@@ -77,11 +77,12 @@ export function SettingsPanel() {
   const sessionResourceId = resourceEnabled ? resourceId : undefined;
 
   const onBehaviorChange = (updates: Partial<AgentControllerSessionSettings>) => {
-    if (!settings || updateSettingsMutation.isPending) return;
-    updateSettingsMutation.mutate(updates, {
-      onSuccess: () => toast.success('Settings updated'),
-      onError: error => toast.error(getSettingsUpdateErrorMessage(error)),
-    });
+    if (!settings) return Promise.resolve();
+    // Returned so a control can hold its pending value until the write settles.
+    // No success toast: the control already shows the new value.
+    return updateSettingsMutation
+      .mutateAsync(updates)
+      .catch(error => toast.error(getSettingsUpdateErrorMessage(error)));
   };
 
   return (
@@ -89,22 +90,21 @@ export function SettingsPanel() {
       <div className="mx-auto grid w-full max-w-4xl grid-cols-[minmax(0,1fr)] py-3">
         {!isMobile && <SettingsHeader autoFocus placement="desktop" />}
         {section === 'account' && <AccountSettingsSection />}
-        {section === 'preferences' && <GeneralSettings theme={theme} onThemeChange={setTheme} />}
+        {section === 'preferences' && <GeneralSettings />}
         {section === 'factory' && <FactoryManagementSection />}
         {section === 'connections' && (
-          <SettingsSubsection title="Connected accounts" description="Connect your account to use Factory from Slack.">
+          <SettingsSubsection
+            scope="personal"
+            title="Connected accounts"
+            description="Connect your account to use Factory from Slack."
+          >
             <ConnectedAccountsSection />
           </SettingsSubsection>
         )}
         {section === 'repositories' && <RepositoriesSection />}
         {section === 'intake' && <IntakeSection />}
         {section === 'models' && (
-          <ModelsSettingsSection
-            models={models}
-            settings={settings}
-            updating={updateSettingsMutation.isPending}
-            onBehaviorChange={onBehaviorChange}
-          />
+          <ModelsSettingsSection models={models} settings={settings} onBehaviorChange={onBehaviorChange} />
         )}
         {section === 'memory' && (
           <MemorySettingsSection
@@ -118,7 +118,6 @@ export function SettingsPanel() {
         {section === 'behavior' && (
           <BehaviorSettings
             settings={settings}
-            updating={updateSettingsMutation.isPending}
             onBehaviorChange={onBehaviorChange}
             permissions={permissions ?? null}
             pendingPermissionCategory={pendingPermissionCategory}
@@ -133,8 +132,7 @@ export function SettingsPanel() {
 interface ModelsSettingsSectionProps {
   models: AvailableModelOption[];
   settings: AgentControllerSessionSettings | null;
-  updating: boolean;
-  onBehaviorChange: (updates: Partial<AgentControllerSessionSettings>) => void;
+  onBehaviorChange: (updates: Partial<AgentControllerSessionSettings>) => Promise<unknown>;
 }
 
 interface MemorySettingsSectionProps {
@@ -145,13 +143,14 @@ interface MemorySettingsSectionProps {
 }
 
 /**
- * Observational-memory settings, split by scope. OM models are useless
+ * Observational-memory settings for one scope at a time. OM models are useless
  * without a provider credential, so until one is connected the page is a
  * zero state pointing at the Models page.
  */
 function MemorySettingsSection({ factoryId, models, sessionResourceId, sessionScope }: MemorySettingsSectionProps) {
   const providersQuery = useProvidersQuery();
   const customProvidersQuery = useCustomProvidersQuery();
+  const scopeControl = useScopeControl(factoryId ? ['personal', 'factory'] : ['personal']);
   const anyConnected =
     (providersQuery.data ?? []).some(p => p.source !== 'none') || (customProvidersQuery.data ?? []).length > 0;
   const providersKnown = providersQuery.isSuccess && customProvidersQuery.isSuccess;
@@ -174,29 +173,28 @@ function MemorySettingsSection({ factoryId, models, sessionResourceId, sessionSc
     );
   }
 
+  const factoryView = scopeControl.shown === 'factory' && factoryId;
+
   return (
-    <div className="flex flex-col gap-8">
-      {/* Without a factory id an unscoped OM request would resolve — and let
-          this section edit — the caller's personal row as if it were shared. */}
-      {factoryId && (
-        <SettingsSubsection
-          title="Factory observational memory"
-          description="Models and token thresholds used to summarize and retain context in Factory runs."
-        >
-          <SettingsCard>
-            <OMSection factoryId={factoryId} models={models} />
-          </SettingsCard>
-        </SettingsSubsection>
-      )}
-      <SettingsSubsection
-        title="Your observational memory"
-        description="Models and token thresholds used to summarize and retain context in your interactive chats."
-      >
+    <SettingsSubsection
+      title="Observational memory"
+      description={
+        factoryView
+          ? 'Models and token thresholds used to summarize and retain context in Factory runs.'
+          : 'Models and token thresholds used to summarize and retain context in your interactive chats.'
+      }
+      scope={scopeControl}
+    >
+      <ScopeSwap control={scopeControl}>
         <SettingsCard>
-          <OMSection resourceId={sessionResourceId} scope={sessionScope} models={models} />
+          {factoryView ? (
+            <OMSection key="factory" factoryId={factoryId} models={models} />
+          ) : (
+            <OMSection key="personal" resourceId={sessionResourceId} scope={sessionScope} models={models} />
+          )}
         </SettingsCard>
-      </SettingsSubsection>
-    </div>
+      </ScopeSwap>
+    </SettingsSubsection>
   );
 }
 
@@ -206,7 +204,7 @@ function MemorySettingsSection({ factoryId, models, sessionResourceId, sessionSc
  * Once connected, model selection moves to the top and provider management
  * drops to the bottom.
  */
-function ModelsSettingsSection({ models, settings, updating, onBehaviorChange }: ModelsSettingsSectionProps) {
+function ModelsSettingsSection({ models, settings, onBehaviorChange }: ModelsSettingsSectionProps) {
   const providersQuery = useProvidersQuery();
   const customProvidersQuery = useCustomProvidersQuery();
   const anyConnected =
@@ -215,15 +213,12 @@ function ModelsSettingsSection({ models, settings, updating, onBehaviorChange }:
 
   const providerSubsections = (
     <>
-      <SettingsSubsection
-        title="Provider access"
+      <ProviderAccessSection
         description={
           anyConnected ? undefined : 'Connect a provider to unlock model selection and observational-memory settings.'
         }
-      >
-        <ProviderAccessSection />
-      </SettingsSubsection>
-      <SettingsSubsection title="Custom providers">
+      />
+      <SettingsSubsection scope="org" title="Custom providers">
         <SettingsCard className="p-4">
           <CustomProvidersSection />
         </SettingsCard>
@@ -239,21 +234,43 @@ function ModelsSettingsSection({ models, settings, updating, onBehaviorChange }:
   return (
     <div className="flex flex-col gap-8">
       <SettingsSubsection
+        scope="factory"
         title="Factory defaults"
         description="Applied to Factory runs (triage, board work items) and channel sessions."
       >
         <SettingsCard>
           <FactoryDefaultModelSection models={models} />
-          <BaseThinkingSection />
         </SettingsCard>
       </SettingsSubsection>
-      <SettingsSubsection id="model-packs" title="Your defaults" description="Applied to your interactive chats.">
+      <SettingsSubsection
+        scope="deployment"
+        title="Thinking defaults"
+        description="Fallback for every run without its own level. One settings file, shared by every Factory on this server."
+      >
+        <SettingsCard>
+          <BaseThinkingSection />
+          <ModeThinkingDefaultsSection />
+        </SettingsCard>
+      </SettingsSubsection>
+      <SettingsSubsection
+        scope="factory"
+        title="Chat defaults"
+        description="Applied to chats opened from this Factory, and shared with everyone working in it."
+      >
+        <SettingsCard>
+          <ModelSettings settings={settings} onBehaviorChange={onBehaviorChange} />
+        </SettingsCard>
+      </SettingsSubsection>
+      <SettingsSubsection
+        scope="personal"
+        id="model-packs"
+        title="Your defaults"
+        description="The pack you run with. Creating or removing a pack changes the list for your whole org."
+      >
         <SettingsCard>
           <div className="p-4">
             <ModelPacksSection models={models} />
           </div>
-          <ModelSettings settings={settings} updating={updating} onBehaviorChange={onBehaviorChange} />
-          <ModeThinkingDefaultsSection />
         </SettingsCard>
       </SettingsSubsection>
       {providerSubsections}

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsScope.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsScope.tsx
@@ -88,13 +88,19 @@ export function useScopeControl(
   options: readonly SettingsScope[],
   initial: SettingsScope = 'personal',
 ): ScopeSwapControl {
-  const [value, setValue] = useState(initial);
-  const [shown, setShown] = useState(initial);
+  const [picked, setPicked] = useState(initial);
+  const [revealed, setRevealed] = useState(initial);
   const bodyRef = useRef<HTMLDivElement>(null);
+
+  // Options shrink when a permission answer lands, so a scope picked while the
+  // answer was pending falls back rather than editing a scope no longer offered.
+  const offered = (scope: SettingsScope) => (options.includes(scope) ? scope : (options[0] ?? initial));
+  const value = offered(picked);
+  const shown = offered(revealed);
 
   const onChange = (next: SettingsScope) => {
     if (next === value) return;
-    setValue(next);
+    setPicked(next);
     const dx = options.indexOf(next) > options.indexOf(value) ? SLIDE_PX : -SLIDE_PX;
     const exit = animate(
       bodyRef.current,
@@ -104,10 +110,10 @@ export function useScopeControl(
       ],
       { duration: 120, easing: 'ease-in', fill: 'forwards' },
     );
-    if (!exit) return setShown(next);
+    if (!exit) return setRevealed(next);
     exit.finished.then(
       () => {
-        flushSync(() => setShown(next));
+        flushSync(() => setRevealed(next));
         animate(
           bodyRef.current,
           [

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsScope.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsScope.tsx
@@ -1,0 +1,134 @@
+import { Badge } from '@mastra/playground-ui/components/Badge';
+import type { BadgeVariant } from '@mastra/playground-ui/components/Badge';
+import { focusRing, transitions } from '@mastra/playground-ui/primitives/transitions';
+import { cn } from '@mastra/playground-ui/utils/cn';
+import { Building2, CircleUserRound, Server, Users } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { ReactNode, RefObject } from 'react';
+import { useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
+
+export type SettingsScope = 'personal' | 'factory' | 'org' | 'deployment';
+
+export type ScopeControl = {
+  value: SettingsScope;
+  options: readonly SettingsScope[];
+  onChange: (scope: SettingsScope) => void;
+};
+
+const SCOPE_BADGE: Record<SettingsScope, { label: string; variant: BadgeVariant; icon: LucideIcon }> = {
+  personal: { label: 'Personal', variant: 'neutral', icon: CircleUserRound },
+  factory: { label: 'Factory-wide', variant: 'blue', icon: Building2 },
+  org: { label: 'Org-wide', variant: 'blue', icon: Users },
+  deployment: { label: 'Deployment-wide', variant: 'blue', icon: Server },
+};
+
+export function ScopeBadge({ scope }: { scope: SettingsScope }) {
+  const { label, variant, icon: Icon } = SCOPE_BADGE[scope];
+  return (
+    <Badge size="sm" variant={variant} icon={<Icon aria-hidden="true" />}>
+      {label}
+    </Badge>
+  );
+}
+
+export function ScopeSwitch({ value, options, onChange }: ScopeControl) {
+  return (
+    <div
+      role="group"
+      aria-label="Who these settings apply to"
+      className="border-border1 inline-flex items-center gap-0.5 rounded-[9px] border p-0.5"
+    >
+      {options.map(scope => {
+        const { label, icon: Icon } = SCOPE_BADGE[scope];
+        const selected = scope === value;
+        return (
+          <button
+            key={scope}
+            type="button"
+            aria-pressed={selected}
+            onClick={() => onChange(scope)}
+            className={cn(
+              'text-icon3 hover:text-icon5 inline-flex h-5 cursor-pointer items-center rounded-[7px] outline-none',
+              focusRing.visible,
+              transitions.colors,
+            )}
+          >
+            {selected ? (
+              <ScopeBadge scope={scope} />
+            ) : (
+              <span className="text-ui-xs inline-flex h-5 items-center gap-1 px-1.5 font-medium">
+                <Icon aria-hidden="true" className="h-icon-sm w-icon-sm" />
+                {label}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function reducedMotion(): boolean {
+  return typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+const SLIDE_PX = 8;
+
+function animate(element: HTMLElement | null, keyframes: Keyframe[], options: KeyframeAnimationOptions) {
+  if (!element || typeof element.animate !== 'function' || reducedMotion()) return null;
+  element.getAnimations().forEach(running => running.cancel());
+  return element.animate(keyframes, options);
+}
+
+export type ScopeSwapControl = ScopeControl & { shown: SettingsScope; bodyRef: RefObject<HTMLDivElement | null> };
+
+/** `value` follows the switch at once; `shown` follows once the current body has slid out, so render the body from `shown` inside `ScopeSwap`. */
+export function useScopeControl(
+  options: readonly SettingsScope[],
+  initial: SettingsScope = 'personal',
+): ScopeSwapControl {
+  const [value, setValue] = useState(initial);
+  const [shown, setShown] = useState(initial);
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  const onChange = (next: SettingsScope) => {
+    if (next === value) return;
+    setValue(next);
+    const dx = options.indexOf(next) > options.indexOf(value) ? SLIDE_PX : -SLIDE_PX;
+    const exit = animate(
+      bodyRef.current,
+      [
+        { opacity: 1, transform: 'none' },
+        { opacity: 0, transform: `translateX(${-dx}px)` },
+      ],
+      { duration: 120, easing: 'ease-in', fill: 'forwards' },
+    );
+    if (!exit) return setShown(next);
+    exit.finished.then(
+      () => {
+        flushSync(() => setShown(next));
+        animate(
+          bodyRef.current,
+          [
+            { opacity: 0, transform: `translateX(${dx}px)` },
+            { opacity: 1, transform: 'none' },
+          ],
+          { duration: 200, easing: 'ease-out' },
+        );
+      },
+      () => {},
+    );
+  };
+
+  return { value, shown, options, onChange, bodyRef };
+}
+
+/** Clips the slide horizontally: a translate on a full-width body widens the page, and every scrollable ancestor answers with a scrollbar. */
+export function ScopeSwap({ control, children }: { control: ScopeSwapControl; children: ReactNode }) {
+  return (
+    <div className="overflow-x-clip">
+      <div ref={control.bodyRef}>{children}</div>
+    </div>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsSubsection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsSubsection.tsx
@@ -2,10 +2,14 @@ import { Txt } from '@mastra/playground-ui/components/Txt';
 import type { ReactNode } from 'react';
 import { useId } from 'react';
 
+import { ScopeBadge, ScopeSwitch } from './SettingsScope';
+import type { ScopeControl, SettingsScope } from './SettingsScope';
+
 export function SettingsSubsection({
   id,
   title,
   description,
+  scope,
   action,
   children,
 }: {
@@ -13,6 +17,7 @@ export function SettingsSubsection({
   id?: string;
   title: string;
   description?: string;
+  scope: SettingsScope | ScopeControl;
   action?: ReactNode;
   children?: ReactNode;
 }) {
@@ -20,11 +25,14 @@ export function SettingsSubsection({
 
   return (
     <section id={id} aria-labelledby={titleId} className="flex min-w-0 scroll-mt-4 flex-col gap-2">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between sm:gap-4">
         <div className="flex min-w-0 flex-col gap-1">
-          <Txt as="h2" id={titleId} variant="ui-sm" className="text-icon6 leading-ui-md font-semibold">
-            {title}
-          </Txt>
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <Txt as="h2" id={titleId} variant="ui-sm" className="text-icon6 leading-ui-md font-semibold">
+              {title}
+            </Txt>
+            <ScopeIndicator scope={scope} />
+          </div>
           {description && (
             <Txt as="p" variant="ui-sm" className="text-icon3">
               {description}
@@ -36,4 +44,10 @@ export function SettingsSubsection({
       {children}
     </section>
   );
+}
+
+function ScopeIndicator({ scope }: { scope: SettingsScope | ScopeControl }) {
+  if (typeof scope === 'string') return <ScopeBadge scope={scope} />;
+  if (scope.options.length > 1) return <ScopeSwitch {...scope} />;
+  return <ScopeBadge scope={scope.value} />;
 }

--- a/mastracode/factory-ui/src/ui/domains/settings/components/ThinkingDefaultsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/ThinkingDefaultsSection.tsx
@@ -71,10 +71,10 @@ export function ModeThinkingDefaultsSection() {
         >
           <ThinkingLevelPicker
             ariaLabel={`${mode} mode thinking level`}
-            value={config?.modeDefaults[mode] ?? null}
+            value={config?.modeDefaults[mode]}
             inherited={config?.globalDefault ?? 'off'}
             disabled={disabled}
-            onChange={level => update.mutateAsync({ modeDefaults: { [mode]: level } }).catch(() => {})}
+            onChange={level => update.mutateAsync({ modeDefaults: { [mode]: level ?? null } }).catch(() => {})}
           />
         </SettingsRow>
       ))}

--- a/mastracode/factory-ui/src/ui/domains/settings/components/ThinkingDefaultsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/ThinkingDefaultsSection.tsx
@@ -1,29 +1,23 @@
-import { Txt } from '@mastra/playground-ui/components/Txt';
+import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
 
 import { useThinkingConfigQuery, useUpdateThinkingMutation } from '../../../../hooks/use-thinking';
-import type { ThinkingLevelValue } from '../../../../hooks/use-thinking';
-import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
-import { Segmented, SegmentedSelect, THINKING_LEVELS } from './SettingsPanel.parts';
-
-/** Sentinel for "no per-mode override — use the global default". */
-const USE_GLOBAL = '__global__';
+import { ThinkingLevelPicker } from './SettingsFields';
 
 function useThinkingSection() {
   const configQuery = useThinkingConfigQuery();
   const update = useUpdateThinkingMutation();
   const config = configQuery.data;
-  const error = update.error ?? configQuery.error;
-  const disabled = !config || update.isPending;
-  return { config, update, error, disabled };
+  const readOnly = !!config && !config.editable;
+  return { config, update, loadError: configQuery.error, disabled: !config || readOnly, readOnly };
 }
 
-function ThinkingError({ error }: { error: unknown }) {
+/** These defaults live in one deployment-wide settings file, so a shared deployment refuses writes. */
+const READ_ONLY_REASON = 'Read-only here — these defaults are shared by everyone on this deployment';
+
+/** A write that failed belongs under the row that asked for it, not above the section. */
+function RowError({ error }: { error: unknown }) {
   if (!error) return null;
-  return (
-    <Txt as="p" variant="ui-xs" className="text-notice-destructive-fg px-4 pt-3">
-      {error instanceof Error ? error.message : String(error)}
-    </Txt>
-  );
+  return <span className="text-notice-destructive-fg">{error instanceof Error ? error.message : String(error)}</span>;
 }
 
 /**
@@ -32,78 +26,56 @@ function ThinkingError({ error }: { error: unknown }) {
  * (triage, board work items) nobody opens interactively.
  */
 export function BaseThinkingSection() {
-  const { config, update, error, disabled } = useThinkingSection();
+  const { config, update, loadError, disabled, readOnly } = useThinkingSection();
+  const writeError = update.variables?.globalDefault !== undefined ? update.error : null;
+
   return (
-    <>
-      <ThinkingError error={error} />
-      <SettingsRow
-        variant="factory"
-        label="Base thinking level"
-        description="Used by every run without a session or mode override"
-      >
-        <div className="w-full lg:hidden">
-          <SegmentedSelect
-            ariaLabel="Base thinking level"
-            value={config?.globalDefault ?? 'off'}
-            disabled={disabled}
-            options={THINKING_LEVELS}
-            onChange={level => update.mutate({ globalDefault: level as ThinkingLevelValue })}
-          />
-        </div>
-        <div className="hidden lg:block">
-          <Segmented
-            ariaLabel="Base thinking level"
-            value={config?.globalDefault ?? 'off'}
-            disabled={disabled}
-            options={THINKING_LEVELS}
-            onChange={level => update.mutate({ globalDefault: level as ThinkingLevelValue })}
-          />
-        </div>
-      </SettingsRow>
-    </>
+    <SettingsRow
+      variant="factory"
+      label="Base thinking level"
+      description={
+        <>
+          <span>Used by every run without a session or mode override</span>
+          {readOnly && <span className="text-neutral2">{READ_ONLY_REASON}</span>}
+          <RowError error={writeError ?? loadError} />
+        </>
+      }
+    >
+      <ThinkingLevelPicker
+        ariaLabel="Base thinking level"
+        value={config?.globalDefault ?? 'off'}
+        disabled={disabled}
+        onChange={level => (level ? update.mutateAsync({ globalDefault: level }).catch(() => {}) : undefined)}
+      />
+    </SettingsRow>
   );
 }
 
 /**
- * Per-mode thinking (reasoning-effort) defaults for interactive chats. A mode
- * row set to "Global" inherits the base level from the Factory tab.
+ * Per-mode overrides of the base level, rendered directly under it so "Follows
+ * base" points at a row the reader can see. A mode without its own level shows
+ * the base level it inherits rather than hiding it.
  */
 export function ModeThinkingDefaultsSection() {
-  const { config, update, error, disabled } = useThinkingSection();
-
-  const modeOptions = [{ value: USE_GLOBAL, label: 'Global' }, ...THINKING_LEVELS];
+  const { config, update, disabled } = useThinkingSection();
+  const writtenMode = Object.keys(update.variables?.modeDefaults ?? {})[0];
 
   return (
     <>
-      <ThinkingError error={error} />
       {(config?.modes ?? []).map(mode => (
-        <SettingsRow variant="factory" key={mode} label={`${mode[0]?.toUpperCase()}${mode.slice(1)} mode`}>
-          <div className="w-full lg:hidden">
-            <SegmentedSelect
-              ariaLabel={`${mode} mode thinking level`}
-              value={config?.modeDefaults[mode] ?? USE_GLOBAL}
-              disabled={disabled}
-              options={modeOptions}
-              onChange={value =>
-                update.mutate({
-                  modeDefaults: { [mode]: value === USE_GLOBAL ? null : (value as ThinkingLevelValue) },
-                })
-              }
-            />
-          </div>
-          <div className="hidden lg:block">
-            <Segmented
-              ariaLabel={`${mode} mode thinking level`}
-              value={config?.modeDefaults[mode] ?? USE_GLOBAL}
-              disabled={disabled}
-              options={modeOptions}
-              onChange={value =>
-                update.mutate({
-                  modeDefaults: { [mode]: value === USE_GLOBAL ? null : (value as ThinkingLevelValue) },
-                })
-              }
-            />
-          </div>
+        <SettingsRow
+          variant="factory"
+          key={mode}
+          label={`${mode[0]?.toUpperCase()}${mode.slice(1)} mode`}
+          description={mode === writtenMode ? <RowError error={update.error} /> : undefined}
+        >
+          <ThinkingLevelPicker
+            ariaLabel={`${mode} mode thinking level`}
+            value={config?.modeDefaults[mode] ?? null}
+            inherited={config?.globalDefault ?? 'off'}
+            disabled={disabled}
+            onChange={level => update.mutateAsync({ modeDefaults: { [mode]: level } }).catch(() => {})}
+          />
         </SettingsRow>
       ))}
     </>

--- a/mastracode/factory-ui/src/ui/domains/settings/components/UserGithubConnectionRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/UserGithubConnectionRow.tsx
@@ -27,7 +27,7 @@ export function UserGithubConnectionRow() {
 
   if (status.userConnected) {
     return (
-      <SettingsSubsection title="GitHub account">
+      <SettingsSubsection scope="personal" title="GitHub account">
         <SettingsCard>
           <SettingsRow
             variant="factory"
@@ -47,7 +47,7 @@ export function UserGithubConnectionRow() {
   if (status.userConnected !== false) return undefined;
 
   return (
-    <SettingsSubsection title="GitHub account">
+    <SettingsSubsection scope="personal" title="GitHub account">
       <SettingsCard>
         <SettingsRow
           variant="factory"

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ProviderAccessSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ProviderAccessSection.msw.test.tsx
@@ -322,7 +322,7 @@ describe('ProviderAccessSection', () => {
       );
 
       const user = userEvent.setup();
-      renderWithProviders(<ProviderAccessSection />);
+      const { client } = renderWithProviders(<ProviderAccessSection />);
 
       await user.click(screen.getByRole('tab', { name: 'Connect with API key' }));
       await screen.findByText('OpenAI');
@@ -332,7 +332,8 @@ describe('ProviderAccessSection', () => {
       await user.type(screen.getByPlaceholderText('Paste API key'), 'sk-org');
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
-      await waitFor(() => expect(putBody).toEqual({ key: 'sk-org', scope: 'org' }));
+      await waitForMutationsIdle(client);
+      expect(putBody).toEqual({ key: 'sk-org', scope: 'org' });
       await waitFor(() => expect(within(rowFor('openai')).getByText('Key saved')).toBeInTheDocument());
       expect(within(rowFor('openai')).getByRole('button', { name: 'Remove key for OpenAI' })).toBeInTheDocument();
 
@@ -430,7 +431,7 @@ describe('ProviderAccessSection', () => {
       );
 
       const user = userEvent.setup();
-      renderWithProviders(<ProviderAccessSection />);
+      const { client } = renderWithProviders(<ProviderAccessSection />);
 
       await screen.findByText('Anthropic');
       expect(within(rowFor('anthropic')).getByRole('button', { name: 'Sign out of Anthropic' })).toBeInTheDocument();
@@ -446,6 +447,7 @@ describe('ProviderAccessSection', () => {
       await user.type(await screen.findByLabelText('Authorization code'), 'code#state');
       await user.click(screen.getByRole('button', { name: 'Complete sign in' }));
 
+      await waitForMutationsIdle(client);
       await waitFor(() =>
         expect(
           within(rowFor('anthropic')).getByRole('button', { name: 'Sign out of Anthropic for the org' }),

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ProviderAccessSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ProviderAccessSection.msw.test.tsx
@@ -300,18 +300,23 @@ describe('ProviderAccessSection', () => {
   });
 
   describe('when auth is enabled', () => {
-    it('saves an organization-scoped API key and shows the org badge', async () => {
+    const authenticated = () =>
+      http.get(`${TEST_BASE_URL}/auth/me`, () =>
+        HttpResponse.json({ authenticated: true, user: { id: 'user-1', organizationId: 'org-1' } }),
+      );
+    const orgWide = () => screen.getByRole('button', { name: 'Org-wide' });
+    const personal = () => screen.getByRole('button', { name: 'Personal' });
+
+    it('saves an org-wide API key from the org view and shows the personal view as covered', async () => {
       window.__MASTRACODE_CONFIG__ = { authEnabled: true };
       const providers: ProviderInfo[] = [{ provider: 'openai', source: 'none' }];
       let putBody: unknown;
       server.use(
-        http.get(`${TEST_BASE_URL}/auth/me`, () =>
-          HttpResponse.json({ authenticated: true, user: { id: 'user-1', organizationId: 'org-1' } }),
-        ),
+        authenticated(),
         http.get(PROVIDERS_URL, () => providersResponse(providers)),
         http.put(keyUrl('openai'), async ({ request }) => {
           putBody = await request.json();
-          providers[0] = { provider: 'openai', source: 'stored-org' };
+          providers[0] = { provider: 'openai', source: 'stored-org', orgKey: true, orgCredential: 'api_key' };
           return HttpResponse.json({ ok: true });
         }),
       );
@@ -321,16 +326,23 @@ describe('ProviderAccessSection', () => {
 
       await user.click(screen.getByRole('tab', { name: 'Connect with API key' }));
       await screen.findByText('OpenAI');
+      await user.click(await screen.findByRole('button', { name: 'Org-wide' }));
       await user.click(within(rowFor('openai')).getByRole('button', { name: 'Add API key for OpenAI' }));
+      expect(screen.queryByText('Everyone in org')).not.toBeInTheDocument();
       await user.type(screen.getByPlaceholderText('Paste API key'), 'sk-org');
-      await user.click(screen.getByText('Everyone in org'));
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
       await waitFor(() => expect(putBody).toEqual({ key: 'sk-org', scope: 'org' }));
-      await waitFor(() => expect(within(rowFor('openai')).getByText('Org key')).toBeInTheDocument());
+      await waitFor(() => expect(within(rowFor('openai')).getByText('Key saved')).toBeInTheDocument());
+      expect(within(rowFor('openai')).getByRole('button', { name: 'Remove key for OpenAI' })).toBeInTheDocument();
+
+      await user.click(personal());
+      expect(within(rowFor('openai')).getByText('Covered by org')).toBeInTheDocument();
+      expect(within(rowFor('openai')).getByRole('button', { name: 'Add API key for OpenAI' })).toBeInTheDocument();
+      expect(within(rowFor('openai')).queryByRole('button', { name: 'Remove key for OpenAI' })).not.toBeInTheDocument();
     });
 
-    it('starts an org-scoped OAuth flow and signs out at org scope', async () => {
+    it('starts an org-scoped OAuth flow and signs out at org scope from the org view', async () => {
       window.__MASTRACODE_CONFIG__ = { authEnabled: true };
       const providers: ProviderInfo[] = [
         { provider: 'anthropic', source: 'none', oauth: { supported: true, modes: ['paste-code'] } },
@@ -338,9 +350,7 @@ describe('ProviderAccessSection', () => {
       let startBody: unknown;
       let signOutScope: string | null = null;
       server.use(
-        http.get(`${TEST_BASE_URL}/auth/me`, () =>
-          HttpResponse.json({ authenticated: true, user: { id: 'user-1', organizationId: 'org-1' } }),
-        ),
+        authenticated(),
         http.get(PROVIDERS_URL, () => providersResponse(providers)),
         http.post(oauthUrl('anthropic', 'start'), async ({ request }) => {
           startBody = await request.json();
@@ -373,10 +383,8 @@ describe('ProviderAccessSection', () => {
       const { client } = renderWithProviders(<ProviderAccessSection />);
 
       await screen.findByText('Anthropic');
+      await user.click(await screen.findByRole('button', { name: 'Org-wide' }));
       await user.click(within(rowFor('anthropic')).getByRole('button', { name: 'Sign in to Anthropic' }));
-      // Org admins pick the scope per provider in a dialog before the flow starts.
-      await user.click(await screen.findByRole('button', { name: 'Everyone in org' }));
-      await user.click(screen.getByRole('button', { name: 'Continue' }));
 
       await waitFor(() => expect(startBody).toEqual({ mode: 'paste-code', scope: 'org' }));
 
@@ -385,7 +393,7 @@ describe('ProviderAccessSection', () => {
       // Settle the complete mutation and its provider-list refresh before
       // asserting on the refreshed row.
       await waitForMutationsIdle(client);
-      await waitFor(() => expect(within(rowFor('anthropic')).getByText('Org sign-in')).toBeInTheDocument());
+      await waitFor(() => expect(within(rowFor('anthropic')).getByText('Signed in')).toBeInTheDocument());
 
       await user.click(within(rowFor('anthropic')).getByRole('button', { name: 'Sign out of Anthropic for the org' }));
       await waitFor(() => expect(signOutScope).toBe('org'));
@@ -403,9 +411,7 @@ describe('ProviderAccessSection', () => {
       ];
       let startBody: unknown;
       server.use(
-        http.get(`${TEST_BASE_URL}/auth/me`, () =>
-          HttpResponse.json({ authenticated: true, user: { id: 'user-1', organizationId: 'org-1' } }),
-        ),
+        authenticated(),
         http.get(PROVIDERS_URL, () => providersResponse(providers)),
         http.post(oauthUrl('anthropic', 'start'), async ({ request }) => {
           startBody = await request.json();
@@ -426,28 +432,62 @@ describe('ProviderAccessSection', () => {
       const user = userEvent.setup();
       renderWithProviders(<ProviderAccessSection />);
 
-      // Personally signed in, but the row still offers Sign in for the org.
       await screen.findByText('Anthropic');
       expect(within(rowFor('anthropic')).getByRole('button', { name: 'Sign out of Anthropic' })).toBeInTheDocument();
-      await user.click(within(rowFor('anthropic')).getByRole('button', { name: 'Sign in to Anthropic' }));
+      expect(
+        within(rowFor('anthropic')).queryByRole('button', { name: 'Sign in to Anthropic' }),
+      ).not.toBeInTheDocument();
 
-      // The already-signed-in personal scope is locked; org is preselected.
-      expect(await screen.findByRole('button', { name: 'Just me' })).toBeDisabled();
-      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      await user.click(await screen.findByRole('button', { name: 'Org-wide' }));
+      expect(within(rowFor('anthropic')).getByText('Not set')).toBeInTheDocument();
+      await user.click(within(rowFor('anthropic')).getByRole('button', { name: 'Sign in to Anthropic' }));
       await waitFor(() => expect(startBody).toEqual({ mode: 'paste-code', scope: 'org' }));
 
       await user.type(await screen.findByLabelText('Authorization code'), 'code#state');
       await user.click(screen.getByRole('button', { name: 'Complete sign in' }));
 
-      // Both scopes are now signed in with independent sign-out actions.
       await waitFor(() =>
         expect(
           within(rowFor('anthropic')).getByRole('button', { name: 'Sign out of Anthropic for the org' }),
         ).toBeInTheDocument(),
       );
+
+      await user.click(personal());
       expect(within(rowFor('anthropic')).getByRole('button', { name: 'Sign out of Anthropic' })).toBeInTheDocument();
+      expect(within(rowFor('anthropic')).getByText('Signed in')).toBeInTheDocument();
+      expect(within(rowFor('anthropic')).queryByText('Covered by org')).not.toBeInTheDocument();
+      expect(orgWide()).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('offers members without org rights only the personal view, with org coverage visible per row', async () => {
+      window.__MASTRACODE_CONFIG__ = { authEnabled: true };
+      server.use(
+        authenticated(),
+        http.get(PROVIDERS_URL, () =>
+          HttpResponse.json({
+            orgKeyAdmin: false,
+            providers: [
+              {
+                provider: 'anthropic',
+                source: 'oauth-org',
+                orgKey: true,
+                orgCredential: 'oauth',
+                oauth: { supported: true, modes: ['paste-code'] },
+              },
+            ],
+          }),
+        ),
+      );
+
+      renderWithProviders(<ProviderAccessSection />);
+
+      await screen.findByText('Anthropic');
+      await waitFor(() => expect(screen.getByText('Personal')).toBeInTheDocument());
+      expect(screen.queryByRole('button', { name: 'Org-wide' })).not.toBeInTheDocument();
+      expect(within(rowFor('anthropic')).getByText('Covered by org')).toBeInTheDocument();
+      expect(within(rowFor('anthropic')).getByRole('button', { name: 'Sign in to Anthropic' })).toBeInTheDocument();
       expect(
-        within(rowFor('anthropic')).queryByRole('button', { name: 'Sign in to Anthropic' }),
+        within(rowFor('anthropic')).queryByRole('button', { name: 'Sign out of Anthropic for the org' }),
       ).not.toBeInTheDocument();
     });
   });

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsFields.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsFields.msw.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import type { DoneSound } from '../../services/doneSound';
+import { SoundPicker } from '../SettingsFields';
+
+function SoundHarness() {
+  const [sound, setSound] = useState<DoneSound>('fanfare');
+  return <SoundPicker value={sound} onChange={setSound} />;
+}
+
+describe('SoundPicker', () => {
+  describe('given a sound is picked and then muted', () => {
+    it('holds on to the sound so unmuting brings it back', async () => {
+      const user = userEvent.setup();
+      render(<SoundHarness />);
+      const sound = screen.getByRole('combobox', { name: 'Completion sound' });
+      expect(sound).toHaveTextContent('Fanfare');
+
+      await user.click(screen.getByRole('switch', { name: 'Play a sound' }));
+
+      expect(sound).toBeDisabled();
+      expect(sound).toHaveTextContent('Fanfare');
+
+      await user.click(screen.getByRole('switch', { name: 'Play a sound' }));
+
+      expect(sound).toBeEnabled();
+      expect(sound).toHaveTextContent('Fanfare');
+    });
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsSubsection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsSubsection.msw.test.tsx
@@ -2,7 +2,14 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
+import { useScopeControl } from '../SettingsScope';
+import type { SettingsScope } from '../SettingsScope';
 import { SettingsSubsection } from '../SettingsSubsection';
+
+function ScopeHarness({ options }: { options: SettingsScope[] }) {
+  const control = useScopeControl(options);
+  return <SettingsSubsection scope={control} title="Provider access" />;
+}
 
 describe('SettingsSubsection', () => {
   describe('given a fixed scope', () => {
@@ -57,6 +64,23 @@ describe('SettingsSubsection', () => {
       await user.click(screen.getByRole('button', { name: 'Org-wide' }));
 
       expect(onChange).toHaveBeenCalledWith('org');
+    });
+  });
+
+  describe('given the picked scope stops being offered', () => {
+    it('falls back to a scope the caller still has', async () => {
+      const user = userEvent.setup();
+      // Org rights are assumed while the permission query is pending, so the
+      // switch offers a scope the answer may take away.
+      const { rerender } = render(<ScopeHarness options={['personal', 'org']} />);
+
+      await user.click(screen.getByRole('button', { name: 'Org-wide' }));
+      expect(screen.getByRole('button', { name: 'Org-wide' })).toHaveAttribute('aria-pressed', 'true');
+
+      rerender(<ScopeHarness options={['personal']} />);
+
+      expect(screen.queryByRole('button', { name: 'Org-wide' })).not.toBeInTheDocument();
+      expect(screen.getByText('Personal')).toBeInTheDocument();
     });
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsSubsection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsSubsection.msw.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SettingsSubsection } from '../SettingsSubsection';
+
+describe('SettingsSubsection', () => {
+  describe('given a fixed scope', () => {
+    it('labels the heading with who the settings apply to', () => {
+      render(<SettingsSubsection scope="factory" title="Factory defaults" />);
+
+      expect(screen.getByRole('heading', { name: 'Factory defaults' })).toBeInTheDocument();
+      expect(screen.getByText('Factory-wide')).toBeInTheDocument();
+      expect(screen.queryByRole('group', { name: 'Who these settings apply to' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('given a deployment-scoped section', () => {
+    it('says the settings reach past this factory', () => {
+      render(<SettingsSubsection scope="deployment" title="Thinking defaults" />);
+
+      expect(screen.getByText('Deployment-wide')).toBeInTheDocument();
+      expect(screen.queryByText('Factory-wide')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('given a scope control with a single option', () => {
+    it('shows that scope as a plain label instead of a switch', () => {
+      render(
+        <SettingsSubsection
+          scope={{ value: 'personal', options: ['personal'], onChange: vi.fn() }}
+          title="Provider access"
+        />,
+      );
+
+      expect(screen.getByText('Personal')).toBeInTheDocument();
+      expect(screen.queryByRole('group', { name: 'Who these settings apply to' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('given a scope control with several options', () => {
+    it('renders a switch that reports the picked scope', async () => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <SettingsSubsection
+          scope={{ value: 'personal', options: ['personal', 'org'], onChange }}
+          title="Provider access"
+        />,
+      );
+
+      const group = screen.getByRole('group', { name: 'Who these settings apply to' });
+      expect(screen.getByRole('button', { name: 'Personal' })).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByRole('button', { name: 'Org-wide' })).toHaveAttribute('aria-pressed', 'false');
+      expect(group).toContainElement(screen.getByRole('button', { name: 'Org-wide' }));
+
+      await user.click(screen.getByRole('button', { name: 'Org-wide' }));
+
+      expect(onChange).toHaveBeenCalledWith('org');
+    });
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ThinkingDefaultsSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ThinkingDefaultsSection.msw.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
@@ -15,7 +15,11 @@ const baseConfig: ThinkingConfigInfo = {
   globalDefault: 'off',
   modeDefaults: { plan: 'max' },
   modes: ['build', 'plan', 'fast'],
+  editable: true,
 };
+
+/** What a drag does: the thumb moves, the value is not saved until the pointer comes up. */
+const dragTo = (slider: HTMLElement, level: number) => fireEvent.change(slider, { target: { value: String(level) } });
 
 describe('BaseThinkingSection', () => {
   it('renders the base thinking level from the server', async () => {
@@ -23,11 +27,11 @@ describe('BaseThinkingSection', () => {
 
     renderWithProviders(<BaseThinkingSection />);
 
-    const base = await screen.findByRole('group', { name: 'Base thinking level' });
-    expect(within(base).getByRole('button', { name: 'Off' })).toHaveAttribute('aria-pressed', 'true');
+    const base = await screen.findByRole('slider', { name: 'Base thinking level' });
+    expect(base).toHaveAttribute('aria-valuetext', 'Off');
   });
 
-  it('saves a new base level and reflects the server response', async () => {
+  it('saves the level the drag ended on', async () => {
     let requestBody: unknown;
     server.use(
       http.get(THINKING_URL, () => HttpResponse.json(baseConfig)),
@@ -37,17 +41,52 @@ describe('BaseThinkingSection', () => {
       }),
     );
 
-    const user = userEvent.setup();
     const { client } = renderWithProviders(<BaseThinkingSection />);
 
-    const base = await screen.findByRole('group', { name: 'Base thinking level' });
-    await user.click(within(base).getByRole('button', { name: 'High' }));
+    const base = await screen.findByRole('slider', { name: 'Base thinking level' });
+    dragTo(base, 5);
+    dragTo(base, 3);
+    fireEvent.pointerUp(base);
 
     await waitForMutationsIdle(client);
     expect(requestBody).toEqual({ globalDefault: 'high' });
-    await waitFor(() =>
-      expect(within(base).getByRole('button', { name: 'High' })).toHaveAttribute('aria-pressed', 'true'),
+    await waitFor(() => expect(base).toHaveAttribute('aria-valuetext', 'High'));
+  });
+
+  it('renders read-only rows when the deployment refuses writes', async () => {
+    let writes = 0;
+    server.use(
+      http.get(THINKING_URL, () => HttpResponse.json({ ...baseConfig, editable: false })),
+      http.put(THINKING_URL, () => {
+        writes += 1;
+        return HttpResponse.json({ ok: true, globalDefault: 'high', modeDefaults: {} });
+      }),
     );
+
+    renderWithProviders(<BaseThinkingSection />);
+
+    expect(await screen.findByText(/shared by everyone on this deployment/)).toBeInTheDocument();
+    expect(screen.getByRole('slider', { name: 'Base thinking level' })).toBeDisabled();
+    expect(writes).toBe(0);
+  });
+
+  it('names the level under the thumb without saving it mid-drag', async () => {
+    let writes = 0;
+    server.use(
+      http.get(THINKING_URL, () => HttpResponse.json(baseConfig)),
+      http.put(THINKING_URL, () => {
+        writes += 1;
+        return HttpResponse.json({ ok: true, globalDefault: 'max', modeDefaults: baseConfig.modeDefaults });
+      }),
+    );
+
+    renderWithProviders(<BaseThinkingSection />);
+
+    const base = await screen.findByRole('slider', { name: 'Base thinking level' });
+    dragTo(base, 5);
+
+    expect(base).toHaveAttribute('aria-valuetext', 'Max');
+    expect(writes).toBe(0);
   });
 
   it('surfaces a write failure from the server', async () => {
@@ -58,16 +97,15 @@ describe('BaseThinkingSection', () => {
       ),
     );
 
-    const user = userEvent.setup();
     const { client } = renderWithProviders(<BaseThinkingSection />);
 
-    const base = await screen.findByRole('group', { name: 'Base thinking level' });
-    await user.click(within(base).getByRole('button', { name: 'High' }));
+    const base = await screen.findByRole('slider', { name: 'Base thinking level' });
+    dragTo(base, 3);
+    fireEvent.pointerUp(base);
 
     await waitForMutationsIdle(client);
     expect(await screen.findByText(/Only organization admins/)).toBeInTheDocument();
-    // The selection did not change.
-    expect(within(base).getByRole('button', { name: 'Off' })).toHaveAttribute('aria-pressed', 'true');
+    await waitFor(() => expect(base).toHaveAttribute('aria-valuetext', 'Off'));
   });
 });
 
@@ -78,11 +116,37 @@ describe('ModeThinkingDefaultsSection', () => {
     renderWithProviders(<ModeThinkingDefaultsSection />);
 
     // plan has an explicit override; build/fast inherit the global default.
-    const plan = await screen.findByRole('group', { name: 'plan mode thinking level' });
-    expect(within(plan).getByRole('button', { name: 'Max' })).toHaveAttribute('aria-pressed', 'true');
-    const build = screen.getByRole('group', { name: 'build mode thinking level' });
-    expect(within(build).getByRole('button', { name: 'Global' })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('group', { name: 'fast mode thinking level' })).toBeInTheDocument();
+    const plan = await screen.findByRole('slider', { name: 'plan mode thinking level' });
+    expect(plan).toHaveAttribute('aria-valuetext', 'Max');
+    expect(screen.getByRole('slider', { name: 'build mode thinking level' })).toHaveAttribute(
+      'aria-valuetext',
+      'Off · follows base',
+    );
+    expect(screen.getByRole('slider', { name: 'fast mode thinking level' })).toBeInTheDocument();
+  });
+
+  it('shows a failed write under the mode row that asked for it', async () => {
+    server.use(
+      http.get(THINKING_URL, () => HttpResponse.json(baseConfig)),
+      http.put(THINKING_URL, () =>
+        HttpResponse.json({ error: 'Deployment thinking defaults can only be changed in local mode' }, { status: 403 }),
+      ),
+    );
+
+    const { client } = renderWithProviders(<ModeThinkingDefaultsSection />);
+
+    const build = await screen.findByRole('slider', { name: 'build mode thinking level' });
+    dragTo(build, 3);
+    fireEvent.pointerUp(build);
+
+    await waitForMutationsIdle(client);
+    const buildRow = build.closest('[data-slot="settings-row"]') as HTMLElement;
+    const planRow = screen
+      .getByRole('slider', { name: 'plan mode thinking level' })
+      .closest('[data-slot="settings-row"]') as HTMLElement;
+
+    expect(await within(buildRow).findByText(/only be changed in local mode/)).toBeInTheDocument();
+    expect(within(planRow).queryByText(/only be changed in local mode/)).not.toBeInTheDocument();
   });
 
   it('clears a per-mode override back to the global default with null', async () => {
@@ -98,13 +162,11 @@ describe('ModeThinkingDefaultsSection', () => {
     const user = userEvent.setup();
     const { client } = renderWithProviders(<ModeThinkingDefaultsSection />);
 
-    const plan = await screen.findByRole('group', { name: 'plan mode thinking level' });
-    await user.click(within(plan).getByRole('button', { name: 'Global' }));
+    const plan = await screen.findByRole('slider', { name: 'plan mode thinking level' });
+    await user.click(screen.getByRole('button', { name: 'Reset to base' }));
 
     await waitForMutationsIdle(client);
     expect(requestBody).toEqual({ modeDefaults: { plan: null } });
-    await waitFor(() =>
-      expect(within(plan).getByRole('button', { name: 'Global' })).toHaveAttribute('aria-pressed', 'true'),
-    );
+    await waitFor(() => expect(plan).toHaveAttribute('aria-valuetext', 'Off · follows base'));
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ThinkingDefaultsSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ThinkingDefaultsSection.msw.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
+import assert from 'node:assert/strict';
 import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../../../../e2e/ui/msw-server';
@@ -20,6 +21,12 @@ const baseConfig: ThinkingConfigInfo = {
 
 /** What a drag does: the thumb moves, the value is not saved until the pointer comes up. */
 const dragTo = (slider: HTMLElement, level: number) => fireEvent.change(slider, { target: { value: String(level) } });
+
+const rowOf = (slider: HTMLElement) => {
+  const row = slider.closest<HTMLElement>('[data-slot="settings-row"]');
+  assert(row, 'the slider should sit inside a settings row');
+  return row;
+};
 
 describe('BaseThinkingSection', () => {
   it('renders the base thinking level from the server', async () => {
@@ -51,6 +58,27 @@ describe('BaseThinkingSection', () => {
     await waitForMutationsIdle(client);
     expect(requestBody).toEqual({ globalDefault: 'high' });
     await waitFor(() => expect(base).toHaveAttribute('aria-valuetext', 'High'));
+  });
+
+  it('writes once when the slider is released and then blurred', async () => {
+    let writes = 0;
+    server.use(
+      http.get(THINKING_URL, () => HttpResponse.json(baseConfig)),
+      http.put(THINKING_URL, () => {
+        writes += 1;
+        return HttpResponse.json({ ok: true, globalDefault: 'high', modeDefaults: baseConfig.modeDefaults });
+      }),
+    );
+
+    const { client } = renderWithProviders(<BaseThinkingSection />);
+
+    const base = await screen.findByRole('slider', { name: 'Base thinking level' });
+    dragTo(base, 3);
+    fireEvent.pointerUp(base);
+    fireEvent.blur(base);
+
+    await waitForMutationsIdle(client);
+    expect(writes).toBe(1);
   });
 
   it('renders read-only rows when the deployment refuses writes', async () => {
@@ -129,7 +157,13 @@ describe('ModeThinkingDefaultsSection', () => {
     server.use(
       http.get(THINKING_URL, () => HttpResponse.json(baseConfig)),
       http.put(THINKING_URL, () =>
-        HttpResponse.json({ error: 'Deployment thinking defaults can only be changed in local mode' }, { status: 403 }),
+        HttpResponse.json(
+          {
+            error:
+              'Deployment thinking defaults are shared by the whole deployment, so they cannot be changed while authentication is enabled',
+          },
+          { status: 403 },
+        ),
       ),
     );
 
@@ -140,13 +174,11 @@ describe('ModeThinkingDefaultsSection', () => {
     fireEvent.pointerUp(build);
 
     await waitForMutationsIdle(client);
-    const buildRow = build.closest('[data-slot="settings-row"]') as HTMLElement;
-    const planRow = screen
-      .getByRole('slider', { name: 'plan mode thinking level' })
-      .closest('[data-slot="settings-row"]') as HTMLElement;
+    const buildRow = rowOf(build);
+    const planRow = rowOf(screen.getByRole('slider', { name: 'plan mode thinking level' }));
 
-    expect(await within(buildRow).findByText(/only be changed in local mode/)).toBeInTheDocument();
-    expect(within(planRow).queryByText(/only be changed in local mode/)).not.toBeInTheDocument();
+    expect(await within(buildRow).findByText(/cannot be changed while authentication is enabled/)).toBeInTheDocument();
+    expect(within(planRow).queryByText(/cannot be changed while authentication is enabled/)).not.toBeInTheDocument();
   });
 
   it('clears a per-mode override back to the global default with null', async () => {

--- a/mastracode/factory-ui/src/ui/pages/SlackConnectionPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/SlackConnectionPage.tsx
@@ -111,11 +111,11 @@ export function SlackConnectionSettings() {
           {accountsQuery.error instanceof Error ? accountsQuery.error.message : 'Failed to load Slack connection'}
         </Txt>
       ) : accountsQuery.data?.reason === 'not_registered' || accountsQuery.data?.unavailable ? (
-        <SettingsSubsection title="Connection">
+        <SettingsSubsection scope="personal" title="Connection">
           <SlackNotConfigured />
         </SettingsSubsection>
       ) : accounts.length === 0 ? (
-        <SettingsSubsection title="Connection">
+        <SettingsSubsection scope="personal" title="Connection">
           <SettingsCard>
             <button
               type="button"
@@ -138,7 +138,7 @@ export function SlackConnectionSettings() {
         </SettingsSubsection>
       ) : (
         <div className="flex flex-col gap-8">
-          <SettingsSubsection title={accounts.length === 1 ? 'Connection' : 'Connections'}>
+          <SettingsSubsection scope="personal" title={accounts.length === 1 ? 'Connection' : 'Connections'}>
             <div className="flex flex-col gap-4">
               {accounts.map(account => (
                 <SettingsCard key={`${account.externalTeamId}:${account.externalUserId}`}>
@@ -170,7 +170,7 @@ export function SlackConnectionSettings() {
             </div>
           </SettingsSubsection>
 
-          <SettingsSubsection title="Session behavior">
+          <SettingsSubsection scope="personal" title="Session behavior">
             <SettingsCard>
               {accounts.map(account => (
                 <SettingsRow
@@ -209,6 +209,11 @@ export function SlackConnectionSettings() {
                   </Select>
                 </SettingsRow>
               ))}
+            </SettingsCard>
+          </SettingsSubsection>
+
+          <SettingsSubsection scope="factory" title="Work items">
+            <SettingsCard>
               <SettingsRow
                 variant="factory"
                 label="Create work items for new Slack threads"
@@ -230,7 +235,7 @@ export function SlackConnectionSettings() {
             </SettingsCard>
           </SettingsSubsection>
 
-          <SettingsSubsection title="Danger zone">
+          <SettingsSubsection scope="personal" title="Danger zone">
             <SettingsCard>
               {accounts.map(account => (
                 <SettingsRow

--- a/mastracode/factory-ui/src/ui/pages/__tests__/SlackConnectionPage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/SlackConnectionPage.msw.test.tsx
@@ -114,8 +114,16 @@ describe('SlackConnectionPage', () => {
     expect(
       within(sessionBehaviorSection).getByRole('combobox', { name: 'Default factory for Test User' }),
     ).toHaveTextContent('Primary Factory');
+
+    // Routing a Slack account is personal; creating work items flips a flag on
+    // the factory, so it sits in its own block rather than under this one.
     expect(
-      within(sessionBehaviorSection).getByRole('switch', { name: 'Create work items for new Slack threads' }),
+      within(sessionBehaviorSection).queryByRole('switch', { name: 'Create work items for new Slack threads' }),
+    ).not.toBeInTheDocument();
+    const workItemsSection = screen.getByRole('heading', { level: 2, name: 'Work items' }).closest('section');
+    if (!workItemsSection) throw new Error('Work items section not found');
+    expect(
+      within(workItemsSection).getByRole('switch', { name: 'Create work items for new Slack threads' }),
     ).toBeInTheDocument();
 
     const dangerZoneSection = screen.getByRole('heading', { level: 2, name: 'Danger zone' }).closest('section');
@@ -128,6 +136,7 @@ describe('SlackConnectionPage', () => {
     expect(screen.getAllByRole('heading', { level: 2 }).map(heading => heading.textContent)).toEqual([
       'Connection',
       'Session behavior',
+      'Work items',
       'Danger zone',
     ]);
   });

--- a/mastracode/factory/src/routes/config.test.ts
+++ b/mastracode/factory/src/routes/config.test.ts
@@ -1426,7 +1426,14 @@ describe('thinking defaults routes', () => {
       globalDefault: 'off',
       modeDefaults: {},
       modes: ['build', 'plan', 'fast'],
+      editable: true,
     });
+  });
+
+  it('reports the defaults as read-only when authentication is enabled', async () => {
+    const res = await buildApp(userA).request('/web/config/thinking');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ editable: false });
   });
 
   it('round-trips global and per-mode defaults through the settings file', async () => {

--- a/mastracode/factory/src/routes/config.ts
+++ b/mastracode/factory/src/routes/config.ts
@@ -529,6 +529,8 @@ export interface ThinkingConfigInfo {
   modeDefaults: Record<string, ThinkingLevelSetting>;
   /** Mode ids known to the controller (for rendering per-mode rows). */
   modes: string[];
+  /** False when the deployment refuses writes, so the UI can render read-only rows. */
+  editable: boolean;
 }
 
 /** `PUT /web/config/thinking` success payload. */
@@ -1183,6 +1185,7 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
               globalDefault: settings.preferences.thinkingLevel,
               modeDefaults: settings.models.modeThinkingDefaults,
               modes,
+              editable: !auth.enabled(),
             });
           } catch (error) {
             return c.json({ error: error instanceof Error ? error.message : String(error) }, 500);
@@ -1195,7 +1198,13 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
         requiresAuth: false,
         handler: async c => {
           if (auth.enabled()) {
-            return c.json({ error: 'Deployment thinking defaults can only be changed in local mode' }, 403);
+            return c.json(
+              {
+                error:
+                  'Deployment thinking defaults are shared by the whole deployment, so they cannot be changed while authentication is enabled',
+              },
+              403,
+            );
           }
           let body: { globalDefault?: unknown; modeDefaults?: unknown };
           try {


### PR DESCRIPTION
Settings sections now say who they apply to: Personal, Factory-wide, Org-wide, and a new Deployment-wide for the few things that live in the server's own settings file. Writing those labels turned up blocks claiming the wrong owner. Thinking level, auto-approve tools, smart editing, notifications and the tool-permission rows all write the factory-level session that everyone in the factory shares, but read Personal. GitHub and Linear issue syncing store one row per person, but read Factory-wide. The Slack work-items switch flips a flag on the factory from inside a personal block. Those moved to where they belong.

Controls match what they set now. Thinking level is a slider rather than six buttons, with the base and per-mode rows grouped together so a row that says it follows the base can actually see it. The completion sound is a select with a mute button tucked under its edge. Writes are optimistic and the slider holds the stop you dropped it on until the write lands, instead of flicking to the old value and back.

One server change: `GET /web/config/thinking` now returns `editable`, so the UI renders those rows read-only where the deployment refuses writes instead of letting you drag a slider that fails on release. The refusal message also said "local mode" when the real condition is authentication being enabled.

Two things left alone on purpose, since they are behaviour rather than labels: editing the personal memory settings still writes the shared factory session as a side effect, and auto-approve, smart editing and permissions are still lost when the server restarts. The UI now says so rather than pretending otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR shows who controls each setting: you, your organization, the factory, or the deployment. It also updates the controls and makes deployment settings read-only when users cannot change them.

## Changes

- Added scope badges and scope switches for settings sections.
- Corrected scopes for session settings, issue syncing, Slack work items, provider access, and observational memory.
- Added shared controls for:
  - Thinking levels with sliders, inherited-value resets, optimistic updates, and stable values during writes.
  - Completion sounds with mute support.
  - Segmented options and theme toggles.
- Serialized thinking-setting writes and prevented duplicate or stale slider updates.
- Prevented unavailable scope selections from being submitted.
- Updated `GET /web/config/thinking` to return `editable`.
- Updated the write refusal message to reference authentication.
- Documented known persistence and side-effect limitations in the settings UI.
- Added or updated tests for scope controls, provider access, sound controls, thinking defaults, Slack settings, and route responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->