### PR TITLE
fix(factory): retain session context for automated runs

### DIFF
--- a/.changeset/quiet-nails-sip.md
+++ b/.changeset/quiet-nails-sip.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Added trusted pull request comment commands to start or re-run Factory reviews.

--- a/.changeset/wild-moons-enter.md
+++ b/.changeset/wild-moons-enter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed autonomous Factory runs so they retain the selected session model.

--- a/mastracode/factory/README.md
+++ b/mastracode/factory/README.md
@@ -29,6 +29,16 @@ A host application calls `MastraFactory.prepare()`, constructs its `Mastra` inst
 
 `prepare()` initializes the Factory-owned resources needed before Mastra is constructed. `finalize()` connects those resources to the completed host, including Factory routes, integrations, storage-backed behavior, and agent-controller features. Consumers should keep frontend concerns in `factory-ui` and host-specific environment or deployment wiring in `web` rather than adding them to this package.
 
+### GitHub review commands
+
+A repository maintainer with write or admin access can start a Factory review from a pull-request comment by posting the exact first-line command:
+
+```text
+@<factory-app> review
+```
+
+`@<factory-app> re-review` is also accepted. Factory resolves `<factory-app>` from its observed or configured GitHub App login (without the `[bot]` suffix), so commands are ignored until that identity is known. The command creates and starts a first Review pass for a missing or Intake card, restarts a completed card with `factory-rereview`, and is a no-op while the card is already Reviewing. Other prose, quoted mentions, edited comments, and comments from untrusted users do not trigger a run.
+
 ### Development
 
 Run focused package checks from the repository root:

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -134,6 +134,37 @@ function issueComment(
   };
 }
 
