### PR TITLE
feat(connect): @mastra/connect — platform-connected integration toolsets (core)

### DIFF
--- a/.changeset/salty-ducks-sip.md
+++ b/.changeset/salty-ducks-sip.md
@@ -1,0 +1,24 @@
+---
+'@mastra/connect': minor
+---
+
+Added @mastra/connect, a new package that turns Mastra-platform integration connections into agent toolsets with zero credential handling. Tools execute through the platform connection proxy, so provider credentials never enter your app.
+
+**Discover everything a project has connected**
+
+```ts
+import { connect } from '@mastra/connect';
+
+const toolsets = await connect(); // uses MASTRA_PROJECT_ID
+const response = await agent.generate('Whats on my plate?', { toolsets });
+```
+
+**Fetch a raw credential for custom interactions**
+
+```ts
+import { credential } from '@mastra/connect';
+
+const cred = await credential('c_...'); // { type: 'oauth2', accessToken, expiresAt } | { type: 'api_key', apiKey }
+```
+
+This release ships the package core: connect() runtime discovery, credential() retrieval, and the proxy-based tool infrastructure, including access limiting via allowTools and a connect() integration allowlist. Provider toolsets follow in subsequent releases.

--- a/packages/connect/eslint.config.js
+++ b/packages/connect/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/packages/connect/lint-staged.config.js
+++ b/packages/connect/lint-staged.config.js
@@ -1,0 +1,9 @@
+export default {
+  '*.{ts,tsx}': [
+    'oxlint --fix --deny-warnings',
+    'eslint --fix --max-warnings=0',
+    'oxfmt --no-error-on-unmatched-pattern',
+  ],
+  '*.{js,jsx}': ['oxfmt --no-error-on-unmatched-pattern'],
+  '*.{json,md,yml,yaml}': ['oxfmt --no-error-on-unmatched-pattern'],
+};

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@mastra/connect",
+  "version": "0.1.0",
+  "description": "Use Mastra platform integration connections as agent toolsets",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build:lib": "tsdown --silent --config tsdown.config.ts",
+    "build:watch": "pnpm build:lib --watch",
+    "lint": "oxlint . && eslint .",
+    "lint:fix": "oxlint --fix . && eslint --fix .",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "mastra",
+    "connect",
+    "integrations",
+    "tools",
+    "ai-agent"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "packages/connect"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "homepage": "https://mastra.ai",
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "zod": ">=3.0.0 || >=4.0.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "tsdown": "0.22.9",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  }
+}

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/connect",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Use Mastra platform integration connections as agent toolsets",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/connect/src/__tests__/client.test.ts
+++ b/packages/connect/src/__tests__/client.test.ts
@@ -258,6 +258,19 @@ describe('proxyRequest', () => {
     });
   });
 
+  it('keeps a provider problem-shaped application/json 404 as proxy_error', async () => {
+    // A provider body that *looks* RFC-7807 (e.g. ASP.NET ProblemDetails) but
+    // is served as plain application/json must not map to connection_not_found.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(Response.json({ title: 'Not Found', status: 404, detail: 'no such page' }, { status: 404 }));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    await expect(proxyRequest(client, 'c_1', { method: 'GET', path: 'pages/x' })).rejects.toMatchObject({
+      code: 'proxy_error',
+      status: 404,
+    });
+  });
+
   it('keeps a provider 401 as proxy_error', async () => {
     const fetchMock = vi.fn().mockResolvedValue(Response.json({ message: 'expired token' }, { status: 401 }));
     const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });

