### PR TITLE
fix(factory): preserve existing triage status labels

### DIFF
--- a/.changeset/green-clocks-post.md
+++ b/.changeset/green-clocks-post.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Factory triage to preserve existing workflow status labels during initial issue handling.

--- a/mastracode/factory/factory-skills/factory-triage/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-triage/SKILL.md
@@ -40,7 +40,7 @@ At the end of this phase, publish a small summary to the source issue as stated 
 | **Next step**  | Pending                                                                                                                                              |
 ```
 
-For GitHub issues, make sure the issue has the `status: needs triage` label. If not, add it using `gh issue edit "$ISSUE" --add-label "status: needs triage"`. For Linear issues, skip this GitHub-only label mutation.
+For GitHub issues, add `status: needs triage` only if no `status:` label is present, using `gh issue edit "$ISSUE" --add-label "status: needs triage"`. For Linear issues, skip this GitHub-only label mutation.
 
 ## Phase 2: Related Issues & Prior Work
 

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -347,6 +347,17 @@ describe('bundled Factory skill assets', () => {
     expect(rereview).toContain('Review runtime: <model>, reasoning setting: <reasoning>.');
   });
 
+  it('guards the initial triage label when any status label is present', async () => {
+    const assetRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'factory-skills');
+    const triage = await fs.readFile(path.join(assetRoot, 'factory-triage', 'SKILL.md'), 'utf8');
+    const phase1 = triage.slice(triage.indexOf('## Phase 1'), triage.indexOf('## Phase 2'));
+
+    expect(phase1).toContain('add `status: needs triage` only if no `status:` label is present');
+    expect(phase1).toContain('gh issue edit "$ISSUE" --add-label "status: needs triage"');
+    expect(phase1).toContain('For Linear issues, skip this GitHub-only label mutation.');
+    expect(triage).toContain('gh issue edit "$ISSUE" --remove-label "status: needs triage"');
+  });
+
   it('keeps the autonomous Factory skills on the terminal-handoff contract', async () => {
     const assetRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'factory-skills');
     const read = (skillName: string) => fs.readFile(path.join(assetRoot, skillName, 'SKILL.md'), 'utf8');


### PR DESCRIPTION
Factory triage currently adds `status: needs triage` during Phase 1 even when an issue already has another workflow status. That can create conflicting status labels and move an issue backward in the workflow.

This updates the canonical triage skill to add `status: needs triage` only when no `status:` label is present. The existing GitHub command, Linear exception, and final reconciliation that removes stale `status: needs triage` remain unchanged.

Added focused bundled-skill coverage for the Phase 1 guard and Phase 5 cleanup behavior.

Verification: `pnpm --filter @mastra/factory exec vitest run src/workspace.test.ts -t "guards the initial triage label when any status label is present" --reporter=dot --bail 1`; formatting and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory now adds `status: needs triage` only when an issue has no existing status label. This prevents conflicting labels and keeps issues from moving backward.

## Changes

- Updated Phase 1 triage instructions.
- Added focused tests for Phase 1 and Phase 5 behavior.
- Added a patch changeset for `@mastra/factory`.
- Preserved existing Linear handling, GitHub commands, and Phase 5 cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->