### PR TITLE
fix(core): stop vendoring hono types, declare hono/hono-openapi as peer dependencies

### DIFF
--- a/.changeset/hono-peer-dependency-types.md
+++ b/.changeset/hono-peer-dependency-types.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Stop vendoring Hono declaration files into `dist/_types/` and declare `hono` / `hono-openapi` as peer dependencies, so consumer typechecks see a single Hono type identity under `moduleResolution: "bundler"`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -913,6 +913,8 @@
     "@modelcontextprotocol/server": "2.0.0"
   },
   "peerDependencies": {
+    "hono": "^4.12.8",
+    "hono-openapi": "^1.3.1",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -137,8 +137,6 @@ export default defineConfig({
         '@internal/external-types',
         '@internal/core',
         '@internal/voice',
-        'hono',
-        'hono-openapi',
         '@internal/auth',
       ]),
     );


### PR DESCRIPTION
fix(core): stop vendoring hono types, declare hono/hono-openapi as peer dependencies

Fixes #22774

`@mastra/core` shipped a byte-identical copy of Hono's `.d.ts` under `dist/_types/hono/` (added in #17410's declaration-bundling allowlist). Hono's `GET_MATCH_RESULT` is a `unique symbol`, so the two copies can never unify nominally and consumers passing their own `MiddlewareHandler`/`Context` to `registerApiRoute` fail `tsc --noEmit` under `moduleResolution: "bundler"`.

Changes:
- Removed `hono` and `hono-openapi` from the `generateTypes` bundled-packages allowlist in `packages/core/tsdown.config.ts`, so emitted declarations import the consumer's real packages (`dist/server/index.d.ts` now has `import type { Handler, MiddlewareHandler } from 'hono'` and no `dist/_types/hono` tree is emitted).
- Declared `hono` (^4.12.8) and `hono-openapi` (^1.3.1) as `peerDependencies` of `@mastra/core` (kept as devDependencies for building/testing), matching the type-builder's requirement that publicly leaked types be bundled or declared.

Verification:
- Minimal consumer fixture from the issue (`registerApiRoute` with a user-supplied `MiddlewareHandler` and `Context` handler, TS 5.9.3, `moduleResolution: "bundler"`, `skipLibCheck: true`): before the fix it fails with the two TS2322 errors ending at `[GET_MATCH_RESULT]`; after rebuilding the declarations with this change it compiles with 0 errors.
- After rebuild, `dist/_types/hono/` and `dist/_types/hono-openapi/` are no longer emitted and `dist/server/index.d.ts`, `dist/server/types.d.ts`, `dist/channels/wait-until.d.ts` reference `hono` / `hono-openapi` directly.
- `vitest run src/server` in `packages/core`: 87 tests passed, no type errors.
- `oxfmt --check`, `oxlint`, and `eslint` clean on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes `@mastra/core` use the consumer’s installed Hono types instead of shipping a duplicate copy. This prevents TypeScript errors when applications use Hono middleware and context types.

## Changes

- Removed `hono` and `hono-openapi` from declaration bundling.
- Added both packages as peer dependencies.
- Kept both packages as development dependencies.
- Added a patch changeset.

This removes duplicate `unique symbol` declarations and fixes typechecking with `moduleResolution: "bundler"`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->