--- a/packages/connect/src/__tests__/client.test.ts
+++ b/packages/connect/src/__tests__/client.test.ts
@@ -1,0 +1,301 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getCredential, listProjectConnections, proxyRequest, resolveClient } from '../client.js';
+import { MastraConnectError } from '../errors.js';
+
+const TOKEN = 'fake-test-token';
+
+function makeClient(fetchMock: ReturnType<typeof vi.fn>, overrides?: Record<string, unknown>) {
+  return resolveClient({ accessToken: TOKEN, fetch: fetchMock as unknown as typeof fetch, ...overrides });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('resolveClient', () => {
+  it('uses an explicit access token', () => {
+    const client = resolveClient({ accessToken: TOKEN });
+    expect(client.headers.authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it('falls back to MASTRA_PLATFORM_ACCESS_TOKEN', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'env-token-a');
+    const client = resolveClient();
+    expect(client.headers.authorization).toBe('Bearer env-token-a');
+  });
+
+  it('falls back to MASTRA_PLATFORM_SECRET_KEY when the access token env is unset', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'env-secret-b');
+    const client = resolveClient();
+    expect(client.headers.authorization).toBe('Bearer env-secret-b');
+  });
+
+  it('throws missing_access_token when no token is available', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
+    try {
+      resolveClient();
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(MastraConnectError);
+      expect((error as MastraConnectError).code).toBe('missing_access_token');
+    }
+  });
+
+  it('defaults to the global integrations URL', () => {
+    vi.stubEnv('MASTRA_INTEGRATIONS_API_URL', '');
+    vi.stubEnv('MASTRA_PLATFORM_REGION', '');
+    const client = resolveClient({ accessToken: TOKEN });
+    expect(client.baseUrl).toBe('https://integrations.mastra.ai');
+  });
+
+  it.each([
+    ['us', 'https://integrations.us.mastra.ai'],
+    ['eu', 'https://integrations.eu.mastra.ai'],
+    ['US', 'https://integrations.us.mastra.ai'],
+    [' Eu ', 'https://integrations.eu.mastra.ai'],
+  ])('resolves region %s to %s', (region, expected) => {
+    vi.stubEnv('MASTRA_INTEGRATIONS_API_URL', '');
+    vi.stubEnv('MASTRA_PLATFORM_REGION', region);
+    const client = resolveClient({ accessToken: TOKEN });
+    expect(client.baseUrl).toBe(expected);
+  });
+
+  it('falls through to the global URL for unknown regions', () => {
+    vi.stubEnv('MASTRA_INTEGRATIONS_API_URL', '');
+    vi.stubEnv('MASTRA_PLATFORM_REGION', 'mars');
+    const client = resolveClient({ accessToken: TOKEN });
+    expect(client.baseUrl).toBe('https://integrations.mastra.ai');
+  });
+
+  it('lets MASTRA_INTEGRATIONS_API_URL override the region', () => {
+    vi.stubEnv('MASTRA_INTEGRATIONS_API_URL', 'https://example.test/api///');
+    vi.stubEnv('MASTRA_PLATFORM_REGION', 'us');
+    const client = resolveClient({ accessToken: TOKEN });
+    expect(client.baseUrl).toBe('https://example.test/api');
+  });
+
+  it('lets an explicit baseUrl option override everything', () => {
+    vi.stubEnv('MASTRA_INTEGRATIONS_API_URL', 'https://example.test/env');
+    const client = resolveClient({ accessToken: TOKEN, baseUrl: 'https://example.test/opt/' });
+    expect(client.baseUrl).toBe('https://example.test/opt');
+  });
+
+  it('omits x-organization-id unless configured', () => {
+    vi.stubEnv('MASTRA_ORG_ID', '');
+    const client = resolveClient({ accessToken: TOKEN });
+    expect(client.headers['x-organization-id']).toBeUndefined();
+  });
+
+  it('sends x-organization-id from the option or MASTRA_ORG_ID', () => {
+    expect(resolveClient({ accessToken: TOKEN, orgId: 'org_1' }).headers['x-organization-id']).toBe('org_1');
+    vi.stubEnv('MASTRA_ORG_ID', 'org_env');
+    expect(resolveClient({ accessToken: TOKEN }).headers['x-organization-id']).toBe('org_env');
+  });
+});
+
+describe('listProjectConnections', () => {
+  const connection = {
+    id: 'c_lin1',
+    integrationId: 'linear',
+    status: 'active',
+    connectedByUserId: 'user_1',
+    connectedAt: '2026-09-01T00:00:00Z',
+    createdAt: '2026-09-01T00:00:00Z',
+    accountLabel: 'Acme',
+  };
+
+  it('parses the connection list and sends auth headers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ connections: [connection] }));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    const connections = await listProjectConnections(client, 'proj_1');
+    expect(connections).toHaveLength(1);
+    expect(connections[0]!.integrationId).toBe('linear');
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://example.test/v2/projects/proj_1/connections');
+    expect(init.headers.authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it('maps a platform 401 to unauthorized', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ error: 'bad token' }, { status: 401 }));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    await expect(listProjectConnections(client, 'proj_1')).rejects.toMatchObject({
+      code: 'unauthorized',
+      status: 401,
+    });
+  });
+
+  it('maps a platform 404 to connection_not_found', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ error: 'no project' }, { status: 404 }));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    await expect(listProjectConnections(client, 'proj_1')).rejects.toMatchObject({
+      code: 'connection_not_found',
+      status: 404,
+    });
+  });
+
+  it('throws platform_error on malformed response shapes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ nope: true }));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    await expect(listProjectConnections(client, 'proj_1')).rejects.toMatchObject({ code: 'platform_error' });
+  });
+
+  it('redacts the access token from transport error messages', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error(`connect failed for Bearer ${TOKEN} at host`));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    try {
+      await listProjectConnections(client, 'proj_1');
+      expect.unreachable();
+    } catch (error) {
+      expect((error as Error).message).not.toContain(TOKEN);
+      expect((error as Error).message).toContain('[REDACTED]');
+    }
+  });
+});
+
+describe('getCredential', () => {
+  it('parses an oauth2 credential', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(Response.json({ type: 'oauth2', accessToken: 'fake-provider-token', expiresAt: null }));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    const result = await getCredential(client, 'c_1');
+    expect(result).toEqual({ type: 'oauth2', accessToken: 'fake-provider-token', expiresAt: null });
+  });
+
+  it('parses an api_key credential', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ type: 'api_key', apiKey: 'fake-api-key' }));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    const result = await getCredential(client, 'c_1');
+    expect(result).toEqual({ type: 'api_key', apiKey: 'fake-api-key' });
+  });
+
+  it('throws unsupported_credential_type for unknown unions', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ type: 'basic', username: 'u' }));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    await expect(getCredential(client, 'c_1')).rejects.toMatchObject({ code: 'unsupported_credential_type' });
+  });
+
+  it('maps the platform unsupported_credential_type problem code', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ title: 'Unsupported credential', status: 502, code: 'unsupported_credential_type' }),
+          { status: 502, headers: { 'content-type': 'application/problem+json' } },
+        ),
+      );
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    await expect(getCredential(client, 'c_1')).rejects.toMatchObject({ code: 'unsupported_credential_type' });
+  });
+});
+
+describe('proxyRequest', () => {
+  it('builds the proxy URL with query params and strips leading slashes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ ok: true }));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    await proxyRequest(client, 'c_1', {
+      method: 'GET',
+      path: '/issues',
+      query: { page: 2, q: 'bug fix', skip: undefined },
+    });
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://example.test/v2/connections/c_1/proxy/issues?page=2&q=bug+fix');
+  });
+
+  it('JSON-encodes bodies and forwards custom headers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ ok: true }));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    await proxyRequest(client, 'c_1', {
+      method: 'POST',
+      path: 'graphql',
+      headers: { 'x-custom': 'v1' },
+      body: { query: '{ viewer { id } }' },
+    });
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(init.method).toBe('POST');
+    expect(init.headers['content-type']).toBe('application/json');
+    expect(init.headers['x-custom']).toBe('v1');
+    expect(JSON.parse(init.body)).toEqual({ query: '{ viewer { id } }' });
+  });
+
+  it('keeps a provider 404 as proxy_error (never connection_not_found)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ message: 'page not found' }, { status: 404 }));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    await expect(proxyRequest(client, 'c_1', { method: 'GET', path: 'pages/x' })).rejects.toMatchObject({
+      code: 'proxy_error',
+      status: 404,
+    });
+  });
+
+  it('maps a platform problem-JSON 404 to connection_not_found', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ title: 'Connection not found', status: 404, detail: 'unknown connection' }), {
+        status: 404,
+        headers: { 'content-type': 'application/problem+json' },
+      }),
+    );
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    await expect(proxyRequest(client, 'c_1', { method: 'GET', path: 'issues' })).rejects.toMatchObject({
+      code: 'connection_not_found',
+      status: 404,
+      detail: 'unknown connection',
+    });
+  });
+
+  it('maps a platform problem-JSON 401 to unauthorized', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ title: 'Unauthorized', status: 401 }), {
+        status: 401,
+        headers: { 'content-type': 'application/problem+json' },
+      }),
+    );
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    await expect(proxyRequest(client, 'c_1', { method: 'GET', path: 'issues' })).rejects.toMatchObject({
+      code: 'unauthorized',
+    });
+  });
+
+  it('keeps a provider 401 as proxy_error', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ message: 'expired token' }, { status: 401 }));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    await expect(proxyRequest(client, 'c_1', { method: 'GET', path: 'me' })).rejects.toMatchObject({
+      code: 'proxy_error',
+      status: 401,
+    });
+  });
+
+  it('never echoes the access token in proxy error messages', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ message: 'boom' }, { status: 500 }));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    try {
+      await proxyRequest(client, 'c_1', { method: 'GET', path: 'x' });
+      expect.unreachable();
+    } catch (error) {
+      expect((error as Error).message).not.toContain(TOKEN);
+    }
+  });
+
+  it('handles non-JSON provider error bodies without echoing them', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('<html>secret page</html>', { status: 500 }));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    try {
+      await proxyRequest(client, 'c_1', { method: 'GET', path: 'x' });
+      expect.unreachable();
+    } catch (error) {
+      expect((error as MastraConnectError).code).toBe('proxy_error');
+      expect((error as Error).message).not.toContain('secret page');
+    }
+  });
+
+  it('returns parsed JSON on 2xx and null on empty bodies', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ data: 1 }));
+    const client = makeClient(fetchMock, { baseUrl: 'https://example.test' });
+    await expect(proxyRequest(client, 'c_1', { method: 'GET', path: 'x' })).resolves.toEqual({ data: 1 });
+
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+    await expect(proxyRequest(client, 'c_1', { method: 'DELETE', path: 'x' })).resolves.toBeNull();
+  });
+});

