### PR TITLE
feat(playground-ui): add ThemeToggle sizes

### DIFF
--- a/.changeset/humble-buses-talk.md
+++ b/.changeset/humble-buses-talk.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added `xs`, `sm`, and `md` sizes to `ThemeToggle`, matching the Badge size scale. The default size is `md`; use `<ThemeToggle size="sm" />` in constrained menus.

--- a/packages/playground-ui/src/ds/components/ThemeProvider/theme-provider.test.tsx
+++ b/packages/playground-ui/src/ds/components/ThemeProvider/theme-provider.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
-import { act, cleanup, render, renderHook } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, renderHook } from '@testing-library/react';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ThemeToggle } from '../ThemeToggle/theme-toggle';
 import { ThemeProvider, useTheme } from './theme-provider';
 
 type SystemPreference = {
@@ -347,5 +348,105 @@ describe('ThemeProvider — remembering the choice', () => {
       );
     });
     expect(result.current.theme).toBe('dark');
+  });
+});
+
+describe('ThemeToggle', () => {
+  beforeAll(() => {
+    if (typeof window.PointerEvent === 'undefined') {
+      Object.defineProperty(window, 'PointerEvent', { configurable: true, value: window.MouseEvent });
+    }
+  });
+
+  it('renders the default options and accessible label', () => {
+    const { getByRole } = render(<ThemeToggle value="dark" onChange={() => undefined} />);
+
+    expect(getByRole('radiogroup', { name: 'Theme' })).toBeTruthy();
+    expect(getByRole('radio', { name: 'System' }).getAttribute('aria-checked')).toBe('false');
+    expect(getByRole('radio', { name: 'Light' }).getAttribute('aria-checked')).toBe('false');
+    expect(getByRole('radio', { name: 'Dark' }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('selects the system option when controlled with the default value', () => {
+    const { getByRole } = render(<ThemeToggle value="system" onChange={() => undefined} />);
+
+    expect(getByRole('radio', { name: 'System' }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('renders safely without options', () => {
+    const { queryAllByRole } = render(<ThemeToggle options={[]} value="dark" onChange={() => undefined} />);
+
+    expect(queryAllByRole('radio')).toHaveLength(0);
+  });
+
+  it('calls the controlled change handler for a selected option', () => {
+    const onChange = vi.fn();
+    const { getByRole } = render(<ThemeToggle value="system" onChange={onChange} />);
+
+    fireEvent.click(getByRole('radio', { name: 'Light' }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('light');
+  });
+
+  it('emits the system value from the default option', () => {
+    const onChange = vi.fn();
+    const { getByRole } = render(<ThemeToggle value="dark" onChange={onChange} />);
+
+    fireEvent.click(getByRole('radio', { name: 'System' }));
+
+    expect(onChange).toHaveBeenCalledWith('system');
+  });
+
+  it('falls back to the first available option', () => {
+    const options = [{ value: 'light', label: 'Only light', icon: <span /> }] as const;
+    const { getByRole } = render(<ThemeToggle options={options} value="dark" onChange={() => undefined} />);
+
+    expect(getByRole('radio', { name: 'Only light' }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('uses medium segment measurements and interaction styles', () => {
+    const { getAllByRole, getByRole } = render(<ThemeToggle size="md" value="dark" onChange={() => undefined} />);
+    const group = getByRole('radiogroup');
+    const indicator = group.querySelector<HTMLSpanElement>(':scope > span[aria-hidden="true"]');
+    const radios = getAllByRole('radio');
+
+    expect(group.classList.contains('gap-0.5')).toBe(true);
+    expect(indicator?.classList.contains('bg-surface5')).toBe(true);
+    expect(indicator?.style.width).toBe('28px');
+    expect(indicator?.style.transform).toBe('translateX(60px)');
+    expect(radios.every(radio => radio.style.width === '28px')).toBe(true);
+    expect(radios.every(radio => radio.classList.contains('rounded-full'))).toBe(true);
+    expect(radios.every(radio => radio.classList.contains('data-[checked]:text-icon6'))).toBe(true);
+    expect(radios.every(radio => radio.classList.contains('focus-visible:outline-hidden'))).toBe(true);
+    expect(radios.every(radio => radio.classList.contains('active:scale-90'))).toBe(true);
+  });
+
+  it('uses extra-small segment measurements at the extra-small size', () => {
+    const { getAllByRole, getByRole } = render(<ThemeToggle size="xs" value="dark" onChange={() => undefined} />);
+    const group = getByRole('radiogroup');
+    const indicator = group.querySelector<HTMLSpanElement>(':scope > span[aria-hidden="true"]');
+
+    expect(group.classList.contains('gap-px')).toBe(true);
+    expect(group.classList.contains('p-px')).toBe(true);
+    expect(indicator?.classList.contains('inset-y-px')).toBe(true);
+    expect(indicator?.style.width).toBe('20px');
+    expect(indicator?.style.transform).toBe('translateX(42px)');
+    expect(getAllByRole('radio').every(radio => radio.style.width === '20px')).toBe(true);
+    expect(getAllByRole('radio').every(radio => radio.classList.contains('h-4'))).toBe(true);
+  });
+
+  it('uses compact segment measurements at the small size', () => {
+    const { getAllByRole, getByRole } = render(<ThemeToggle size="sm" value="dark" onChange={() => undefined} />);
+    const group = getByRole('radiogroup');
+    const indicator = group.querySelector<HTMLSpanElement>(':scope > span[aria-hidden="true"]');
+
+    expect(group.classList.contains('gap-px')).toBe(true);
+    expect(group.classList.contains('p-px')).toBe(true);
+    expect(indicator?.classList.contains('inset-y-px')).toBe(true);
+    expect(indicator?.style.width).toBe('24px');
+    expect(indicator?.style.transform).toBe('translateX(50px)');
+    expect(getAllByRole('radio').every(radio => radio.style.width === '24px')).toBe(true);
+    expect(getAllByRole('radio').every(radio => radio.classList.contains('h-5'))).toBe(true);
   });
 });

--- a/packages/playground-ui/src/ds/components/ThemeToggle/theme-toggle.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ThemeToggle/theme-toggle.stories.tsx
@@ -17,6 +17,9 @@ export default meta;
 type Story = StoryObj<typeof ThemeToggle>;
 
 export const Default: Story = {
+  args: {
+    size: 'md',
+  },
   decorators: [
     Story => (
       <ThemeProvider storageKey="storybook-theme">
@@ -24,6 +27,49 @@ export const Default: Story = {
       </ThemeProvider>
     ),
   ],
+};
+
+export const ExtraSmall: Story = {
+  args: {
+    size: 'xs',
+  },
+  decorators: [
+    Story => (
+      <ThemeProvider storageKey="storybook-theme-extra-small">
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+};
+
+export const Small: Story = {
+  args: {
+    size: 'sm',
+  },
+  decorators: [
+    Story => (
+      <ThemeProvider storageKey="storybook-theme-small">
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+};
+
+export const Sizes: Story = {
+  decorators: [
+    Story => (
+      <ThemeProvider storageKey="storybook-theme-sizes">
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+  render: () => (
+    <div className="flex items-center gap-4">
+      <ThemeToggle size="xs" />
+      <ThemeToggle size="sm" />
+      <ThemeToggle size="md" />
+    </div>
+  ),
 };
 
 export const Controlled: Story = {

--- a/packages/playground-ui/src/ds/components/ThemeToggle/theme-toggle.tsx
+++ b/packages/playground-ui/src/ds/components/ThemeToggle/theme-toggle.tsx
@@ -19,8 +19,29 @@ const DEFAULT_OPTIONS: ReadonlyArray<ThemeToggleOption> = [
   { value: 'dark', label: 'Dark', icon: <Moon /> },
 ];
 
-const ITEM_WIDTH = 28;
-const ITEM_GAP = 2;
+const SIZE_CONFIG = {
+  md: {
+    itemGap: 2,
+    itemWidth: 28,
+    root: 'gap-0.5 p-0.5',
+    indicator: 'inset-y-0.5 left-0.5',
+    item: 'h-6 [&_svg]:size-3.5',
+  },
+  xs: {
+    itemGap: 1,
+    itemWidth: 20,
+    root: 'gap-px p-px',
+    indicator: 'inset-y-px left-px',
+    item: 'h-4 [&_svg]:h-icon-sm [&_svg]:w-icon-sm',
+  },
+  sm: {
+    itemGap: 1,
+    itemWidth: 24,
+    root: 'gap-px p-px',
+    indicator: 'inset-y-px left-px',
+    item: 'h-5 [&_svg]:h-icon-sm [&_svg]:w-icon-sm',
+  },
+} as const;
 
 type RadioRootProps = Omit<
   RadioGroupPrimitive.Props,
@@ -34,12 +55,14 @@ type UncontrolledProps = { value?: undefined; onChange?: undefined };
 
 export type ThemeToggleProps = RadioRootProps & {
   options?: ReadonlyArray<ThemeToggleOption>;
+  size?: keyof typeof SIZE_CONFIG;
 } & (ControlledProps | UncontrolledProps);
 
 export const ThemeToggle = ({
   value,
   onChange,
   options = DEFAULT_OPTIONS,
+  size = 'md',
   className,
   'aria-label': ariaLabel = 'Theme',
   ...rest
@@ -58,7 +81,8 @@ export const ThemeToggle = ({
     0,
     options.findIndex(option => option.value === effectiveCurrent),
   );
-  const indicatorOffset = activeIndex * (ITEM_WIDTH + ITEM_GAP);
+  const sizeConfig = SIZE_CONFIG[size];
+  const indicatorOffset = activeIndex * (sizeConfig.itemWidth + sizeConfig.itemGap);
 
   return (
     <RadioGroupPrimitive
@@ -67,28 +91,31 @@ export const ThemeToggle = ({
       onValueChange={handleChange}
       aria-label={ariaLabel}
       className={cn(
-        'relative inline-flex w-fit items-center gap-0.5 rounded-full border border-border1 bg-surface3 p-0.5',
+        'relative inline-flex w-fit items-center rounded-full border border-border1 bg-surface3',
+        sizeConfig.root,
         className,
       )}
     >
       <span
         aria-hidden="true"
         className={cn(
-          'pointer-events-none absolute inset-y-0.5 left-0.5 rounded-full bg-surface5 motion-reduce:transition-none',
+          'pointer-events-none absolute rounded-full bg-surface5 motion-reduce:transition-none',
           transitions.transform,
+          sizeConfig.indicator,
         )}
-        style={{ width: ITEM_WIDTH, transform: `translateX(${indicatorOffset}px)` }}
+        style={{ width: sizeConfig.itemWidth, transform: `translateX(${indicatorOffset}px)` }}
       />
       {options.map(option => (
         <RadioPrimitive.Root
           key={option.value}
           value={option.value}
           aria-label={option.label}
-          style={{ width: ITEM_WIDTH }}
+          style={{ width: sizeConfig.itemWidth }}
           className={cn(
-            'relative inline-flex h-6 cursor-pointer items-center justify-center rounded-full',
+            'relative inline-flex cursor-pointer items-center justify-center rounded-full',
             // Base UI exposes `data-checked` instead of Radix's `data-state="checked"`.
-            'text-icon3 hover:text-icon6 data-[checked]:text-icon6 [&_svg]:size-3.5',
+            'text-icon3 hover:text-icon6 data-[checked]:text-icon6',
+            sizeConfig.item,
             'focus-visible:outline-hidden',
             'active:scale-90 motion-reduce:transition-none',
             transitions.colors,


### PR DESCRIPTION
Adds `xs`, `sm`, and `md` sizes to `ThemeToggle`, with `md` as the default. Compact consumers can use the component API instead of scaling the whole control with CSS.

```tsx
<ThemeToggle size="sm" />
```

This follows up on the scaled ThemeToggle usage in mastra-ai/platform#2501.

| Light | Dark |
| --- | --- |
| ![ThemeToggle xs, sm, and md sizes in light mode](https://github.com/user-attachments/assets/fd18e4bc-e01c-4354-9115-e57f4141b92e) | ![ThemeToggle xs, sm, and md sizes in dark mode](https://github.com/user-attachments/assets/dcbcf1de-7bb7-4141-8d42-da0eb78bbce5) |

Validated with the Playground UI test suite, typecheck, package and Storybook builds, mutation testing, Agent Browser, and Playwright.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

`ThemeToggle` now supports three sizes. Smaller controls fit compact layouts without custom CSS scaling.

## Changes

- Added `xs`, `sm`, and `md` size variants.
- Set `md` as the default size.
- Added size-specific dimensions, spacing, indicator positions, and icon sizes.
- Added `size` to `ThemeToggleProps`.
- Added Storybook stories for each size and a combined size view.
- Added tests for accessibility, selection, callbacks, fallback behavior, and size styling.
- Added a minor changeset for `@mastra/playground-ui`.

## Validation

- Playground UI tests
- Typecheck
- Package and Storybook builds
- Mutation testing
- Agent Browser
- Playwright

<!-- end of auto-generated comment: release notes by coderabbit.ai -->