### PR TITLE
fix(server): keep non-allowlisted providerOptions namespaces in agent execution schema

### DIFF
--- a/.changeset/provider-options-open-record.md
+++ b/.changeset/provider-options-open-record.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Stop stripping non-allowlisted `providerOptions` namespaces (deepseek, bedrock, groq, ...) during agent execution request validation. The schema listed only four providers and zod removes unknown keys from nested objects, so every other provider's options were silently dropped at the route boundary. Fixes #22617.

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -7,17 +7,17 @@
 
 export type Simplify<T> = { [K in keyof T]: T[K] } & {};
 
-type Shared_Auxiliary_298 =
+type Shared_Auxiliary_272 =
   | string
   | number
   | boolean
   | null
-  | Shared_Auxiliary_298[]
+  | Shared_Auxiliary_272[]
   | {
-      [key: string]: Shared_Auxiliary_298;
+      [key: string]: Shared_Auxiliary_272;
     };
 
-type Shared_Auxiliary_1097 =
+type Shared_Auxiliary_1096 =
   | {
       op: 'eq' | 'ne' | 'lt' | 'lte' | 'gt' | 'gte';
       left:
@@ -62,19 +62,19 @@ type Shared_Auxiliary_1097 =
     }
   | {
       op: 'and' | 'or';
-      args: Shared_Auxiliary_1097[];
+      args: Shared_Auxiliary_1096[];
     }
   | {
       op: 'not';
-      arg: Shared_Auxiliary_1097;
+      arg: Shared_Auxiliary_1096;
     };
 