--- a/packages/connect/src/__tests__/connect.test.ts
+++ b/packages/connect/src/__tests__/connect.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { connect } from '../connect.js';
+import { PROVIDERS } from '../registry.js';
+import type { ProviderRegistration } from '../registry.js';
+
+const TOKEN = 'fake-test-token';
+
+const fakeTools = { linear_fake_tool: { id: 'linear_fake_tool' } } as never;
+
+function stubProvider(overrides?: Partial<ProviderRegistration>): { createTools: ReturnType<typeof vi.fn> } {
+  const createTools = vi.fn().mockReturnValue(fakeTools);
+  PROVIDERS.linear = {
+    integrationId: 'linear',
+    envVar: 'MASTRA_LINEAR_CONNECTION_ID',
+    createTools,
+    ...overrides,
+  };
+  return { createTools };
+}
+
+function makeConnection(overrides?: Record<string, unknown>) {
+  return {
+    id: 'c_lin1',
+    integrationId: 'linear',
+    status: 'active',
+    connectedByUserId: 'user_1',
+    connectedAt: '2026-09-01T00:00:00Z',
+    createdAt: '2026-09-01T00:00:00Z',
+    accountLabel: 'Acme',
+    ...overrides,
+  };
+}
+
+function clientFor(connections: unknown[]) {
+  const fetchMock = vi.fn().mockResolvedValue(Response.json({ connections }));
+  return {
+    projectId: 'proj_1',
+    client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+  };
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  delete PROVIDERS.linear;
+  vi.unstubAllEnvs();
+  warnSpy.mockRestore();
+});
+
+describe('connect', () => {
+  it('throws missing_project_id without a project id', async () => {
+    vi.stubEnv('MASTRA_PROJECT_ID', '');
+    await expect(connect({ client: { accessToken: TOKEN } })).rejects.toMatchObject({ code: 'missing_project_id' });
+  });
+
+  it('falls back to MASTRA_PROJECT_ID', async () => {
+    stubProvider();
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ connections: [] }));
+    vi.stubEnv('MASTRA_PROJECT_ID', 'proj_env');
+    await connect({ client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as never } });
+    expect(String(fetchMock.mock.calls[0]![0])).toContain('/v2/projects/proj_env/connections');
+  });
+
+  it('returns a toolset per supported connected provider (undirected)', async () => {
+    const { createTools } = stubProvider();
+    const result = await connect(clientFor([makeConnection()]));
+    expect(Object.keys(result)).toEqual(['linear']);
+    expect(result.linear).toBe(fakeTools);
+    expect(createTools).toHaveBeenCalledWith(expect.objectContaining({ connectionId: 'c_lin1' }));
+  });
+
+  it('warns and skips unsupported platform integrations', async () => {
+    stubProvider();
+    const result = await connect(
+      clientFor([makeConnection(), makeConnection({ id: 'c_unk1', integrationId: 'salesforce' })]),
+    );
+    expect(Object.keys(result)).toEqual(['linear']);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('salesforce'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('c_unk1'));
+  });
+
+  it('treats the integrations option as an allowlist', async () => {
+    stubProvider();
+    const result = await connect({ ...clientFor([makeConnection()]), integrations: { linear: true } });
+    expect(Object.keys(result)).toEqual(['linear']);
+  });
+
+  it('excludes providers marked false without throwing', async () => {
+    stubProvider();
+    const result = await connect({ ...clientFor([makeConnection()]), integrations: { linear: false } });
+    expect(result).toEqual({});
+  });
+
+  it('throws connection_not_found for listed providers with no project connection', async () => {
+    stubProvider();
+    await expect(connect({ ...clientFor([]), integrations: { linear: true } })).rejects.toMatchObject({
+      code: 'connection_not_found',
+    });
+  });
+
+  it('never throws for false entries even when the provider is absent', async () => {
+    stubProvider();
+    await expect(connect({ ...clientFor([]), integrations: { linear: false } })).resolves.toEqual({});
+  });
+
+  it('passes allowTools from the integration options through to the builder', async () => {
+    const { createTools } = stubProvider();
+    await connect({
+      ...clientFor([makeConnection()]),
+      integrations: { linear: { allowTools: ['linear_fake_tool'] } },
+    });
+    expect(createTools).toHaveBeenCalledWith(expect.objectContaining({ allowTools: ['linear_fake_tool'] }));
+  });
+
+  it('lets the env var pick among multiple connections', async () => {
+    const { createTools } = stubProvider();
+    vi.stubEnv('MASTRA_LINEAR_CONNECTION_ID', 'c_lin2');
+    await connect(clientFor([makeConnection(), makeConnection({ id: 'c_lin2' })]));
+    expect(createTools).toHaveBeenCalledWith(expect.objectContaining({ connectionId: 'c_lin2' }));
+  });
+
+  it('lets an explicit connectionId option win over ambiguity', async () => {
+    const { createTools } = stubProvider();
+    await connect({
+      ...clientFor([makeConnection(), makeConnection({ id: 'c_lin2' })]),
+      integrations: { linear: { connectionId: 'c_lin1' } },
+    });
+    expect(createTools).toHaveBeenCalledWith(expect.objectContaining({ connectionId: 'c_lin1' }));
+  });
+
+  it('throws multiple_connections when an explicitly requested provider is ambiguous', async () => {
+    stubProvider();
+    await expect(
+      connect({
+        ...clientFor([makeConnection(), makeConnection({ id: 'c_lin2' })]),
+        integrations: { linear: true },
+      }),
+    ).rejects.toMatchObject({ code: 'multiple_connections' });
+  });
+
+  it('warns and skips ambiguous providers in undirected mode, listing candidates', async () => {
+    stubProvider();
+    const result = await connect(clientFor([makeConnection(), makeConnection({ id: 'c_lin2' })]));
+    expect(result).toEqual({});
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('c_lin1'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('c_lin2'));
+  });
+
+  it('throws needs_reauth when an explicitly requested provider only has needs_reauth connections', async () => {
+    stubProvider();
+    await expect(
+      connect({
+        ...clientFor([makeConnection({ status: 'needs_reauth' })]),
+        integrations: { linear: true },
+      }),
+    ).rejects.toMatchObject({ code: 'needs_reauth' });
+  });
+
+  it('warns and skips needs_reauth providers in undirected mode', async () => {
+    stubProvider();
+    const result = await connect(clientFor([makeConnection({ status: 'needs_reauth' })]));
+    expect(result).toEqual({});
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('re-authentication'));
+  });
+
+  it('throws needs_reauth when the env var names a needs_reauth connection', async () => {
+    stubProvider();
+    vi.stubEnv('MASTRA_LINEAR_CONNECTION_ID', 'c_lin1');
+    await expect(connect(clientFor([makeConnection({ status: 'needs_reauth' })]))).rejects.toMatchObject({
+      code: 'needs_reauth',
+    });
+  });
+
+  it('rejects unknown integration keys in options', async () => {
+    stubProvider();
+    await expect(
+      connect({ ...clientFor([makeConnection()]), integrations: { salesforce: true } as never }),
+    ).rejects.toMatchObject({ code: 'connection_not_found' });
+  });
+});

--- a/packages/connect/src/__tests__/connect.test.ts
+++ b/packages/connect/src/__tests__/connect.test.ts
@@ -176,6 +176,27 @@ describe('connect', () => {
     });
   });
 
