### PR TITLE
fix(mastracode): render resumed output after plan approval

### DIFF
--- a/.changeset/clever-falcons-play.md
+++ b/.changeset/clever-falcons-play.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed resumed agent output failing to render after plan approval.

--- a/mastracode/tui/e2e/tui/plan-approval-handoff.ts
+++ b/mastracode/tui/e2e/tui/plan-approval-handoff.ts
@@ -23,7 +23,7 @@ export const planApprovalHandoffScenario: McE2eScenario = {
     terminal.write('\r');
     await runtime.waitForScreenText(/✓\s+Approved/i, terminal, 10_000);
     await runtime.waitForScreenText(/▐build▌/i, terminal, 10_000);
-    await runtime.sleep(1_000);
+    await runtime.waitForScreenText(/Build handoff e2e acknowledged\./i, terminal, 10_000);
 
     terminal.keyCtrlC();
   },

--- a/mastracode/tui/src/tui/handlers/__tests__/prompts.test.ts
+++ b/mastracode/tui/src/tui/handlers/__tests__/prompts.test.ts
@@ -264,6 +264,31 @@ describe('handlePlanApproval regular approval', () => {
     expect(ctx.notify).not.toHaveBeenCalled();
   });
 
+  it('releases the event queue after starting the plan resume', async () => {
+    const projectPath = createTmpProjectWithPlan(PLAN_TITLE, 'Build the feature');
+    const { state, ctx } = createPlanApprovalCtx(projectPath);
+    let releaseResume!: () => void;
+    const resume = new Promise<void>(resolve => {
+      releaseResume = resolve;
+    });
+    state.session.respondToToolSuspension = vi.fn().mockReturnValue(resume);
+
+    const { promise, component } = await renderPlanApproval(ctx, state, PLAN_PATH);
+    const approval = (component as any).onApprove();
+
+    await vi.waitFor(() => expect(state.session.respondToToolSuspension).toHaveBeenCalledTimes(1));
+    let handlerResolved = false;
+    void promise.then(() => {
+      handlerResolved = true;
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(handlerResolved).toBe(true);
+
+    releaseResume();
+    await approval;
+    await promise;
+  });
+
   it('approves the plan without sending a handoff signal', async () => {
     const projectPath = createTmpProjectWithPlan(PLAN_TITLE, 'Build the feature');
     const { state, ctx, sendSignal } = createPlanApprovalCtx(projectPath);

--- a/mastracode/tui/src/tui/handlers/prompts.ts
+++ b/mastracode/tui/src/tui/handlers/prompts.ts
@@ -291,13 +291,11 @@ export async function handleSandboxAccessRequest(
  * "Request changes" rejects the tool call and aborts the agent so the user can
  * provide revision feedback via a normal chat message.
  */
-async function approvePlan(
+async function prepareApprovedPlan(
   ctx: EventHandlerContext,
-  toolCallId: string,
   title: string,
   plan: string,
   planPath: string | undefined,
-  submittedPath: string,
 ): Promise<void> {
   const { state } = ctx;
   await state.session.state.set({
@@ -321,8 +319,16 @@ async function approvePlan(
   // Reset in-memory diff state so the next plan doesn't diff against this one.
   state.previousPlanSnapshot = undefined;
   state.lastSubmitPlanComponent = undefined;
+}
 
-  await state.session.respondToToolSuspension({
+function resumeApprovedPlan(
+  ctx: EventHandlerContext,
+  toolCallId: string,
+  title: string,
+  plan: string,
+  submittedPath: string,
+): Promise<void> {
+  return ctx.state.session.respondToToolSuspension({
     toolCallId,
     resumeData: { action: 'approved', path: submittedPath, title, plan },
   });
@@ -401,15 +407,21 @@ export async function handlePlanApproval(
       onApprove: async () => {
         releaseApprovalFocus();
         firePermissionResult('approved');
-        await approvePlan(ctx, toolCallId, resolvedTitle, plan, planPath, snapshotKey);
+        await prepareApprovedPlan(ctx, resolvedTitle, plan, planPath);
+        const resumed = resumeApprovedPlan(ctx, toolCallId, resolvedTitle, plan, snapshotKey);
+        // The controller emits the resumed tool's terminal events while this
+        // handler owns its serialized event queue. Let those events reach their
+        // render boundaries immediately instead of waiting for the resume promise.
         resolve();
+        await resumed;
       },
       onGoal: async () => {
         releaseApprovalFocus();
         firePermissionResult('approved');
-        await approvePlan(ctx, toolCallId, resolvedTitle, plan, planPath, snapshotKey);
+        await prepareApprovedPlan(ctx, resolvedTitle, plan, planPath);
+        await resumeApprovedPlan(ctx, toolCallId, resolvedTitle, plan, snapshotKey);
 
-        // `approvePlan` waits for plan mode to idle before `startGoal` sends
+        // The plan-mode resume reaches its idle boundary before `startGoal` sends
         // the canonical goal reminder, so this starts a fresh build-mode run.
         const objective = formatPlanGoalObjective(resolvedTitle, plan);
         await ctx.startGoal(objective, 'Goal cancelled.');


### PR DESCRIPTION
Plan approval previously held the serialized event queue until `respondToToolSuspension` completed, which could leave resumed agent output pending until another input event. This releases the approval handler after resumption starts so events reach their render boundaries immediately, while preserving the goal-mode ordering requirement.

Before:
```ts
onApprove: async () => {
  releaseApprovalFocus();
  firePermissionResult('approved');
  await approvePlan(ctx, toolCallId, resolvedTitle, plan, planPath, snapshotKey);
  resolve();
},
```

After:
```ts
onApprove: async () => {
  releaseApprovalFocus();
  firePermissionResult('approved');
  await prepareApprovedPlan(ctx, resolvedTitle, plan, planPath);
  const resumed = resumeApprovedPlan(ctx, toolCallId, resolvedTitle, plan, snapshotKey);
  resolve();
  await resumed;
},
```

The `onGoal` path keeps the stricter ordering — it awaits the resume boundary before calling `startGoal`, since the goal reminder must not be sent until plan mode is idle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a plan is approved, the agent can now show its resumed output immediately. Goal mode still waits for the plan to fully finish before it starts.

## Changes

- Resolve the approval handler as soon as suspension resumption starts.
- Allow serialized events to reach render boundaries without waiting for `respondToToolSuspension` to finish.
- Keep goal mode ordering strict by waiting for the resume boundary before starting the goal.
- Add a regression test for immediate handler resolution.
- Replace the fixed one-second E2E delay with an explicit acknowledgment message.
- Add a patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->