-type Shared_Auxiliary_1238 = {
+type Shared_Auxiliary_1237 = {
   id?: string | undefined;
   name: string;
   type: 'file' | 'folder';
   content?: string | undefined;
-  children?: Shared_Auxiliary_1238[] | undefined;
+  children?: Shared_Auxiliary_1237[] | undefined;
 };
 
 type Shared_Type_0 = {
@@ -989,29 +989,6 @@ type Shared_Type_44 = {
 };
 
 type Shared_Type_45 = {
-  anthropic?:
-    | {
-        [key: string]: unknown;
-      }
-    | undefined;
-  google?:
-    | {
-        [key: string]: unknown;
-      }
-    | undefined;
-  openai?:
-    | {
-        [key: string]: unknown;
-      }
-    | undefined;
-  xai?:
-    | {
-        [key: string]: unknown;
-      }
-    | undefined;
-};
-
-type Shared_Type_46 = {
   metadata?:
     | {
         [key: string]: unknown;
@@ -1025,7 +1002,7 @@ type Shared_Type_46 = {
   hideOutput?: boolean | undefined;
 };
 
-type Shared_Type_47 = {
+type Shared_Type_46 = {
   schema: {
     [x: string]: unknown;
   };
@@ -1036,7 +1013,7 @@ type Shared_Type_47 = {
   fallbackValue?: unknown | undefined;
 };
 
-type Shared_Type_48 = {
+type Shared_Type_47 = {
   behavior?: ('deliver' | 'persist' | 'discard') | undefined;
   attributes?:
     | {
@@ -1045,19 +1022,19 @@ type Shared_Type_48 = {
     | undefined;
 };
 
-type Shared_Type_49 = {
+type Shared_Type_48 = {
   type: 'text';
   text: string;
   providerOptions?:
     | {
         [key: string]: {
-          [key: string]: Shared_Auxiliary_298;
+          [key: string]: Shared_Auxiliary_272;
         };
       }
     | undefined;
 };
 
-type Shared_Type_50 = {
+type Shared_Type_49 = {
   type: 'file';
   data: string;
   mediaType: string;
@@ -1065,14 +1042,14 @@ type Shared_Type_50 = {
   providerOptions?:
     | {
         [key: string]: {
-          [key: string]: Shared_Auxiliary_298;
+          [key: string]: Shared_Auxiliary_272;
         };
       }
     | undefined;
 };
 
-type Shared_Type_51 = {
-  contents: string | (Shared_Type_49 | Shared_Type_50)[];
+type Shared_Type_50 = {
+  contents: string | (Shared_Type_48 | Shared_Type_49)[];
   attributes?:
     | {
         [key: string]: string | number | boolean | null | undefined;
@@ -1080,19 +1057,19 @@ type Shared_Type_51 = {
     | undefined;
   metadata?:
     | {
-        [key: string]: Shared_Auxiliary_298;
+        [key: string]: Shared_Auxiliary_272;
       }
     | undefined;
   providerOptions?:
     | {
         [key: string]: {
-          [key: string]: Shared_Auxiliary_298;
+          [key: string]: Shared_Auxiliary_272;
         };
       }
     | undefined;
 };
 
-type Shared_Type_52 = {
+type Shared_Type_51 = {
   instructions?: (string | string[] | unknown | unknown[]) | undefined;
   system?: (string | string[] | unknown | unknown[]) | undefined;
   context?: unknown[] | undefined;
@@ -1108,7 +1085,13 @@ type Shared_Type_52 = {
   maxSteps?: number | undefined;
   stopWhen?: unknown | undefined;
   model?: string | undefined;
-  providerOptions?: Shared_Type_45 | undefined;
+  providerOptions?:
+    | {
+        [key: string]: {
+          [key: string]: Shared_Auxiliary_272;
+        };
+      }
+    | undefined;
   modelSettings?: unknown | undefined;
   activeTools?: string[] | undefined;
   toolsets?:
@@ -1145,9 +1128,9 @@ type Shared_Type_52 = {
       )
     | undefined;
   returnScorerData?: boolean | undefined;
-  tracingOptions?: Shared_Type_46 | undefined;
+  tracingOptions?: Shared_Type_45 | undefined;
   output?: unknown | undefined;
-  structuredOutput?: Shared_Type_47 | undefined;
+  structuredOutput?: Shared_Type_46 | undefined;
   untilIdle?:
     | (
         | boolean
@@ -1159,9 +1142,9 @@ type Shared_Type_52 = {
   [x: string]: unknown;
 };
 
-type Shared_Type_53 = {
+type Shared_Type_52 = {
   behavior?: ('wake' | 'persist' | 'discard') | undefined;
-  streamOptions?: Shared_Type_52 | undefined;
+  streamOptions?: Shared_Type_51 | undefined;
   attributes?:
     | {
         [key: string]: string | number | boolean | null | undefined;
@@ -1169,12 +1152,12 @@ type Shared_Type_53 = {
     | undefined;
 };
 
-type Shared_Type_54 = {
+type Shared_Type_53 = {
   id?: string | undefined;
   createdAt?: (string | Date) | undefined;
   metadata?:
     | {
-        [key: string]: Shared_Auxiliary_298;
+        [key: string]: Shared_Auxiliary_272;
       }
     | undefined;
   attributes?:
@@ -1183,11 +1166,11 @@ type Shared_Type_54 = {
       }
     | undefined;
   tagName?: string | undefined;
-  contents: string | (Shared_Type_49 | Shared_Type_50)[];
+  contents: string | (Shared_Type_48 | Shared_Type_49)[];
   providerOptions?:
     | {
         [key: string]: {
-          [key: string]: Shared_Auxiliary_298;
+          [key: string]: Shared_Auxiliary_272;
         };
       }
     | undefined;
@@ -1195,12 +1178,12 @@ type Shared_Type_54 = {
   transient?: never | undefined;
 };
 
-type Shared_Type_55 = {
+type Shared_Type_54 = {
   id?: string | undefined;
   createdAt?: (string | Date) | undefined;
   metadata?:
     | {
-        [key: string]: Shared_Auxiliary_298;
+        [key: string]: Shared_Auxiliary_272;
       }
     | undefined;
   attributes?:
@@ -1209,11 +1192,11 @@ type Shared_Type_55 = {
       }
     | undefined;
   tagName?: string | undefined;
-  contents: string | (Shared_Type_49 | Shared_Type_50)[];
+  contents: string | (Shared_Type_48 | Shared_Type_49)[];
   providerOptions?:
     | {
         [key: string]: {
-          [key: string]: Shared_Auxiliary_298;
+          [key: string]: Shared_Auxiliary_272;
         };
       }
     | undefined;
@@ -1221,7 +1204,7 @@ type Shared_Type_55 = {
   transient?: boolean | undefined;
 };
 
-type Shared_Type_56 = {
+type Shared_Type_55 = {
   type: 'sso' | 'credentials' | 'both';
   sso?:
     | {
@@ -1236,7 +1219,7 @@ type Shared_Type_56 = {
   description?: string | undefined;
 };
 
-type Shared_Type_57 = {
+type Shared_Type_56 = {
   id: string;
   description?: string | undefined;
   stateSchema?: string | undefined;
@@ -1253,12 +1236,12 @@ type Shared_Type_57 = {
     | undefined;
 };
 
-type Shared_Type_58 = {
+type Shared_Type_57 = {
   steps: {
-    [key: string]: Shared_Type_57;
+    [key: string]: Shared_Type_56;
   };
   allSteps: {
-    [key: string]: Shared_Type_57;
+    [key: string]: Shared_Type_56;
   };
   name?: string | undefined;
   description?: string | undefined;
@@ -1290,7 +1273,7 @@ type Shared_Type_58 = {
   origin?: ('code' | 'dynamic') | undefined;
 };
 
-type Shared_Type_59 = {
+type Shared_Type_58 = {
   id: string;
   role: 'user' | 'assistant' | 'system' | 'tool' | 'signal';
   createdAt?: Date | undefined;
@@ -1305,7 +1288,7 @@ type Shared_Type_59 = {
   [x: string]: unknown;
 };
 
-type Shared_Type_60 = {
+type Shared_Type_59 = {
   type: 'json_schema';
   name: string;
   description?: string | undefined;
@@ -1315,7 +1298,7 @@ type Shared_Type_60 = {
   strict?: boolean | undefined;
 };
 
-type Shared_Type_61 = {
+type Shared_Type_60 = {
   /** OpenAI provider options such as previousResponseId, conversation, or responseId */
   openai?:
     | {
@@ -1331,7 +1314,7 @@ type Shared_Type_61 = {
   [x: string]: unknown;
 };
 
-type Shared_Type_62 = {
+type Shared_Type_61 = {
   id: string;
   type: 'function_call';
   call_id: string;
@@ -1340,7 +1323,7 @@ type Shared_Type_62 = {
   status?: ('in_progress' | 'completed' | 'incomplete') | undefined;
 };
 
-type Shared_Type_63 = {
+type Shared_Type_62 = {
   id: string;
   title?: string | undefined;
   resourceId: string;
@@ -1353,7 +1336,7 @@ type Shared_Type_63 = {
     | undefined;
 };
 
-type Shared_Type_64 = {
+type Shared_Type_63 = {
   id?: string | undefined;
   cycleId: string;
   observations: string;
@@ -1378,14 +1361,14 @@ type Shared_Type_64 = {
     | undefined;
 };
 
-type Shared_Type_65 = {
+type Shared_Type_64 = {
   id: string;
   scope: 'thread' | 'resource';
   resourceId: string;
   threadId: string | null;
   activeObservations: string;
   bufferedObservations?: string | undefined;
-  bufferedObservationChunks?: Shared_Type_64[] | undefined;
+  bufferedObservationChunks?: Shared_Type_63[] | undefined;
   bufferedReflection?: string | undefined;
   originType: 'initial' | 'observation' | 'reflection';
   generationCount: number;
@@ -1407,7 +1390,7 @@ type Shared_Type_65 = {
   updatedAt: Date;
 };
 
-type Shared_Type_66 = {
+type Shared_Type_65 = {
   dateRange?:
     | {
         start?: Date | undefined;
@@ -1424,7 +1407,7 @@ type Shared_Type_66 = {
     | undefined;
 };
 
-type Shared_Type_67 = {
+type Shared_Type_66 = {
   config: {
     id: string;
     name?: string | undefined;
@@ -1434,8 +1417,8 @@ type Shared_Type_67 = {
   };
 };
 
-type Shared_Type_68 = {
-  scorer: Shared_Type_67;
+type Shared_Type_67 = {
+  scorer: Shared_Type_66;
   sampling?: {} | undefined;
   agentIds: string[];
   agentNames: string[];
@@ -1444,7 +1427,7 @@ type Shared_Type_68 = {
   source: 'code' | 'stored' | 'fs';
 };
 
-type Shared_Type_69 = {
+type Shared_Type_68 = {
   /** Start of date range (inclusive by default) */
   start?: Date | undefined;
   /** End of date range (inclusive by default) */
@@ -1455,7 +1438,7 @@ type Shared_Type_69 = {
   endExclusive?: boolean | undefined;
 };
 
-type Shared_Type_70 =
+type Shared_Type_69 =
   | 'agent_run'
   | 'scorer_run'
   | 'scorer_step'
@@ -1487,7 +1470,7 @@ type Shared_Type_70 =
   | 'mapping'
   | 'skill_resolution';
 
-type Shared_Type_71 =
+type Shared_Type_70 =
   | 'agent'
   | 'scorer'
   | 'rag_ingestion'
@@ -1502,7 +1485,7 @@ type Shared_Type_71 =
   | 'workflow_run'
   | 'memory';
 
-type Shared_Type_72 = {
+type Shared_Type_71 = {
   /** Total number of items available */
   total: number;
   /** Current page */
@@ -1513,14 +1496,14 @@ type Shared_Type_72 = {
   hasMore: boolean;
 };
 
-type Shared_Type_73 = {
+type Shared_Type_72 = {
   /** Maximum number of updates requested for this delta poll */
   limit: number;
   /** True when more matching updates remain after this response */
   hasMore: boolean;
 };
 
-type Shared_Type_74 = {
+type Shared_Type_73 = {
   /** Unique trace identifier */
   traceId: string;
   /** Unique span identifier within a trace */
@@ -1528,19 +1511,19 @@ type Shared_Type_74 = {
   /** Human-readable span name */
   name: string;
   /** Span type (e.g., WORKFLOW_RUN, AGENT_RUN, TOOL_CALL, etc.) */
-  spanType: Shared_Type_70;
+  spanType: Shared_Type_69;
   /** Whether this is an event (point-in-time) vs a span (duration) */
   isEvent: boolean;
   /** When the span started */
   startedAt: Date;
   parentSpanId?: (string | null) | undefined;
-  entityType?: (Shared_Type_71 | null) | undefined;
+  entityType?: (Shared_Type_70 | null) | undefined;
   entityId?: (string | null) | undefined;
   entityName?: (string | null) | undefined;
-  parentEntityType?: (Shared_Type_71 | null) | undefined;
+  parentEntityType?: (Shared_Type_70 | null) | undefined;
   parentEntityId?: (string | null) | undefined;
   parentEntityName?: (string | null) | undefined;
-  rootEntityType?: (Shared_Type_71 | null) | undefined;
+  rootEntityType?: (Shared_Type_70 | null) | undefined;
   rootEntityId?: (string | null) | undefined;
   rootEntityName?: (string | null) | undefined;
   userId?: (string | null) | undefined;
@@ -1593,7 +1576,7 @@ type Shared_Type_74 = {
   status: 'success' | 'error' | 'running';
 };
 
-type Shared_Type_75 = {
+type Shared_Type_74 = {
   /** Unique trace identifier */
   traceId: string;
   /** Unique span identifier within a trace */
@@ -1601,7 +1584,7 @@ type Shared_Type_75 = {
   /** Human-readable span name */
   name: string;
   /** Span type (e.g., WORKFLOW_RUN, AGENT_RUN, TOOL_CALL, etc.) */
-  spanType: Shared_Type_70;
+  spanType: Shared_Type_69;
   /** Whether this is an event (point-in-time) vs a span (duration) */
   isEvent: boolean;
   /** When the span started */
@@ -1610,7 +1593,7 @@ type Shared_Type_75 = {
   endedAt?: (Date | null) | undefined;
   error?: (unknown | null) | undefined;
   status?: (('success' | 'error' | 'running') | null) | undefined;
-  entityType?: (Shared_Type_71 | null) | undefined;
+  entityType?: (Shared_Type_70 | null) | undefined;
   entityId?: (string | null) | undefined;
   entityName?: (string | null) | undefined;
   metadata?:
@@ -1625,7 +1608,7 @@ type Shared_Type_75 = {
   updatedAt: Date | null;
 };
 
-type Shared_Type_76 = {
+type Shared_Type_75 = {
   /** Unique trace identifier */
   traceId: string;
   /** Unique span identifier within a trace */
@@ -1633,19 +1616,19 @@ type Shared_Type_76 = {
   /** Human-readable span name */
   name: string;
   /** Span type (e.g., WORKFLOW_RUN, AGENT_RUN, TOOL_CALL, etc.) */
-  spanType: Shared_Type_70;
+  spanType: Shared_Type_69;
   /** Whether this is an event (point-in-time) vs a span (duration) */
   isEvent: boolean;
   /** When the span started */
   startedAt: Date;
   parentSpanId?: (string | null) | undefined;
-  entityType?: (Shared_Type_71 | null) | undefined;
+  entityType?: (Shared_Type_70 | null) | undefined;
   entityId?: (string | null) | undefined;
   entityName?: (string | null) | undefined;
-  parentEntityType?: (Shared_Type_71 | null) | undefined;
+  parentEntityType?: (Shared_Type_70 | null) | undefined;
   parentEntityId?: (string | null) | undefined;
   parentEntityName?: (string | null) | undefined;
-  rootEntityType?: (Shared_Type_71 | null) | undefined;
+  rootEntityType?: (Shared_Type_70 | null) | undefined;
   rootEntityId?: (string | null) | undefined;
   rootEntityName?: (string | null) | undefined;
   userId?: (string | null) | undefined;
@@ -1696,7 +1679,7 @@ type Shared_Type_76 = {
   updatedAt: Date | null;
 };
 
-type Shared_Type_77 = {
+type Shared_Type_76 = {
   /** Unique id for this score event */
   scoreId?: (string | null) | undefined;
   /** When the score was recorded */
@@ -1714,13 +1697,13 @@ type Shared_Type_77 = {
   /** Score value (range defined by scorer) */
   score: number;
   reason?: (string | null) | undefined;
-  entityType?: (Shared_Type_71 | null) | undefined;
+  entityType?: (Shared_Type_70 | null) | undefined;
   entityId?: (string | null) | undefined;
   entityName?: (string | null) | undefined;
-  parentEntityType?: (Shared_Type_71 | null) | undefined;
+  parentEntityType?: (Shared_Type_70 | null) | undefined;
   parentEntityId?: (string | null) | undefined;
   parentEntityName?: (string | null) | undefined;
-  rootEntityType?: (Shared_Type_71 | null) | undefined;
+  rootEntityType?: (Shared_Type_70 | null) | undefined;
   rootEntityId?: (string | null) | undefined;
   rootEntityName?: (string | null) | undefined;
   userId?: (string | null) | undefined;
@@ -1753,15 +1736,15 @@ type Shared_Type_77 = {
     | undefined;
 };
 
-type Shared_Type_78 = {
+type Shared_Type_77 = {
   /** Filter by timestamp range */
-  timestamp?: Shared_Type_69 | undefined;
+  timestamp?: Shared_Type_68 | undefined;
   /** Filter by trace ID */
   traceId?: string | undefined;
   /** Filter by span ID */
   spanId?: string | undefined;
   /** Entity type (e.g., 'agent' | 'processor' | 'tool' | 'workflow') */
-  entityType?: Shared_Type_71 | undefined;
+  entityType?: Shared_Type_70 | undefined;
   /** Name of the entity */
   entityName?: string | undefined;
   /** Version ID of the entity that produced this signal (e.g., agent version, workflow version) */
@@ -1781,11 +1764,11 @@ type Shared_Type_78 = {
   /** Environment (e.g., "production" | "staging" | "development") */
   environment?: string | undefined;
   /** Entity type of the parent entity */
-  parentEntityType?: Shared_Type_71 | undefined;
+  parentEntityType?: Shared_Type_70 | undefined;
   /** Name of the parent entity */
   parentEntityName?: string | undefined;
   /** Entity type of the root entity */
-  rootEntityType?: Shared_Type_71 | undefined;
+  rootEntityType?: Shared_Type_70 | undefined;
   /** Name of the root entity */
   rootEntityName?: string | undefined;
   /** Broader resource context (Mastra memory compatibility) */
@@ -1816,7 +1799,7 @@ type Shared_Type_78 = {
   source?: string | undefined;
 };
 
-type Shared_Type_79 = {
+type Shared_Type_78 = {
   /** Unique id for this feedback event */
   feedbackId?: (string | null) | undefined;
   /** When the feedback was recorded */
@@ -1833,13 +1816,13 @@ type Shared_Type_79 = {
   value: number | string;
   comment?: (string | null) | undefined;
   feedbackUserId?: (string | null) | undefined;
-  entityType?: (Shared_Type_71 | null) | undefined;
+  entityType?: (Shared_Type_70 | null) | undefined;
   entityId?: (string | null) | undefined;
   entityName?: (string | null) | undefined;
-  parentEntityType?: (Shared_Type_71 | null) | undefined;
+  parentEntityType?: (Shared_Type_70 | null) | undefined;
   parentEntityId?: (string | null) | undefined;
   parentEntityName?: (string | null) | undefined;
-  rootEntityType?: (Shared_Type_71 | null) | undefined;
+  rootEntityType?: (Shared_Type_70 | null) | undefined;
   rootEntityId?: (string | null) | undefined;
   rootEntityName?: (string | null) | undefined;
   userId?: (string | null) | undefined;
@@ -1874,15 +1857,15 @@ type Shared_Type_79 = {
   reviewStatus: 'needs-review' | 'reviewed';
 };
 
-type Shared_Type_80 = {
+type Shared_Type_79 = {
   /** Filter by timestamp range */
-  timestamp?: Shared_Type_69 | undefined;
+  timestamp?: Shared_Type_68 | undefined;
   /** Filter by trace ID */
   traceId?: string | undefined;
   /** Filter by span ID */
   spanId?: string | undefined;
   /** Entity type (e.g., 'agent' | 'processor' | 'tool' | 'workflow') */
-  entityType?: Shared_Type_71 | undefined;
+  entityType?: Shared_Type_70 | undefined;
   /** Name of the entity */
   entityName?: string | undefined;
   /** Version ID of the entity that produced this signal (e.g., agent version, workflow version) */
@@ -1902,11 +1885,11 @@ type Shared_Type_80 = {
   /** Environment (e.g., "production" | "staging" | "development") */
   environment?: string | undefined;
   /** Entity type of the parent entity */
-  parentEntityType?: Shared_Type_71 | undefined;
+  parentEntityType?: Shared_Type_70 | undefined;
   /** Name of the parent entity */
   parentEntityName?: string | undefined;
   /** Entity type of the root entity */
-  rootEntityType?: Shared_Type_71 | undefined;
+  rootEntityType?: Shared_Type_70 | undefined;
   /** Name of the root entity */
   rootEntityName?: string | undefined;
   /** Broader resource context (Mastra memory compatibility) */
@@ -1934,7 +1917,7 @@ type Shared_Type_80 = {
   reviewStatus?: ('needs-review' | 'reviewed') | undefined;
 };
 
-type Shared_Type_81 =
+type Shared_Type_80 =
   | 'entityType'
   | 'entityName'
   | 'parentEntityType'
@@ -1950,15 +1933,15 @@ type Shared_Type_81 =
   | 'threadId'
   | 'resourceId';
 
-type Shared_Type_82 = {
+type Shared_Type_81 = {
   /** Filter by timestamp range */
-  timestamp?: Shared_Type_69 | undefined;
+  timestamp?: Shared_Type_68 | undefined;
   /** Filter by trace ID */
   traceId?: string | undefined;
   /** Filter by span ID */
   spanId?: string | undefined;
   /** Entity type (e.g., 'agent' | 'processor' | 'tool' | 'workflow') */
-  entityType?: Shared_Type_71 | undefined;
+  entityType?: Shared_Type_70 | undefined;
   /** Name of the entity */
   entityName?: string | undefined;
   /** Version ID of the entity that produced this signal (e.g., agent version, workflow version) */
@@ -1978,11 +1961,11 @@ type Shared_Type_82 = {
   /** Environment (e.g., "production" | "staging" | "development") */
   environment?: string | undefined;
   /** Entity type of the parent entity */
-  parentEntityType?: Shared_Type_71 | undefined;
+  parentEntityType?: Shared_Type_70 | undefined;
   /** Name of the parent entity */
   parentEntityName?: string | undefined;
   /** Entity type of the root entity */
-  rootEntityType?: Shared_Type_71 | undefined;
+  rootEntityType?: Shared_Type_70 | undefined;
   /** Name of the root entity */
   rootEntityName?: string | undefined;
   /** Broader resource context (Mastra memory compatibility) */
@@ -2019,7 +2002,7 @@ type Shared_Type_82 = {
     | undefined;
 };
 
-type Shared_Type_83 = {
+type Shared_Type_82 = {
   /** Part type - text for TextParts */
   kind: 'text';
   /** Text content */
@@ -2032,7 +2015,7 @@ type Shared_Type_83 = {
     | undefined;
 };
 
-type Shared_Type_84 = {
+type Shared_Type_83 = {
   /** base64 encoded content of the file */
   bytes: string;
   /** Optional mimeType for the file */
@@ -2041,7 +2024,7 @@ type Shared_Type_84 = {
   name?: string | undefined;
 };
 
-type Shared_Type_85 = {
+type Shared_Type_84 = {
   /** URL for the File content */
   uri: string;
   /** Optional mimeType for the file */
@@ -2050,11 +2033,11 @@ type Shared_Type_85 = {
   name?: string | undefined;
 };
 
-type Shared_Type_86 = {
+type Shared_Type_85 = {
   /** Part type - file for FileParts */
   kind: 'file';
   /** File content either as url or bytes */
-  file: Shared_Type_84 | Shared_Type_85;
+  file: Shared_Type_83 | Shared_Type_84;
   /** Optional metadata associated with the part */
   metadata?:
     | {
@@ -2063,7 +2046,7 @@ type Shared_Type_86 = {
     | undefined;
 };
 
-type Shared_Type_87 = {
+type Shared_Type_86 = {
   /** Part type - data for DataParts */
   kind: 'data';
   /** Structured data content */
@@ -2078,7 +2061,7 @@ type Shared_Type_87 = {
     | undefined;
 };
 
-type Shared_Type_88 = {
+type Shared_Type_87 = {
   text?: string | undefined;
   raw?: string | undefined;
   url?: string | undefined;
@@ -2092,7 +2075,7 @@ type Shared_Type_88 = {
     | undefined;
 };
 
-type Shared_Type_89 = {
+type Shared_Type_88 = {
   /** Event type */
   kind?: 'message' | undefined;
   /** Identifier created by the message creator */
@@ -2100,7 +2083,7 @@ type Shared_Type_89 = {
   /** Message sender's role */
   role: 'user' | 'agent' | 'ROLE_USER' | 'ROLE_AGENT';
   /** Message content */
-  parts: ((Shared_Type_83 | Shared_Type_86 | Shared_Type_87) | Shared_Type_88)[];
+  parts: ((Shared_Type_82 | Shared_Type_85 | Shared_Type_86) | Shared_Type_87)[];
   /** The context the message is associated with */
   contextId?: string | undefined;
   /** Identifier of task the message is related to */
@@ -2117,24 +2100,24 @@ type Shared_Type_89 = {
     | undefined;
 };
 
-type Shared_Type_90 = {
+type Shared_Type_89 = {
   /** Supported authentication schemes - e.g. Basic, Bearer */
   schemes: string[];
   /** Optional credentials */
   credentials?: string | undefined;
 };
 
-type Shared_Type_91 = {
+type Shared_Type_90 = {
   /** URL for sending the push notifications */
   url: string;
   /** Push Notification ID - created by server to support multiple callbacks */
   id?: string | undefined;
   /** Token unique to this task/session */
   token?: string | undefined;
-  authentication?: Shared_Type_90 | undefined;
+  authentication?: Shared_Type_89 | undefined;
 };
 
-type Shared_Type_92 = {
+type Shared_Type_91 = {
   /** Accepted output modalities by the client */
   acceptedOutputModes?: string[] | undefined;
   /** If the server should treat the client as a blocking request */
@@ -2143,13 +2126,13 @@ type Shared_Type_92 = {
   returnImmediately?: boolean | undefined;
   /** Number of recent messages to be retrieved */
   historyLength?: number | undefined;
-  pushNotificationConfig?: Shared_Type_91 | undefined;
-  taskPushNotificationConfig?: Shared_Type_91 | undefined;
+  pushNotificationConfig?: Shared_Type_90 | undefined;
+  taskPushNotificationConfig?: Shared_Type_90 | undefined;
 };
 
-type Shared_Type_93 = {
-  message: Shared_Type_89;
-  configuration?: Shared_Type_92 | undefined;
+type Shared_Type_92 = {
+  message: Shared_Type_88;
+  configuration?: Shared_Type_91 | undefined;
   /** Extension metadata */
   metadata?:
     | {
@@ -2158,7 +2141,7 @@ type Shared_Type_93 = {
     | undefined;
 };
 
-type Shared_Type_94 = {
+type Shared_Type_93 = {
   name: string;
   description?: string | undefined;
   inputSchema: unknown;
@@ -2171,7 +2154,7 @@ type Shared_Type_94 = {
     | undefined;
 };
 
-type Shared_Type_95 =
+type Shared_Type_94 =
   | (
       | (
           | {
@@ -2186,7 +2169,7 @@ type Shared_Type_95 =
     )
   | undefined;
 
-type Shared_Type_96 =
+type Shared_Type_95 =
   | (
       | (
           | Shared_Type_4
@@ -2200,7 +2183,7 @@ type Shared_Type_96 =
     )
   | undefined;
 
-type Shared_Type_97 =
+type Shared_Type_96 =
   | (
       | (
           | {
@@ -2217,7 +2200,7 @@ type Shared_Type_97 =
     )
   | undefined;
 
-type Shared_Type_98 =
+type Shared_Type_97 =
   | (
       | (
           | {
@@ -2234,7 +2217,7 @@ type Shared_Type_98 =
     )
   | undefined;
 
-type Shared_Type_99 =
+type Shared_Type_98 =
   | (
       | (
           | {
@@ -2251,7 +2234,7 @@ type Shared_Type_99 =
     )
   | undefined;
 
-type Shared_Type_100 =
+type Shared_Type_99 =
   | (
       | (
           | (
@@ -2271,7 +2254,7 @@ type Shared_Type_100 =
     )
   | undefined;
 
-type Shared_Type_101 = {
+type Shared_Type_100 = {
   /** Unique identifier for the version (UUID) */
   id: string;
   /** ID of the agent this version belongs to */
@@ -2408,7 +2391,7 @@ type Shared_Type_101 = {
   createdAt: Date;
 };
 
-type Shared_Type_102 = {
+type Shared_Type_101 = {
   /** The field path that changed */
   field: string;
   /** The value in the "from" version */
@@ -2417,7 +2400,7 @@ type Shared_Type_102 = {
   currentValue: unknown;
 };
 
-type Shared_Type_103 = {
+type Shared_Type_102 = {
   id: string;
   description?: string | undefined;
   metadata?:
@@ -2437,7 +2420,7 @@ type Shared_Type_103 = {
   updatedAt: Date | string;
 };
 
-type Shared_Type_104 = {
+type Shared_Type_103 = {
   type: 'agent';
   id: string;
   agentId: string;
@@ -2459,7 +2442,7 @@ type Shared_Type_104 = {
     | undefined;
 };
 
-type Shared_Type_105 = {
+type Shared_Type_104 = {
   type: 'tool';
   id: string;
   toolId: string;
@@ -2476,9 +2459,9 @@ type Shared_Type_105 = {
     | undefined;
 };
 
-type Shared_Type_106 =
+type Shared_Type_105 =
+  | Shared_Type_103
   | Shared_Type_104
-  | Shared_Type_105
   | {
       type: 'mapping';
       id: string;
@@ -2491,11 +2474,11 @@ type Shared_Type_106 =
       description?: string | undefined;
     };
 
-type Shared_Type_107 = {
+type Shared_Type_106 = {
   type: 'foreach';
   step:
+    | Shared_Type_103
     | Shared_Type_104
-    | Shared_Type_105
     | {
         type: 'workflow';
         id: string;
@@ -2509,9 +2492,9 @@ type Shared_Type_107 = {
     | undefined;
 };
 
-type Shared_Type_108 =
+type Shared_Type_107 =
+  | Shared_Type_103
   | Shared_Type_104
-  | Shared_Type_105
   | {
       type: 'mapping';
       id: string;
@@ -2525,9 +2508,9 @@ type Shared_Type_108 =
     }
   | {
       type: 'parallel';
-      steps: Shared_Type_106[];
+      steps: Shared_Type_105[];
     }
-  | Shared_Type_107
+  | Shared_Type_106
   | {
       type: 'sleep';
       id: string;
@@ -2540,17 +2523,17 @@ type Shared_Type_108 =
     }
   | {
       type: 'conditional';
-      steps: Shared_Type_106[];
-      predicates: Shared_Auxiliary_1097[];
+      steps: Shared_Type_105[];
+      predicates: Shared_Auxiliary_1096[];
     }
   | {
       type: 'loop';
-      step: Shared_Type_106;
+      step: Shared_Type_105;
       loopType: 'dowhile' | 'dountil';
-      predicate: Shared_Auxiliary_1097;
+      predicate: Shared_Auxiliary_1096;
     };
 
-type Shared_Type_109 = {
+type Shared_Type_108 = {
   /** Transport type: stdio for local processes, http for remote servers */
   type: 'stdio' | 'http';
   /** Command to run (stdio only) */
@@ -2569,7 +2552,7 @@ type Shared_Type_109 = {
   timeout?: number | undefined;
 };
 
-type Shared_Type_110 = {
+type Shared_Type_109 = {
   id: string;
   /** MCP client status: draft, published, or archived */
   status: string;
@@ -2588,11 +2571,11 @@ type Shared_Type_110 = {
   description?: string | undefined;
   /** Map of server name to server configuration */
   servers: {
-    [key: string]: Shared_Type_109;
+    [key: string]: Shared_Type_108;
   };
 };
 
-type Shared_Type_111 = {
+type Shared_Type_110 = {
   type: 'stdio' | 'http';
   command?: string | undefined;
   args?: string[] | undefined;
@@ -2605,7 +2588,7 @@ type Shared_Type_111 = {
   timeout?: number | undefined;
 };
 
-type Shared_Type_112 = {
+type Shared_Type_111 = {
   /** Unique identifier for the version (UUID) */
   id: string;
   /** ID of the MCP client this version belongs to */
@@ -2617,7 +2600,7 @@ type Shared_Type_112 = {
   /** Description of the MCP client */
   description?: string | undefined;
   servers: {
-    [key: string]: Shared_Type_111;
+    [key: string]: Shared_Type_110;
   };
   /** Array of field names that changed from the previous version */
   changedFields?: string[] | undefined;
@@ -2627,7 +2610,7 @@ type Shared_Type_112 = {
   createdAt: Date;
 };
 
-type Shared_Type_113 = {
+type Shared_Type_112 = {
   id: string;
   /** Prompt block status: draft, published, or archived */
   status: string;
@@ -2658,7 +2641,7 @@ type Shared_Type_113 = {
     | undefined;
 };
 
-type Shared_Type_114 = {
+type Shared_Type_113 = {
   /** Unique identifier for the version (UUID) */
   id: string;
   /** ID of the prompt block this version belongs to */
@@ -2687,7 +2670,7 @@ type Shared_Type_114 = {
   createdAt: Date;
 };
 
-type Shared_Type_115 =
+type Shared_Type_114 =
   | 'llm-judge'
   | 'answer-relevancy'
   | 'answer-similarity'
@@ -2701,7 +2684,7 @@ type Shared_Type_115 =
   | 'tool-call-accuracy'
   | 'toxicity';
 
-type Shared_Type_116 = {
+type Shared_Type_115 = {
   id: string;
   /** Scorer status: draft, published, or archived */
   status: string;
@@ -2719,7 +2702,7 @@ type Shared_Type_116 = {
   /** Description of the scorer */
   description?: string | undefined;
   /** Scorer type: llm-judge for custom, or a preset type name */
-  type: Shared_Type_115;
+  type: Shared_Type_114;
   model?: Shared_Type_11 | undefined;
   /** System instructions for the judge LLM */
   instructions?: string | undefined;
@@ -2747,7 +2730,7 @@ type Shared_Type_116 = {
     | undefined;
 };
 
-type Shared_Type_117 =
+type Shared_Type_116 =
   | {
       /** Minimum score value (default: 0) */
       min?: number | undefined;
@@ -2756,7 +2739,7 @@ type Shared_Type_117 =
     }
   | undefined;
 
-type Shared_Type_118 = {
+type Shared_Type_117 = {
   /** Unique identifier for the version (UUID) */
   id: string;
   /** ID of the scorer this version belongs to */
@@ -2767,7 +2750,7 @@ type Shared_Type_118 = {
   name: string;
   /** Description of the scorer */
   description?: string | undefined;
-  type: Shared_Type_115;
+  type: Shared_Type_114;
   model?: Shared_Type_11 | undefined;
   instructions?: string | undefined;
   scoreRange?:
@@ -2800,7 +2783,7 @@ type Shared_Type_118 = {
   createdAt: Date;
 };
 
-type Shared_Type_119 = {
+type Shared_Type_118 = {
   id: string;
   /** Workspace status: draft, published, or archived */
   status: string;
@@ -2835,7 +2818,7 @@ type Shared_Type_119 = {
   operationTimeout?: number | undefined;
 };
 
-type Shared_Type_120 =
+type Shared_Type_119 =
   | {
       type: 'external';
       /** Package path for external source */
@@ -2852,7 +2835,7 @@ type Shared_Type_120 =
       mastraPath: string;
     };
 
-type Shared_Type_121 = {
+type Shared_Type_120 = {
   id: string;
   /** Skill status: draft, published, or archived */
   status: string;
@@ -2876,7 +2859,7 @@ type Shared_Type_121 = {
   /** Compatibility requirements */
   compatibility?: unknown | undefined;
   /** Source location of the skill */
-  source?: Shared_Type_120 | undefined;
+  source?: Shared_Type_119 | undefined;
   /** List of reference file paths */
   references?: string[] | undefined;
   /** List of script file paths */
@@ -2884,7 +2867,7 @@ type Shared_Type_121 = {
   /** List of asset file paths */
   assets?: string[] | undefined;
   /** Full file tree structure for the skill */
-  files?: Shared_Auxiliary_1238[] | undefined;
+  files?: Shared_Auxiliary_1237[] | undefined;
   /** Additional metadata for the skill */
   metadata?:
     | {
@@ -2893,7 +2876,7 @@ type Shared_Type_121 = {
     | undefined;
 };
 
-type Shared_Type_122 = {
+type Shared_Type_121 = {
   id: string;
   name: string;
   description?: (string | undefined) | null;
@@ -2929,7 +2912,7 @@ type Shared_Type_122 = {
   updatedAt: Date;
 };
 
-type Shared_Type_123 = {
+type Shared_Type_122 = {
   /** Name of the tool this mock applies to */
   toolName: string;
   /** Arguments to match against the tool call */
@@ -2942,14 +2925,14 @@ type Shared_Type_123 = {
   matchArgs?: ('strict' | 'ignore') | undefined;
 };
 
-type Shared_Type_124 = {
+type Shared_Type_123 = {
   /** How this item was created */
   type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener';
   /** Reference identifier (e.g., trace id, csv filename) */
   referenceId?: string | undefined;
 };
 
-type Shared_Type_125 = {
+type Shared_Type_124 = {
   id: string;
   datasetId: string;
   datasetVersion: number;
@@ -2958,7 +2941,7 @@ type Shared_Type_125 = {
   groundTruth?: unknown | undefined;
   expectedTrajectory?: unknown | undefined;
   /** Ordered item-level static tool mocks served in place of executing the real tool */
-  toolMocks?: Shared_Type_123[] | undefined;
+  toolMocks?: Shared_Type_122[] | undefined;
   /** Policy for undeclared tool calls. 'allow' runs them live; 'deny' fails the experiment item */
   unmockedToolPolicy?: ('allow' | 'deny') | undefined;
   scorerIds?: string[] | undefined;
@@ -2973,12 +2956,12 @@ type Shared_Type_125 = {
       }
     | undefined;
   /** Source/provenance of this dataset item */
-  source?: Shared_Type_124 | undefined;
+  source?: Shared_Type_123 | undefined;
   createdAt: Date;
   updatedAt: Date;
 };
 
-type Shared_Type_126 = {
+type Shared_Type_125 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3003,7 +2986,7 @@ type Shared_Type_126 = {
   success?: boolean | undefined;
 };
 
-type Shared_Type_127 = {
+type Shared_Type_126 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3029,7 +3012,7 @@ type Shared_Type_127 = {
   success?: boolean | undefined;
 };
 
-type Shared_Type_128 = {
+type Shared_Type_127 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3047,7 +3030,7 @@ type Shared_Type_128 = {
   finishReason?: string | undefined;
 };
 
-type Shared_Type_129 = {
+type Shared_Type_128 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3062,7 +3045,7 @@ type Shared_Type_129 = {
   agentId?: string | undefined;
 };
 
-type Shared_Type_130 = {
+type Shared_Type_129 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3083,7 +3066,7 @@ type Shared_Type_130 = {
     | undefined;
 };
 
-type Shared_Type_131 = {
+type Shared_Type_130 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3099,7 +3082,7 @@ type Shared_Type_131 = {
   status?: string | undefined;
 };
 
-type Shared_Type_132 = {
+type Shared_Type_131 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3115,7 +3098,7 @@ type Shared_Type_132 = {
   selectedSteps?: string[] | undefined;
 };
 
-type Shared_Type_133 = {
+type Shared_Type_132 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3131,7 +3114,7 @@ type Shared_Type_133 = {
   parallelSteps?: string[] | undefined;
 };
 
-type Shared_Type_134 = {
+type Shared_Type_133 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3147,7 +3130,7 @@ type Shared_Type_134 = {
   totalIterations?: number | undefined;
 };
 
-type Shared_Type_135 = {
+type Shared_Type_134 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3163,7 +3146,7 @@ type Shared_Type_135 = {
   sleepType?: string | undefined;
 };
 
-type Shared_Type_136 = {
+type Shared_Type_135 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3179,7 +3162,7 @@ type Shared_Type_136 = {
   eventReceived?: boolean | undefined;
 };
 
-type Shared_Type_137 = {
+type Shared_Type_136 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3194,7 +3177,8 @@ type Shared_Type_137 = {
   processorId?: string | undefined;
 };
 
-type Shared_Type_138 =
+type Shared_Type_137 =
+  | Shared_Type_125
   | Shared_Type_126
   | Shared_Type_127
   | Shared_Type_128
@@ -3205,10 +3189,9 @@ type Shared_Type_138 =
   | Shared_Type_133
   | Shared_Type_134
   | Shared_Type_135
-  | Shared_Type_136
-  | Shared_Type_137;
+  | Shared_Type_136;
 
-type Shared_Type_139 = {
+type Shared_Type_138 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3222,9 +3205,9 @@ type Shared_Type_139 = {
   stepType?: undefined | undefined;
 };
 
-type Shared_Type_140 = {
+type Shared_Type_139 = {
   /** Expected steps for accuracy checking */
-  steps?: (Shared_Type_138 | Shared_Type_139)[] | undefined;
+  steps?: (Shared_Type_137 | Shared_Type_138)[] | undefined;
   /** How to compare step ordering (default: relaxed) */
   ordering?: ('strict' | 'relaxed' | 'unordered') | undefined;
   /** Whether to allow repeated steps (default: true) */
@@ -3245,7 +3228,7 @@ type Shared_Type_140 = {
   maxRetriesPerTool?: number | undefined;
 };
 
-type Shared_Type_141 = {
+type Shared_Type_140 = {
   source?: string | undefined;
   sourceId?: string | undefined;
   sourceVersion?: string | undefined;
@@ -3256,7 +3239,7 @@ type Shared_Type_141 = {
     | undefined;
 };
 
-type Shared_Type_142 = {
+type Shared_Type_141 = {
   id: string;
   datasetId: string | null;
   datasetVersion: number | null;
@@ -3271,7 +3254,7 @@ type Shared_Type_142 = {
         [key: string]: unknown;
       }
     | undefined;
-  provenance?: (Shared_Type_141 | null) | undefined;
+  provenance?: (Shared_Type_140 | null) | undefined;
   runnerAttestation?:
     | ({
         runnerId: string;
@@ -3294,7 +3277,7 @@ type Shared_Type_142 = {
   updatedAt: Date;
 };
 
-type Shared_Type_143 = {
+type Shared_Type_142 = {
   served: {
     mockIndex: number;
     toolName: string;
@@ -3318,7 +3301,7 @@ type Shared_Type_143 = {
     | undefined;
 };
 
-type Shared_Type_144 = {
+type Shared_Type_143 = {
   id: string;
   experimentId: string;
   itemId: string;
@@ -3349,11 +3332,11 @@ type Shared_Type_144 = {
   tags?: (string[] | null) | undefined;
   comment?: (string | null) | undefined;
   /** Diagnostic receipt for item-level tool mocks */
-  toolMockReport?: (Shared_Type_143 | undefined) | null;
+  toolMockReport?: (Shared_Type_142 | undefined) | null;
   createdAt: Date;
 };
 
-type Shared_Type_145 = {
+type Shared_Type_144 = {
   id: string;
   status: 'pending' | 'running' | 'suspended' | 'completed' | 'failed' | 'cancelled' | 'timed_out';
   toolName: string;
@@ -3381,21 +3364,21 @@ type Shared_Type_145 = {
   suspendPayload?: unknown | undefined;
 };
 
+type Shared_Type_145 =
+  | {
+      kind: 'custom';
+      provider: string;
+      modelId?: string | undefined;
+    }
+  | {
+      provider: string;
+      modelId?: string | undefined;
+    };
+
 type Shared_Type_146 =
   | {
       kind: 'custom';
       provider: string;
-      modelId?: string | undefined;
-    }
-  | {
-      provider: string;
-      modelId?: string | undefined;
-    };
-
-type Shared_Type_147 =
-  | {
-      kind: 'custom';
-      provider: string;
       modelId: string;
     }
   | {
@@ -3403,7 +3386,7 @@ type Shared_Type_147 =
       modelId: string;
     };
 
-type Shared_Type_148 = {
+type Shared_Type_147 = {
   behavior?: ('deliver' | 'persist' | 'discard') | undefined;
   attributes?:
     | {
@@ -3412,7 +3395,7 @@ type Shared_Type_148 = {
     | undefined;
 };
 
-type Shared_Type_149 = {
+type Shared_Type_148 = {
   behavior?: ('wake' | 'persist' | 'discard') | undefined;
   attributes?:
     | {
@@ -3430,7 +3413,7 @@ type Shared_Type_149 = {
     | undefined;
 };
 
-type Shared_Type_150 = {
+type Shared_Type_149 = {
   id: string;
   agentId: string;
   workflowId?: undefined | undefined;
@@ -3452,8 +3435,8 @@ type Shared_Type_150 = {
         [key: string]: (string | number | boolean | null) | undefined;
       }
     | undefined;
-  ifActive?: Shared_Type_148 | undefined;
-  ifIdle?: Shared_Type_149 | undefined;
+  ifActive?: Shared_Type_147 | undefined;
+  ifIdle?: Shared_Type_148 | undefined;
   providerOptions?:
     | {
         [key: string]: unknown;
@@ -3468,7 +3451,7 @@ type Shared_Type_150 = {
   updatedAt: number;
 };
 
-type Shared_Type_151 = {
+type Shared_Type_150 = {
   status:
     | 'running'
     | 'success'
@@ -3487,7 +3470,7 @@ type Shared_Type_151 = {
   error?: string | undefined;
 };
 
-type Shared_Type_152 = {
+type Shared_Type_151 = {
   id: string;
   workflowId: string;
   agentId?: undefined | undefined;
@@ -3497,7 +3480,7 @@ type Shared_Type_152 = {
   nextFireAt: number;
   lastFireAt?: number | undefined;
   lastRunId?: string | undefined;
-  lastRun?: Shared_Type_151 | undefined;
+  lastRun?: Shared_Type_150 | undefined;
   inputData?: unknown | undefined;
   initialState?: unknown | undefined;
   requestContext?:
@@ -3717,7 +3700,13 @@ export type PostAgentsAgentIdGenerate_Body = {
   maxSteps?: number | undefined;
   stopWhen?: unknown | undefined;
   model?: string | undefined;
-  providerOptions?: Shared_Type_45 | undefined;
+  providerOptions?:
+    | {
+        [key: string]: {
+          [key: string]: Shared_Auxiliary_272;
+        };
+      }
+    | undefined;
   modelSettings?: unknown | undefined;
   activeTools?: string[] | undefined;
   toolsets?:
@@ -3754,9 +3743,9 @@ export type PostAgentsAgentIdGenerate_Body = {
       )
     | undefined;
   returnScorerData?: boolean | undefined;
-  tracingOptions?: Shared_Type_46 | undefined;
+  tracingOptions?: Shared_Type_45 | undefined;
   output?: unknown | undefined;
-  structuredOutput?: Shared_Type_47 | undefined;
+  structuredOutput?: Shared_Type_46 | undefined;
   untilIdle?:
     | (
         | boolean
@@ -3869,7 +3858,13 @@ export type PostAgentsAgentIdStreamUntilIdle_Body = {
   maxSteps?: number | undefined;
   stopWhen?: unknown | undefined;
   model?: string | undefined;
-  providerOptions?: Shared_Type_45 | undefined;
+  providerOptions?:
+    | {
+        [key: string]: {
+          [key: string]: Shared_Auxiliary_272;
+        };
+      }
+    | undefined;
   modelSettings?: unknown | undefined;
   activeTools?: string[] | undefined;
   toolsets?:
@@ -3906,9 +3901,9 @@ export type PostAgentsAgentIdStreamUntilIdle_Body = {
       )
     | undefined;
   returnScorerData?: boolean | undefined;
-  tracingOptions?: Shared_Type_46 | undefined;
+  tracingOptions?: Shared_Type_45 | undefined;
   output?: unknown | undefined;
-  structuredOutput?: Shared_Type_47 | undefined;
+  structuredOutput?: Shared_Type_46 | undefined;
   untilIdle?:
     | (
         | boolean
@@ -4017,20 +4012,20 @@ export type PostAgentsAgentIdSendMessage_PathParams = GetAgentsAgentId_PathParam
 
 export type PostAgentsAgentIdSendMessage_Body =
   | {
-      ifActive?: Shared_Type_48 | undefined;
+      ifActive?: Shared_Type_47 | undefined;
       runId: string;
       resourceId?: string | undefined;
       threadId?: string | undefined;
       ifIdle?: undefined | undefined;
-      message: (string | (Shared_Type_49 | Shared_Type_50)[]) | Shared_Type_51;
+      message: (string | (Shared_Type_48 | Shared_Type_49)[]) | Shared_Type_50;
     }
   | {
-      ifActive?: Shared_Type_48 | undefined;
+      ifActive?: Shared_Type_47 | undefined;
       runId?: undefined | undefined;
       resourceId: string;
       threadId: string;
-      ifIdle?: Shared_Type_53 | undefined;
-      message: (string | (Shared_Type_49 | Shared_Type_50)[]) | Shared_Type_51;
+      ifIdle?: Shared_Type_52 | undefined;
+      message: (string | (Shared_Type_48 | Shared_Type_49)[]) | Shared_Type_50;
     };
 
 export type PostAgentsAgentIdSendMessage_Response = {
@@ -4093,20 +4088,20 @@ export type PostAgentsAgentIdSignals_PathParams = GetAgentsAgentId_PathParams;
 
 export type PostAgentsAgentIdSignals_Body =
   | {
-      ifActive?: Shared_Type_48 | undefined;
+      ifActive?: Shared_Type_47 | undefined;
       runId: string;
       resourceId?: string | undefined;
       threadId?: string | undefined;
       ifIdle?: undefined | undefined;
-      signal: Shared_Type_54 | Shared_Type_55;
+      signal: Shared_Type_53 | Shared_Type_54;
     }
   | {
-      ifActive?: Shared_Type_48 | undefined;
+      ifActive?: Shared_Type_47 | undefined;
       runId?: undefined | undefined;
       resourceId: string;
       threadId: string;
-      ifIdle?: Shared_Type_53 | undefined;
-      signal: Shared_Type_54 | Shared_Type_55;
+      ifIdle?: Shared_Type_52 | undefined;
+      signal: Shared_Type_53 | Shared_Type_54;
     };
 
 export type PostAgentsAgentIdSignals_Response = PostAgentsAgentIdSendMessage_Response;
@@ -4438,7 +4433,13 @@ export type PostAgentsAgentIdResumeStream_Body = {
   maxSteps?: number | undefined;
   stopWhen?: unknown | undefined;
   model?: string | undefined;
-  providerOptions?: Shared_Type_45 | undefined;
+  providerOptions?:
+    | {
+        [key: string]: {
+          [key: string]: Shared_Auxiliary_272;
+        };
+      }
+    | undefined;
   modelSettings?: unknown | undefined;
   activeTools?: string[] | undefined;
   toolsets?:
@@ -4475,9 +4476,9 @@ export type PostAgentsAgentIdResumeStream_Body = {
       )
     | undefined;
   returnScorerData?: boolean | undefined;
-  tracingOptions?: Shared_Type_46 | undefined;
+  tracingOptions?: Shared_Type_45 | undefined;
   output?: unknown | undefined;
-  structuredOutput?: Shared_Type_47 | undefined;
+  structuredOutput?: Shared_Type_46 | undefined;
   untilIdle?:
     | (
         | boolean
@@ -4723,7 +4724,13 @@ export type PostAgentsAgentIdResumeStreamUntilIdle_Body = {
   maxSteps?: number | undefined;
   stopWhen?: unknown | undefined;
   model?: string | undefined;
-  providerOptions?: Shared_Type_45 | undefined;
+  providerOptions?:
+    | {
+        [key: string]: {
+          [key: string]: Shared_Auxiliary_272;
+        };
+      }
+    | undefined;
   modelSettings?: unknown | undefined;
   activeTools?: string[] | undefined;
   toolsets?:
@@ -4760,9 +4767,9 @@ export type PostAgentsAgentIdResumeStreamUntilIdle_Body = {
       )
     | undefined;
   returnScorerData?: boolean | undefined;
-  tracingOptions?: Shared_Type_46 | undefined;
+  tracingOptions?: Shared_Type_45 | undefined;
   output?: unknown | undefined;
-  structuredOutput?: Shared_Type_47 | undefined;
+  structuredOutput?: Shared_Type_46 | undefined;
   untilIdle?:
     | (
         | boolean
@@ -5391,7 +5398,7 @@ export interface PostAgentsAgentIdStreamUi_RouteContract {
 export type GetAuthCapabilities_Response =
   | {
       enabled: boolean;
-      login: Shared_Type_56 | null;
+      login: Shared_Type_55 | null;
       user: {
         id: string;
         email?: string | undefined;
@@ -5412,7 +5419,7 @@ export type GetAuthCapabilities_Response =
     }
   | {
       enabled: boolean;
-      login: Shared_Type_56 | null;
+      login: Shared_Type_55 | null;
     };
 
 export type GetAuthCapabilities_Request = Simplify<
@@ -5660,7 +5667,7 @@ export interface GetAuthPermissionPatterns_RouteContract {
 export type GetWorkflows_QueryParams = GetAgents_QueryParams;
 
 export type GetWorkflows_Response = {
-  [key: string]: Shared_Type_58;
+  [key: string]: Shared_Type_57;
 };
 
 export type GetWorkflows_Request = Simplify<
@@ -5715,7 +5722,7 @@ export type GetWorkflowsWorkflowId_PathParams = {
   workflowId: string;
 };
 
-export type GetWorkflowsWorkflowId_Response = Shared_Type_58;
+export type GetWorkflowsWorkflowId_Response = Shared_Type_57;
 
 export type GetWorkflowsWorkflowId_Request = Simplify<
   (GetWorkflowsWorkflowId_PathParams extends never ? {} : { params: GetWorkflowsWorkflowId_PathParams }) &
@@ -5976,7 +5983,7 @@ export type PostWorkflowsWorkflowIdStream_Body = {
         [key: string]: unknown;
       }
     | undefined;
-  tracingOptions?: Shared_Type_46 | undefined;
+  tracingOptions?: Shared_Type_45 | undefined;
   perStep?: boolean | undefined;
   closeOnSuspend?: boolean | undefined;
 };
@@ -6019,7 +6026,7 @@ export type PostWorkflowsWorkflowIdResumeStream_Body = {
         [key: string]: unknown;
       }
     | undefined;
-  tracingOptions?: Shared_Type_46 | undefined;
+  tracingOptions?: Shared_Type_45 | undefined;
   perStep?: boolean | undefined;
   forEachIndex?: number | undefined;
 };
@@ -6067,7 +6074,7 @@ export type PostWorkflowsWorkflowIdStartAsync_Body = {
         [key: string]: unknown;
       }
     | undefined;
-  tracingOptions?: Shared_Type_46 | undefined;
+  tracingOptions?: Shared_Type_45 | undefined;
   perStep?: boolean | undefined;
 };
 
@@ -6373,7 +6380,7 @@ export type PostWorkflowsWorkflowIdTimeTravel_Body = {
         [key: string]: unknown;
       }
     | undefined;
-  tracingOptions?: Shared_Type_46 | undefined;
+  tracingOptions?: Shared_Type_45 | undefined;
   perStep?: boolean | undefined;
 };
 
@@ -6487,7 +6494,7 @@ export type PostWorkflowsWorkflowIdRestart_Body = {
         [key: string]: unknown;
       }
     | undefined;
-  tracingOptions?: Shared_Type_46 | undefined;
+  tracingOptions?: Shared_Type_45 | undefined;
 };
 
 export type PostWorkflowsWorkflowIdRestart_Response = PostAgentsAgentIdModel_Response;
@@ -6847,7 +6854,7 @@ export type PostProcessorsProcessorIdExecute_PathParams = GetProcessorsProcessor
 
 export type PostProcessorsProcessorIdExecute_Body = {
   phase: 'input' | 'inputStep' | 'outputStream' | 'outputResult' | 'outputStep' | 'toolResult';
-  messages: Shared_Type_59[];
+  messages: Shared_Type_58[];
   agentId?: string | undefined;
   requestContext?:
     | {
@@ -6859,10 +6866,10 @@ export type PostProcessorsProcessorIdExecute_Body = {
 export type PostProcessorsProcessorIdExecute_Response = {
   success: boolean;
   phase: string;
-  messages?: Shared_Type_59[] | undefined;
+  messages?: Shared_Type_58[] | undefined;
   messageList?:
     | {
-        messages: Shared_Type_59[];
+        messages: Shared_Type_58[];
       }
     | undefined;
   tripwire?:
@@ -6924,13 +6931,13 @@ export type PostV1Responses_Body = {
               /** Requests JSON object output compatibility for the response */
               type: 'json_object';
             }
-          | Shared_Type_60;
+          | Shared_Type_59;
       }
     | undefined;
   /** Optional conversation ID. In Mastra this is the raw threadId. */
   conversation_id?: string | undefined;
   /** Optional provider-specific options passed through to the underlying model call */
-  providerOptions?: Shared_Type_61 | undefined;
+  providerOptions?: Shared_Type_60 | undefined;
   stream: boolean | undefined;
   store: boolean | undefined;
   previous_response_id?: string | undefined;
@@ -6957,7 +6964,7 @@ export type PostV1Responses_Response = {
           logprobs?: unknown[] | undefined;
         }[];
       }
-    | Shared_Type_62
+    | Shared_Type_61
     | {
         id: string;
         type: 'function_call_output';
@@ -6990,12 +6997,12 @@ export type PostV1Responses_Response = {
               /** Requests JSON object output compatibility for the response */
               type: 'json_object';
             }
-          | Shared_Type_60;
+          | Shared_Type_59;
       } | null)
     | undefined;
   previous_response_id?: (string | null) | undefined;
   conversation_id?: (string | null) | undefined;
-  providerOptions?: Shared_Type_61 | undefined;
+  providerOptions?: Shared_Type_60 | undefined;
   tools?:
     | {
         type: 'function';
@@ -7098,7 +7105,7 @@ export type PostV1Conversations_Body = {
 export type PostV1Conversations_Response = {
   id: string;
   object: 'conversation';
-  thread: Shared_Type_63;
+  thread: Shared_Type_62;
 };
 
 export type PostV1Conversations_Request = Simplify<
@@ -7173,7 +7180,7 @@ export type GetV1ConversationsConversationIdItems_Response = {
             }
         )[];
       }
-    | Shared_Type_62
+    | Shared_Type_61
     | {
         id: string;
         type: 'function_call_output';
@@ -7373,8 +7380,8 @@ export type GetMemoryObservationalMemory_QueryParams = {
 };
 
 export type GetMemoryObservationalMemory_Response = {
-  record: Shared_Type_65 | null;
-  history?: Shared_Type_65[] | undefined;
+  record: Shared_Type_64 | null;
+  history?: Shared_Type_64[] | undefined;
 };
 
 export type GetMemoryObservationalMemory_Request = Simplify<
@@ -7402,7 +7409,7 @@ export interface GetMemoryObservationalMemory_RouteContract {
 export type PostMemoryObservationalMemoryBufferStatus_Body = GetMemoryStatus_QueryParams;
 
 export type PostMemoryObservationalMemoryBufferStatus_Response = {
-  record: Shared_Type_65 | null;
+  record: Shared_Type_64 | null;
 };
 
 export type PostMemoryObservationalMemoryBufferStatus_Request = Simplify<
@@ -7453,7 +7460,7 @@ export type GetMemoryThreads_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  threads: Shared_Type_63[];
+  threads: Shared_Type_62[];
 };
 
 export type GetMemoryThreads_Request = Simplify<
@@ -7488,7 +7495,7 @@ export type GetMemoryThreadsThreadId_QueryParams = {
   resourceId?: string | undefined;
 };
 
-export type GetMemoryThreadsThreadId_Response = Shared_Type_63;
+export type GetMemoryThreadsThreadId_Response = Shared_Type_62;
 
 export type GetMemoryThreadsThreadId_Request = Simplify<
   (GetMemoryThreadsThreadId_PathParams extends never ? {} : { params: GetMemoryThreadsThreadId_PathParams }) &
@@ -7536,7 +7543,7 @@ export type GetMemoryThreadsThreadIdMessages_QueryParams = {
         withNextMessages?: number | undefined;
       }[]
     | undefined;
-  filter?: Shared_Type_66 | undefined;
+  filter?: Shared_Type_65 | undefined;
   includeSystemReminders?: boolean | undefined;
 };
 
@@ -7790,7 +7797,7 @@ export type PostMemoryThreadsThreadIdClone_Body = {
 };
 
 export type PostMemoryThreadsThreadIdClone_Response = {
-  thread: Shared_Type_63;
+  thread: Shared_Type_62;
   clonedMessages: unknown[];
 };
 
@@ -8060,7 +8067,7 @@ export type GetMemoryNetworkThreadsThreadIdMessages_QueryParams = {
         withNextMessages?: number | undefined;
       }[]
     | undefined;
-  filter?: Shared_Type_66 | undefined;
+  filter?: Shared_Type_65 | undefined;
 };
 
 export type GetMemoryNetworkThreadsThreadIdMessages_Response = GetMemoryThreadsThreadIdMessages_Response;
@@ -8252,7 +8259,7 @@ export interface PostMemoryNetworkMessagesDelete_RouteContract {
 // Route: GET /scores/scorers
 // ============================================================================
 export type GetScoresScorers_Response = {
-  [key: string]: Shared_Type_68;
+  [key: string]: Shared_Type_67;
 };
 
 export type GetScoresScorers_Request = Simplify<
@@ -8278,7 +8285,7 @@ export type GetScoresScorersScorerId_PathParams = {
   scorerId: string;
 };
 
-export type GetScoresScorersScorerId_Response = Shared_Type_68 | null;
+export type GetScoresScorersScorerId_Response = Shared_Type_67 | null;
 
 export type GetScoresScorersScorerId_Request = Simplify<
   (GetScoresScorersScorerId_PathParams extends never ? {} : { params: GetScoresScorersScorerId_PathParams }) &
@@ -8434,18 +8441,18 @@ export interface PostScores_RouteContract {
 // Route: GET /observability/traces
 // ============================================================================
 export type GetObservabilityTraces_QueryParams = {
-  startedAt?: ((Shared_Type_69 | undefined) | undefined) | unknown;
-  endedAt?: ((Shared_Type_69 | undefined) | undefined) | unknown;
-  spanType?: (Shared_Type_70 | undefined) | undefined;
+  startedAt?: ((Shared_Type_68 | undefined) | undefined) | unknown;
+  endedAt?: ((Shared_Type_68 | undefined) | undefined) | unknown;
+  spanType?: (Shared_Type_69 | undefined) | undefined;
   /** Filter by trace ID (matches root span) */
   traceId?: (string | undefined) | undefined;
-  entityType?: ((Shared_Type_71 | null) | undefined) | undefined;
+  entityType?: ((Shared_Type_70 | null) | undefined) | undefined;
   entityId?: ((string | null) | undefined) | undefined;
   entityName?: ((string | null) | undefined) | undefined;
-  parentEntityType?: ((Shared_Type_71 | null) | undefined) | undefined;
+  parentEntityType?: ((Shared_Type_70 | null) | undefined) | undefined;
   parentEntityId?: ((string | null) | undefined) | undefined;
   parentEntityName?: ((string | null) | undefined) | undefined;
-  rootEntityType?: ((Shared_Type_71 | null) | undefined) | undefined;
+  rootEntityType?: ((Shared_Type_70 | null) | undefined) | undefined;
   rootEntityId?: ((string | null) | undefined) | undefined;
   rootEntityName?: ((string | null) | undefined) | undefined;
   userId?: ((string | null) | undefined) | undefined;
@@ -8487,7 +8494,7 @@ export type GetObservabilityTraces_QueryParams = {
   tags?: (((string[] | null) | undefined) | undefined) | unknown;
   status?: (('success' | 'error' | 'running') | undefined) | undefined;
   hasChildError?: (boolean | undefined) | undefined;
-  dateRange?: ((Shared_Type_69 | undefined) | undefined) | unknown;
+  dateRange?: ((Shared_Type_68 | undefined) | undefined) | unknown;
   name?: (string | undefined) | undefined;
   page?: (number | undefined) | undefined;
   perPage?: (number | undefined) | undefined;
@@ -8502,12 +8509,12 @@ export type GetObservabilityTraces_QueryParams = {
 };
 
 export type GetObservabilityTraces_Response = {
-  pagination?: Shared_Type_72 | undefined;
+  pagination?: Shared_Type_71 | undefined;
   /** Incremental polling metadata */
-  delta?: Shared_Type_73 | undefined;
+  delta?: Shared_Type_72 | undefined;
   /** Opaque cursor value for incremental polling */
   deltaCursor?: string | undefined;
-  spans: Shared_Type_74[];
+  spans: Shared_Type_73[];
 };
 
 export type GetObservabilityTraces_Request = Simplify<
@@ -8535,12 +8542,12 @@ export interface GetObservabilityTraces_RouteContract {
 export type GetObservabilityTracesLight_QueryParams = GetObservabilityTraces_QueryParams;
 
 export type GetObservabilityTracesLight_Response = {
-  pagination?: Shared_Type_72 | undefined;
+  pagination?: Shared_Type_71 | undefined;
   /** Incremental polling metadata */
-  delta?: Shared_Type_73 | undefined;
+  delta?: Shared_Type_72 | undefined;
   /** Opaque cursor value for incremental polling */
   deltaCursor?: string | undefined;
-  spans: Shared_Type_75[];
+  spans: Shared_Type_74[];
 };
 
 export type GetObservabilityTracesLight_Request = Simplify<
@@ -8566,18 +8573,18 @@ export interface GetObservabilityTracesLight_RouteContract {
 // Route: GET /observability/branches
 // ============================================================================
 export type GetObservabilityBranches_QueryParams = {
-  startedAt?: ((Shared_Type_69 | undefined) | undefined) | unknown;
-  endedAt?: ((Shared_Type_69 | undefined) | undefined) | unknown;
-  spanType?: (Shared_Type_70 | undefined) | undefined;
+  startedAt?: ((Shared_Type_68 | undefined) | undefined) | unknown;
+  endedAt?: ((Shared_Type_68 | undefined) | undefined) | unknown;
+  spanType?: (Shared_Type_69 | undefined) | undefined;
   /** Filter by parent trace ID */
   traceId?: (string | undefined) | undefined;
-  entityType?: ((Shared_Type_71 | null) | undefined) | undefined;
+  entityType?: ((Shared_Type_70 | null) | undefined) | undefined;
   entityId?: ((string | null) | undefined) | undefined;
   entityName?: ((string | null) | undefined) | undefined;
-  parentEntityType?: ((Shared_Type_71 | null) | undefined) | undefined;
+  parentEntityType?: ((Shared_Type_70 | null) | undefined) | undefined;
   parentEntityId?: ((string | null) | undefined) | undefined;
   parentEntityName?: ((string | null) | undefined) | undefined;
-  rootEntityType?: ((Shared_Type_71 | null) | undefined) | undefined;
+  rootEntityType?: ((Shared_Type_70 | null) | undefined) | undefined;
   rootEntityId?: ((string | null) | undefined) | undefined;
   rootEntityName?: ((string | null) | undefined) | undefined;
   userId?: ((string | null) | undefined) | undefined;
@@ -8631,12 +8638,12 @@ export type GetObservabilityBranches_QueryParams = {
 };
 
 export type GetObservabilityBranches_Response = {
-  pagination?: Shared_Type_72 | undefined;
+  pagination?: Shared_Type_71 | undefined;
   /** Incremental polling metadata */
-  delta?: Shared_Type_73 | undefined;
+  delta?: Shared_Type_72 | undefined;
   /** Opaque cursor value for incremental polling */
   deltaCursor?: string | undefined;
-  branches: Shared_Type_74[];
+  branches: Shared_Type_73[];
 };
 
 export type GetObservabilityBranches_Request = Simplify<
@@ -8676,7 +8683,7 @@ export type GetObservabilityTracesTraceIdBranchesSpanId_QueryParams = {
 export type GetObservabilityTracesTraceIdBranchesSpanId_Response = {
   /** Unique trace identifier */
   traceId: string;
-  spans: Shared_Type_76[];
+  spans: Shared_Type_75[];
 };
 
 export type GetObservabilityTracesTraceIdBranchesSpanId_Request = Simplify<
@@ -8711,7 +8718,7 @@ export type GetObservabilityTracesTraceId_PathParams = {
 export type GetObservabilityTracesTraceId_Response = {
   /** Unique trace identifier */
   traceId: string;
-  spans: Shared_Type_74[];
+  spans: Shared_Type_73[];
 };
 
 export type GetObservabilityTracesTraceId_Request = Simplify<
@@ -8737,7 +8744,7 @@ export type GetObservabilityTracesTraceIdLight_PathParams = GetObservabilityTrac
 export type GetObservabilityTracesTraceIdLight_Response = {
   /** Unique trace identifier */
   traceId: string;
-  spans: Shared_Type_75[];
+  spans: Shared_Type_74[];
 };
 
 export type GetObservabilityTracesTraceIdLight_Request = Simplify<
@@ -8765,7 +8772,7 @@ export type GetObservabilityTracesTraceIdSpansSpanId_PathParams =
 
 export type GetObservabilityTracesTraceIdSpansSpanId_Response = {
   /** Span record data */
-  span: Shared_Type_76;
+  span: Shared_Type_75;
 };
 
 export type GetObservabilityTracesTraceIdSpansSpanId_Request = Simplify<
@@ -8866,7 +8873,7 @@ export type GetObservabilityTracesTraceIdSpanIdScores_QueryParams = {
 };
 
 export type GetObservabilityTracesTraceIdSpanIdScores_Response = {
-  pagination: Shared_Type_72;
+  pagination: Shared_Type_71;
   scores: {
     id: string;
     scorerId: string;
@@ -9000,12 +9007,12 @@ export interface GetObservabilityTracesTraceIdSpanIdScores_RouteContract {
 // Route: GET /observability/metrics
 // ============================================================================
 export type GetObservabilityMetrics_QueryParams = {
-  timestamp?: ((Shared_Type_69 | undefined) | undefined) | unknown;
+  timestamp?: ((Shared_Type_68 | undefined) | undefined) | unknown;
   /** Filter by trace ID */
   traceId?: (string | undefined) | undefined;
   /** Filter by span ID */
   spanId?: (string | undefined) | undefined;
-  entityType?: (Shared_Type_71 | undefined) | undefined;
+  entityType?: (Shared_Type_70 | undefined) | undefined;
   entityName?: (string | undefined) | undefined;
   entityVersionId?: (string | undefined) | undefined;
   parentEntityVersionId?: (string | undefined) | undefined;
@@ -9015,9 +9022,9 @@ export type GetObservabilityMetrics_QueryParams = {
   experimentId?: (string | undefined) | undefined;
   serviceName?: (string | undefined) | undefined;
   environment?: (string | undefined) | undefined;
-  parentEntityType?: (Shared_Type_71 | undefined) | undefined;
+  parentEntityType?: (Shared_Type_70 | undefined) | undefined;
   parentEntityName?: (string | undefined) | undefined;
-  rootEntityType?: (Shared_Type_71 | undefined) | undefined;
+  rootEntityType?: (Shared_Type_70 | undefined) | undefined;
   rootEntityName?: (string | undefined) | undefined;
   resourceId?: (string | undefined) | undefined;
   runId?: (string | undefined) | undefined;
@@ -9057,9 +9064,9 @@ export type GetObservabilityMetrics_QueryParams = {
 };
 
 export type GetObservabilityMetrics_Response = {
-  pagination?: Shared_Type_72 | undefined;
+  pagination?: Shared_Type_71 | undefined;
   /** Incremental polling metadata */
-  delta?: Shared_Type_73 | undefined;
+  delta?: Shared_Type_72 | undefined;
   /** Opaque cursor value for incremental polling */
   deltaCursor?: string | undefined;
   metrics: {
@@ -9073,13 +9080,13 @@ export type GetObservabilityMetrics_Response = {
     value: number;
     traceId?: (string | null) | undefined;
     spanId?: (string | null) | undefined;
-    entityType?: (Shared_Type_71 | null) | undefined;
+    entityType?: (Shared_Type_70 | null) | undefined;
     entityId?: (string | null) | undefined;
     entityName?: (string | null) | undefined;
-    parentEntityType?: (Shared_Type_71 | null) | undefined;
+    parentEntityType?: (Shared_Type_70 | null) | undefined;
     parentEntityId?: (string | null) | undefined;
     parentEntityName?: (string | null) | undefined;
-    rootEntityType?: (Shared_Type_71 | null) | undefined;
+    rootEntityType?: (Shared_Type_70 | null) | undefined;
     rootEntityId?: (string | null) | undefined;
     rootEntityName?: (string | null) | undefined;
     userId?: (string | null) | undefined;
@@ -9154,12 +9161,12 @@ export interface GetObservabilityMetrics_RouteContract {
 // Route: GET /observability/logs
 // ============================================================================
 export type GetObservabilityLogs_QueryParams = {
-  timestamp?: ((Shared_Type_69 | undefined) | undefined) | unknown;
+  timestamp?: ((Shared_Type_68 | undefined) | undefined) | unknown;
   /** Filter by trace ID */
   traceId?: (string | undefined) | undefined;
   /** Filter by span ID */
   spanId?: (string | undefined) | undefined;
-  entityType?: (Shared_Type_71 | undefined) | undefined;
+  entityType?: (Shared_Type_70 | undefined) | undefined;
   entityName?: (string | undefined) | undefined;
   entityVersionId?: (string | undefined) | undefined;
   parentEntityVersionId?: (string | undefined) | undefined;
@@ -9169,9 +9176,9 @@ export type GetObservabilityLogs_QueryParams = {
   experimentId?: (string | undefined) | undefined;
   serviceName?: (string | undefined) | undefined;
   environment?: (string | undefined) | undefined;
-  parentEntityType?: (Shared_Type_71 | undefined) | undefined;
+  parentEntityType?: (Shared_Type_70 | undefined) | undefined;
   parentEntityName?: (string | undefined) | undefined;
-  rootEntityType?: (Shared_Type_71 | undefined) | undefined;
+  rootEntityType?: (Shared_Type_70 | undefined) | undefined;
   rootEntityName?: (string | undefined) | undefined;
   resourceId?: (string | undefined) | undefined;
   runId?: (string | undefined) | undefined;
@@ -9202,9 +9209,9 @@ export type GetObservabilityLogs_QueryParams = {
 };
 
 export type GetObservabilityLogs_Response = {
-  pagination?: Shared_Type_72 | undefined;
+  pagination?: Shared_Type_71 | undefined;
   /** Incremental polling metadata */
-  delta?: Shared_Type_73 | undefined;
+  delta?: Shared_Type_72 | undefined;
   /** Opaque cursor value for incremental polling */
   deltaCursor?: string | undefined;
   logs: {
@@ -9223,13 +9230,13 @@ export type GetObservabilityLogs_Response = {
       | undefined;
     traceId?: (string | null) | undefined;
     spanId?: (string | null) | undefined;
-    entityType?: (Shared_Type_71 | null) | undefined;
+    entityType?: (Shared_Type_70 | null) | undefined;
     entityId?: (string | null) | undefined;
     entityName?: (string | null) | undefined;
-    parentEntityType?: (Shared_Type_71 | null) | undefined;
+    parentEntityType?: (Shared_Type_70 | null) | undefined;
     parentEntityId?: (string | null) | undefined;
     parentEntityName?: (string | null) | undefined;
-    rootEntityType?: (Shared_Type_71 | null) | undefined;
+    rootEntityType?: (Shared_Type_70 | null) | undefined;
     rootEntityId?: (string | null) | undefined;
     rootEntityName?: (string | null) | undefined;
     userId?: (string | null) | undefined;
@@ -9285,12 +9292,12 @@ export interface GetObservabilityLogs_RouteContract {
 // Route: GET /observability/scores
 // ============================================================================
 export type GetObservabilityScores_QueryParams = {
-  timestamp?: ((Shared_Type_69 | undefined) | undefined) | unknown;
+  timestamp?: ((Shared_Type_68 | undefined) | undefined) | unknown;
   /** Filter by trace ID */
   traceId?: (string | undefined) | undefined;
   /** Filter by span ID */
   spanId?: (string | undefined) | undefined;
-  entityType?: (Shared_Type_71 | undefined) | undefined;
+  entityType?: (Shared_Type_70 | undefined) | undefined;
   entityName?: (string | undefined) | undefined;
   entityVersionId?: (string | undefined) | undefined;
   parentEntityVersionId?: (string | undefined) | undefined;
@@ -9300,9 +9307,9 @@ export type GetObservabilityScores_QueryParams = {
   experimentId?: (string | undefined) | undefined;
   serviceName?: (string | undefined) | undefined;
   environment?: (string | undefined) | undefined;
-  parentEntityType?: (Shared_Type_71 | undefined) | undefined;
+  parentEntityType?: (Shared_Type_70 | undefined) | undefined;
   parentEntityName?: (string | undefined) | undefined;
-  rootEntityType?: (Shared_Type_71 | undefined) | undefined;
+  rootEntityType?: (Shared_Type_70 | undefined) | undefined;
   rootEntityName?: (string | undefined) | undefined;
   resourceId?: (string | undefined) | undefined;
   runId?: (string | undefined) | undefined;
@@ -9341,12 +9348,12 @@ export type GetObservabilityScores_QueryParams = {
 };
 
 export type GetObservabilityScores_Response = {
-  pagination?: Shared_Type_72 | undefined;
+  pagination?: Shared_Type_71 | undefined;
   /** Incremental polling metadata */
-  delta?: Shared_Type_73 | undefined;
+  delta?: Shared_Type_72 | undefined;
   /** Opaque cursor value for incremental polling */
   deltaCursor?: string | undefined;
-  scores: Shared_Type_77[];
+  scores: Shared_Type_76[];
 };
 
 export type GetObservabilityScores_Request = Simplify<
@@ -9388,13 +9395,13 @@ export type PostObservabilityScores_Body = {
     /** Score value (range defined by scorer) */
     score: number;
     reason?: (string | null) | undefined;
-    entityType?: (Shared_Type_71 | null) | undefined;
+    entityType?: (Shared_Type_70 | null) | undefined;
     entityId?: (string | null) | undefined;
     entityName?: (string | null) | undefined;
-    parentEntityType?: (Shared_Type_71 | null) | undefined;
+    parentEntityType?: (Shared_Type_70 | null) | undefined;
     parentEntityId?: (string | null) | undefined;
     parentEntityName?: (string | null) | undefined;
-    rootEntityType?: (Shared_Type_71 | null) | undefined;
+    rootEntityType?: (Shared_Type_70 | null) | undefined;
     rootEntityId?: (string | null) | undefined;
     rootEntityName?: (string | null) | undefined;
     userId?: (string | null) | undefined;
@@ -9458,7 +9465,7 @@ export type GetObservabilityScoresScoreId_PathParams = {
 
 export type GetObservabilityScoresScoreId_Response = {
   /** Score record as stored in the database */
-  score: Shared_Type_77 | null;
+  score: Shared_Type_76 | null;
 };
 
 export type GetObservabilityScoresScoreId_Request = Simplify<
@@ -9487,7 +9494,7 @@ export type PostObservabilityScoresAggregate_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Filters for querying scores */
-  filters?: Shared_Type_78 | undefined;
+  filters?: Shared_Type_77 | undefined;
   /** Comparison period for aggregate queries */
   comparePeriod?: ('previous_period' | 'previous_day' | 'previous_week') | undefined;
 };
@@ -9533,7 +9540,7 @@ export type PostObservabilityScoresBreakdown_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Filters for querying scores */
-  filters?: Shared_Type_78 | undefined;
+  filters?: Shared_Type_77 | undefined;
 };
 
 export type PostObservabilityScoresBreakdown_Response = {
@@ -9579,7 +9586,7 @@ export type PostObservabilityScoresTimeseries_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Filters for querying scores */
-  filters?: Shared_Type_78 | undefined;
+  filters?: Shared_Type_77 | undefined;
   /** Fields to group by */
   groupBy?: string[] | undefined;
 };
@@ -9629,7 +9636,7 @@ export type PostObservabilityScoresPercentiles_Body = {
   /** Time bucket interval */
   interval: '1m' | '5m' | '15m' | '1h' | '1d';
   /** Filters for querying scores */
-  filters?: Shared_Type_78 | undefined;
+  filters?: Shared_Type_77 | undefined;
 };
 
 export type PostObservabilityScoresPercentiles_Response = {
@@ -9668,12 +9675,12 @@ export interface PostObservabilityScoresPercentiles_RouteContract {
 // Route: GET /observability/feedback
 // ============================================================================
 export type GetObservabilityFeedback_QueryParams = {
-  timestamp?: ((Shared_Type_69 | undefined) | undefined) | unknown;
+  timestamp?: ((Shared_Type_68 | undefined) | undefined) | unknown;
   /** Filter by trace ID */
   traceId?: (string | undefined) | undefined;
   /** Filter by span ID */
   spanId?: (string | undefined) | undefined;
-  entityType?: (Shared_Type_71 | undefined) | undefined;
+  entityType?: (Shared_Type_70 | undefined) | undefined;
   entityName?: (string | undefined) | undefined;
   entityVersionId?: (string | undefined) | undefined;
   parentEntityVersionId?: (string | undefined) | undefined;
@@ -9683,9 +9690,9 @@ export type GetObservabilityFeedback_QueryParams = {
   experimentId?: (string | undefined) | undefined;
   serviceName?: (string | undefined) | undefined;
   environment?: (string | undefined) | undefined;
-  parentEntityType?: (Shared_Type_71 | undefined) | undefined;
+  parentEntityType?: (Shared_Type_70 | undefined) | undefined;
   parentEntityName?: (string | undefined) | undefined;
-  rootEntityType?: (Shared_Type_71 | undefined) | undefined;
+  rootEntityType?: (Shared_Type_70 | undefined) | undefined;
   rootEntityName?: (string | undefined) | undefined;
   resourceId?: (string | undefined) | undefined;
   runId?: (string | undefined) | undefined;
@@ -9713,12 +9720,12 @@ export type GetObservabilityFeedback_QueryParams = {
 };
 
 export type GetObservabilityFeedback_Response = {
-  pagination?: Shared_Type_72 | undefined;
+  pagination?: Shared_Type_71 | undefined;
   /** Incremental polling metadata */
-  delta?: Shared_Type_73 | undefined;
+  delta?: Shared_Type_72 | undefined;
   /** Opaque cursor value for incremental polling */
   deltaCursor?: string | undefined;
-  feedback: Shared_Type_79[];
+  feedback: Shared_Type_78[];
 };
 
 export type GetObservabilityFeedback_Request = Simplify<
@@ -9759,13 +9766,13 @@ export type PostObservabilityFeedback_Body = {
     value: number | string;
     comment?: (string | null) | undefined;
     feedbackUserId?: (string | null) | undefined;
-    entityType?: (Shared_Type_71 | null) | undefined;
+    entityType?: (Shared_Type_70 | null) | undefined;
     entityId?: (string | null) | undefined;
     entityName?: (string | null) | undefined;
-    parentEntityType?: (Shared_Type_71 | null) | undefined;
+    parentEntityType?: (Shared_Type_70 | null) | undefined;
     parentEntityId?: (string | null) | undefined;
     parentEntityName?: (string | null) | undefined;
-    rootEntityType?: (Shared_Type_71 | null) | undefined;
+    rootEntityType?: (Shared_Type_70 | null) | undefined;
     rootEntityId?: (string | null) | undefined;
     rootEntityName?: (string | null) | undefined;
     userId?: (string | null) | undefined;
@@ -9833,7 +9840,7 @@ export type PatchObservabilityFeedbackFeedbackIdReviewStatus_Body = {
   reviewStatus: 'needs-review' | 'reviewed';
 };
 
-export type PatchObservabilityFeedbackFeedbackIdReviewStatus_Response = Shared_Type_79;
+export type PatchObservabilityFeedbackFeedbackIdReviewStatus_Response = Shared_Type_78;
 
 export type PatchObservabilityFeedbackFeedbackIdReviewStatus_Request = Simplify<
   (PatchObservabilityFeedbackFeedbackIdReviewStatus_PathParams extends never
@@ -9867,7 +9874,7 @@ export type PostObservabilityFeedbackAggregate_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Filters for querying feedback */
-  filters?: Shared_Type_80 | undefined;
+  filters?: Shared_Type_79 | undefined;
   /** Comparison period for aggregate queries */
   comparePeriod?: ('previous_period' | 'previous_day' | 'previous_week') | undefined;
 };
@@ -9906,7 +9913,7 @@ export type PostObservabilityFeedbackBreakdown_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Filters for querying feedback */
-  filters?: Shared_Type_80 | undefined;
+  filters?: Shared_Type_79 | undefined;
 };
 
 export type PostObservabilityFeedbackBreakdown_Response = PostObservabilityScoresBreakdown_Response;
@@ -9943,7 +9950,7 @@ export type PostObservabilityFeedbackTimeseries_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Filters for querying feedback */
-  filters?: Shared_Type_80 | undefined;
+  filters?: Shared_Type_79 | undefined;
   /** Fields to group by */
   groupBy?: string[] | undefined;
 };
@@ -9993,7 +10000,7 @@ export type PostObservabilityFeedbackPercentiles_Body = {
   /** Time bucket interval */
   interval: '1m' | '5m' | '15m' | '1h' | '1d';
   /** Filters for querying feedback */
-  filters?: Shared_Type_80 | undefined;
+  filters?: Shared_Type_79 | undefined;
 };
 
 export type PostObservabilityFeedbackPercentiles_Response = PostObservabilityScoresPercentiles_Response;
@@ -10026,9 +10033,9 @@ export type PostObservabilityMetricsAggregate_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Column to apply count_distinct over (required when aggregation is 'count_distinct'). Restricted to allowlisted metric dimensions. */
-  distinctColumn?: Shared_Type_81 | undefined;
+  distinctColumn?: Shared_Type_80 | undefined;
   /** Filters for querying metrics */
-  filters?: Shared_Type_82 | undefined;
+  filters?: Shared_Type_81 | undefined;
   /** Comparison period for aggregate queries */
   comparePeriod?: ('previous_period' | 'previous_day' | 'previous_week') | undefined;
 };
@@ -10080,9 +10087,9 @@ export type PostObservabilityMetricsBreakdown_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Column to apply count_distinct over (required when aggregation is 'count_distinct'). Restricted to allowlisted metric dimensions. */
-  distinctColumn?: Shared_Type_81 | undefined;
+  distinctColumn?: Shared_Type_80 | undefined;
   /** Filters for querying metrics */
-  filters?: Shared_Type_82 | undefined;
+  filters?: Shared_Type_81 | undefined;
   /** Maximum number of groups to return (server-side TopK). Required for high-cardinality groupBy. */
   limit?: number | undefined;
   /** Sort direction for the aggregated value (defaults to 'DESC' at the storage layer; pairs with limit for top/bottom-N). */
@@ -10134,9 +10141,9 @@ export type PostObservabilityMetricsTimeseries_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Column to apply count_distinct over (required when aggregation is 'count_distinct'). Restricted to allowlisted metric dimensions. */
-  distinctColumn?: Shared_Type_81 | undefined;
+  distinctColumn?: Shared_Type_80 | undefined;
   /** Filters for querying metrics */
-  filters?: Shared_Type_82 | undefined;
+  filters?: Shared_Type_81 | undefined;
   /** Fields to group by */
   groupBy?: string[] | undefined;
 };
@@ -10188,7 +10195,7 @@ export type PostObservabilityMetricsPercentiles_Body = {
   /** Time bucket interval */
   interval: '1m' | '5m' | '15m' | '1h' | '1d';
   /** Filters for querying metrics */
-  filters?: Shared_Type_82 | undefined;
+  filters?: Shared_Type_81 | undefined;
 };
 
 export type PostObservabilityMetricsPercentiles_Response = PostObservabilityScoresPercentiles_Response;
@@ -10321,7 +10328,7 @@ export interface GetObservabilityDiscoveryMetricLabelValues_RouteContract {
 // ============================================================================
 export type GetObservabilityDiscoveryEntityTypes_Response = {
   /** Distinct entity types */
-  entityTypes: Shared_Type_71[];
+  entityTypes: Shared_Type_70[];
 };
 
 export type GetObservabilityDiscoveryEntityTypes_Request = Simplify<
@@ -10344,7 +10351,7 @@ export interface GetObservabilityDiscoveryEntityTypes_RouteContract {
 // ============================================================================
 export type GetObservabilityDiscoveryEntityNames_QueryParams = {
   /** Optional entity type filter */
-  entityType?: (Shared_Type_71 | undefined) | undefined;
+  entityType?: (Shared_Type_70 | undefined) | undefined;
 };
 
 export type GetObservabilityDiscoveryEntityNames_Response = {
@@ -10881,13 +10888,13 @@ export type PostA2aAgentId_Body =
       jsonrpc: '2.0';
       id: string | number;
       method: 'message/send';
-      params: Shared_Type_93;
+      params: Shared_Type_92;
     }
   | {
       jsonrpc: '2.0';
       id: string | number;
       method: 'message/stream';
-      params: Shared_Type_93;
+      params: Shared_Type_92;
     }
   | {
       jsonrpc: '2.0';
@@ -10955,7 +10962,7 @@ export type PostA2aAgentId_Body =
       params: {
         /** Task id */
         taskId: string;
-        pushNotificationConfig: Shared_Type_91;
+        pushNotificationConfig: Shared_Type_90;
       };
     }
   | {
@@ -12030,7 +12037,13 @@ export type PostAgentsAgentIdGenerateLegacy_Body = {
   maxSteps?: number | undefined;
   stopWhen?: unknown | undefined;
   model?: string | undefined;
-  providerOptions?: Shared_Type_45 | undefined;
+  providerOptions?:
+    | {
+        [key: string]: {
+          [key: string]: Shared_Auxiliary_272;
+        };
+      }
+    | undefined;
   modelSettings?: unknown | undefined;
   activeTools?: string[] | undefined;
   toolsets?:
@@ -12067,9 +12080,9 @@ export type PostAgentsAgentIdGenerateLegacy_Body = {
       )
     | undefined;
   returnScorerData?: boolean | undefined;
-  tracingOptions?: Shared_Type_46 | undefined;
+  tracingOptions?: Shared_Type_45 | undefined;
   output?: unknown | undefined;
-  structuredOutput?: Shared_Type_47 | undefined;
+  structuredOutput?: Shared_Type_46 | undefined;
   untilIdle?:
     | (
         | boolean
@@ -12298,7 +12311,7 @@ export type GetMcpServerIdTools_PathParams = {
 };
 
 export type GetMcpServerIdTools_Response = {
-  tools: Shared_Type_94[];
+  tools: Shared_Type_93[];
 };
 
 export type GetMcpServerIdTools_Request = Simplify<
@@ -12326,7 +12339,7 @@ export type GetMcpServerIdToolsToolId_PathParams = {
   toolId: string;
 };
 
-export type GetMcpServerIdToolsToolId_Response = Shared_Type_94;
+export type GetMcpServerIdToolsToolId_Response = Shared_Type_93;
 
 export type GetMcpServerIdToolsToolId_Request = Simplify<
   (GetMcpServerIdToolsToolId_PathParams extends never ? {} : { params: GetMcpServerIdToolsToolId_PathParams }) &
@@ -12659,19 +12672,19 @@ export type PostStoredAgentsStoredAgentIdExport_Body = {
       )
     | undefined;
   /** Tool keys mapped to per-tool config — static or conditional */
-  tools?: Shared_Type_95;
+  tools?: Shared_Type_94;
   /** Default options for generate/stream calls — static or conditional */
-  defaultOptions?: Shared_Type_96;
+  defaultOptions?: Shared_Type_95;
   /** Workflow keys with optional per-workflow config — static or conditional */
-  workflows?: Shared_Type_95;
+  workflows?: Shared_Type_94;
   /** Agent keys with optional per-agent config — static or conditional */
-  agents?: Shared_Type_95;
+  agents?: Shared_Type_94;
   /** Map of tool provider IDs to their tool configurations — static or conditional */
-  integrationTools?: Shared_Type_97;
+  integrationTools?: Shared_Type_96;
   /** Tool provider connections and per-tool config (provider-agnostic). Coexists with the deprecated `integrationTools` field. */
-  toolProviders?: Shared_Type_98;
+  toolProviders?: Shared_Type_97;
   /** Map of stored MCP client IDs to their tool configurations — static or conditional */
-  mcpClients?: Shared_Type_97;
+  mcpClients?: Shared_Type_96;
   /** Input processor graph — static or conditional */
   inputProcessors?: (Shared_Type_20 | undefined) | undefined;
   /** Output processor graph — static or conditional */
@@ -12693,7 +12706,7 @@ export type PostStoredAgentsStoredAgentIdExport_Body = {
       )
     | undefined;
   /** Scorer keys with optional sampling config — static or conditional */
-  scorers?: Shared_Type_99;
+  scorers?: Shared_Type_98;
   /** Skill IDs mapped to per-skill config — static or conditional */
   skills?:
     | (
@@ -12708,7 +12721,7 @@ export type PostStoredAgentsStoredAgentIdExport_Body = {
       )
     | undefined;
   /** Workspace reference (stored ID or inline config) — static or conditional */
-  workspace?: Shared_Type_100;
+  workspace?: Shared_Type_99;
   /** Browser configuration — object config, true (apply default), false/null (disable) */
   browser?: ((Shared_Type_41 | boolean | null) | undefined) | undefined;
   /** JSON Schema defining valid request context variables for conditional rule evaluation */
@@ -12788,19 +12801,19 @@ export type PostStoredAgentsStoredAgentIdChangeRequest_Body = {
       )
     | undefined;
   /** Tool keys mapped to per-tool config — static or conditional */
-  tools?: Shared_Type_95;
+  tools?: Shared_Type_94;
   /** Default options for generate/stream calls — static or conditional */
-  defaultOptions?: Shared_Type_96;
+  defaultOptions?: Shared_Type_95;
   /** Workflow keys with optional per-workflow config — static or conditional */
-  workflows?: Shared_Type_95;
+  workflows?: Shared_Type_94;
   /** Agent keys with optional per-agent config — static or conditional */
-  agents?: Shared_Type_95;
+  agents?: Shared_Type_94;
   /** Map of tool provider IDs to their tool configurations — static or conditional */
-  integrationTools?: Shared_Type_97;
+  integrationTools?: Shared_Type_96;
   /** Tool provider connections and per-tool config (provider-agnostic). Coexists with the deprecated `integrationTools` field. */
-  toolProviders?: Shared_Type_98;
+  toolProviders?: Shared_Type_97;
   /** Map of stored MCP client IDs to their tool configurations — static or conditional */
-  mcpClients?: Shared_Type_97;
+  mcpClients?: Shared_Type_96;
   /** Input processor graph — static or conditional */
   inputProcessors?: (Shared_Type_20 | undefined) | undefined;
   /** Output processor graph — static or conditional */
@@ -12822,7 +12835,7 @@ export type PostStoredAgentsStoredAgentIdChangeRequest_Body = {
       )
     | undefined;
   /** Scorer keys with optional sampling config — static or conditional */
-  scorers?: Shared_Type_99;
+  scorers?: Shared_Type_98;
   /** Skill IDs mapped to per-skill config — static or conditional */
   skills?:
     | (
@@ -12837,7 +12850,7 @@ export type PostStoredAgentsStoredAgentIdChangeRequest_Body = {
       )
     | undefined;
   /** Workspace reference (stored ID or inline config) — static or conditional */
-  workspace?: Shared_Type_100;
+  workspace?: Shared_Type_99;
   /** Browser configuration — object config, true (apply default), false/null (disable) */
   browser?: ((Shared_Type_41 | boolean | null) | undefined) | undefined;
   /** JSON Schema defining valid request context variables for conditional rule evaluation */
@@ -13475,7 +13488,7 @@ export type GetStoredAgentsAgentIdVersions_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  versions: Shared_Type_101[];
+  versions: Shared_Type_100[];
 };
 
 export type GetStoredAgentsAgentIdVersions_Request = Simplify<
@@ -13711,7 +13724,7 @@ export type GetStoredAgentsAgentIdVersionsCompare_QueryParams = {
 
 export type GetStoredAgentsAgentIdVersionsCompare_Response = {
   /** List of differences between versions */
-  diffs: Shared_Type_102[];
+  diffs: Shared_Type_101[];
   /** The source version */
   fromVersion: {
     /** Unique identifier for the version (UUID) */
@@ -14019,7 +14032,7 @@ export type GetStoredAgentsAgentIdVersionsVersionId_PathParams = {
   versionId: string;
 };
 
-export type GetStoredAgentsAgentIdVersionsVersionId_Response = Shared_Type_101;
+export type GetStoredAgentsAgentIdVersionsVersionId_Response = Shared_Type_100;
 
 export type GetStoredAgentsAgentIdVersionsVersionId_Request = Simplify<
   (GetStoredAgentsAgentIdVersionsVersionId_PathParams extends never
@@ -14315,7 +14328,7 @@ export type GetStoredWorkflows_QueryParams = {
 };
 
 export type GetStoredWorkflows_Response = {
-  workflows: Shared_Type_103[];
+  workflows: Shared_Type_102[];
   total: number;
 };
 
@@ -14369,7 +14382,7 @@ export type PostStoredWorkflows_Body = {
       }
     | undefined;
   /** Static workflow graph — ordered array of serialized step entries with all refs as ids. */
-  graph: Shared_Type_108[];
+  graph: Shared_Type_107[];
   /** Helper workflow definitions this workflow nests. Saved with it as one unit — the whole set is validated together, hydrated in derived dependency order, and rejected together, so a failed save never leaves orphaned helpers behind. Each helper becomes an ordinary dynamic workflow in its own right. */
   dependencies?:
     | {
@@ -14400,7 +14413,7 @@ export type PostStoredWorkflows_Body = {
             }
           | undefined;
         /** Static workflow graph — ordered array of serialized step entries with all refs as ids. */
-        graph: Shared_Type_108[];
+        graph: Shared_Type_107[];
       }[]
     | undefined;
 };
@@ -14439,7 +14452,7 @@ export type GetStoredWorkflowsDynamicWorkflowId_PathParams = {
   dynamicWorkflowId: string;
 };
 
-export type GetStoredWorkflowsDynamicWorkflowId_Response = Shared_Type_103;
+export type GetStoredWorkflowsDynamicWorkflowId_Response = Shared_Type_102;
 
 export type GetStoredWorkflowsDynamicWorkflowId_Request = Simplify<
   (GetStoredWorkflowsDynamicWorkflowId_PathParams extends never
@@ -14514,7 +14527,7 @@ export type GetStoredMcpClients_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  mcpClients: Shared_Type_110[];
+  mcpClients: Shared_Type_109[];
 };
 
 export type GetStoredMcpClients_Request = Simplify<
@@ -14546,7 +14559,7 @@ export type GetStoredMcpClientsStoredMCPClientId_PathParams = {
 
 export type GetStoredMcpClientsStoredMCPClientId_QueryParams = GetStoredAgentsStoredAgentId_QueryParams;
 
-export type GetStoredMcpClientsStoredMCPClientId_Response = Shared_Type_110;
+export type GetStoredMcpClientsStoredMCPClientId_Response = Shared_Type_109;
 
 export type GetStoredMcpClientsStoredMCPClientId_Request = Simplify<
   (GetStoredMcpClientsStoredMCPClientId_PathParams extends never
@@ -14589,7 +14602,7 @@ export type PostStoredMcpClients_Body = {
   description?: string | undefined;
   /** Map of server name to server configuration */
   servers: {
-    [key: string]: Shared_Type_109;
+    [key: string]: Shared_Type_108;
   };
 };
 
@@ -14636,7 +14649,7 @@ export type PatchStoredMcpClientsStoredMCPClientId_Body = {
   /** Map of server name to server configuration */
   servers?:
     | {
-        [key: string]: Shared_Type_109;
+        [key: string]: Shared_Type_108;
       }
     | undefined;
 };
@@ -14655,7 +14668,7 @@ export type PatchStoredMcpClientsStoredMCPClientId_Response =
       createdAt: Date;
       updatedAt: Date;
     }
-  | Shared_Type_110;
+  | Shared_Type_109;
 
 export type PatchStoredMcpClientsStoredMCPClientId_Request = Simplify<
   (PatchStoredMcpClientsStoredMCPClientId_PathParams extends never
@@ -14717,7 +14730,7 @@ export type GetStoredMcpClientsMcpClientIdVersions_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  versions: Shared_Type_112[];
+  versions: Shared_Type_111[];
 };
 
 export type GetStoredMcpClientsMcpClientIdVersions_Request = Simplify<
@@ -14758,7 +14771,7 @@ export type PostStoredMcpClientsMcpClientIdVersions_Response = {
   description?: (string | undefined) | undefined;
   servers?:
     | {
-        [key: string]: Shared_Type_111;
+        [key: string]: Shared_Type_110;
       }
     | undefined;
   /** Array of field names that changed from the previous version */
@@ -14800,7 +14813,7 @@ export type GetStoredMcpClientsMcpClientIdVersionsCompare_QueryParams =
 
 export type GetStoredMcpClientsMcpClientIdVersionsCompare_Response = {
   /** List of differences between versions */
-  diffs: Shared_Type_102[];
+  diffs: Shared_Type_101[];
   /** The source version */
   fromVersion: {
     /** Unique identifier for the version (UUID) */
@@ -14814,7 +14827,7 @@ export type GetStoredMcpClientsMcpClientIdVersionsCompare_Response = {
     /** Description of the MCP client */
     description?: string | undefined;
     servers: {
-      [key: string]: Shared_Type_111;
+      [key: string]: Shared_Type_110;
     };
     /** Array of field names that changed from the previous version */
     changedFields?: string[] | undefined;
@@ -14836,7 +14849,7 @@ export type GetStoredMcpClientsMcpClientIdVersionsCompare_Response = {
     /** Description of the MCP client */
     description?: string | undefined;
     servers: {
-      [key: string]: Shared_Type_111;
+      [key: string]: Shared_Type_110;
     };
     /** Array of field names that changed from the previous version */
     changedFields?: string[] | undefined;
@@ -14878,7 +14891,7 @@ export type GetStoredMcpClientsMcpClientIdVersionsVersionId_PathParams = {
   versionId: string;
 };
 
-export type GetStoredMcpClientsMcpClientIdVersionsVersionId_Response = Shared_Type_112;
+export type GetStoredMcpClientsMcpClientIdVersionsVersionId_Response = Shared_Type_111;
 
 export type GetStoredMcpClientsMcpClientIdVersionsVersionId_Request = Simplify<
   (GetStoredMcpClientsMcpClientIdVersionsVersionId_PathParams extends never
@@ -15003,7 +15016,7 @@ export type GetStoredPromptBlocks_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  promptBlocks: Shared_Type_113[];
+  promptBlocks: Shared_Type_112[];
 };
 
 export type GetStoredPromptBlocks_Request = Simplify<
@@ -15035,7 +15048,7 @@ export type GetStoredPromptBlocksStoredPromptBlockId_PathParams = {
 
 export type GetStoredPromptBlocksStoredPromptBlockId_QueryParams = GetStoredAgentsStoredAgentId_QueryParams;
 
-export type GetStoredPromptBlocksStoredPromptBlockId_Response = Shared_Type_113;
+export type GetStoredPromptBlocksStoredPromptBlockId_Response = Shared_Type_112;
 
 export type GetStoredPromptBlocksStoredPromptBlockId_Request = Simplify<
   (GetStoredPromptBlocksStoredPromptBlockId_PathParams extends never
@@ -15154,7 +15167,7 @@ export type PatchStoredPromptBlocksStoredPromptBlockId_Response =
       createdAt: Date;
       updatedAt: Date;
     }
-  | Shared_Type_113;
+  | Shared_Type_112;
 
 export type PatchStoredPromptBlocksStoredPromptBlockId_Request = Simplify<
   (PatchStoredPromptBlocksStoredPromptBlockId_PathParams extends never
@@ -15217,7 +15230,7 @@ export type GetStoredPromptBlocksPromptBlockIdVersions_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  versions: Shared_Type_114[];
+  versions: Shared_Type_113[];
 };
 
 export type GetStoredPromptBlocksPromptBlockIdVersions_Request = Simplify<
@@ -15309,7 +15322,7 @@ export type GetStoredPromptBlocksPromptBlockIdVersionsCompare_QueryParams =
 
 export type GetStoredPromptBlocksPromptBlockIdVersionsCompare_Response = {
   /** List of differences between versions */
-  diffs: Shared_Type_102[];
+  diffs: Shared_Type_101[];
   /** The source version */
   fromVersion: {
     /** Unique identifier for the version (UUID) */
@@ -15401,7 +15414,7 @@ export type GetStoredPromptBlocksPromptBlockIdVersionsVersionId_PathParams = {
   versionId: string;
 };
 
-export type GetStoredPromptBlocksPromptBlockIdVersionsVersionId_Response = Shared_Type_114;
+export type GetStoredPromptBlocksPromptBlockIdVersionsVersionId_Response = Shared_Type_113;
 
 export type GetStoredPromptBlocksPromptBlockIdVersionsVersionId_Request = Simplify<
   (GetStoredPromptBlocksPromptBlockIdVersionsVersionId_PathParams extends never
@@ -15526,7 +15539,7 @@ export type GetStoredScorers_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  scorerDefinitions: Shared_Type_116[];
+  scorerDefinitions: Shared_Type_115[];
 };
 
 export type GetStoredScorers_Request = Simplify<
@@ -15558,7 +15571,7 @@ export type GetStoredScorersStoredScorerId_PathParams = {
 
 export type GetStoredScorersStoredScorerId_QueryParams = GetStoredAgentsStoredAgentId_QueryParams;
 
-export type GetStoredScorersStoredScorerId_Response = Shared_Type_116;
+export type GetStoredScorersStoredScorerId_Response = Shared_Type_115;
 
 export type GetStoredScorersStoredScorerId_Request = Simplify<
   (GetStoredScorersStoredScorerId_PathParams extends never
@@ -15600,13 +15613,13 @@ export type PostStoredScorers_Body = {
   /** Description of the scorer */
   description?: string | undefined;
   /** Scorer type: llm-judge for custom, or a preset type name */
-  type: Shared_Type_115;
+  type: Shared_Type_114;
   /** Model configuration for LLM judge */
   model?: Shared_Type_11 | undefined;
   /** System instructions for the judge LLM (used when type is llm-judge) */
   instructions?: string | undefined;
   /** Score range configuration (used when type is llm-judge) */
-  scoreRange?: Shared_Type_117;
+  scoreRange?: Shared_Type_116;
   /** Serializable config options for preset scorers */
   presetConfig?:
     | {
@@ -15668,13 +15681,13 @@ export type PatchStoredScorersStoredScorerId_Body = {
   /** Description of the scorer */
   description?: (string | undefined) | undefined;
   /** Scorer type: llm-judge for custom, or a preset type name */
-  type?: Shared_Type_115 | undefined;
+  type?: Shared_Type_114 | undefined;
   /** Model configuration for LLM judge */
   model?: (Shared_Type_11 | undefined) | undefined;
   /** System instructions for the judge LLM (used when type is llm-judge) */
   instructions?: (string | undefined) | undefined;
   /** Score range configuration (used when type is llm-judge) */
-  scoreRange?: Shared_Type_117 | undefined;
+  scoreRange?: Shared_Type_116 | undefined;
   /** Serializable config options for preset scorers */
   presetConfig?:
     | (
@@ -15715,7 +15728,7 @@ export type PatchStoredScorersStoredScorerId_Response =
       createdAt: Date;
       updatedAt: Date;
     }
-  | Shared_Type_116;
+  | Shared_Type_115;
 
 export type PatchStoredScorersStoredScorerId_Request = Simplify<
   (PatchStoredScorersStoredScorerId_PathParams extends never
@@ -15777,7 +15790,7 @@ export type GetStoredScorersScorerIdVersions_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  versions: Shared_Type_118[];
+  versions: Shared_Type_117[];
 };
 
 export type GetStoredScorersScorerIdVersions_Request = Simplify<
@@ -15816,7 +15829,7 @@ export type PostStoredScorersScorerIdVersions_Response = {
   name?: string | undefined;
   /** Description of the scorer */
   description?: (string | undefined) | undefined;
-  type?: Shared_Type_115 | undefined;
+  type?: Shared_Type_114 | undefined;
   model?: (Shared_Type_11 | undefined) | undefined;
   instructions?: (string | undefined) | undefined;
   scoreRange?:
@@ -15887,7 +15900,7 @@ export type GetStoredScorersScorerIdVersionsCompare_QueryParams = GetStoredAgent
 
 export type GetStoredScorersScorerIdVersionsCompare_Response = {
   /** List of differences between versions */
-  diffs: Shared_Type_102[];
+  diffs: Shared_Type_101[];
   /** The source version */
   fromVersion: {
     /** Unique identifier for the version (UUID) */
@@ -15900,7 +15913,7 @@ export type GetStoredScorersScorerIdVersionsCompare_Response = {
     name: string;
     /** Description of the scorer */
     description?: string | undefined;
-    type: Shared_Type_115;
+    type: Shared_Type_114;
     model?: Shared_Type_11 | undefined;
     instructions?: string | undefined;
     scoreRange?:
@@ -15944,7 +15957,7 @@ export type GetStoredScorersScorerIdVersionsCompare_Response = {
     name: string;
     /** Description of the scorer */
     description?: string | undefined;
-    type: Shared_Type_115;
+    type: Shared_Type_114;
     model?: Shared_Type_11 | undefined;
     instructions?: string | undefined;
     scoreRange?:
@@ -16009,7 +16022,7 @@ export type GetStoredScorersScorerIdVersionsVersionId_PathParams = {
   versionId: string;
 };
 
-export type GetStoredScorersScorerIdVersionsVersionId_Response = Shared_Type_118;
+export type GetStoredScorersScorerIdVersionsVersionId_Response = Shared_Type_117;
 
 export type GetStoredScorersScorerIdVersionsVersionId_Request = Simplify<
   (GetStoredScorersScorerIdVersionsVersionId_PathParams extends never
@@ -16197,7 +16210,7 @@ export type GetStoredWorkspacesStoredWorkspaceId_PathParams = {
   storedWorkspaceId: string;
 };
 
-export type GetStoredWorkspacesStoredWorkspaceId_Response = Shared_Type_119;
+export type GetStoredWorkspacesStoredWorkspaceId_Response = Shared_Type_118;
 
 export type GetStoredWorkspacesStoredWorkspaceId_Request = Simplify<
   (GetStoredWorkspacesStoredWorkspaceId_PathParams extends never
@@ -16323,7 +16336,7 @@ export type PatchStoredWorkspacesStoredWorkspaceId_Response =
       createdAt: Date;
       updatedAt: Date;
     }
-  | Shared_Type_119;
+  | Shared_Type_118;
 
 export type PatchStoredWorkspacesStoredWorkspaceId_Request = Simplify<
   (PatchStoredWorkspacesStoredWorkspaceId_PathParams extends never
@@ -16405,7 +16418,7 @@ export type GetStoredSkills_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  skills: Shared_Type_121[];
+  skills: Shared_Type_120[];
 };
 
 export type GetStoredSkills_Request = Simplify<
@@ -16435,7 +16448,7 @@ export type GetStoredSkillsStoredSkillId_PathParams = {
   storedSkillId: string;
 };
 
-export type GetStoredSkillsStoredSkillId_Response = Shared_Type_121;
+export type GetStoredSkillsStoredSkillId_Response = Shared_Type_120;
 
 export type GetStoredSkillsStoredSkillId_Request = Simplify<
   (GetStoredSkillsStoredSkillId_PathParams extends never ? {} : { params: GetStoredSkillsStoredSkillId_PathParams }) &
@@ -16473,7 +16486,7 @@ export type PostStoredSkills_Body = {
   /** Compatibility requirements */
   compatibility?: unknown | undefined;
   /** Source location of the skill */
-  source?: Shared_Type_120 | undefined;
+  source?: Shared_Type_119 | undefined;
   /** List of reference file paths */
   references?: string[] | undefined;
   /** List of script file paths */
@@ -16481,7 +16494,7 @@ export type PostStoredSkills_Body = {
   /** List of asset file paths */
   assets?: string[] | undefined;
   /** Full file tree structure for the skill */
-  files?: Shared_Auxiliary_1238[] | undefined;
+  files?: Shared_Auxiliary_1237[] | undefined;
   /** Additional metadata for the skill */
   metadata?:
     | {
@@ -16531,7 +16544,7 @@ export type PatchStoredSkillsStoredSkillId_Body = {
   /** Compatibility requirements */
   compatibility?: (unknown | undefined) | undefined;
   /** Source location of the skill */
-  source?: (Shared_Type_120 | undefined) | undefined;
+  source?: (Shared_Type_119 | undefined) | undefined;
   /** List of reference file paths */
   references?: (string[] | undefined) | undefined;
   /** List of script file paths */
@@ -16539,7 +16552,7 @@ export type PatchStoredSkillsStoredSkillId_Body = {
   /** List of asset file paths */
   assets?: (string[] | undefined) | undefined;
   /** Full file tree structure for the skill */
-  files?: (Shared_Auxiliary_1238[] | undefined) | undefined;
+  files?: (Shared_Auxiliary_1237[] | undefined) | undefined;
   /** Additional metadata for the skill */
   metadata?:
     | (
@@ -16561,7 +16574,7 @@ export type PatchStoredSkillsStoredSkillId_Response =
       createdAt: Date;
       updatedAt: Date;
     }
-  | Shared_Type_121;
+  | Shared_Type_120;
 
 export type PatchStoredSkillsStoredSkillId_Request = Simplify<
   (PatchStoredSkillsStoredSkillId_PathParams extends never
@@ -17417,7 +17430,7 @@ export interface GetSystemApiSchema_RouteContract {
 export type GetDatasets_QueryParams = GetScoresRunRunId_QueryParams;
 
 export type GetDatasets_Response = {
-  datasets: Shared_Type_122[];
+  datasets: Shared_Type_121[];
   pagination: {
     total: number;
     page: number;
@@ -17485,7 +17498,7 @@ export type PostDatasets_Body = {
   scorerIds?: string[] | undefined;
 };
 
-export type PostDatasets_Response = Shared_Type_122;
+export type PostDatasets_Response = Shared_Type_121;
 
 export type PostDatasets_Request = Simplify<
   (never extends never ? {} : { params: never }) &
@@ -17521,7 +17534,7 @@ export type GetDatasetsDatasetId_QueryParams = {
   projectId?: string | undefined;
 };
 
-export type GetDatasetsDatasetId_Response = Shared_Type_122 | null;
+export type GetDatasetsDatasetId_Response = Shared_Type_121 | null;
 
 export type GetDatasetsDatasetId_Request = Simplify<
   (GetDatasetsDatasetId_PathParams extends never ? {} : { params: GetDatasetsDatasetId_PathParams }) &
@@ -17654,7 +17667,7 @@ export type GetDatasetsDatasetIdItems_QueryParams = {
 };
 
 export type GetDatasetsDatasetIdItems_Response = {
-  items: Shared_Type_125[];
+  items: Shared_Type_124[];
   pagination: {
     total: number;
     page: number;
@@ -17695,9 +17708,9 @@ export type PostDatasetsDatasetIdItems_Body = {
   /** Expected output for comparison */
   groundTruth?: unknown | undefined;
   /** Expected trajectory configuration for trajectory scoring */
-  expectedTrajectory?: (Shared_Type_140 | undefined) | null;
+  expectedTrajectory?: (Shared_Type_139 | undefined) | null;
   /** Ordered item-level static tool mocks served in place of executing the real tool */
-  toolMocks?: Shared_Type_123[] | undefined;
+  toolMocks?: Shared_Type_122[] | undefined;
   /** Policy for undeclared tool calls. 'allow' runs them live; 'deny' fails the experiment item */
   unmockedToolPolicy?: ('allow' | 'deny') | undefined;
   /** IDs of scorers selected for this item */
@@ -17715,10 +17728,10 @@ export type PostDatasetsDatasetIdItems_Body = {
       }
     | undefined;
   /** Source/provenance of this dataset item */
-  source?: Shared_Type_124 | undefined;
+  source?: Shared_Type_123 | undefined;
 };
 
-export type PostDatasetsDatasetIdItems_Response = Shared_Type_125;
+export type PostDatasetsDatasetIdItems_Response = Shared_Type_124;
 
 export type PostDatasetsDatasetIdItems_Request = Simplify<
   (PostDatasetsDatasetIdItems_PathParams extends never ? {} : { params: PostDatasetsDatasetIdItems_PathParams }) &
@@ -17750,9 +17763,9 @@ export type PostDatasetsDatasetIdItemsBatch_Body = {
     input: unknown;
     groundTruth?: unknown | undefined;
     /** Expected trajectory configuration for trajectory scoring */
-    expectedTrajectory?: (Shared_Type_140 | undefined) | null;
+    expectedTrajectory?: (Shared_Type_139 | undefined) | null;
     /** Ordered item-level static tool mocks served in place of executing the real tool */
-    toolMocks?: Shared_Type_123[] | undefined;
+    toolMocks?: Shared_Type_122[] | undefined;
     /** Policy for undeclared tool calls. 'allow' runs them live; 'deny' fails the experiment item */
     unmockedToolPolicy?: ('allow' | 'deny') | undefined;
     scorerIds?: string[] | undefined;
@@ -17767,12 +17780,12 @@ export type PostDatasetsDatasetIdItemsBatch_Body = {
         }
       | undefined;
     /** Source/provenance of this dataset item */
-    source?: Shared_Type_124 | undefined;
+    source?: Shared_Type_123 | undefined;
   }[];
 };
 
 export type PostDatasetsDatasetIdItemsBatch_Response = {
-  items: Shared_Type_125[];
+  items: Shared_Type_124[];
   count: number;
 };
 
@@ -17842,7 +17855,7 @@ export type GetDatasetsDatasetIdItemsItemId_PathParams = {
   itemId: string;
 };
 
-export type GetDatasetsDatasetIdItemsItemId_Response = Shared_Type_125 | null;
+export type GetDatasetsDatasetIdItemsItemId_Response = Shared_Type_124 | null;
 
 export type GetDatasetsDatasetIdItemsItemId_Request = Simplify<
   (GetDatasetsDatasetIdItemsItemId_PathParams extends never
@@ -17872,9 +17885,9 @@ export type PatchDatasetsDatasetIdItemsItemId_Body = {
   /** Expected output for comparison */
   groundTruth?: unknown | undefined;
   /** Expected trajectory configuration for trajectory scoring */
-  expectedTrajectory?: (Shared_Type_140 | undefined) | null;
+  expectedTrajectory?: (Shared_Type_139 | undefined) | null;
   /** Ordered item-level static tool mocks served in place of executing the real tool */
-  toolMocks?: Shared_Type_123[] | undefined;
+  toolMocks?: Shared_Type_122[] | undefined;
   /** Policy for undeclared tool calls. 'allow' runs them live; 'deny' fails the experiment item */
   unmockedToolPolicy?: ('allow' | 'deny') | undefined;
   /** IDs of scorers selected for this item */
@@ -17892,7 +17905,7 @@ export type PatchDatasetsDatasetIdItemsItemId_Body = {
       }
     | undefined;
   /** Source/provenance of this dataset item */
-  source?: Shared_Type_124 | undefined;
+  source?: Shared_Type_123 | undefined;
 };
 
 export type PatchDatasetsDatasetIdItemsItemId_Response = PostDatasetsDatasetIdItems_Response;
@@ -17997,7 +18010,7 @@ export type GetDatasetsDatasetIdItemsItemIdHistory_Response = {
     groundTruth?: unknown | undefined;
     expectedTrajectory?: unknown | undefined;
     /** Ordered item-level static tool mocks served in place of executing the real tool */
-    toolMocks?: Shared_Type_123[] | undefined;
+    toolMocks?: Shared_Type_122[] | undefined;
     /** Policy for undeclared tool calls. 'allow' runs them live; 'deny' fails the experiment item */
     unmockedToolPolicy?: ('allow' | 'deny') | undefined;
     scorerIds?: string[] | undefined;
@@ -18074,7 +18087,7 @@ export type GetExperiments_QueryParams = {
 };
 
 export type GetExperiments_Response = {
-  experiments: Shared_Type_142[];
+  experiments: Shared_Type_141[];
   pagination: {
     total: number;
     page: number;
@@ -18268,7 +18281,7 @@ export type PostDatasetsDatasetIdExperiments_Response = {
     completedAt: Date;
     retryCount: number;
     /** Diagnostic receipt for item-level tool mocks */
-    toolMockReport?: (Shared_Type_143 | undefined) | null;
+    toolMockReport?: (Shared_Type_142 | undefined) | null;
     scores: {
       scorerId: string;
       scorerName: string;
@@ -18324,7 +18337,7 @@ export type PostDatasetsDatasetIdExperimentsExperimentIdItemsItemIdRun_Body = {
 };
 
 export type PostDatasetsDatasetIdExperimentsExperimentIdItemsItemIdRun_Response = {
-  result: Shared_Type_144;
+  result: Shared_Type_143;
   scores: {
     scorerId: string;
     scorerName: string;
@@ -18407,7 +18420,7 @@ export type PostDatasetsDatasetIdExperimentsExperimentIdResults_Body = {
     | undefined;
 };
 
-export type PostDatasetsDatasetIdExperimentsExperimentIdResults_Response = Shared_Type_144;
+export type PostDatasetsDatasetIdExperimentsExperimentIdResults_Response = Shared_Type_143;
 
 export type PostDatasetsDatasetIdExperimentsExperimentIdResults_Request = Simplify<
   (PostDatasetsDatasetIdExperimentsExperimentIdResults_PathParams extends never
@@ -18436,7 +18449,7 @@ export interface PostDatasetsDatasetIdExperimentsExperimentIdResults_RouteContra
 export type PostDatasetsDatasetIdExperimentsExperimentIdFinalize_PathParams =
   PostDatasetsDatasetIdExperimentsExperimentIdResults_PathParams;
 
-export type PostDatasetsDatasetIdExperimentsExperimentIdFinalize_Response = Shared_Type_142;
+export type PostDatasetsDatasetIdExperimentsExperimentIdFinalize_Response = Shared_Type_141;
 
 export type PostDatasetsDatasetIdExperimentsExperimentIdFinalize_Request = Simplify<
   (PostDatasetsDatasetIdExperimentsExperimentIdFinalize_PathParams extends never
@@ -18461,7 +18474,7 @@ export interface PostDatasetsDatasetIdExperimentsExperimentIdFinalize_RouteContr
 export type GetDatasetsDatasetIdExperimentsExperimentId_PathParams =
   PostDatasetsDatasetIdExperimentsExperimentIdResults_PathParams;
 
-export type GetDatasetsDatasetIdExperimentsExperimentId_Response = Shared_Type_142 | null;
+export type GetDatasetsDatasetIdExperimentsExperimentId_Response = Shared_Type_141 | null;
 
 export type GetDatasetsDatasetIdExperimentsExperimentId_Request = Simplify<
   (GetDatasetsDatasetIdExperimentsExperimentId_PathParams extends never
@@ -18532,7 +18545,7 @@ export type GetDatasetsDatasetIdExperimentsExperimentIdResults_PathParams =
 export type GetDatasetsDatasetIdExperimentsExperimentIdResults_QueryParams = GetScoresRunRunId_QueryParams;
 
 export type GetDatasetsDatasetIdExperimentsExperimentIdResults_Response = {
-  results: Shared_Type_144[];
+  results: Shared_Type_143[];
   pagination: {
     total: number;
     page: number;
@@ -18821,7 +18834,7 @@ export type GetBackgroundTasks_QueryParams = {
 };
 
 export type GetBackgroundTasks_Response = {
-  tasks: Shared_Type_145[];
+  tasks: Shared_Type_144[];
   total: number;
 };
 
@@ -18851,7 +18864,7 @@ export type GetBackgroundTasksBackgroundTaskId_PathParams = {
   backgroundTaskId: string;
 };
 
-export type GetBackgroundTasksBackgroundTaskId_Response = Shared_Type_145;
+export type GetBackgroundTasksBackgroundTaskId_Response = Shared_Type_144;
 
 export type GetBackgroundTasksBackgroundTaskId_Request = Simplify<
   (GetBackgroundTasksBackgroundTaskId_PathParams extends never
@@ -18900,8 +18913,8 @@ export type GetEditorBuilderSettings_Response = {
           | {
               models?:
                 | {
-                    allowed?: Shared_Type_146[] | undefined;
-                    default?: Shared_Type_147 | undefined;
+                    allowed?: Shared_Type_145[] | undefined;
+                    default?: Shared_Type_146 | undefined;
                   }
                 | undefined;
               tools?:
@@ -18928,8 +18941,8 @@ export type GetEditorBuilderSettings_Response = {
     | {
         active: boolean;
         pickerVisible?: boolean | undefined;
-        allowed?: Shared_Type_146[] | undefined;
-        default?: Shared_Type_147 | undefined;
+        allowed?: Shared_Type_145[] | undefined;
+        default?: Shared_Type_146 | undefined;
       }
     | undefined;
   picker?:
@@ -19746,7 +19759,7 @@ export type GetSchedules_QueryParams = {
 };
 
 export type GetSchedules_Response = {
-  schedules: (Shared_Type_150 | Shared_Type_152)[];
+  schedules: (Shared_Type_149 | Shared_Type_151)[];
 };
 
 export type GetSchedules_Request = Simplify<
@@ -19775,7 +19788,7 @@ export type GetSchedulesScheduleId_PathParams = {
   scheduleId: string;
 };
 
-export type GetSchedulesScheduleId_Response = Shared_Type_150 | Shared_Type_152;
+export type GetSchedulesScheduleId_Response = Shared_Type_149 | Shared_Type_151;
 
 export type GetSchedulesScheduleId_Request = Simplify<
   (GetSchedulesScheduleId_PathParams extends never ? {} : { params: GetSchedulesScheduleId_PathParams }) &
@@ -19812,8 +19825,8 @@ export type PostSchedules_Body =
             [key: string]: (string | number | boolean | null) | undefined;
           }
         | undefined;
-      ifActive?: Shared_Type_148 | undefined;
-      ifIdle?: Shared_Type_149 | undefined;
+      ifActive?: Shared_Type_147 | undefined;
+      ifIdle?: Shared_Type_148 | undefined;
       providerOptions?:
         | {
             [key: string]: unknown;
@@ -19888,8 +19901,8 @@ export type PatchSchedulesScheduleId_Body = {
         [key: string]: (string | number | boolean | null) | undefined;
       }
     | undefined;
-  ifActive?: Shared_Type_148 | undefined;
-  ifIdle?: Shared_Type_149 | undefined;
+  ifActive?: Shared_Type_147 | undefined;
+  ifIdle?: Shared_Type_148 | undefined;
   providerOptions?:
     | {
         [key: string]: unknown;
@@ -19989,7 +20002,7 @@ export type GetSchedulesScheduleIdTriggers_Response = {
           [key: string]: unknown;
         }
       | undefined;
-    run?: Shared_Type_151 | undefined;
+    run?: Shared_Type_150 | undefined;
   }[];
 };
 

--- a/packages/server/src/server/schemas/agents.test.ts
+++ b/packages/server/src/server/schemas/agents.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { agentExecutionBodySchema } from './agents';
+
+/**
+ * Regression tests for GitHub Issue #22617
+ *
+ * `providerOptions` was validated as a closed object listing only anthropic,
+ * google, openai, and xai. Nested zod objects strip unknown keys and the outer
+ * `.passthrough()` does not apply inside them, so every other provider
+ * namespace (deepseek, bedrock, ...) was silently removed at the route
+ * boundary before reaching the handler. In-process agent calls were
+ * unaffected, which is why the same options worked via the raw client but not
+ * over HTTP.
+ */
+describe('agentExecutionBodySchema providerOptions', () => {
+  it('keeps provider namespaces beyond the previously allowlisted four', () => {
+    const providerOptions = {
+      deepseek: { thinking: { type: 'disabled' } },
+      bedrock: { reasoningConfig: { type: 'enabled', budgetTokens: 1024 } },
+      openai: { reasoningEffort: 'low' },
+    };
+
+    const result = agentExecutionBodySchema.safeParse({ messages: 'hi', providerOptions });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.providerOptions).toEqual(providerOptions);
+    }
+  });
+
+  it('keeps nested option values intact for a single arbitrary namespace', () => {
+    const result = agentExecutionBodySchema.safeParse({
+      messages: 'hi',
+      providerOptions: { groq: { serviceTier: 'flex', structuredOutputs: true } },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.providerOptions?.groq).toEqual({ serviceTier: 'flex', structuredOutputs: true });
+    }
+  });
+
+  it('rejects a namespace whose value is not an object', () => {
+    const result = agentExecutionBodySchema.safeParse({
+      messages: 'hi',
+      providerOptions: { deepseek: 'disabled' },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/server/src/server/schemas/agents.ts
+++ b/packages/server/src/server/schemas/agents.ts
@@ -22,13 +22,6 @@ import { z } from 'zod/v4';
  */
 type StopConditionArg = (event: unknown) => boolean | PromiseLike<boolean>;
 
-/**
- * Structural mirror of the ai-sdk JSONValue type, which is not publicly
- * exported from @mastra/core. Used to keep providerOptions assignable to
- * ProviderOptions (Record<string, JSONObject>) with portable declaration emit.
- */
-type JSONValue = null | string | number | boolean | { [key: string]: JSONValue } | JSONValue[];
-
 type ModelSettings = {
   maxOutputTokens?: number;
   temperature?: number;
@@ -403,14 +396,10 @@ export const agentExecutionBodySchema = z
 
     // Model Configuration
     model: z.string().optional(),
-    providerOptions: typedPermissive<Record<string, Record<string, JSONValue>>>(
-      z.object({
-        anthropic: z.record(z.string(), z.unknown()).optional(),
-        google: z.record(z.string(), z.unknown()).optional(),
-        openai: z.record(z.string(), z.unknown()).optional(),
-        xai: z.record(z.string(), z.unknown()).optional(),
-      }),
-    ).optional(),
+    // Open record: an allowlist here silently strips every other provider's
+    // namespace (deepseek, bedrock, ...) because nested objects drop unknown
+    // keys regardless of the outer passthrough(). See #22617.
+    providerOptions: z.record(z.string(), z.record(z.string(), jsonValueSchema)).optional(),
     modelSettings: typedPermissive<ModelSettings>(z.unknown()).optional(),
 
     // Tool Configuration


### PR DESCRIPTION
Fixes #22617

`agentExecutionBodySchema` validated `providerOptions` as a closed object listing only `anthropic`, `google`, `openai`, and `xai`. Zod strips unknown keys inside nested objects and the outer `.passthrough()` does not apply to them, so every other provider namespace (`deepseek`, `bedrock`, `groq`, custom OpenAI-compatible providers) was removed at the route boundary before the handler ran. In-process calls were unaffected, which is why the option worked via the raw client but not over HTTP. The same body schema backs the generate, stream, legacy, and network routes, so this applies to all of them.

Changes:
- `providerOptions` now uses the open record shape the message-part schemas in this file already use: `z.record(z.string(), z.record(z.string(), jsonValueSchema))`.
- Removed the local `JSONValue` type that existed only to cast the closed schema to the permissive type.
- Regression tests: arbitrary provider namespaces survive parsing, nested values arrive intact, non-object namespaces are still rejected. All three fail against the previous schema.

Repro against the previous schema is in the issue thread: parsing `{ deepseek: ..., bedrock: ..., openai: ... }` returned only `{ openai: ... }`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Provider settings were being removed when requests passed through the server. This change keeps settings for any provider, including DeepSeek, so options such as `deepseek.thinking` reach the provider correctly.

## Changes

- Changed `agentExecutionBodySchema.providerOptions` to accept arbitrary provider namespaces.
- Preserved nested provider option values during request validation.
- Kept non-object provider namespaces invalid.
- Removed the obsolete local `JSONValue` type.
- Added regression tests for DeepSeek, Bedrock, Groq, and custom provider options.
- Added a patch release note for `@mastra/server`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->