+  it('tolerates connections with unknown statuses: skips them in undirected mode', async () => {
+    stubProvider();
+    const result = await connect(clientFor([makeConnection({ status: 'pending' })]));
+    expect(result).toEqual({});
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('c_lin1: pending'));
+  });
+
+  it('throws connection_not_found when an explicitly requested provider only has unknown-status connections', async () => {
+    stubProvider();
+    await expect(
+      connect({ ...clientFor([makeConnection({ status: 'pending' })]), integrations: { linear: true } }),
+    ).rejects.toMatchObject({ code: 'connection_not_found' });
+  });
+
+  it('an unknown status on one connection does not break resolution of an active one', async () => {
+    const { createTools } = stubProvider();
+    const result = await connect(clientFor([makeConnection({ id: 'c_lin2', status: 'pending' }), makeConnection()]));
+    expect(Object.keys(result)).toEqual(['linear']);
+    expect(createTools).toHaveBeenCalledWith(expect.objectContaining({ connectionId: 'c_lin1' }));
+  });
+
   it('rejects unknown integration keys in options', async () => {
     stubProvider();
     await expect(

--- a/packages/connect/src/__tests__/credential.test.ts
+++ b/packages/connect/src/__tests__/credential.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { credential } from '../credential.js';
+
+const TOKEN = 'fake-test-token';
+
+function options(fetchMock: ReturnType<typeof vi.fn>) {
+  return {
+    client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+  };
+}
+
+describe('credential', () => {
+  it('fetches and returns the oauth2 credential union', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        Response.json({ type: 'oauth2', accessToken: 'fake-provider-token', expiresAt: '2026-10-01T00:00:00Z' }),
+      );
+    const result = await credential('c_1', options(fetchMock));
+    expect(result).toEqual({ type: 'oauth2', accessToken: 'fake-provider-token', expiresAt: '2026-10-01T00:00:00Z' });
+    expect(String(fetchMock.mock.calls[0]![0])).toBe('https://example.test/v2/connections/c_1/credentials');
+  });
+
+  it('returns the api_key union', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ type: 'api_key', apiKey: 'fake-api-key' }));
+    await expect(credential('c_1', options(fetchMock))).resolves.toEqual({ type: 'api_key', apiKey: 'fake-api-key' });
+  });
+
+  it('maps a 404 to connection_not_found', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ error: 'nope' }, { status: 404 }));
+    await expect(credential('c_missing', options(fetchMock))).rejects.toMatchObject({
+      code: 'connection_not_found',
+      status: 404,
+    });
+  });
+});