+function pullRequestComment(
+  deliveryId: string,
+  options: { action?: 'created' | 'edited' | 'deleted'; sender?: string; author?: string; body?: string; state?: string } = {},
+) {
+  const sender = options.sender ?? 'maintainer';
+  const author = options.author ?? sender;
+  return {
+    event: 'issue_comment',
+    deliveryId,
+    payload: {
+      action: options.action ?? 'created',
+      installation: { id: 7 },
+      repository: { id: 10, full_name: 'acme/repo' },
+      sender: { login: sender },
+      issue: {
+        number: 17,
+        title: 'PR 17',
+        html_url: 'https://github.com/acme/repo/pull/17',
+        state: options.state ?? 'open',
+        pull_request: {},
+        user: { login: 'pr-author' },
+      },
+      comment: {
+        id: 101,
+        body: options.body ?? '@factory-app review',
+        user: { login: author, type: author.endsWith('[bot]') ? 'Bot' : 'User' },
+      },
+    },
+  };
+}
+
 async function createLinkedIssue(
   workItems: Awaited<ReturnType<typeof createFactoryStorageForTests>>['workItems'],
   projectId: string,
@@ -528,7 +559,10 @@ describe('GithubRules', () => {
           agentEndListeners.add(listener);
           return () => agentEndListeners.delete(listener);
         }),
-        state: { set: vi.fn(async () => {}) },
+        state: { get: vi.fn(() => ({ factoryProjectId: project.id })), set: vi.fn(async () => {}) },
+        mode: { get: vi.fn(() => 'build') },
+        model: { get: vi.fn(() => 'openai/gpt-5.6-sol') },
+        identity: { getId: vi.fn(() => key), getOwnerId: vi.fn(() => 'user-1') },
         permissions: { setForTool: vi.fn(async () => {}) },
         sendMessage: vi.fn(async () => {}),
         sendNotificationSignal: vi.fn(async () => ({ persisted: Promise.resolve(), accepted: Promise.resolve() })),
@@ -792,6 +826,53 @@ describe('GithubRules', () => {
     expect(await workItems.list({ orgId: 'org-1', factoryProjectId: project.id })).toHaveLength(1);
   });
 
+  it('materializes a Review card from Factory\'s exact PR comment command', async () => {
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
+    const rules = builtInFactoryRules();
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules,
+    });
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: { getSessionByResource: vi.fn(async () => undefined) } as never,
+      transitionService: new FactoryTransitionService({ storage: workItems, rules }),
+      storage: workItems,
+      isAutoRunEnabled: async () => true,
+      ownerId: 'worker-1',
+    });
+
+    await expect(service.ingest(pullRequestComment('delivery-comment-review'))).resolves.toEqual({ status: 'committed' });
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+
+    const [card] = await workItems.list({ orgId: 'org-1', factoryProjectId: project.id });
+    expect(card).toMatchObject({
+      title: 'PR 17',
+      stages: ['intake'],
+      metadata: { author: 'pr-author', authorTrusted: true, factoryAuthored: false, autoStartCandidate: true },
+    });
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workItemId: card!.id,
+          decision: expect.objectContaining({ type: 'invokeSkill', skillName: 'factory-review', role: 'review' }),
+        }),
+      ]),
+    );
+
+    await expect(service.ingest(pullRequestComment('delivery-comment-review'))).resolves.toEqual({ status: 'replayed' });
+    await expect(
+      service.ingest(pullRequestComment('delivery-comment-prose', { body: 'Please @factory-app review this PR.' })),
+    ).resolves.toEqual({ status: 'committed' });
+    await expect(
+      service.ingest(pullRequestComment('delivery-comment-quoted', { body: '> @factory-app review' })),
+    ).resolves.toEqual({ status: 'committed' });
+    expect(await workItems.list({ orgId: 'org-1', factoryProjectId: project.id })).toHaveLength(1);
+  });
+
   it('does not materialize a Review card when an untrusted actor requests Factory', async () => {
     const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('read');
     const service = new GithubRules({
@@ -829,6 +910,29 @@ describe('GithubRules', () => {
     ).resolves.toEqual({ status: 'committed' });
     expect(await workItems.list({ orgId: 'org-1', factoryProjectId: project.id })).toEqual([]);
     expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual([]);
+
+    await expect(
+      service.ingest(pullRequestComment('delivery-comment-review-untrusted', { sender: 'contributor' })),
+    ).resolves.toEqual({ status: 'committed' });
+    expect(await workItems.list({ orgId: 'org-1', factoryProjectId: project.id })).toEqual([]);
+  });
+
+  it('ignores comment commands until Factory can resolve its own GitHub identity', async () => {
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
+    (github as { slug?: string }).slug = undefined;
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await expect(service.ingest(pullRequestComment('delivery-comment-review-unknown-identity'))).resolves.toEqual({
+      status: 'committed',
+    });
+    expect(await workItems.list({ orgId: 'org-1', factoryProjectId: project.id })).toEqual([]);
   });
 
   it('commits a re-review transition when review is re-requested from the Factory bot', async () => {
@@ -895,6 +999,18 @@ describe('GithubRules', () => {
         decision: expect.objectContaining({ type: 'transition', board: 'review', stage: 'review' }),
       }),
     ]);
+
+    await expect(
+      service.ingest(pullRequestComment('delivery-rr-comment', { body: '@factory-app re-review' })),
+    ).resolves.toEqual({ status: 'committed' });
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workItemId: reviewed.item.id,
+          decision: expect.objectContaining({ type: 'transition', board: 'review', stage: 'review' }),
+        }),
+      ]),
+    );
   });
 
   it('re-reviews a Factory-authored PR: provenance binds neither the card nor the human requester', async () => {
@@ -1061,6 +1177,7 @@ describe('GithubRules', () => {
     await expect(service.ingest(reviewRequested('delivery-rr-dispatch'))).resolves.toEqual({ status: 'replayed' });
     // A second re-request while the card is already Reviewing is a guarded no-op.
     await expect(service.ingest(reviewRequested('delivery-rr-again'))).resolves.toEqual({ status: 'committed' });
+    await expect(service.ingest(pullRequestComment('delivery-rr-comment-again'))).resolves.toEqual({ status: 'committed' });
     const decisions = await workItems.listDeferredDecisions('org-1', project.id);
     expect(decisions.filter(entry => entry.decision.type === 'transition')).toHaveLength(1);
     expect(decisions.filter(entry => entry.decision.type === 'invokeSkill')).toHaveLength(1);
@@ -1461,7 +1578,10 @@ describe('GithubRules', () => {
       },
       getWorkspace: () => ({ skills: { maybeRefresh: vi.fn(async () => {}), get: vi.fn(async () => undefined) } }),
       subscribe: vi.fn(() => () => {}),
-      state: { set: vi.fn(async () => {}) },
+      state: { get: vi.fn(() => ({ factoryProjectId: project.id })), set: vi.fn(async () => {}) },
+      mode: { get: vi.fn(() => 'build') },
+      model: { get: vi.fn(() => 'openai/gpt-5.6-sol') },
+      identity: { getId: vi.fn(() => 'session-work-42'), getOwnerId: vi.fn(() => 'user-1') },
       permissions: { setForTool: vi.fn(async () => {}) },
       sendMessage: vi.fn(async () => {}),
       sendSignal: vi.fn(() => ({ accepted: Promise.resolve({ accepted: true, action: 'wake' }) })),

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -1228,16 +1228,16 @@ describe('GithubRules', () => {
     expect(item).toMatchObject({ id: card.item.id, stages: ['review'] });
     const decisions = await workItems.listDeferredDecisions('org-1', project.id);
     expect(decisions.filter(entry => entry.decision.type === 'transition')).toHaveLength(1);
-    // The onEnter review rule sees a re-entry (from a post-intake stage) and dispatches
-    // factory-rereview, asking the dispatcher to cancel any in-flight review run first.
+    // A completed pass has no active run to supersede. Its re-entry dispatches
+    // factory-rereview without aborting the newly prepared session.
     const invocations = decisions.filter(entry => entry.decision.type === 'invokeSkill');
     expect(invocations).toHaveLength(1);
     expect(invocations[0]!.decision).toMatchObject({
       type: 'invokeSkill',
       skillName: 'factory-rereview',
       role: 'review',
-      cancelInFlight: true,
     });
+    expect(invocations[0]!.decision).not.toHaveProperty('cancelInFlight');
 
     // A follow-up push while the card is still Reviewing supersedes the pass it
     // just started, which is now reading code the push replaced. Re-entering

--- a/mastracode/factory/src/integrations/github/rules.ts
+++ b/mastracode/factory/src/integrations/github/rules.ts
@@ -73,6 +73,23 @@ function labelNames(value: unknown): string[] {
   });
 }
 
+function parseFactoryReviewCommand(
+  body: string | undefined,
+  target: string | undefined,
+): { command: 'review' | 're-review'; target: string } | undefined {
+  if (!body || !target) return undefined;
+  const firstLine = body
+    .split('\n')
+    .map(line => line.trim())
+    .find(line => line.length > 0)
+    ?.toLowerCase();
+  if (!firstLine) return undefined;
+  const mention = `@${target.toLowerCase().replace(/\[bot\]$/, '')}`;
+  if (firstLine === `${mention} review`) return { command: 'review', target };
+  if (firstLine === `${mention} re-review`) return { command: 're-review', target };
+  return undefined;
+}
+
 function eventName(parsed: ParsedGithubWebhook): FactoryGithubEventName | undefined {
   const action = string(parsed.payload.action);
   if (parsed.event === 'issues' && action === 'opened') return 'issueOpened';
@@ -262,6 +279,13 @@ export class GithubRules {
     return login.toLowerCase() === `${slug.toLowerCase()}[bot]`;
   }
 
+  #factoryMentionTarget(): string | undefined {
+    const identity = this.options.github.identity;
+    if (identity?.known) return identity.login;
+    const slug = this.options.github.slug?.trim();
+    return slug ? `${slug.toLowerCase()}[bot]` : undefined;
+  }
+
   async ingest(parsed: ParsedGithubWebhook): Promise<{ status: 'ignored' | 'committed' | 'replayed' | 'missing' }> {
     const event = eventName(parsed);
     const repository = object(parsed.payload.repository);
@@ -331,6 +355,11 @@ export class GithubRules {
     // sender is whoever clicked re-request, so a Factory-authored PR must not
     // brand a human requester as factory-authored.
     const reviewRequested = event === 'pullRequestReviewRequested';
+    const reviewCommand =
+      event === 'pullRequestCommentCreated'
+        ? parseFactoryReviewCommand(string(issueComment?.body), this.#factoryMentionTarget())
+        : undefined;
+    const reviewEntryRequested = reviewRequested || reviewCommand !== undefined;
     // Provenance proves the *pull request* came from Factory, which is not the
     // same as the sender of this event. For events where the sender is whoever
     // reacted to the PR — re-requesting review, commenting, submitting a review
@@ -338,11 +367,11 @@ export class GithubRules {
     // bot as Factory. Only the app login identifies Factory for those.
     const senderIsResponder =
       reviewRequested || event === 'pullRequestCommentCreated' || event === 'pullRequestReviewSubmitted';
-    const reReviewEvent = reviewRequested || event === 'pullRequestUpdated';
+    const reReviewEvent = reviewEntryRequested || event === 'pullRequestUpdated';
     const requestedReviewer = string(object(parsed.payload.requested_reviewer)?.login);
     const pullRequestAuthor = string(object(pullRequest?.user)?.login);
     const pullRequestFactoryAuthored = provenance !== null || this.#isFactoryLogin(pullRequestAuthor);
-    const relatedItem = await this.#relatedItem(
+    const resolvedItem = await this.#relatedItem(
       project.orgId,
       project.factoryProjectId,
       repositoryId,
@@ -351,8 +380,12 @@ export class GithubRules {
       pullRequestNumber,
       string(object(pullRequest?.head)?.ref),
       reReviewEvent ? null : provenance,
-      senderIsResponder && !reviewRequested,
+      senderIsResponder && !reviewEntryRequested,
     );
+    // A review-entry request must never treat a branch-matched authoring Work
+    // card as the PR's Review card. A missing Review card is materialized below.
+    const relatedItem =
+      reviewEntryRequested && resolvedItem?.externalSource?.type !== 'pull-request' ? undefined : resolvedItem;
     const actor = await githubActor(this.options.github, {
       installationId,
       repository: repositoryName,
@@ -473,6 +506,7 @@ export class GithubRules {
               },
             }
           : {}),
+        ...(reviewCommand ? { reviewCommand } : {}),
         ...(object(parsed.payload.review)
           ? {
               review: {

--- a/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
@@ -287,7 +287,7 @@ describe('PlatformGithubEventWorker', () => {
     await resumed.stop();
   });
 
-  it('hands review feedback to the factory rules so the authoring agent is woken', async () => {
+  it('forwards created PR comments to Factory rules but never retriggers from edits', async () => {
     const settings = createSettingsStorage();
     const dispatch = vi.fn<typeof dispatchGithubWebhook>().mockResolvedValue({
       delivered: 1,

--- a/mastracode/factory/src/rules/defaults.test.ts
+++ b/mastracode/factory/src/rules/defaults.test.ts
@@ -369,7 +369,7 @@ describe('defaultFactoryRules', () => {
     expect(decision).not.toHaveProperty('cancelInFlight');
   });
 
-  it('cancels an in-flight review pass and dispatches factory-rereview when a push into an already-reviewed PR restarts Review', async () => {
+  it('dispatches factory-rereview without cancellation when a completed review restarts', async () => {
     const rule = defaultFactoryRules({ version: 'deployment-7' }).review.review?.pullRequest?.onEnter;
     const context = {
       ...stageContext({ type: 'github', login: 'author', trusted: true, factoryAuthored: false }, 'review'),
@@ -378,12 +378,13 @@ describe('defaultFactoryRules', () => {
       fromStage: 'done',
       toStage: 'review',
     } as FactoryStageRuleContext;
-    expect(await rule?.(context)).toMatchObject({
+    const decision = await rule?.(context);
+    expect(decision).toMatchObject({
       type: 'invokeSkill',
       role: 'review',
       skillName: 'factory-rereview',
-      cancelInFlight: true,
     });
+    expect(decision).not.toHaveProperty('cancelInFlight');
   });
 
   it('cancels an in-flight review pass but stays on factory-review when the re-entry did not follow a completed pass', async () => {

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -390,6 +390,10 @@ function requestsChangesVerdict(body: string | undefined): boolean {
 }
 
 function addressPullRequestComment(context: FactoryGithubRuleContext) {
+  // A validated Factory mention is a review-entry request, not feedback for the
+  // authoring Work session. Invalid or unrecognized comments retain the normal
+  // feedback route below.
+  if (context.reviewCommand) return reReviewRequestedPullRequest(context);
   if (!context.item || !context.pullRequest || !context.issueComment) return;
   // Provenance binds the comment to the Work item that authored the PR — the
   // only session that can act on it. A Review card must not react to comments
@@ -440,9 +444,10 @@ function pullRequestClosed(context: FactoryGithubRuleContext) {
 }
 
 function reReviewRequestedPullRequest(context: FactoryGithubRuleContext) {
-  // Only a review requested from Factory's own bot starts a Factory review —
-  // requesting a human reviewer is not Factory's signal.
-  if ((context.item && context.board !== 'review') || !context.reviewRequest?.factoryReviewer) return;
+  // GitHub reviewer requests and Factory's exact mention command are both
+  // explicit requests to enter the same Review lifecycle.
+  const factoryReviewEntry = context.reviewRequest?.factoryReviewer || context.reviewCommand !== undefined;
+  if ((context.item && context.board !== 'review') || !factoryReviewEntry) return;
   if (!context.pullRequest || context.pullRequest.state !== 'open' || context.pullRequest.merged) return;
   // Trusted (write/admin) requesters only: creating or re-entering review checks
   // out and executes PR code, the same bar pullRequestOpened applies to auto-review.

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -140,11 +140,10 @@ function completeIssue(context: FactoryStageRuleContext) {
 }
 
 function reviewPullRequest(context: FactoryStageRuleContext) {
-  // A re-entry into Review (from any post-intake stage) supersedes whichever
-  // review pass previously ran on this card: cancel any in-flight run before
-  // dispatching a fresh one so we don't burn tokens on the stale pass and race
-  // two agents on the same card. Cancellation is safe when nothing is in flight.
-  const supersedes = context.fromStage !== 'intake';
+  // Only a Review-to-Review re-entry can supersede an active pass. A card
+  // returning from Done has no live review to cancel; aborting its bound session
+  // would instead cancel the fresh re-review kickoff.
+  const supersedes = context.fromStage === 'review';
   // The re-review skill only applies when a prior review pass actually completed
   // (the card is returning from `done`). A cancelled first-time review that
   // re-enters Review from `review` itself still has no prior pass to reconcile —

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -143,7 +143,16 @@ function createSession(
         get: vi.fn(async (name: string) => ({ name, instructions: 'Follow the skill.' })),
       },
     }),
-    state: { set: vi.fn(async () => {}) },
+    state: {
+      get: vi.fn(() => ({ factoryProjectId: PROJECT_ID })),
+      set: vi.fn(async () => {}),
+    },
+    model: { get: vi.fn(() => 'openai/gpt-5.6-sol') },
+    mode: { get: vi.fn(() => 'build') },
+    identity: {
+      getId: vi.fn(() => 'session-1'),
+      getOwnerId: vi.fn(() => 'user-1'),
+    },
     permissions: { setForTool: vi.fn(async () => {}) },
     sendMessage: vi.fn(async () => {}),
     sendSignal: vi.fn((input: { id: string }, _options: { requestContext: { get(key: string): unknown } }) => {
@@ -1110,6 +1119,11 @@ describe('FactoryDecisionDispatcher', () => {
     );
     const requestContext = session.sendSignal.mock.calls[0]?.[1]?.requestContext;
     expect(requestContext?.get('user')).toEqual({ workosId: 'user-1', organizationId: 'org-1' });
+    expect(requestContext?.get('controller')).toMatchObject({
+      resourceId: PROJECT_ID,
+      threadId: 'thread-1',
+      session: { modeId: 'build', modelId: 'openai/gpt-5.6-sol' },
+    });
     expect(session.subscribe).toHaveBeenCalledTimes(1);
     expect(getAgentEndListenerCount()).toBe(0);
   });

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -1244,6 +1244,7 @@ describe('FactoryDecisionDispatcher', () => {
 
     await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
 
+    expect(session.thread.switch).not.toHaveBeenCalled();
     expect(abort).toHaveBeenCalledTimes(1);
     expect(abort.mock.invocationCallOrder[0]!).toBeLessThan(session.sendSignal.mock.invocationCallOrder[0]!);
     expect(session.sendSignal).toHaveBeenCalledTimes(1);

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -59,6 +59,7 @@ function createSession(
     suspendsOnTool?: string;
     /** The resumed run writes another plan, so an uncapped gate would never end. */
     replansAfterApproval?: boolean;
+    streamActive?: boolean;
   },
 ) {
   let threadId = 'thread-1';
@@ -136,6 +137,7 @@ function createSession(
       requireId: vi.fn(() => threadId),
       listActiveMessages: vi.fn(async () => [...deliveredSignals].map(id => ({ id }))),
     },
+    stream: { isActive: vi.fn(() => options?.streamActive ?? false) },
     abort,
     getWorkspace: () => ({
       skills: {
@@ -1212,7 +1214,7 @@ describe('FactoryDecisionDispatcher', () => {
       idempotencyKey: 'skill-cancel-1',
       cancelInFlight: true,
     });
-    const { controller, session, abort } = createSession();
+    const { controller, session, abort } = createSession(undefined, { streamActive: true });
     await storage.prepareRunStart({
       orgId: 'org-1',
       userId: 'user-1',

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -3821,6 +3821,11 @@ describe('FactoryDecisionDispatcher', () => {
     expect(primeCredentials).toHaveBeenCalledWith({ orgId: 'org-1', userId: 'user-1' });
     const kickoffOptions = sendNotificationSignal.mock.calls[0]![1];
     expect(kickoffOptions?.requestContext?.get('user')).toEqual({ workosId: 'user-1', organizationId: 'org-1' });
+    expect(kickoffOptions?.requestContext?.get('controller')).toMatchObject({
+      threadId: 'thread-1',
+      resourceId: 'session-1',
+      session: { id: 'session-1', ownerId: 'user-1', modeId: 'build', modelId: 'openai/gpt-5.6-sol' },
+    });
     expect((await storage.listPendingStarts('org-1', PROJECT_ID))[0]?.status).toBe('sent');
   });
 

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -1103,9 +1103,13 @@ export class FactoryDecisionDispatcher {
           const startedBy = item?.sessions[binding.role]?.startedBy;
           if (!startedBy) throw new Error(`Factory binding ${binding.id} has no authenticated session owner.`);
           await this.#primeCredentials?.({ orgId: record.orgId, userId: startedBy });
-          const requestContext = new RequestContext();
-          requestContext.set('user', { workosId: startedBy, organizationId: record.orgId });
           const session = await this.#requireSession(binding);
+          const requestContext = factoryRequestContext({
+            session,
+            binding,
+            userId: startedBy,
+            orgId: record.orgId,
+          });
           // The run's own verdict, not the delivery's: a kickoff delivered
           // into a run that is already terminating is consumed without
           // execution, and completing the pending start on the delivery ack

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -195,6 +195,32 @@ interface DispatcherSession extends SkillSession {
 type FactoryController = Pick<AgentController<MastraCodeState>, 'getSessionByResource'>;
 type BoundDispatcherSession = Session<MastraCodeState>;
 
+function factoryRequestContext(input: {
+  session: BoundDispatcherSession;
+  binding: FactoryRunBindingRecord;
+  userId: string;
+  orgId: string;
+}): RequestContext {
+  const { session, binding, userId, orgId } = input;
+  const requestContext = new RequestContext();
+  requestContext.set('user', { workosId: userId, organizationId: orgId });
+  const modeId = session.mode.get();
+  requestContext.set('controller', {
+    state: session.state.get(),
+    getState: () => session.state.get(),
+    threadId: binding.threadId,
+    resourceId: binding.resourceId,
+    session: {
+      id: session.identity.getId(),
+      ownerId: session.identity.getOwnerId(),
+      modeId,
+      modelId: session.model.get() ?? '',
+    },
+    workspace: session.getWorkspace(),
+  });
+  return requestContext;
+}
+
 export interface FactoryBindingPreparationInput {
   record: FactoryDeferredDecisionRecord;
   item: WorkItemRow;
@@ -618,10 +644,14 @@ export class FactoryDecisionDispatcher {
         const startedBy = item.sessions[binding.role]?.startedBy;
         if (!startedBy) return;
         await this.#primeCredentials?.({ orgId: record.orgId, userId: startedBy });
-        const requestContext = new RequestContext();
-        requestContext.set('user', { workosId: startedBy, organizationId: record.orgId });
         const session = await this.#findSession(binding);
         if (!session) return;
+        const requestContext = factoryRequestContext({
+          session,
+          binding,
+          userId: startedBy,
+          orgId: record.orgId,
+        });
         await awaitNotification(
           () =>
             session.sendNotificationSignal(
@@ -654,8 +684,13 @@ export class FactoryDecisionDispatcher {
         const startedBy = item?.sessions[binding.role]?.startedBy;
         if (!startedBy) throw new Error(`Factory binding ${binding.id} has no authenticated session owner.`);
         await this.#primeCredentials?.({ orgId: record.orgId, userId: startedBy });
-        const requestContext = new RequestContext();
-        requestContext.set('user', { workosId: startedBy, organizationId: record.orgId });
+        const session = await this.#requireSession(binding);
+        const requestContext = factoryRequestContext({
+          session,
+          binding,
+          userId: startedBy,
+          orgId: record.orgId,
+        });
         const resolved =
           decision.skillName === undefined
             ? await resolvePromptInvocation(this.#controller, {
@@ -667,7 +702,6 @@ export class FactoryDecisionDispatcher {
                 name: decision.skillName,
                 arguments: decision.arguments,
               });
-        const session = resolved.session as DispatcherSession;
         await this.#switchThread(session, binding);
         const deliveryId =
           record.deliveryGeneration === 0 ? record.id : `${record.id}:retry:${record.deliveryGeneration}`;
@@ -781,9 +815,13 @@ export class FactoryDecisionDispatcher {
         const startedBy = item?.sessions[binding.role]?.startedBy;
         if (!startedBy) throw new Error(`Factory binding ${binding.id} has no authenticated session owner.`);
         await this.#primeCredentials?.({ orgId: record.orgId, userId: startedBy });
-        const requestContext = new RequestContext();
-        requestContext.set('user', { workosId: startedBy, organizationId: record.orgId });
         const session = await this.#requireSession(binding);
+        const requestContext = factoryRequestContext({
+          session,
+          binding,
+          userId: startedBy,
+          orgId: record.orgId,
+        });
         await awaitNotification(
           () =>
             session.sendNotificationSignal(

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -184,6 +184,7 @@ interface DispatcherSession extends SkillSession {
     switch(input: { threadId: string }): Promise<unknown>;
     listActiveMessages(): Promise<Array<{ id: string }>>;
   };
+  stream: { isActive(): boolean };
   abort(): void;
   sendSignal(
     input: { id: string; type: 'user'; tagName: 'user'; contents: string },
@@ -714,7 +715,7 @@ export class FactoryDecisionDispatcher {
           { orgId: record.orgId, factoryProjectId: record.factoryProjectId, workItemId: record.workItemId },
           resolved.message,
         );
-        if (decision.cancelInFlight) session.abort();
+        if (decision.cancelInFlight && session.stream.isActive()) session.abort();
         const precedingMessage = decision.precedingMessage;
         if (precedingMessage) {
           await awaitNotification(() =>

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -166,6 +166,7 @@ function waitForAgentEndOrTimeout(agentEnd: Promise<void>, timeoutMs: number): P
 
 interface ThreadSwitchSession {
   thread: {
+    requireId(): string;
     switch(input: { threadId: string }): Promise<unknown>;
   };
 }
@@ -1047,6 +1048,7 @@ export class FactoryDecisionDispatcher {
   }
 
   async #switchThread(session: ThreadSwitchSession, binding: FactoryRunBindingRecord): Promise<void> {
+    if (session.thread.requireId() === binding.threadId) return;
     await session.thread.switch({ threadId: binding.threadId });
   }
 

--- a/mastracode/factory/src/rules/terminal-cleanup.test.ts
+++ b/mastracode/factory/src/rules/terminal-cleanup.test.ts
@@ -73,6 +73,25 @@ describe('createTerminalStageCleanup', () => {
     ]);
   });
 
+  it('does not revoke a re-entered card after terminal cleanup becomes stale', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const prepared = await prepareBinding(storage);
+    const releaseSandboxes = vi.fn();
+    const cleanup = createTerminalStageCleanup({ workItems: storage, releaseSandboxes });
+
+    await cleanup({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: prepared.item.id,
+      revision: prepared.item.revision + 1,
+    });
+
+    await expect(storage.listRunBindings('org-1', PROJECT_ID, prepared.item.id)).resolves.toEqual([
+      expect.objectContaining({ id: prepared.binding.id, status: 'active' }),
+    ]);
+    expect(releaseSandboxes).not.toHaveBeenCalled();
+  });
+
   it('skips reconcile for bindings that are already revoked', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const prepared = await prepareBinding(storage);
@@ -206,6 +225,7 @@ describe('createTerminalStageCleanup', () => {
     const releaseSandboxes = vi.fn(async () => {});
     const cleanup = createTerminalStageCleanup({
       workItems: {
+        get: vi.fn().mockResolvedValue({ revision: 1 }),
         listRunBindings: vi.fn().mockRejectedValue(new Error('storage down')),
         revokeRunBindingsForWorkItem: vi.fn(),
         supersedeTerminalDecisionsForWorkItem: vi.fn().mockRejectedValue(new Error('storage down')),

--- a/mastracode/factory/src/rules/terminal-cleanup.ts
+++ b/mastracode/factory/src/rules/terminal-cleanup.ts
@@ -3,7 +3,7 @@ import type { FactoryRunBindingRecord, WorkItemsStorage } from '../storage/domai
 export interface TerminalStageCleanupOptions {
   workItems: Pick<
     WorkItemsStorage,
-    'listRunBindings' | 'revokeRunBindingsForWorkItem' | 'supersedeTerminalDecisionsForWorkItem'
+    'get' | 'listRunBindings' | 'revokeRunBindingsForWorkItem' | 'supersedeTerminalDecisionsForWorkItem'
   >;
   /** Final ingest of trailing tool results before the binding is revoked. */
   reconcileBinding?: (binding: FactoryRunBindingRecord) => Promise<void>;
@@ -15,6 +15,8 @@ export interface TerminalStageCleanupArgs {
   orgId: string;
   factoryProjectId: string;
   workItemId: string;
+  /** Revision produced by the terminal transition that scheduled this cleanup. */
+  revision?: number;
 }
 
 /**
@@ -38,6 +40,12 @@ export function createTerminalStageCleanup(options: TerminalStageCleanupOptions)
     } catch {
       // Best-effort; revocation below does not depend on the listing.
     }
+    // Cleanup can outlive the terminal transition's response window. Do not
+    // revoke a new binding or retire its workspace if the card has since been
+    // re-entered for another pass.
+    const item = await options.workItems.get({ orgId: args.orgId, id: args.workItemId }).catch(() => null);
+    if (args.revision !== undefined && item?.revision !== args.revision) return;
+
     try {
       await options.workItems.revokeRunBindingsForWorkItem({
         orgId: args.orgId,

--- a/mastracode/factory/src/rules/transition-service.test.ts
+++ b/mastracode/factory/src/rules/transition-service.test.ts
@@ -413,6 +413,7 @@ describe('FactoryTransitionService', () => {
       factoryProjectId: PROJECT_ID,
       workItemId: item.id,
       stage: 'done',
+      revision: expect.any(Number),
     });
   });
 

--- a/mastracode/factory/src/rules/transition-service.ts
+++ b/mastracode/factory/src/rules/transition-service.ts
@@ -71,6 +71,7 @@ export interface FactoryTransitionServiceOptions {
     factoryProjectId: string;
     workItemId: string;
     stage: FactoryRuleStage;
+    revision: number;
   }) => Promise<void> | void;
   /** Upper bound on how long a committed transition waits for
    * `onTerminalStage` before returning (default 30s). The cleanup continues
@@ -491,6 +492,7 @@ export class FactoryTransitionService {
             factoryProjectId: request.factoryProjectId,
             workItemId: request.workItemId,
             stage: result.stage,
+            revision: result.revision,
           }),
         );
         // A late rejection after the timeout wins the race must not surface

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -235,6 +235,8 @@ export interface FactoryGithubRuleContext extends FactoryRuleContextBase {
   };
   /** Present on `pullRequestReviewRequested`: who review was (re-)requested from. */
   reviewRequest?: { reviewer: string; factoryReviewer: boolean };
+  /** Present when a PR comment uses Factory's exact review command. */
+  reviewCommand?: { command: 'review' | 're-review'; target: string };
   /** Present on `pullRequestReviewSubmitted`: the review that was just posted. */
   review?: { id: number; state: string; url: string };
 }


### PR DESCRIPTION
## Summary
- retain the bound Factory session model, mode, and controller state when dispatching automated signals
- prevent autonomous review/work runs from failing solely because they lack an interactive request context
- cover the dispatched skill kickoff context

## Test plan
- `pnpm --filter @mastra/factory exec vitest run src/rules/dispatcher.test.ts --reporter=dot --bail=1`
- `pnpm --filter @mastra/factory exec vitest run src/integrations/github/rules.test.ts --reporter=dot`
- `pnpm --filter @mastra/factory exec vitest run src/integrations/github/webhook.test.ts --reporter=dot`
- `pnpm --filter @mastra/factory lint`
- `pnpm --filter @mastra/factory build:lib`

`pnpm --filter @mastra/factory check` remains blocked by the existing `src/workspace.ts:458` `void | Promise` error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Factory now keeps the session details required for automated runs. GitHub users can start or repeat reviews by posting approved pull-request commands.

## Changes

- Preserve the bound session’s model, mode, controller state, and identity during automated dispatches.
- Add exact, case-insensitive `@factory review` and `@factory re-review` GitHub comment commands.
- Route valid commands to the pull request’s Review card.
- Cancel only active review runs.
- Preserve sessions when rerunning completed reviews.
- Ignore untrusted, invalid, duplicate, edited, and unsupported comments.
- Document the comment commands and trust requirements.
- Add dispatcher, GitHub integration, webhook, and review re-entry tests.
- Add Factory patch-release changesets.

## Validation

- Include Factory linting and library build checks.
- The Factory check remains blocked by the existing `src/workspace.ts:458` `void | Promise` error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->