--- a/packages/connect/src/__tests__/toolset.test.ts
+++ b/packages/connect/src/__tests__/toolset.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { MastraConnectError } from '../errors.js';
+import { applyAllowTools, defineProxyTool, resolveConnectionId } from '../toolset.js';
+
+const TOKEN = 'fake-test-token';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('resolveConnectionId', () => {
+  it('prefers the explicit option', () => {
+    vi.stubEnv('MASTRA_LINEAR_CONNECTION_ID', 'c_env');
+    expect(resolveConnectionId('MASTRA_LINEAR_CONNECTION_ID', 'c_opt')).toBe('c_opt');
+  });
+
+  it('falls back to the env var', () => {
+    vi.stubEnv('MASTRA_LINEAR_CONNECTION_ID', 'c_env');
+    expect(resolveConnectionId('MASTRA_LINEAR_CONNECTION_ID')).toBe('c_env');
+  });
+
+  it('throws missing_connection_id naming the env var', () => {
+    vi.stubEnv('MASTRA_LINEAR_CONNECTION_ID', '');
+    try {
+      resolveConnectionId('MASTRA_LINEAR_CONNECTION_ID');
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(MastraConnectError);
+      expect((error as MastraConnectError).code).toBe('missing_connection_id');
+      expect((error as Error).message).toContain('MASTRA_LINEAR_CONNECTION_ID');
+    }
+  });
+});
+
+describe('applyAllowTools', () => {
+  const tools = { a: { id: 'a' }, b: { id: 'b' } } as never;
+
+  it('returns the toolset unchanged without a filter', () => {
+    expect(applyAllowTools(tools)).toBe(tools);
+  });
+
+  it('filters to the listed tool keys', () => {
+    expect(Object.keys(applyAllowTools(tools, ['b']))).toEqual(['b']);
+  });
+
+  it('throws at build time on unknown names', () => {
+    expect(() => applyAllowTools(tools, ['a', 'typo'])).toThrow(/typo/);
+  });
+});
+
+describe('defineProxyTool', () => {
+  function makeTool(fetchMock: ReturnType<typeof vi.fn>, connectionId?: string) {
+    return defineProxyTool(
+      {
+        envVar: 'MASTRA_LINEAR_CONNECTION_ID',
+        options: {
+          connectionId,
+          client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+        },
+      },
+      {
+        id: 'linear_fake_tool',
+        description: 'A fake tool for tests',
+        inputSchema: z.object({ name: z.string() }),
+        outputSchema: z.object({ echoed: z.string() }),
+        request: input => ({ method: 'POST', path: 'graphql', body: { name: input.name } }),
+        transform: raw => ({ echoed: String((raw as { name: string }).name) }),
+      },
+    );
+  }
+
+  it('builds without env vars or credentials set (lazy resolution)', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
+    vi.stubEnv('MASTRA_LINEAR_CONNECTION_ID', '');
+    const tool = defineProxyTool(
+      { envVar: 'MASTRA_LINEAR_CONNECTION_ID' },
+      {
+        id: 'linear_fake_tool',
+        description: 'A fake tool for tests',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+        request: () => ({ method: 'GET', path: 'x' }),
+        transform: () => ({}),
+      },
+    );
+    expect(tool.id).toBe('linear_fake_tool');
+  });
+
+  it('executes through the proxy and shapes the result', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ name: 'hi' }));
+    const tool = makeTool(fetchMock, 'c_1');
+    const result = await tool.execute!({ name: 'hi' }, {} as never);
+    expect(result).toEqual({ echoed: 'hi' });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://example.test/v2/connections/c_1/proxy/graphql');
+    expect(init.method).toBe('POST');
+  });
+
+  it('resolves the connection id from the env var at execute time', async () => {
+    vi.stubEnv('MASTRA_LINEAR_CONNECTION_ID', 'c_env');
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ name: 'x' }));
+    const tool = makeTool(fetchMock);
+    await tool.execute!({ name: 'x' }, {} as never);
+    expect(String(fetchMock.mock.calls[0]![0])).toContain('/v2/connections/c_env/proxy/');
+  });
+
+  it('throws missing_connection_id at execute time when unresolvable', async () => {
+    vi.stubEnv('MASTRA_LINEAR_CONNECTION_ID', '');
+    const fetchMock = vi.fn();
+    const tool = makeTool(fetchMock);
+    await expect(tool.execute!({ name: 'x' }, {} as never)).rejects.toMatchObject({
+      code: 'missing_connection_id',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/connect/src/client.ts
+++ b/packages/connect/src/client.ts
@@ -132,7 +132,10 @@ async function throwPlatformError(response: Response, context: string): Promise<
 export const connectionSchema = z.object({
   id: z.string(),
   integrationId: z.string(),
-  status: z.enum(['active', 'needs_reauth']),
+  // Lenient on purpose: an unknown future status must not fail the whole
+  // connection list — resolution treats anything but 'active'/'needs_reauth'
+  // as unusable.
+  status: z.string(),
   connectedByUserId: z.string().nullish(),
   connectedAt: z.string().nullish(),
   createdAt: z.string().nullish(),

--- a/packages/connect/src/client.ts
+++ b/packages/connect/src/client.ts
@@ -1,0 +1,270 @@
+import { z } from 'zod';
+
+import { extractProblemDetail, MastraConnectError } from './errors.js';
+
+/**
+ * Configuration for talking to the Mastra platform integrations service.
+ * Every field falls back to an environment variable, so a fully env-configured
+ * app can pass nothing at all.
+ */
+export interface ConnectClientOptions {
+  /** Platform access token. Falls back to MASTRA_PLATFORM_ACCESS_TOKEN, then MASTRA_PLATFORM_SECRET_KEY. */
+  accessToken?: string;
+  /** Organization id. Falls back to MASTRA_ORG_ID; the x-organization-id header is omitted when absent. */
+  orgId?: string;
+  /**
+   * Integrations service base URL. Falls back to MASTRA_INTEGRATIONS_API_URL,
+   * then the regional default from MASTRA_PLATFORM_REGION ('us' | 'eu'),
+   * then https://integrations.mastra.ai.
+   */
+  baseUrl?: string;
+  /** Fetch implementation, for testing or custom transports. Defaults to globalThis.fetch. */
+  fetch?: typeof globalThis.fetch;
+}
+
+export interface ResolvedClient {
+  baseUrl: string;
+  headers: Record<string, string>;
+  fetch: typeof globalThis.fetch;
+  accessToken: string;
+}
+
+const DEFAULT_INTEGRATIONS_URL = 'https://integrations.mastra.ai';
+const REGIONAL_INTEGRATIONS_URLS: Record<'us' | 'eu', string> = {
+  us: 'https://integrations.us.mastra.ai',
+  eu: 'https://integrations.eu.mastra.ai',
+};
+
+/**
+ * Mirrors the URL conventions of the platform factory api-client
+ * (`MASTRA_PLATFORM_REGION` case-insensitive 'us'/'eu'; unknown regions fall
+ * through to the global default).
+ */
+function resolveIntegrationsUrl(): string {
+  const region = process.env.MASTRA_PLATFORM_REGION?.trim().toLowerCase();
+  if (region === 'us' || region === 'eu') return REGIONAL_INTEGRATIONS_URLS[region];
+  return DEFAULT_INTEGRATIONS_URL;
+}
+
+function stripTrailingSlashes(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+export function resolveClient(options?: ConnectClientOptions): ResolvedClient {
+  const accessToken =
+    options?.accessToken?.trim() ||
+    process.env.MASTRA_PLATFORM_ACCESS_TOKEN?.trim() ||
+    process.env.MASTRA_PLATFORM_SECRET_KEY?.trim();
+  if (!accessToken) {
+    throw new MastraConnectError(
+      'missing_access_token',
+      'Missing Mastra platform access token: set MASTRA_PLATFORM_ACCESS_TOKEN (or MASTRA_PLATFORM_SECRET_KEY), or pass client.accessToken.',
+    );
+  }
+
+  const baseUrl = stripTrailingSlashes(
+    options?.baseUrl?.trim() || process.env.MASTRA_INTEGRATIONS_API_URL?.trim() || resolveIntegrationsUrl(),
+  );
+
+  const headers: Record<string, string> = {
+    accept: 'application/json',
+    authorization: `Bearer ${accessToken}`,
+  };
+  const orgId = options?.orgId?.trim() || process.env.MASTRA_ORG_ID?.trim();
+  if (orgId) {
+    headers['x-organization-id'] = orgId;
+  }
+
+  return { baseUrl, headers, fetch: options?.fetch ?? globalThis.fetch, accessToken };
+}
+
+function redact(message: string, accessToken: string): string {
+  return message.split(accessToken).join('[REDACTED]');
+}
+
+async function platformFetch(client: ResolvedClient, path: string, init?: RequestInit): Promise<Response> {
+  try {
+    return await client.fetch(`${client.baseUrl}${path}`, {
+      ...init,
+      headers: { ...client.headers, ...(init?.headers as Record<string, string> | undefined) },
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes(client.accessToken)) {
+      const redacted = new Error(redact(error.message, client.accessToken));
+      redacted.name = error.name;
+      throw redacted;
+    }
+    throw error;
+  }
+}
+
+/** Maps a non-2xx response from the platform's own endpoints to a typed error. */
+async function throwPlatformError(response: Response, context: string): Promise<never> {
+  const { detail, code } = await extractProblemDetail(response);
+  if (response.status === 401 || response.status === 403) {
+    throw new MastraConnectError('unauthorized', `Unauthorized while ${context}${detail ? `: ${detail}` : '.'}`, {
+      status: response.status,
+      detail,
+    });
+  }
+  if (response.status === 404) {
+    throw new MastraConnectError('connection_not_found', `Not found while ${context}${detail ? `: ${detail}` : '.'}`, {
+      status: response.status,
+      detail,
+    });
+  }
+  if (code === 'unsupported_credential_type') {
+    throw new MastraConnectError(
+      'unsupported_credential_type',
+      `Unsupported credential type while ${context}${detail ? `: ${detail}` : '.'}`,
+      { status: response.status, detail },
+    );
+  }
+  throw new MastraConnectError(
+    'platform_error',
+    `Platform request failed (${response.status}) while ${context}${detail ? `: ${detail}` : '.'}`,
+    { status: response.status, detail },
+  );
+}
+
+// —— response schemas (mirroring the platform's http-schemas) ——
+
+export const connectionSchema = z.object({
+  id: z.string(),
+  integrationId: z.string(),
+  status: z.enum(['active', 'needs_reauth']),
+  connectedByUserId: z.string().nullish(),
+  connectedAt: z.string().nullish(),
+  createdAt: z.string().nullish(),
+  accountLabel: z.string().nullish(),
+});
+
+export type ProjectConnection = z.infer<typeof connectionSchema>;
+
+const connectionListSchema = z.object({
+  connections: z.array(connectionSchema),
+});
+
+export const credentialSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('oauth2'), accessToken: z.string(), expiresAt: z.string().nullable() }),
+  z.object({ type: z.literal('api_key'), apiKey: z.string() }),
+]);
+
+export type ConnectionCredential = z.infer<typeof credentialSchema>;
+
+// —— endpoint functions ——
+
+export async function listProjectConnections(client: ResolvedClient, projectId: string): Promise<ProjectConnection[]> {
+  const response = await platformFetch(client, `/v2/projects/${encodeURIComponent(projectId)}/connections`);
+  if (!response.ok) {
+    await throwPlatformError(response, `listing connections for project ${projectId}`);
+  }
+  const parsed = connectionListSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new MastraConnectError(
+      'platform_error',
+      `Platform returned an unexpected connection list shape for project ${projectId}.`,
+    );
+  }
+  return parsed.data.connections;
+}
+
+export async function getCredential(client: ResolvedClient, connectionId: string): Promise<ConnectionCredential> {
+  const response = await platformFetch(client, `/v2/connections/${encodeURIComponent(connectionId)}/credentials`);
+  if (!response.ok) {
+    await throwPlatformError(response, `fetching credentials for connection ${connectionId}`);
+  }
+  const parsed = credentialSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new MastraConnectError(
+      'unsupported_credential_type',
+      `Platform returned an unsupported credential type for connection ${connectionId}.`,
+    );
+  }
+  return parsed.data;
+}
+
+export interface ProxyRequestOptions {
+  method: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  /** Provider-relative path (no leading slash required; absolute URLs and '..' are rejected by the platform). */
+  path: string;
+  query?: Record<string, string | number | boolean | undefined>;
+  headers?: Record<string, string>;
+  body?: unknown;
+}
+
+/**
+ * Sends a request through the platform connection proxy and returns the
+ * provider's parsed JSON on 2xx.
+ *
+ * Error-mapping scope: 401/404 map to `unauthorized`/`connection_not_found`
+ * only when the response carries a platform RFC-7807 problem body — a
+ * provider's own 401/404 passed through the proxy stays `proxy_error` with the
+ * provider status attached.
+ */
+export async function proxyRequest(
+  client: ResolvedClient,
+  connectionId: string,
+  options: ProxyRequestOptions,
+): Promise<unknown> {
+  const cleanPath = options.path.replace(/^\/+/, '');
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(options.query ?? {})) {
+    if (value !== undefined) search.set(key, String(value));
+  }
+  const queryString = search.size > 0 ? `?${search.toString()}` : '';
+  const url = `/v2/connections/${encodeURIComponent(connectionId)}/proxy/${cleanPath}${queryString}`;
+
+  const headers: Record<string, string> = { ...options.headers };
+  const init: RequestInit = { method: options.method, headers };
+  if (options.body !== undefined) {
+    headers['content-type'] = 'application/json';
+    init.body = JSON.stringify(options.body);
+  }
+
+  const response = await platformFetch(client, url, init);
+
+  if (!response.ok) {
+    const { detail, isProblemJson } = await extractProblemDetail(response);
+    if (isProblemJson) {
+      // Platform-originated error (bad path, unknown connection, auth, limits).
+      if (response.status === 401 || response.status === 403) {
+        throw new MastraConnectError(
+          'unauthorized',
+          `Unauthorized calling the connection proxy${detail ? `: ${detail}` : '.'}`,
+          { status: response.status, detail },
+        );
+      }
+      if (response.status === 404) {
+        throw new MastraConnectError(
+          'connection_not_found',
+          `Connection ${connectionId} not found${detail ? `: ${detail}` : '.'}`,
+          { status: response.status, detail },
+        );
+      }
+      throw new MastraConnectError(
+        'proxy_error',
+        `Proxy request failed (${response.status})${detail ? `: ${detail}` : '.'}`,
+        {
+          status: response.status,
+          detail,
+        },
+      );
+    }
+    // Provider-originated error passed through the proxy.
+    throw new MastraConnectError(
+      'proxy_error',
+      `Provider request failed (${response.status})${detail ? `: ${detail}` : '.'}`,
+      { status: response.status, detail },
+    );
+  }
+
+  if (response.status === 204) return null;
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}

--- a/packages/connect/src/connect.ts
+++ b/packages/connect/src/connect.ts
@@ -1,0 +1,171 @@
+import type { ToolsInput } from '@mastra/core/agent';
+
+import type { ConnectClientOptions, ProjectConnection } from './client.js';
+import { listProjectConnections, resolveClient } from './client.js';
+import { MastraConnectError } from './errors.js';
+import type { ProviderKey, ProviderRegistration } from './registry.js';
+import { PROVIDERS, findProviderByIntegrationId } from './registry.js';
+
+export interface ConnectIntegrationOptions {
+  connectionId?: string;
+  allowTools?: string[];
+}
+
+export interface ConnectOptions {
+  /** Platform project whose connections to discover. Falls back to MASTRA_PROJECT_ID. */
+  projectId?: string;
+  /**
+   * Integration allowlist. When provided, only listed providers are returned:
+   * `true` (or an options object) includes a provider, `false` excludes it.
+   * Providers listed but absent from the project's connections throw.
+   */
+  integrations?: Partial<Record<ProviderKey, ConnectIntegrationOptions | boolean>>;
+  client?: ConnectClientOptions;
+}
+
+interface ResolvedIntegrationRequest {
+  key: ProviderKey;
+  registration: ProviderRegistration;
+  explicit: boolean;
+  options: ConnectIntegrationOptions;
+}
+
+/**
+ * Discovers the project's platform connections and returns a toolset per
+ * connected provider, suitable for an agent's `toolsets` option.
+ */
+export async function connect(options?: ConnectOptions): Promise<Record<string, ToolsInput>> {
+  const projectId = options?.projectId?.trim() || process.env.MASTRA_PROJECT_ID?.trim();
+  if (!projectId) {
+    throw new MastraConnectError('missing_project_id', 'Missing project id: set MASTRA_PROJECT_ID or pass projectId.');
+  }
+
+  const client = resolveClient(options?.client);
+  const connections = await listProjectConnections(client, projectId);
+
+  const byIntegrationId = new Map<string, ProjectConnection[]>();
+  for (const connection of connections) {
+    const list = byIntegrationId.get(connection.integrationId) ?? [];
+    list.push(connection);
+    byIntegrationId.set(connection.integrationId, list);
+  }
+
+  const requests = buildRequests(options?.integrations, byIntegrationId);
+
+  const result: Record<string, ToolsInput> = {};
+  for (const request of requests) {
+    const candidates = byIntegrationId.get(request.registration.integrationId) ?? [];
+    const connectionId = resolveProviderConnection(request, candidates);
+    if (!connectionId) continue; // warned + skipped
+    result[request.key] = request.registration.createTools({
+      connectionId,
+      allowTools: request.options.allowTools,
+      client: options?.client,
+    });
+  }
+  return result;
+}
+
+/** Builds the list of providers to resolve: the allowlist when given, else every supported connected provider. */
+function buildRequests(
+  integrations: ConnectOptions['integrations'],
+  byIntegrationId: Map<string, ProjectConnection[]>,
+): ResolvedIntegrationRequest[] {
+  if (integrations) {
+    const requests: ResolvedIntegrationRequest[] = [];
+    for (const [key, value] of Object.entries(integrations) as [ProviderKey, ConnectIntegrationOptions | boolean][]) {
+      if (value === false) continue;
+      const registration = PROVIDERS[key];
+      if (!registration) {
+        throw new MastraConnectError(
+          'connection_not_found',
+          `Unknown integration '${key}' in connect() options: no such provider is supported by @mastra/connect.`,
+        );
+      }
+      const options = value === true ? {} : value;
+      if (!byIntegrationId.has(registration.integrationId)) {
+        throw new MastraConnectError(
+          'connection_not_found',
+          `No ${key} connection found in this project. Connect ${key} on the Mastra platform or remove it from connect() integrations.`,
+        );
+      }
+      requests.push({ key, registration, explicit: true, options });
+    }
+    return requests;
+  }
+
+  const requests: ResolvedIntegrationRequest[] = [];
+  for (const integrationId of byIntegrationId.keys()) {
+    const found = findProviderByIntegrationId(integrationId);
+    if (!found) {
+      const ids = (byIntegrationId.get(integrationId) ?? []).map(connection => connection.id).join(', ');
+      console.warn(
+        `[@mastra/connect] Skipping unsupported integration '${integrationId}' (connection ${ids}): no toolset is registered for it.`,
+      );
+      continue;
+    }
+    requests.push({ key: found.key, registration: found.registration, explicit: false, options: {} });
+  }
+  return requests;
+}
+
+function readEnvConnectionId(registration: ProviderRegistration): string | undefined {
+  return process.env[registration.envVar]?.trim() || undefined;
+}
+
+/**
+ * Resolves the connection to use for one provider, per the contract:
+ * option/env var wins; else a single active connection; ambiguity throws for
+ * explicitly requested providers and warns+skips otherwise. A needs_reauth
+ * connection is never silently mapped.
+ */
+function resolveProviderConnection(
+  request: ResolvedIntegrationRequest,
+  candidates: ProjectConnection[],
+): string | undefined {
+  const directed = request.options.connectionId?.trim() || readEnvConnectionId(request.registration);
+  if (directed) {
+    const match = candidates.find(connection => connection.id === directed);
+    if (match?.status === 'needs_reauth') {
+      throw new MastraConnectError(
+        'needs_reauth',
+        `Connection ${directed} (${request.key}) needs re-authentication. Reconnect it on the Mastra platform.`,
+      );
+    }
+    return directed;
+  }
+
+  const active = candidates.filter(connection => connection.status === 'active');
+  if (active.length === 1) return active[0]!.id;
+
+  if (active.length === 0) {
+    const reauth = candidates.filter(connection => connection.status === 'needs_reauth');
+    if (reauth.length > 0) {
+      if (request.explicit) {
+        throw new MastraConnectError(
+          'needs_reauth',
+          `All ${request.key} connections need re-authentication (${reauth.map(connection => connection.id).join(', ')}). Reconnect on the Mastra platform.`,
+        );
+      }
+      console.warn(
+        `[@mastra/connect] Skipping ${request.key}: its connection(s) need re-authentication (${reauth.map(connection => connection.id).join(', ')}).`,
+      );
+      return undefined;
+    }
+    // No candidates at all: explicit requests were already rejected in
+    // buildRequests, so this only happens in undirected mode.
+    return undefined;
+  }
+
+  const ids = active.map(connection => connection.id).join(', ');
+  if (request.explicit) {
+    throw new MastraConnectError(
+      'multiple_connections',
+      `Multiple ${request.key} connections found (${ids}). Set ${request.registration.envVar} or pass integrations.${request.key}.connectionId to choose one.`,
+    );
+  }
+  console.warn(
+    `[@mastra/connect] Skipping ${request.key}: multiple connections found (${ids}). Set ${request.registration.envVar} to choose one.`,
+  );
+  return undefined;
+}

--- a/packages/connect/src/connect.ts
+++ b/packages/connect/src/connect.ts
@@ -152,8 +152,16 @@ function resolveProviderConnection(
       );
       return undefined;
     }
-    // No candidates at all: explicit requests were already rejected in
-    // buildRequests, so this only happens in undirected mode.
+    // No usable candidates (e.g. only connections in an unknown status).
+    if (request.explicit) {
+      throw new MastraConnectError(
+        'connection_not_found',
+        `No usable ${request.key} connection found in this project (${candidates.map(connection => `${connection.id}: ${connection.status}`).join(', ')}).`,
+      );
+    }
+    console.warn(
+      `[@mastra/connect] Skipping ${request.key}: no usable connection (${candidates.map(connection => `${connection.id}: ${connection.status}`).join(', ')}).`,
+    );
     return undefined;
   }
 

--- a/packages/connect/src/credential.ts
+++ b/packages/connect/src/credential.ts
@@ -1,0 +1,14 @@
+import type { ConnectClientOptions, ConnectionCredential } from './client.js';
+import { getCredential, resolveClient } from './client.js';
+
+/**
+ * Fetches the raw credential for a connection, for building custom
+ * interactions (own SDKs, MCP servers). Never log the result.
+ */
+export async function credential(
+  connectionId: string,
+  options?: { client?: ConnectClientOptions },
+): Promise<ConnectionCredential> {
+  const client = resolveClient(options?.client);
+  return getCredential(client, connectionId);
+}

--- a/packages/connect/src/errors.ts
+++ b/packages/connect/src/errors.ts
@@ -47,15 +47,14 @@ export async function extractProblemDetail(
   response: Response,
 ): Promise<{ detail?: string; code?: string; isProblemJson: boolean }> {
   const contentType = response.headers.get('content-type') ?? '';
-  let isProblemJson = contentType.includes('application/problem+json');
+  // Platform-originated errors are identified strictly by the RFC-7807 content
+  // type. A provider error body that merely *looks* problem-shaped (e.g.
+  // ASP.NET ProblemDetails served as application/json) must not be
+  // misclassified as a platform error.
+  const isProblemJson = contentType.includes('application/problem+json');
   try {
     const data = (await response.clone().json()) as ProblemJson;
     if (data && typeof data === 'object') {
-      // RFC-7807 shape fallback: some platform responses use a plain JSON
-      // content type but still carry the problem structure.
-      if (!isProblemJson && typeof data.title === 'string' && typeof data.status === 'number') {
-        isProblemJson = true;
-      }
       const code = typeof data.code === 'string' ? data.code : undefined;
       for (const field of ['detail', 'title', 'error'] as const) {
         const value = data[field];

--- a/packages/connect/src/errors.ts
+++ b/packages/connect/src/errors.ts
@@ -1,0 +1,72 @@
+export type MastraConnectErrorCode =
+  | 'missing_access_token'
+  | 'missing_project_id'
+  | 'missing_connection_id'
+  | 'connection_not_found'
+  | 'multiple_connections'
+  | 'needs_reauth'
+  | 'unauthorized'
+  | 'proxy_error'
+  | 'unsupported_credential_type'
+  | 'platform_error';
+
+const MAX_DETAIL_LENGTH = 2000;
+
+export class MastraConnectError extends Error {
+  readonly code: MastraConnectErrorCode;
+  readonly status?: number;
+  readonly detail?: string;
+
+  constructor(code: MastraConnectErrorCode, message: string, options?: { status?: number; detail?: string }) {
+    super(message);
+    this.name = 'MastraConnectError';
+    this.code = code;
+    this.status = options?.status;
+    this.detail = options?.detail ? truncate(options.detail) : undefined;
+  }
+}
+
+function truncate(text: string): string {
+  return text.length > MAX_DETAIL_LENGTH ? `${text.slice(0, MAX_DETAIL_LENGTH)}…` : text;
+}
+
+interface ProblemJson {
+  title?: string;
+  status?: number;
+  detail?: string;
+  code?: string;
+  error?: string;
+}
+
+/**
+ * Extracts a human-readable detail string from an RFC-7807 problem JSON body
+ * (or a plain `{ error }` body) without echoing anything else from the response.
+ * Returns undefined when the body is not parseable JSON.
+ */
+export async function extractProblemDetail(
+  response: Response,
+): Promise<{ detail?: string; code?: string; isProblemJson: boolean }> {
+  const contentType = response.headers.get('content-type') ?? '';
+  let isProblemJson = contentType.includes('application/problem+json');
+  try {
+    const data = (await response.clone().json()) as ProblemJson;
+    if (data && typeof data === 'object') {
+      // RFC-7807 shape fallback: some platform responses use a plain JSON
+      // content type but still carry the problem structure.
+      if (!isProblemJson && typeof data.title === 'string' && typeof data.status === 'number') {
+        isProblemJson = true;
+      }
+      const code = typeof data.code === 'string' ? data.code : undefined;
+      for (const field of ['detail', 'title', 'error'] as const) {
+        const value = data[field];
+        if (typeof value === 'string' && value) {
+          return { detail: truncate(value), code, isProblemJson };
+        }
+      }
+      return { code, isProblemJson };
+    }
+  } catch {
+    // Non-JSON body: fall through without echoing it.
+  }
+  return { isProblemJson };
+}

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,0 +1,8 @@
+export { connect } from './connect.js';
+export type { ConnectOptions, ConnectIntegrationOptions } from './connect.js';
+export { credential } from './credential.js';
+export { MastraConnectError } from './errors.js';
+export type { MastraConnectErrorCode } from './errors.js';
+export type { ConnectClientOptions, ConnectionCredential, ProjectConnection } from './client.js';
+export type { ProviderKey } from './registry.js';
+export type { ProviderToolsOptions } from './toolset.js';

--- a/packages/connect/src/registry.ts
+++ b/packages/connect/src/registry.ts
@@ -1,0 +1,37 @@
+import type { ToolsInput } from '@mastra/core/agent';
+
+import type { ProviderToolsOptions } from './toolset.js';
+
+export type ProviderKey =
+  | 'linear'
+  | 'notion'
+  | 'jira'
+  | 'gitlab'
+  | 'snowflake'
+  | 'neon'
+  | 'cloudflare'
+  | 'resend'
+  | 'anthropic';
+
+export interface ProviderRegistration {
+  /** Platform catalog integration id (differs from the provider key for gitlab → gitlab-group-token). */
+  integrationId: string;
+  /** Env var consulted when no connectionId option is given. */
+  envVar: string;
+  createTools: (options?: ProviderToolsOptions) => ToolsInput;
+}
+
+/**
+ * Providers with shipped toolsets. Later segments add entries; `connect()`
+ * warns and skips platform connections whose integrationId is not listed here.
+ */
+export const PROVIDERS: Partial<Record<ProviderKey, ProviderRegistration>> = {};
+
+export function findProviderByIntegrationId(
+  integrationId: string,
+): { key: ProviderKey; registration: ProviderRegistration } | undefined {
+  for (const [key, registration] of Object.entries(PROVIDERS) as [ProviderKey, ProviderRegistration][]) {
+    if (registration.integrationId === integrationId) return { key, registration };
+  }
+  return undefined;
+}

--- a/packages/connect/src/toolset.ts
+++ b/packages/connect/src/toolset.ts
@@ -1,0 +1,78 @@
+import type { ToolsInput } from '@mastra/core/agent';
+import { createTool } from '@mastra/core/tools';
+import type { z } from 'zod';
+
+import type { ConnectClientOptions, ProxyRequestOptions } from './client.js';
+import { proxyRequest, resolveClient } from './client.js';
+import { MastraConnectError } from './errors.js';
+
+export interface ProviderToolsOptions {
+  /** Connection to use. Falls back to the provider's MASTRA_<PROVIDER>_CONNECTION_ID env var at execute time. */
+  connectionId?: string;
+  /** Restrict the returned toolset to these tool keys. Unknown names throw immediately. */
+  allowTools?: string[];
+  client?: ConnectClientOptions;
+}
+
+/** Resolves a connection id lazily at execute time: option → env var → typed error naming the env var. */
+export function resolveConnectionId(envVar: string, connectionId?: string): string {
+  const resolved = connectionId?.trim() || process.env[envVar]?.trim();
+  if (!resolved) {
+    throw new MastraConnectError('missing_connection_id', `Missing connection id: set ${envVar} or pass connectionId.`);
+  }
+  return resolved;
+}
+
+export interface ProxyToolConfig<TIn, TOut> {
+  id: string;
+  description: string;
+  inputSchema: z.ZodType<TIn>;
+  outputSchema: z.ZodType<TOut>;
+  /** Builds the proxy request for a parsed input. */
+  request: (input: TIn) => ProxyRequestOptions;
+  /** Shapes the provider's raw JSON into the output schema's shape. */
+  transform: (raw: unknown, input: TIn) => TOut;
+}
+
+export interface ProxyToolContext {
+  envVar: string;
+  options?: ProviderToolsOptions;
+}
+
+/**
+ * Wraps `createTool` so the tool executes through the platform connection
+ * proxy. Connection id and client config resolve lazily inside execute, so
+ * building tools without env vars set never throws.
+ */
+export function defineProxyTool<TIn, TOut>(context: ProxyToolContext, config: ProxyToolConfig<TIn, TOut>) {
+  return createTool({
+    id: config.id,
+    description: config.description,
+    inputSchema: config.inputSchema,
+    outputSchema: config.outputSchema,
+    execute: async input => {
+      const connectionId = resolveConnectionId(context.envVar, context.options?.connectionId);
+      const client = resolveClient(context.options?.client);
+      const raw = await proxyRequest(client, connectionId, config.request(input));
+      return config.transform(raw, input);
+    },
+  });
+}
+
+/**
+ * Filters a toolset by tool key. Throws at build time on unknown names so
+ * typos in access-limiting config surface immediately.
+ */
+export function applyAllowTools<T extends ToolsInput>(tools: T, allowTools?: string[]): ToolsInput {
+  if (!allowTools) return tools;
+  const known = Object.keys(tools);
+  const unknown = allowTools.filter(name => !known.includes(name));
+  if (unknown.length > 0) {
+    throw new Error(`Unknown tool name(s) in allowTools: ${unknown.join(', ')}. Known tools: ${known.join(', ')}.`);
+  }
+  const filtered: ToolsInput = {};
+  for (const name of allowTools) {
+    filtered[name] = tools[name]!;
+  }
+  return filtered;
+}

--- a/packages/connect/tsconfig.build.json
+++ b/packages/connect/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/packages/connect/tsconfig.json
+++ b/packages/connect/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsdown.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/packages/connect/tsdown.config.ts
+++ b/packages/connect/tsdown.config.ts
@@ -1,0 +1,16 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  fixedExtension: false,
+  nodeProtocol: 'strip',
+  clean: true,
+  dts: false,
+  treeshake: true,
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/packages/connect/turbo.json
+++ b/packages/connect/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://v2-9-16.turborepo.dev/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tsdown.config.ts",
+        "tsconfig.json",
+        "package.json",
+        "!**/*.md",
+        "!**/*.test.ts",
+        "!**/*.spec.ts",
+        "!**/__tests__/**"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "build": {
+      "dependsOn": ["build:lib"],
+      "inputs": ["package.json"]
+    }
+  }
+}

--- a/packages/connect/vitest.config.ts
+++ b/packages/connect/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'unit:packages/connect',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4529,6 +4529,30 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0)(supports-color@10.2.2))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
 
+  packages/connect:
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../core
+      tsdown:
+        specifier: 0.22.9
+        version: 0.22.9(@volar/typescript@2.4.23(typescript@7.0.2))(oxc-resolver@11.20.0)(tsx@4.23.1)(typescript@7.0.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0)(supports-color@10.2.2))(msw@2.14.6(@types/node@22.19.15)(typescript@7.0.2))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+
   packages/core:
     dependencies:
       '@a2a-js/sdk-v0_3':


### PR DESCRIPTION
## Summary

New publishable package `@mastra/connect` (`packages/connect`) that turns Mastra-platform integration connections into agent toolsets with **zero credential handling** — tools execute through the platform connection proxy (`/v2/connections/:connectionId/proxy/*`), so provider credentials never enter the app.

This is segment 1 of a 4-PR stack (core → OAuth wave → API-key wave → docs):

- **Tool infrastructure** — provider registry plus the proxy-tool builder used by every toolset, with `allowTools` name filtering (unknown names throw at build time) and lazy connection-id resolution (`connectionId` option → `MASTRA_<PROVIDER>_CONNECTION_ID` at execute time). Provider toolsets land in the stacked follow-ups (starting with #22999).
- **`connect(options?)`** — runtime discovery via `GET /v2/projects/:projectId/connections`; returns `Record<providerKey, ToolsInput>` for an agent's `toolsets` option. Deterministic resolution (env/option → single active connection → explicit-request throws / undirected warns+skips), `needs_reauth` never silently mapped, unsupported platform integrations warned and skipped, optional `integrations` allowlist.
- **`credential(connectionId)`** — raw credential union (`oauth2 | api_key`) from `GET /v2/connections/:connectionId/credentials` for custom interactions (own SDKs, MCP).
- **`ConnectClient`** — env-driven platform client mirroring this branch's conventions: `MASTRA_INTEGRATIONS_API_URL` override → `MASTRA_PLATFORM_REGION` (us/eu) → `https://integrations.mastra.ai`; token `MASTRA_PLATFORM_ACCESS_TOKEN` → `MASTRA_PLATFORM_SECRET_KEY`; bearer auth with `x-organization-id` only when configured; access-token redaction in error messages.
- **Typed errors** — `MastraConnectError` with stable codes. Platform errors are identified strictly by RFC-7807 `application/problem+json` content type; a provider's own 401/404 through the proxy stays `proxy_error` (a missing Notion page never becomes `connection_not_found`).

Based on `mint-vanadium` (PR #20925) to align on the regional-endpoint URL conventions.

## Test plan

- `pnpm --filter @mastra/connect test` — 66 tests, 4 files, all mocked fetch (no live network): client env/URL/token resolution, error mapping scope (platform vs provider), connect() resolution semantics (allowlist, ambiguity, needs_reauth, unknown statuses/integrations), credential union parsing, allowTools filtering.
- `npx tsc --noEmit -p tsconfig.json` in `packages/connect` — clean.
- `pnpm --filter @mastra/connect lint` — clean.
- `pnpm turbo build --filter @mastra/connect` — green (esm+cjs+d.ts).

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>
