### PR TITLE
feat(connect): add Linear, Notion, Jira, and Snowflake toolsets (OAuth wave)

### DIFF
--- a/.changeset/tame-steaks-kick.md
+++ b/.changeset/tame-steaks-kick.md
@@ -1,0 +1,22 @@
+---
+'@mastra/connect': minor
+---
+
+Added Linear, Notion, Jira, and Snowflake toolsets. These OAuth-connected integrations let agents work with Linear issues, Notion pages and databases, Jira issues, and Snowflake SQL over platform-managed connections — no provider credentials in your app:
+
+```ts
+import { Agent } from '@mastra/core/agent';
+import { createLinearTools, createNotionTools, createJiraTools, createSnowflakeTools } from '@mastra/connect';
+
+const agent = new Agent({
+  name: 'ops',
+  instructions: 'You manage our workspaces.',
+  model: 'openai/gpt-5-mini',
+  toolsets: {
+    linear: createLinearTools({ allowTools: ['linear_search_issues', 'linear_list_issues'] }),
+    notion: createNotionTools({ allowTools: ['notion_search', 'notion_get_page'] }),
+    jira: createJiraTools(),
+    snowflake: createSnowflakeTools(),
+  },
+});
+```

--- a/packages/connect/src/__tests__/connect.test.ts
+++ b/packages/connect/src/__tests__/connect.test.ts
@@ -8,6 +8,8 @@ const TOKEN = 'fake-test-token';
 
 const fakeTools = { linear_fake_tool: { id: 'linear_fake_tool' } } as never;
 
+const originalLinear = PROVIDERS.linear;
+
 function stubProvider(overrides?: Partial<ProviderRegistration>): { createTools: ReturnType<typeof vi.fn> } {
   const createTools = vi.fn().mockReturnValue(fakeTools);
   PROVIDERS.linear = {
@@ -47,7 +49,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  delete PROVIDERS.linear;
+  PROVIDERS.linear = originalLinear;
   vi.unstubAllEnvs();
   warnSpy.mockRestore();
 });

--- a/packages/connect/src/__tests__/providers/jira.test.ts
+++ b/packages/connect/src/__tests__/providers/jira.test.ts
@@ -90,7 +90,7 @@ describe('createJiraTools', () => {
     expect(url).toBe('https://example.test/v2/connections/c_jir1/proxy/oauth/token/accessible-resources');
   });
 
-  it('searches issues via GET search/jql under the ex/jira/{cloudId} prefix', async () => {
+  it('searches issues via POST search/jql under the ex/jira/{cloudId} prefix', async () => {
     const fetchMock = vi.fn().mockResolvedValue(Response.json({ issues: [issueObject], nextPageToken: 'tok1' }));
     const tools = makeTools(fetchMock);
     const result = await tool(tools, 'jira_search_issues').execute(
@@ -182,7 +182,12 @@ describe('createJiraTools', () => {
       { cloudId: CLOUD_ID, issueKey: 'ENG-123' },
       {} as never,
     );
+    const emptyString = await tool(tools, 'jira_update_issue').execute(
+      { cloudId: CLOUD_ID, issueKey: 'ENG-123', summary: '' },
+      {} as never,
+    );
     expect(result).toMatchObject({ error: true });
+    expect(emptyString).toMatchObject({ error: true });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/packages/connect/src/__tests__/providers/jira.test.ts
+++ b/packages/connect/src/__tests__/providers/jira.test.ts
@@ -98,12 +98,14 @@ describe('createJiraTools', () => {
       {} as never,
     );
     expect(result).toEqual({ issues: [shapedIssue], nextPageToken: 'tok1' });
-    const [url] = fetchMock.mock.calls[0]!;
+    const [url, init] = fetchMock.mock.calls[0]!;
     const parsed = new URL(String(url));
     expect(parsed.pathname).toBe(`/v2/connections/c_jir1/proxy/ex/jira/${CLOUD_ID}/rest/api/3/search/jql`);
-    expect(parsed.searchParams.get('jql')).toBe('project = ENG');
-    expect(parsed.searchParams.get('maxResults')).toBe('10');
-    expect(parsed.searchParams.get('fields')).toContain('summary');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body);
+    expect(body.jql).toBe('project = ENG');
+    expect(body.maxResults).toBe(10);
+    expect(body.fields).toContain('summary');
   });
 
   it('gets an issue and flattens its ADF description to plain text', async () => {
@@ -171,6 +173,17 @@ describe('createJiraTools', () => {
     const [, init] = fetchMock.mock.calls[0]!;
     expect(init.method).toBe('PUT');
     expect(JSON.parse(init.body).fields.summary).toBe('Renamed');
+  });
+
+  it('rejects an update_issue call with no fields to change', async () => {
+    const fetchMock = vi.fn();
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'jira_update_issue').execute(
+      { cloudId: CLOUD_ID, issueKey: 'ENG-123' },
+      {} as never,
+    );
+    expect(result).toMatchObject({ error: true });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('lists transitions with their target statuses', async () => {

--- a/packages/connect/src/__tests__/providers/jira.test.ts
+++ b/packages/connect/src/__tests__/providers/jira.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createJiraTools } from '../../providers/jira.js';
+
+const TOKEN = 'fake-test-token';
+const CLOUD_ID = 'cloud-uuid-1';
+
+const EXPECTED_TOOLS = [
+  'jira_get_accessible_resources',
+  'jira_search_issues',
+  'jira_get_issue',
+  'jira_create_issue',
+  'jira_update_issue',
+  'jira_transition_issue',
+  'jira_list_transitions',
+  'jira_add_comment',
+  'jira_list_comments',
+  'jira_list_projects',
+];
+
+const issueObject = {
+  id: '10001',
+  key: 'ENG-123',
+  fields: {
+    summary: 'Fix the bug',
+    status: { name: 'In Progress' },
+    assignee: { displayName: 'Ada' },
+    priority: { name: 'High' },
+    issuetype: { name: 'Bug' },
+    created: '2026-09-01T00:00:00.000+0000',
+    updated: '2026-09-02T00:00:00.000+0000',
+  },
+};
+
+const shapedIssue = {
+  id: '10001',
+  key: 'ENG-123',
+  summary: 'Fix the bug',
+  status: 'In Progress',
+  assignee: 'Ada',
+  priority: 'High',
+  issueType: 'Bug',
+  created: '2026-09-01T00:00:00.000+0000',
+  updated: '2026-09-02T00:00:00.000+0000',
+};
+
+function makeTools(fetchMock: ReturnType<typeof vi.fn>, options?: Parameters<typeof createJiraTools>[0]) {
+  return createJiraTools({
+    connectionId: 'c_jir1',
+    client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+    ...options,
+  });
+}
+
+interface ExecutableTool {
+  id: string;
+  execute: (input: unknown, context: unknown) => Promise<unknown>;
+}
+
+function tool(tools: ReturnType<typeof createJiraTools>, key: string): ExecutableTool {
+  expect(tools[key]).toBeDefined();
+  return tools[key] as unknown as ExecutableTool;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('createJiraTools', () => {
+  it('returns the full curated toolset', () => {
+    expect(Object.keys(createJiraTools()).sort()).toEqual([...EXPECTED_TOOLS].sort());
+  });
+
+  it('filters with allowTools and throws on unknown names', () => {
+    const tools = createJiraTools({ allowTools: ['jira_get_issue'] });
+    expect(Object.keys(tools)).toEqual(['jira_get_issue']);
+    expect(() => createJiraTools({ allowTools: ['jira_nope'] })).toThrow(/jira_nope/);
+  });
+
+  it('discovers accessible resources without a cloud id', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        Response.json([{ id: CLOUD_ID, name: 'Acme', url: 'https://acme.atlassian.net', scopes: [] }]),
+      );
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'jira_get_accessible_resources').execute({}, {} as never);
+    expect(result).toEqual({ sites: [{ cloudId: CLOUD_ID, name: 'Acme', url: 'https://acme.atlassian.net' }] });
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://example.test/v2/connections/c_jir1/proxy/oauth/token/accessible-resources');
+  });
+
+  it('searches issues via GET search/jql under the ex/jira/{cloudId} prefix', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ issues: [issueObject], nextPageToken: 'tok1' }));
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'jira_search_issues').execute(
+      { cloudId: CLOUD_ID, jql: 'project = ENG', limit: 10 },
+      {} as never,
+    );
+    expect(result).toEqual({ issues: [shapedIssue], nextPageToken: 'tok1' });
+    const [url] = fetchMock.mock.calls[0]!;
+    const parsed = new URL(String(url));
+    expect(parsed.pathname).toBe(`/v2/connections/c_jir1/proxy/ex/jira/${CLOUD_ID}/rest/api/3/search/jql`);
+    expect(parsed.searchParams.get('jql')).toBe('project = ENG');
+    expect(parsed.searchParams.get('maxResults')).toBe('10');
+    expect(parsed.searchParams.get('fields')).toContain('summary');
+  });
+
+  it('gets an issue and flattens its ADF description to plain text', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        ...issueObject,
+        fields: {
+          ...issueObject.fields,
+          description: {
+            type: 'doc',
+            version: 1,
+            content: [
+              {
+                type: 'paragraph',
+                content: [
+                  { type: 'text', text: 'It is ' },
+                  { type: 'text', text: 'broken.' },
+                ],
+              },
+              { type: 'paragraph', content: [{ type: 'text', text: 'Badly.' }] },
+            ],
+          },
+        },
+      }),
+    );
+    const tools = makeTools(fetchMock);
+    const result = (await tool(tools, 'jira_get_issue').execute(
+      { cloudId: CLOUD_ID, issueKey: 'ENG-123' },
+      {} as never,
+    )) as { issue: { description: string } };
+    expect(result.issue.description).toBe('It is broken.\nBadly.');
+    const parsed = new URL(String(fetchMock.mock.calls[0]![0]));
+    expect(parsed.pathname).toBe(`/v2/connections/c_jir1/proxy/ex/jira/${CLOUD_ID}/rest/api/3/issue/ENG-123`);
+  });
+
+  it('creates an issue wrapping the description in ADF', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ id: '10002', key: 'ENG-124' }));
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'jira_create_issue').execute(
+      { cloudId: CLOUD_ID, projectKey: 'ENG', summary: 'New task', issueType: 'Task', description: 'Do the thing' },
+      {} as never,
+    );
+    expect(result).toEqual({ issue: { id: '10002', key: 'ENG-124' } });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toContain(`/proxy/ex/jira/${CLOUD_ID}/rest/api/3/issue`);
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body);
+    expect(body.fields.project).toEqual({ key: 'ENG' });
+    expect(body.fields.issuetype).toEqual({ name: 'Task' });
+    expect(body.fields.description).toEqual({
+      type: 'doc',
+      version: 1,
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Do the thing' }] }],
+    });
+  });
+
+  it('updates an issue via PUT and reports updated on an empty 204', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'jira_update_issue').execute(
+      { cloudId: CLOUD_ID, issueKey: 'ENG-123', summary: 'Renamed' },
+      {} as never,
+    );
+    expect(result).toEqual({ updated: true });
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body).fields.summary).toBe('Renamed');
+  });
+
+  it('lists transitions with their target statuses', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(Response.json({ transitions: [{ id: '31', name: 'Done', to: { name: 'Done' } }] }));
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'jira_list_transitions').execute(
+      { cloudId: CLOUD_ID, issueKey: 'ENG-123' },
+      {} as never,
+    );
+    expect(result).toEqual({ transitions: [{ id: '31', name: 'Done', toStatus: 'Done' }] });
+  });
+
+  it('POSTs a transition id to move an issue', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'jira_transition_issue').execute(
+      { cloudId: CLOUD_ID, issueKey: 'ENG-123', transitionId: '31' },
+      {} as never,
+    );
+    expect(result).toEqual({ transitioned: true });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toContain('/rest/api/3/issue/ENG-123/transitions');
+    expect(JSON.parse(init.body)).toEqual({ transition: { id: '31' } });
+  });
+
+  it('adds a comment as ADF and lists comments back as plain text', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ id: 'cm-1', created: '2026-09-03T00:00:00.000+0000' }))
+      .mockResolvedValueOnce(
+        Response.json({
+          comments: [
+            {
+              id: 'cm-1',
+              author: { displayName: 'Ada' },
+              body: {
+                type: 'doc',
+                version: 1,
+                content: [{ type: 'paragraph', content: [{ type: 'text', text: 'LGTM' }] }],
+              },
+              created: '2026-09-03T00:00:00.000+0000',
+            },
+          ],
+          total: 1,
+        }),
+      );
+    const tools = makeTools(fetchMock);
+    const added = await tool(tools, 'jira_add_comment').execute(
+      { cloudId: CLOUD_ID, issueKey: 'ENG-123', body: 'LGTM' },
+      {} as never,
+    );
+    expect(added).toEqual({ comment: { id: 'cm-1', created: '2026-09-03T00:00:00.000+0000' } });
+    expect(JSON.parse(fetchMock.mock.calls[0]![1].body).body.content[0].content[0].text).toBe('LGTM');
+
+    const listed = await tool(tools, 'jira_list_comments').execute(
+      { cloudId: CLOUD_ID, issueKey: 'ENG-123' },
+      {} as never,
+    );
+    expect(listed).toEqual({
+      comments: [{ id: 'cm-1', author: 'Ada', body: 'LGTM', created: '2026-09-03T00:00:00.000+0000' }],
+      total: 1,
+    });
+  });
+
+  it('lists projects from project/search values', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        Response.json({ values: [{ id: '9', key: 'ENG', name: 'Engineering' }], total: 1, isLast: true }),
+      );
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'jira_list_projects').execute({ cloudId: CLOUD_ID, query: 'eng' }, {} as never);
+    expect(result).toEqual({ projects: [{ id: '9', key: 'ENG', name: 'Engineering' }], total: 1, isLast: true });
+    const parsed = new URL(String(fetchMock.mock.calls[0]![0]));
+    expect(parsed.pathname).toBe(`/v2/connections/c_jir1/proxy/ex/jira/${CLOUD_ID}/rest/api/3/project/search`);
+    expect(parsed.searchParams.get('query')).toBe('eng');
+  });
+
+  it('falls back to MASTRA_JIRA_CONNECTION_ID at execute time', async () => {
+    vi.stubEnv('MASTRA_JIRA_CONNECTION_ID', 'c_env8');
+    const fetchMock = vi.fn().mockResolvedValue(Response.json([]));
+    const tools = createJiraTools({
+      client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+    });
+    await tool(tools, 'jira_get_accessible_resources').execute({}, {} as never);
+    expect(String(fetchMock.mock.calls[0]![0])).toContain('/v2/connections/c_env8/proxy/');
+  });
+
+  it('throws missing_connection_id when unresolvable', async () => {
+    vi.stubEnv('MASTRA_JIRA_CONNECTION_ID', '');
+    const tools = createJiraTools({ client: { accessToken: TOKEN, baseUrl: 'https://example.test' } });
+    await expect(tool(tools, 'jira_get_accessible_resources').execute({}, {} as never)).rejects.toMatchObject({
+      code: 'missing_connection_id',
+    });
+  });
+});

--- a/packages/connect/src/__tests__/providers/linear.test.ts
+++ b/packages/connect/src/__tests__/providers/linear.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MastraConnectError } from '../../errors.js';
+import { createLinearTools } from '../../providers/linear.js';
+
+const TOKEN = 'fake-test-token';
+
+const EXPECTED_TOOLS = [
+  'linear_list_teams',
+  'linear_list_issues',
+  'linear_get_issue',
+  'linear_search_issues',
+  'linear_create_issue',
+  'linear_update_issue',
+  'linear_add_comment',
+  'linear_list_projects',
+  'linear_list_users',
+];
+
+const issueNode = {
+  id: 'issue-uuid-1',
+  identifier: 'ENG-123',
+  title: 'Fix the bug',
+  description: 'It is broken',
+  priority: 2,
+  url: 'https://linear.app/acme/issue/ENG-123',
+  createdAt: '2026-09-01T00:00:00Z',
+  updatedAt: '2026-09-02T00:00:00Z',
+  state: { id: 's1', name: 'In Progress', type: 'started' },
+  assignee: { id: 'u1', name: 'Ada' },
+  team: { id: 't1', key: 'ENG', name: 'Engineering' },
+};
+
+function makeTools(fetchMock: ReturnType<typeof vi.fn>, options?: Parameters<typeof createLinearTools>[0]) {
+  return createLinearTools({
+    connectionId: 'c_lin1',
+    client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+    ...options,
+  });
+}
+
+interface ExecutableTool {
+  id: string;
+  execute: (input: unknown, context: unknown) => Promise<unknown>;
+}
+
+function tool(tools: ReturnType<typeof createLinearTools>, key: string): ExecutableTool {
+  expect(tools[key]).toBeDefined();
+  return tools[key] as unknown as ExecutableTool;
+}
+
+function graphqlOk(data: unknown) {
+  return Response.json({ data });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('createLinearTools', () => {
+  it('returns the full curated toolset', () => {
+    expect(Object.keys(createLinearTools()).sort()).toEqual([...EXPECTED_TOOLS].sort());
+  });
+
+  it('filters with allowTools and throws on unknown names', () => {
+    const tools = createLinearTools({ allowTools: ['linear_list_teams', 'linear_get_issue'] });
+    expect(Object.keys(tools)).toEqual(['linear_list_teams', 'linear_get_issue']);
+    expect(() => createLinearTools({ allowTools: ['linear_nope'] })).toThrow(/linear_nope/);
+  });
+
+  it('POSTs a teams query to the proxy graphql path', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      graphqlOk({
+        teams: {
+          nodes: [{ id: 't1', key: 'ENG', name: 'Engineering' }],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      }),
+    );
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'linear_list_teams').execute({}, {} as never);
+    expect(result).toEqual({
+      teams: [{ id: 't1', key: 'ENG', name: 'Engineering' }],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://example.test/v2/connections/c_lin1/proxy/graphql');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body);
+    expect(body.query).toContain('teams(first: $first');
+    expect(body.variables).toEqual({ first: 25, after: null });
+  });
+
+  it('caps pagination at 50 via the input schema', async () => {
+    const fetchMock = vi.fn();
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'linear_list_teams').execute({ limit: 999 }, {} as never);
+    // createTool validates input and returns a validation error object instead of calling execute
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ error: true });
+  });
+
+  it('sends the issue create mutation and shapes the result', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(graphqlOk({ issueCreate: { success: true, issue: issueNode } }));
+    const tools = makeTools(fetchMock);
+    const result = (await tool(tools, 'linear_create_issue').execute(
+      { teamId: 't1', title: 'Fix the bug', priority: 2 },
+      {} as never,
+    )) as { issue: { identifier: string } };
+    expect(result.issue.identifier).toBe('ENG-123');
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.query).toContain('issueCreate');
+    expect(body.variables.input).toMatchObject({ teamId: 't1', title: 'Fix the bug', priority: 2 });
+  });
+
+  it('builds issue filters from teamKey/assigneeEmail/stateName', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        graphqlOk({ issues: { nodes: [issueNode], pageInfo: { hasNextPage: true, endCursor: 'cur1' } } }),
+      );
+    const tools = makeTools(fetchMock);
+    const result = (await tool(tools, 'linear_list_issues').execute(
+      { teamKey: 'ENG', stateName: 'In Progress', limit: 10 },
+      {} as never,
+    )) as { issues: unknown[]; pageInfo: { endCursor: string | null } };
+    expect(result.issues).toHaveLength(1);
+    expect(result.pageInfo.endCursor).toBe('cur1');
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.variables.filter).toEqual({ team: { key: { eq: 'ENG' } }, state: { name: { eq: 'In Progress' } } });
+    expect(body.variables.first).toBe(10);
+  });
+
+  it('sends the issue update mutation with id outside the input payload', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(graphqlOk({ issueUpdate: { success: true, issue: issueNode } }));
+    const tools = makeTools(fetchMock);
+    const result = (await tool(tools, 'linear_update_issue').execute(
+      { id: 'issue-uuid-1', title: 'New title', stateId: 's2' },
+      {} as never,
+    )) as { issue: { identifier: string } };
+    expect(result.issue.identifier).toBe('ENG-123');
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.query).toContain('issueUpdate');
+    expect(body.variables.id).toBe('issue-uuid-1');
+    expect(body.variables.input).toMatchObject({ title: 'New title', stateId: 's2' });
+    expect(body.variables.input).not.toHaveProperty('id');
+  });
+
+  it('maps search query to the searchIssues term variable', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        graphqlOk({ searchIssues: { nodes: [issueNode], pageInfo: { hasNextPage: false, endCursor: null } } }),
+      );
+    const tools = makeTools(fetchMock);
+    const result = (await tool(tools, 'linear_search_issues').execute({ query: 'broken login' }, {} as never)) as {
+      issues: { identifier: string }[];
+    };
+    expect(result.issues[0]!.identifier).toBe('ENG-123');
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.query).toContain('searchIssues');
+    expect(body.variables.term).toBe('broken login');
+  });
+
+  it('shapes projects and users list results', async () => {
+    const projectsFetch = vi.fn().mockResolvedValue(
+      graphqlOk({
+        projects: {
+          nodes: [{ id: 'p1', name: 'Launch', state: 'started', url: 'https://linear.app/acme/project/p1' }],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      }),
+    );
+    await expect(tool(makeTools(projectsFetch), 'linear_list_projects').execute({}, {} as never)).resolves.toEqual({
+      projects: [{ id: 'p1', name: 'Launch', state: 'started', url: 'https://linear.app/acme/project/p1' }],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    });
+
+    const usersFetch = vi.fn().mockResolvedValue(
+      graphqlOk({
+        users: {
+          nodes: [{ id: 'u1', name: 'Ada', email: 'ada@acme.test', active: true }],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      }),
+    );
+    await expect(tool(makeTools(usersFetch), 'linear_list_users').execute({}, {} as never)).resolves.toEqual({
+      users: [{ id: 'u1', name: 'Ada', email: 'ada@acme.test', active: true }],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    });
+  });
+
+  it('throws proxy_error for GraphQL errors in a 200 response', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(Response.json({ errors: [{ message: 'Field "nope" does not exist' }] }));
+    const tools = makeTools(fetchMock);
+    try {
+      await tool(tools, 'linear_get_issue').execute({ id: 'ENG-123' }, {} as never);
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(MastraConnectError);
+      expect((error as MastraConnectError).code).toBe('proxy_error');
+      expect((error as Error).message).toContain('Field "nope" does not exist');
+    }
+  });
+
+  it('throws proxy_error when linear_get_issue finds nothing', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(graphqlOk({ issue: null }));
+    const tools = makeTools(fetchMock);
+    await expect(tool(tools, 'linear_get_issue').execute({ id: 'ENG-999' }, {} as never)).rejects.toMatchObject({
+      code: 'proxy_error',
+    });
+  });
+
+  it('falls back to MASTRA_LINEAR_CONNECTION_ID at execute time', async () => {
+    vi.stubEnv('MASTRA_LINEAR_CONNECTION_ID', 'c_env9');
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(graphqlOk({ teams: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } }));
+    const tools = createLinearTools({
+      client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+    });
+    await tool(tools, 'linear_list_teams').execute({}, {} as never);
+    expect(String(fetchMock.mock.calls[0]![0])).toContain('/v2/connections/c_env9/proxy/graphql');
+  });
+
+  it('throws missing_connection_id at execute time when unresolvable', async () => {
+    vi.stubEnv('MASTRA_LINEAR_CONNECTION_ID', '');
+    const fetchMock = vi.fn();
+    const tools = createLinearTools({
+      client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+    });
+    await expect(tool(tools, 'linear_list_teams').execute({}, {} as never)).rejects.toMatchObject({
+      code: 'missing_connection_id',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('adds a comment through the commentCreate mutation', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      graphqlOk({
+        commentCreate: {
+          success: true,
+          comment: { id: 'cm1', body: 'Nice', url: 'https://linear.app/acme/comment/cm1' },
+        },
+      }),
+    );
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'linear_add_comment').execute(
+      { issueId: 'issue-uuid-1', body: 'Nice' },
+      {} as never,
+    );
+    expect(result).toEqual({
+      comment: { id: 'cm1', body: 'Nice', url: 'https://linear.app/acme/comment/cm1' },
+    });
+  });
+});

--- a/packages/connect/src/__tests__/providers/notion.test.ts
+++ b/packages/connect/src/__tests__/providers/notion.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createNotionTools } from '../../providers/notion.js';
+
+const TOKEN = 'fake-test-token';
+
+const EXPECTED_TOOLS = [
+  'notion_search',
+  'notion_get_page',
+  'notion_create_page',
+  'notion_update_page_properties',
+  'notion_get_block_children',
+  'notion_append_block_children',
+  'notion_query_database',
+  'notion_get_database',
+  'notion_create_comment',
+];
+
+const pageObject = {
+  id: 'page-uuid-1',
+  object: 'page',
+  url: 'https://www.notion.so/Roadmap-page-uuid-1',
+  archived: false,
+  properties: {
+    Name: { id: 'title', type: 'title', title: [{ type: 'text', plain_text: 'Roadmap' }] },
+    Status: { id: 'st', type: 'select', select: { name: 'Active' } },
+  },
+};
+
+function makeTools(fetchMock: ReturnType<typeof vi.fn>, options?: Parameters<typeof createNotionTools>[0]) {
+  return createNotionTools({
+    connectionId: 'c_not1',
+    client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+    ...options,
+  });
+}
+
+interface ExecutableTool {
+  id: string;
+  execute: (input: unknown, context: unknown) => Promise<unknown>;
+}
+
+function tool(tools: ReturnType<typeof createNotionTools>, key: string): ExecutableTool {
+  expect(tools[key]).toBeDefined();
+  return tools[key] as unknown as ExecutableTool;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('createNotionTools', () => {
+  it('returns the full curated toolset', () => {
+    expect(Object.keys(createNotionTools()).sort()).toEqual([...EXPECTED_TOOLS].sort());
+  });
+
+  it('filters with allowTools and throws on unknown names', () => {
+    const tools = createNotionTools({ allowTools: ['notion_search'] });
+    expect(Object.keys(tools)).toEqual(['notion_search']);
+    expect(() => createNotionTools({ allowTools: ['notion_nope'] })).toThrow(/notion_nope/);
+  });
+
+  it('POSTs search with the Notion-Version header and shapes titled results', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        results: [
+          pageObject,
+          {
+            id: 'db-1',
+            object: 'database',
+            url: 'https://notion.so/db-1',
+            title: [{ type: 'text', plain_text: 'Tasks DB' }],
+          },
+        ],
+        next_cursor: 'cur1',
+        has_more: true,
+      }),
+    );
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'notion_search').execute({ query: 'roadmap', filter: 'page' }, {} as never);
+    expect(result).toEqual({
+      results: [
+        { id: 'page-uuid-1', object: 'page', url: 'https://www.notion.so/Roadmap-page-uuid-1', title: 'Roadmap' },
+        { id: 'db-1', object: 'database', url: 'https://notion.so/db-1', title: 'Tasks DB' },
+      ],
+      nextCursor: 'cur1',
+      hasMore: true,
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://example.test/v2/connections/c_not1/proxy/v1/search');
+    expect(init.method).toBe('POST');
+    expect(init.headers['Notion-Version']).toBe('2022-06-28');
+    const body = JSON.parse(init.body);
+    expect(body).toMatchObject({
+      query: 'roadmap',
+      filter: { property: 'object', value: 'page' },
+      page_size: 25,
+    });
+  });
+
+  it('GETs a page and extracts the title from the title property', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json(pageObject));
+    const tools = makeTools(fetchMock);
+    const result = (await tool(tools, 'notion_get_page').execute({ pageId: 'page-uuid-1' }, {} as never)) as {
+      page: { title: string };
+    };
+    expect(result.page.title).toBe('Roadmap');
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://example.test/v2/connections/c_not1/proxy/v1/pages/page-uuid-1');
+    expect(init.method).toBe('GET');
+  });
+
+  it('creates a page under a parent page with plain-text content paragraphs', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json(pageObject));
+    const tools = makeTools(fetchMock);
+    await tool(tools, 'notion_create_page').execute(
+      { parentPageId: 'parent-1', title: 'Roadmap', content: ['First paragraph'] },
+      {} as never,
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.parent).toEqual({ page_id: 'parent-1' });
+    expect(body.properties.title.title[0].text.content).toBe('Roadmap');
+    expect(body.children).toEqual([
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: { rich_text: [{ type: 'text', text: { content: 'First paragraph' } }] },
+      },
+    ]);
+  });
+
+  it('rejects create_page with both or neither parent via the input schema', async () => {
+    const fetchMock = vi.fn();
+    const tools = makeTools(fetchMock);
+    const neither = await tool(tools, 'notion_create_page').execute({ title: 'X' }, {} as never);
+    const both = await tool(tools, 'notion_create_page').execute(
+      { parentPageId: 'a', parentDatabaseId: 'b', title: 'X' },
+      {} as never,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(neither).toMatchObject({ error: true });
+    expect(both).toMatchObject({ error: true });
+  });
+
+  it('PATCHes page properties and archived state', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ ...pageObject, archived: true }));
+    const tools = makeTools(fetchMock);
+    const result = (await tool(tools, 'notion_update_page_properties').execute(
+      { pageId: 'page-uuid-1', archived: true },
+      {} as never,
+    )) as { page: { archived: boolean } };
+    expect(result.page.archived).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://example.test/v2/connections/c_not1/proxy/v1/pages/page-uuid-1');
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(init.body)).toEqual({ archived: true });
+  });
+
+  it('lists block children via query params and flattens rich text', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        results: [
+          {
+            id: 'b1',
+            type: 'paragraph',
+            has_children: false,
+            paragraph: {
+              rich_text: [
+                { type: 'text', plain_text: 'Hello ' },
+                { type: 'text', plain_text: 'world' },
+              ],
+            },
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      }),
+    );
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'notion_get_block_children').execute(
+      { blockId: 'page-uuid-1', limit: 10 },
+      {} as never,
+    );
+    expect(result).toEqual({
+      blocks: [{ id: 'b1', type: 'paragraph', text: 'Hello world', hasChildren: false }],
+      nextCursor: null,
+      hasMore: false,
+    });
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://example.test/v2/connections/c_not1/proxy/v1/blocks/page-uuid-1/children?page_size=10');
+  });
+
+  it('appends plain-text paragraphs as blocks and requires content', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ results: [] }));
+    const tools = makeTools(fetchMock);
+    await tool(tools, 'notion_append_block_children').execute({ blockId: 'b0', paragraphs: ['Note'] }, {} as never);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://example.test/v2/connections/c_not1/proxy/v1/blocks/b0/children');
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(init.body).children[0].paragraph.rich_text[0].text.content).toBe('Note');
+
+    const empty = await tool(tools, 'notion_append_block_children').execute({ blockId: 'b0' }, {} as never);
+    expect(empty).toMatchObject({ error: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('queries a database with a raw filter and shapes pages', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(Response.json({ results: [pageObject], next_cursor: null, has_more: false }));
+    const tools = makeTools(fetchMock);
+    const result = (await tool(tools, 'notion_query_database').execute(
+      { databaseId: 'db-1', filter: { property: 'Status', select: { equals: 'Active' } } },
+      {} as never,
+    )) as { pages: { title: string }[] };
+    expect(result.pages[0]!.title).toBe('Roadmap');
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://example.test/v2/connections/c_not1/proxy/v1/databases/db-1/query');
+    expect(JSON.parse(init.body).filter).toEqual({ property: 'Status', select: { equals: 'Active' } });
+  });
+
+  it('gets a database and shapes column names/types', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        id: 'db-1',
+        url: 'https://notion.so/db-1',
+        title: [{ type: 'text', plain_text: 'Tasks DB' }],
+        properties: { Name: { id: 'title', type: 'title' }, Status: { id: 'st', type: 'select' } },
+      }),
+    );
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'notion_get_database').execute({ databaseId: 'db-1' }, {} as never);
+    expect(result).toEqual({
+      database: {
+        id: 'db-1',
+        url: 'https://notion.so/db-1',
+        title: 'Tasks DB',
+        properties: { Name: { type: 'title' }, Status: { type: 'select' } },
+      },
+    });
+  });
+
+  it('creates a comment on a page and enforces the pageId/discussionId invariant', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ id: 'cm-1', discussion_id: 'd-1' }));
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'notion_create_comment').execute(
+      { pageId: 'page-uuid-1', body: 'Looks good' },
+      {} as never,
+    );
+    expect(result).toEqual({ comment: { id: 'cm-1', discussionId: 'd-1' } });
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.parent).toEqual({ page_id: 'page-uuid-1' });
+    expect(body.rich_text[0].text.content).toBe('Looks good');
+
+    const invalid = await tool(tools, 'notion_create_comment').execute({ body: 'orphan' }, {} as never);
+    expect(invalid).toMatchObject({ error: true });
+  });
+
+  it('falls back to MASTRA_NOTION_CONNECTION_ID at execute time', async () => {
+    vi.stubEnv('MASTRA_NOTION_CONNECTION_ID', 'c_env7');
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ results: [], next_cursor: null, has_more: false }));
+    const tools = createNotionTools({
+      client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+    });
+    await tool(tools, 'notion_search').execute({}, {} as never);
+    expect(String(fetchMock.mock.calls[0]![0])).toContain('/v2/connections/c_env7/proxy/v1/search');
+  });
+
+  it('throws missing_connection_id when unresolvable', async () => {
+    vi.stubEnv('MASTRA_NOTION_CONNECTION_ID', '');
+    const tools = createNotionTools({ client: { accessToken: TOKEN, baseUrl: 'https://example.test' } });
+    await expect(tool(tools, 'notion_search').execute({}, {} as never)).rejects.toMatchObject({
+      code: 'missing_connection_id',
+    });
+  });
+});

--- a/packages/connect/src/__tests__/providers/notion.test.ts
+++ b/packages/connect/src/__tests__/providers/notion.test.ts
@@ -129,7 +129,23 @@ describe('createNotionTools', () => {
     ]);
   });
 
-  it('rejects create_page with both or neither parent via the input schema', async () => {
+  it('creates a database page with caller-supplied properties and no synthesized title', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json(pageObject));
+    const tools = makeTools(fetchMock);
+    await tool(tools, 'notion_create_page').execute(
+      {
+        parentDatabaseId: 'db-1',
+        properties: { Name: { title: [{ type: 'text', text: { content: 'Row' } }] } },
+      },
+      {} as never,
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.parent).toEqual({ database_id: 'db-1' });
+    expect(body.properties).toEqual({ Name: { title: [{ type: 'text', text: { content: 'Row' } }] } });
+    expect(body.properties.title).toBeUndefined();
+  });
+
+  it('rejects create_page with both or neither parent, or missing required title/properties', async () => {
     const fetchMock = vi.fn();
     const tools = makeTools(fetchMock);
     const neither = await tool(tools, 'notion_create_page').execute({ title: 'X' }, {} as never);
@@ -137,9 +153,16 @@ describe('createNotionTools', () => {
       { parentPageId: 'a', parentDatabaseId: 'b', title: 'X' },
       {} as never,
     );
+    const pageParentNoTitle = await tool(tools, 'notion_create_page').execute({ parentPageId: 'a' }, {} as never);
+    const dbParentNoProperties = await tool(tools, 'notion_create_page').execute(
+      { parentDatabaseId: 'db-1' },
+      {} as never,
+    );
     expect(fetchMock).not.toHaveBeenCalled();
     expect(neither).toMatchObject({ error: true });
     expect(both).toMatchObject({ error: true });
+    expect(pageParentNoTitle).toMatchObject({ error: true });
+    expect(dbParentNoProperties).toMatchObject({ error: true });
   });
 
   it('PATCHes page properties and archived state', async () => {
@@ -154,6 +177,14 @@ describe('createNotionTools', () => {
     expect(url).toBe('https://example.test/v2/connections/c_not1/proxy/v1/pages/page-uuid-1');
     expect(init.method).toBe('PATCH');
     expect(JSON.parse(init.body)).toEqual({ archived: true });
+  });
+
+  it('rejects an update_page_properties call with nothing to update', async () => {
+    const fetchMock = vi.fn();
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'notion_update_page_properties').execute({ pageId: 'page-uuid-1' }, {} as never);
+    expect(result).toMatchObject({ error: true });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('lists block children via query params and flattens rich text', async () => {

--- a/packages/connect/src/__tests__/providers/notion.test.ts
+++ b/packages/connect/src/__tests__/providers/notion.test.ts
@@ -158,11 +158,21 @@ describe('createNotionTools', () => {
       { parentDatabaseId: 'db-1' },
       {} as never,
     );
+    const pageParentWithProperties = await tool(tools, 'notion_create_page').execute(
+      { parentPageId: 'a', title: 'X', properties: { Foo: {} } },
+      {} as never,
+    );
+    const dbParentWithTitle = await tool(tools, 'notion_create_page').execute(
+      { parentDatabaseId: 'db-1', title: 'X', properties: { Name: {} } },
+      {} as never,
+    );
     expect(fetchMock).not.toHaveBeenCalled();
     expect(neither).toMatchObject({ error: true });
     expect(both).toMatchObject({ error: true });
     expect(pageParentNoTitle).toMatchObject({ error: true });
     expect(dbParentNoProperties).toMatchObject({ error: true });
+    expect(pageParentWithProperties).toMatchObject({ error: true });
+    expect(dbParentWithTitle).toMatchObject({ error: true });
   });
 
   it('PATCHes page properties and archived state', async () => {
@@ -183,7 +193,12 @@ describe('createNotionTools', () => {
     const fetchMock = vi.fn();
     const tools = makeTools(fetchMock);
     const result = await tool(tools, 'notion_update_page_properties').execute({ pageId: 'page-uuid-1' }, {} as never);
+    const emptyProperties = await tool(tools, 'notion_update_page_properties').execute(
+      { pageId: 'page-uuid-1', properties: {} },
+      {} as never,
+    );
     expect(result).toMatchObject({ error: true });
+    expect(emptyProperties).toMatchObject({ error: true });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/packages/connect/src/__tests__/providers/snowflake.test.ts
+++ b/packages/connect/src/__tests__/providers/snowflake.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createSnowflakeTools } from '../../providers/snowflake.js';
+
+const TOKEN = 'fake-test-token';
+
+const EXPECTED_TOOLS = [
+  'snowflake_execute_sql',
+  'snowflake_get_statement_status',
+  'snowflake_cancel_statement',
+  'snowflake_list_databases',
+  'snowflake_list_tables',
+  'snowflake_describe_table',
+];
+
+const sqlResponse = {
+  statementHandle: 'handle-abc',
+  requestId: 'req-1',
+  sqlState: '00000',
+  code: '0',
+  statementStatus: 'SUCCESS',
+  progress: 'Statement executed successfully',
+  message: 'Statement executed successfully',
+  createdOn: 1788400000000,
+  resultSetMetaData: {
+    format: 'json',
+    rowType: [{ name: 'id' }, { name: 'name' }],
+    numRows: 2,
+  },
+  data: [
+    ['1', 'alpha'],
+    ['2', 'beta'],
+  ],
+};
+
+function makeTools(fetchMock: ReturnType<typeof vi.fn>, options?: Parameters<typeof createSnowflakeTools>[0]) {
+  return createSnowflakeTools({
+    connectionId: 'c_snw1',
+    client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+    ...options,
+  });
+}
+
+interface ExecutableTool {
+  id: string;
+  execute: (input: unknown, context: unknown) => Promise<unknown>;
+}
+
+function tool(tools: ReturnType<typeof createSnowflakeTools>, key: string): ExecutableTool {
+  expect(tools[key]).toBeDefined();
+  return tools[key] as unknown as ExecutableTool;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('createSnowflakeTools', () => {
+  it('returns the full curated toolset', () => {
+    expect(Object.keys(createSnowflakeTools()).sort()).toEqual([...EXPECTED_TOOLS].sort());
+  });
+
+  it('filters with allowTools and throws on unknown names', () => {
+    const tools = createSnowflakeTools({ allowTools: ['snowflake_execute_sql'] });
+    expect(Object.keys(tools)).toEqual(['snowflake_execute_sql']);
+    expect(() => createSnowflakeTools({ allowTools: ['snowflake_nope'] })).toThrow(/snowflake_nope/);
+  });
+
+  it('POSTs statements to api/v2/statements and shapes rows by column name', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json(sqlResponse));
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'snowflake_execute_sql').execute(
+      { statement: 'SELECT id, name FROM t', warehouse: 'WH', database: 'DB1', schema: 'PUBLIC', timeout: 30 },
+      {} as never,
+    );
+    expect(result).toMatchObject({
+      statementHandle: 'handle-abc',
+      status: 'SUCCESS',
+      columns: ['id', 'name'],
+      numRows: 2,
+    });
+    expect((result as { rows: unknown[] }).rows).toEqual([
+      { id: '1', name: 'alpha' },
+      { id: '2', name: 'beta' },
+    ]);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('https://example.test/v2/connections/c_snw1/proxy/api/v2/statements');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({
+      statement: 'SELECT id, name FROM t',
+      warehouse: 'WH',
+      database: 'DB1',
+      schema: 'PUBLIC',
+      timeout: 30,
+    });
+  });
+
+  it('surfaces async RUNNING statements so callers can poll', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({ statementHandle: 'handle-abc', statementStatus: 'RUNNING', message: '' }, { status: 202 }),
+      )
+      .mockResolvedValueOnce(Response.json(sqlResponse));
+    const tools = makeTools(fetchMock);
+
+    const running = (await tool(tools, 'snowflake_execute_sql').execute(
+      { statement: 'SELECT 1', warehouse: 'WH', database: 'DB1', schema: 'PUBLIC' },
+      {} as never,
+    )) as { status: string };
+    expect(running.status).toBe('RUNNING');
+
+    const done = await tool(tools, 'snowflake_get_statement_status').execute(
+      { statementHandle: 'handle-abc' },
+      {} as never,
+    );
+    expect(done).toMatchObject({ status: 'SUCCESS' });
+    const [pollUrl] = fetchMock.mock.calls[1]!;
+    expect(String(pollUrl)).toBe('https://example.test/v2/connections/c_snw1/proxy/api/v2/statements/handle-abc');
+  });
+
+  it('passes the partition query param when fetching partitioned results', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json(sqlResponse));
+    const tools = makeTools(fetchMock);
+    await tool(tools, 'snowflake_get_statement_status').execute(
+      { statementHandle: 'handle/abc+2', partition: 3 },
+      {} as never,
+    );
+    const [url] = fetchMock.mock.calls[0]!;
+    const parsed = new URL(String(url));
+    expect(parsed.pathname).toBe(
+      `/v2/connections/c_snw1/proxy/api/v2/statements/${encodeURIComponent('handle/abc+2')}`,
+    );
+    expect(parsed.searchParams.get('partition')).toBe('3');
+  });
+
+  it('cancels a statement via POST :handle/cancel', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(Response.json({ statementStatus: 'SUCCESS', message: 'Statement execution canceled.' }));
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'snowflake_cancel_statement').execute(
+      { statementHandle: 'handle-abc' },
+      {} as never,
+    );
+    expect(result).toEqual({ status: 'SUCCESS', message: 'Statement execution canceled.' });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('https://example.test/v2/connections/c_snw1/proxy/api/v2/statements/handle-abc/cancel');
+    expect(init.method).toBe('POST');
+  });
+
+  it('lists databases via SHOW DATABASES and extracts names', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        statementHandle: 'h1',
+        statementStatus: 'SUCCESS',
+        message: '',
+        resultSetMetaData: { rowType: [{ name: 'created_on' }, { name: 'name' }], numRows: 2 },
+        data: [
+          ['2026-01-01', 'DB1'],
+          ['2026-01-02', 'DB2'],
+        ],
+      }),
+    );
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'snowflake_list_databases').execute({ warehouse: 'WH' }, {} as never);
+    expect(result).toEqual({ databases: ['DB1', 'DB2'] });
+    expect(JSON.parse(fetchMock.mock.calls[0]![1].body).statement).toBe('SHOW DATABASES LIMIT 50');
+  });
+
+  it('lists tables with validated identifiers interpolated', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        statementHandle: 'h2',
+        statementStatus: 'SUCCESS',
+        message: '',
+        resultSetMetaData: { rowType: [{ name: 'name' }, { name: 'database_name' }], numRows: 1 },
+        data: [['ORDERS', 'DB1']],
+      }),
+    );
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'snowflake_list_tables').execute(
+      { warehouse: 'WH', database: 'DB1', schema: 'PUBLIC' },
+      {} as never,
+    );
+    expect(result).toEqual({ tables: ['ORDERS'] });
+    expect(JSON.parse(fetchMock.mock.calls[0]![1].body).statement).toBe('SHOW TABLES IN DB1.PUBLIC LIMIT 50');
+  });
+
+  it('rejects identifier-injection attempts at the schema layer without calling fetch', async () => {
+    const fetchMock = vi.fn();
+    const tools = makeTools(fetchMock);
+
+    for (const malicious of [
+      'PUBLIC; DROP TABLE ORDERS',
+      'PUBLIC--',
+      'PUBLIC" OR 1=1',
+      "PUBLIC'; DELETE FROM t",
+      'PUBLIC.SECRET',
+    ]) {
+      const rejected = await tool(tools, 'snowflake_list_tables').execute(
+        { warehouse: 'WH', database: 'DB1', schema: malicious },
+        {} as never,
+      );
+      expect(rejected).toMatchObject({ error: true });
+    }
+
+    const badTable = await tool(tools, 'snowflake_describe_table').execute(
+      { warehouse: 'WH', database: 'DB1', schema: 'PUBLIC', table: 'T; SELECT * FROM secrets' },
+      {} as never,
+    );
+    expect(badTable).toMatchObject({ error: true });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('describes a table into typed column records', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        statementHandle: 'h3',
+        statementStatus: 'SUCCESS',
+        message: '',
+        resultSetMetaData: {
+          rowType: [
+            { name: 'name' },
+            { name: 'type' },
+            { name: 'kind' },
+            { name: 'null?' },
+            { name: 'default' },
+            { name: 'comment' },
+          ],
+          numRows: 1,
+        },
+        data: [['ID', 'NUMBER(38,0)', 'COLUMN', 'N', null, 'primary id']],
+      }),
+    );
+    const tools = makeTools(fetchMock);
+    const result = await tool(tools, 'snowflake_describe_table').execute(
+      { warehouse: 'WH', database: 'DB1', schema: 'PUBLIC', table: 'ORDERS' },
+      {} as never,
+    );
+    expect(result).toEqual({
+      columns: [
+        { name: 'ID', type: 'NUMBER(38,0)', kind: 'COLUMN', nullable: false, default: null, comment: 'primary id' },
+      ],
+    });
+    expect(JSON.parse(fetchMock.mock.calls[0]![1].body).statement).toBe('DESCRIBE TABLE DB1.PUBLIC.ORDERS');
+  });
+
+  it('falls back to MASTRA_SNOWFLAKE_CONNECTION_ID at execute time', async () => {
+    vi.stubEnv('MASTRA_SNOWFLAKE_CONNECTION_ID', 'c_env9');
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        Response.json({
+          statementHandle: 'h',
+          statementStatus: 'SUCCESS',
+          message: '',
+          resultSetMetaData: { rowType: [] },
+          data: [],
+        }),
+      );
+    const tools = createSnowflakeTools({
+      client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+    });
+    await tool(tools, 'snowflake_list_databases').execute({ warehouse: 'WH' }, {} as never);
+    expect(String(fetchMock.mock.calls[0]![0])).toContain('/v2/connections/c_env9/proxy/api/v2/statements');
+  });
+
+  it('throws missing_connection_id when unresolvable', async () => {
+    vi.stubEnv('MASTRA_SNOWFLAKE_CONNECTION_ID', '');
+    const tools = createSnowflakeTools({ client: { accessToken: TOKEN, baseUrl: 'https://example.test' } });
+    await expect(
+      tool(tools, 'snowflake_list_databases').execute({ warehouse: 'WH' }, {} as never),
+    ).rejects.toMatchObject({
+      code: 'missing_connection_id',
+    });
+  });
+});

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -6,5 +6,6 @@ export type { MastraConnectErrorCode } from './errors.js';
 export type { ConnectClientOptions, ConnectionCredential, ProjectConnection } from './client.js';
 export type { ProviderKey } from './registry.js';
 export type { ProviderToolsOptions } from './toolset.js';
+export { createJiraTools } from './providers/jira.js';
 export { createLinearTools } from './providers/linear.js';
 export { createNotionTools } from './providers/notion.js';

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -7,3 +7,4 @@ export type { ConnectClientOptions, ConnectionCredential, ProjectConnection } fr
 export type { ProviderKey } from './registry.js';
 export type { ProviderToolsOptions } from './toolset.js';
 export { createLinearTools } from './providers/linear.js';
+export { createNotionTools } from './providers/notion.js';

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -6,3 +6,4 @@ export type { MastraConnectErrorCode } from './errors.js';
 export type { ConnectClientOptions, ConnectionCredential, ProjectConnection } from './client.js';
 export type { ProviderKey } from './registry.js';
 export type { ProviderToolsOptions } from './toolset.js';
+export { createLinearTools } from './providers/linear.js';

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -9,3 +9,4 @@ export type { ProviderToolsOptions } from './toolset.js';
 export { createJiraTools } from './providers/jira.js';
 export { createLinearTools } from './providers/linear.js';
 export { createNotionTools } from './providers/notion.js';
+export { createSnowflakeTools } from './providers/snowflake.js';

--- a/packages/connect/src/providers/jira.ts
+++ b/packages/connect/src/providers/jira.ts
@@ -60,7 +60,7 @@ const issueSchema = z.object({
   updated: z.string(),
 });
 
-const ISSUE_FIELDS = 'summary,status,assignee,priority,issuetype,created,updated';
+const ISSUE_FIELDS = ['summary', 'status', 'assignee', 'priority', 'issuetype', 'created', 'updated'];
 
 function shapeIssue(issue: Record<string, unknown>) {
   const fields = asRecord(issue.fields);
@@ -120,9 +120,9 @@ export function createJiraTools(options?: ProviderToolsOptions): ToolsInput {
         nextPageToken: z.string().nullable(),
       }),
       request: input => ({
-        method: 'GET',
+        method: 'POST',
         path: jiraPath(input.cloudId, 'search/jql'),
-        query: {
+        body: {
           jql: input.jql,
           maxResults: input.limit ?? 25,
           nextPageToken: input.nextPageToken,
@@ -149,7 +149,7 @@ export function createJiraTools(options?: ProviderToolsOptions): ToolsInput {
       request: input => ({
         method: 'GET',
         path: jiraPath(input.cloudId, `issue/${encodeURIComponent(input.issueKey)}`),
-        query: { fields: `${ISSUE_FIELDS},description` },
+        query: { fields: `${ISSUE_FIELDS.join(',')},description` },
       }),
       transform: raw => {
         const issue = asRecord(raw);
@@ -162,7 +162,7 @@ export function createJiraTools(options?: ProviderToolsOptions): ToolsInput {
     jira_create_issue: defineProxyTool(context, {
       id: 'jira_create_issue',
       description:
-        'Create a Jira issue. The description is plain text and is wrapped into Atlassian Document Format automatically.',
+        'Create a Jira issue. The description is plain text and is wrapped into Atlassian Document Format automatically. Issue types are referenced by name, which works for classic projects; team-managed projects that require issue type ids are not supported.',
       inputSchema: z.object({
         cloudId: cloudIdInput,
         projectKey: z.string().describe('Project key (e.g. "ENG")'),
@@ -199,15 +199,25 @@ export function createJiraTools(options?: ProviderToolsOptions): ToolsInput {
       id: 'jira_update_issue',
       description:
         'Update fields of a Jira issue (summary, plain-text description, assignee, labels, or priority). Use jira_transition_issue to change status.',
-      inputSchema: z.object({
-        cloudId: cloudIdInput,
-        issueKey: z.string().describe('Issue key like "ENG-123"'),
-        summary: z.string().optional().describe('New summary'),
-        description: z.string().optional().describe('New plain-text description'),
-        assigneeAccountId: z.string().optional().describe('Atlassian account id of the new assignee'),
-        labels: z.array(z.string()).optional().describe('Replacement labels'),
-        priority: z.string().optional().describe('New priority name'),
-      }),
+      inputSchema: z
+        .object({
+          cloudId: cloudIdInput,
+          issueKey: z.string().describe('Issue key like "ENG-123"'),
+          summary: z.string().optional().describe('New summary'),
+          description: z.string().optional().describe('New plain-text description'),
+          assigneeAccountId: z.string().optional().describe('Atlassian account id of the new assignee'),
+          labels: z.array(z.string()).optional().describe('Replacement labels'),
+          priority: z.string().optional().describe('New priority name'),
+        })
+        .refine(
+          input =>
+            input.summary !== undefined ||
+            input.description !== undefined ||
+            input.assigneeAccountId !== undefined ||
+            input.labels !== undefined ||
+            input.priority !== undefined,
+          { message: 'Provide at least one field to update.' },
+        ),
       outputSchema: z.object({ updated: z.boolean() }),
       request: input => ({
         method: 'PUT',

--- a/packages/connect/src/providers/jira.ts
+++ b/packages/connect/src/providers/jira.ts
@@ -1,0 +1,359 @@
+import type { ToolsInput } from '@mastra/core/agent';
+import { z } from 'zod';
+
+import type { ProviderToolsOptions } from '../toolset.js';
+import { applyAllowTools, defineProxyTool } from '../toolset.js';
+
+const ENV_VAR = 'MASTRA_JIRA_CONNECTION_ID';
+
+/**
+ * Nango's `jira` provider proxies to the bare `https://api.atlassian.com`
+ * origin (the Atlassian cloud id is NOT templated into the base URL), so
+ * every Jira REST call must be prefixed with `ex/jira/{cloudId}`. Tools take
+ * a `cloudId` input; `jira_get_accessible_resources` discovers it.
+ */
+const cloudIdInput = z
+  .string()
+  .describe('Atlassian cloud id of the Jira site (discover it with jira_get_accessible_resources)');
+
+function jiraPath(cloudId: string, rest: string): string {
+  return `ex/jira/${encodeURIComponent(cloudId)}/rest/api/3/${rest}`;
+}
+
+const paginationInput = {
+  limit: z.number().int().min(1).max(50).optional().describe('Max results to return (1-50, default 25)'),
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+/** Wraps plain text in a minimal Atlassian Document Format (ADF) document. */
+function adfDocument(text: string) {
+  return {
+    type: 'doc',
+    version: 1,
+    content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+  };
+}
+
+/** Flattens an ADF node tree to plain text. */
+function adfText(node: unknown): string {
+  const record = asRecord(node);
+  if (record.type === 'text' && typeof record.text === 'string') return record.text;
+  if (Array.isArray(record.content)) {
+    const inner = record.content.map(adfText).join('');
+    return record.type === 'paragraph' ? `${inner}\n` : inner;
+  }
+  return '';
+}
+
+const issueSchema = z.object({
+  id: z.string(),
+  key: z.string(),
+  summary: z.string(),
+  status: z.string(),
+  assignee: z.string().nullable(),
+  priority: z.string().nullable(),
+  issueType: z.string(),
+  created: z.string(),
+  updated: z.string(),
+});
+
+const ISSUE_FIELDS = 'summary,status,assignee,priority,issuetype,created,updated';
+
+function shapeIssue(issue: Record<string, unknown>) {
+  const fields = asRecord(issue.fields);
+  const assignee = asRecord(fields.assignee);
+  const priority = asRecord(fields.priority);
+  return {
+    id: String(issue.id ?? ''),
+    key: String(issue.key ?? ''),
+    summary: String(fields.summary ?? ''),
+    status: String(asRecord(fields.status).name ?? ''),
+    assignee: typeof assignee.displayName === 'string' ? assignee.displayName : null,
+    priority: typeof priority.name === 'string' ? priority.name : null,
+    issueType: String(asRecord(fields.issuetype).name ?? ''),
+    created: String(fields.created ?? ''),
+    updated: String(fields.updated ?? ''),
+  };
+}
+
+/**
+ * Curated Jira Cloud toolset executing through the platform connection proxy.
+ * All tools resolve the connection from `options.connectionId` or
+ * MASTRA_JIRA_CONNECTION_ID at execute time.
+ */
+export function createJiraTools(options?: ProviderToolsOptions): ToolsInput {
+  const context = { envVar: ENV_VAR, options };
+
+  const tools = {
+    jira_get_accessible_resources: defineProxyTool(context, {
+      id: 'jira_get_accessible_resources',
+      description:
+        'List the Jira sites accessible to this connection, with their cloud ids. Call this first: every other jira_* tool needs a cloudId.',
+      inputSchema: z.object({}),
+      outputSchema: z.object({
+        sites: z.array(z.object({ cloudId: z.string(), name: z.string(), url: z.string() })),
+      }),
+      request: () => ({ method: 'GET', path: 'oauth/token/accessible-resources' }),
+      transform: raw => ({
+        sites: (Array.isArray(raw) ? raw.map(asRecord) : []).map(site => ({
+          cloudId: String(site.id ?? ''),
+          name: String(site.name ?? ''),
+          url: String(site.url ?? ''),
+        })),
+      }),
+    }),
+
+    jira_search_issues: defineProxyTool(context, {
+      id: 'jira_search_issues',
+      description: 'Search Jira issues with a JQL query (e.g. \'project = ENG AND status = "In Progress"\').',
+      inputSchema: z.object({
+        cloudId: cloudIdInput,
+        jql: z.string().describe('JQL query string'),
+        nextPageToken: z.string().optional().describe('Pagination token from a previous page'),
+        ...paginationInput,
+      }),
+      outputSchema: z.object({
+        issues: z.array(issueSchema),
+        nextPageToken: z.string().nullable(),
+      }),
+      request: input => ({
+        method: 'GET',
+        path: jiraPath(input.cloudId, 'search/jql'),
+        query: {
+          jql: input.jql,
+          maxResults: input.limit ?? 25,
+          nextPageToken: input.nextPageToken,
+          fields: ISSUE_FIELDS,
+        },
+      }),
+      transform: raw => {
+        const data = asRecord(raw);
+        return {
+          issues: (Array.isArray(data.issues) ? data.issues.map(asRecord) : []).map(shapeIssue),
+          nextPageToken: typeof data.nextPageToken === 'string' ? data.nextPageToken : null,
+        };
+      },
+    }),
+
+    jira_get_issue: defineProxyTool(context, {
+      id: 'jira_get_issue',
+      description: 'Get a Jira issue by key (e.g. "ENG-123"), including its plain-text description.',
+      inputSchema: z.object({
+        cloudId: cloudIdInput,
+        issueKey: z.string().describe('Issue key like "ENG-123"'),
+      }),
+      outputSchema: z.object({ issue: issueSchema.extend({ description: z.string() }) }),
+      request: input => ({
+        method: 'GET',
+        path: jiraPath(input.cloudId, `issue/${encodeURIComponent(input.issueKey)}`),
+        query: { fields: `${ISSUE_FIELDS},description` },
+      }),
+      transform: raw => {
+        const issue = asRecord(raw);
+        return {
+          issue: { ...shapeIssue(issue), description: adfText(asRecord(issue.fields).description).trim() },
+        };
+      },
+    }),
+
+    jira_create_issue: defineProxyTool(context, {
+      id: 'jira_create_issue',
+      description:
+        'Create a Jira issue. The description is plain text and is wrapped into Atlassian Document Format automatically.',
+      inputSchema: z.object({
+        cloudId: cloudIdInput,
+        projectKey: z.string().describe('Project key (e.g. "ENG")'),
+        summary: z.string().describe('Issue summary (title)'),
+        issueType: z.string().describe('Issue type name (e.g. "Task", "Bug", "Story")'),
+        description: z.string().optional().describe('Plain-text description'),
+        assigneeAccountId: z.string().optional().describe('Atlassian account id of the assignee'),
+        labels: z.array(z.string()).optional().describe('Labels to apply'),
+        priority: z.string().optional().describe('Priority name (e.g. "High")'),
+      }),
+      outputSchema: z.object({ issue: z.object({ id: z.string(), key: z.string() }) }),
+      request: input => ({
+        method: 'POST',
+        path: jiraPath(input.cloudId, 'issue'),
+        body: {
+          fields: {
+            project: { key: input.projectKey },
+            summary: input.summary,
+            issuetype: { name: input.issueType },
+            description: input.description ? adfDocument(input.description) : undefined,
+            assignee: input.assigneeAccountId ? { id: input.assigneeAccountId } : undefined,
+            labels: input.labels,
+            priority: input.priority ? { name: input.priority } : undefined,
+          },
+        },
+      }),
+      transform: raw => {
+        const data = asRecord(raw);
+        return { issue: { id: String(data.id ?? ''), key: String(data.key ?? '') } };
+      },
+    }),
+
+    jira_update_issue: defineProxyTool(context, {
+      id: 'jira_update_issue',
+      description:
+        'Update fields of a Jira issue (summary, plain-text description, assignee, labels, or priority). Use jira_transition_issue to change status.',
+      inputSchema: z.object({
+        cloudId: cloudIdInput,
+        issueKey: z.string().describe('Issue key like "ENG-123"'),
+        summary: z.string().optional().describe('New summary'),
+        description: z.string().optional().describe('New plain-text description'),
+        assigneeAccountId: z.string().optional().describe('Atlassian account id of the new assignee'),
+        labels: z.array(z.string()).optional().describe('Replacement labels'),
+        priority: z.string().optional().describe('New priority name'),
+      }),
+      outputSchema: z.object({ updated: z.boolean() }),
+      request: input => ({
+        method: 'PUT',
+        path: jiraPath(input.cloudId, `issue/${encodeURIComponent(input.issueKey)}`),
+        body: {
+          fields: {
+            summary: input.summary,
+            description: input.description ? adfDocument(input.description) : undefined,
+            assignee: input.assigneeAccountId ? { id: input.assigneeAccountId } : undefined,
+            labels: input.labels,
+            priority: input.priority ? { name: input.priority } : undefined,
+          },
+        },
+      }),
+      transform: () => ({ updated: true }),
+    }),
+
+    jira_list_transitions: defineProxyTool(context, {
+      id: 'jira_list_transitions',
+      description: 'List the workflow transitions currently available for a Jira issue.',
+      inputSchema: z.object({
+        cloudId: cloudIdInput,
+        issueKey: z.string().describe('Issue key like "ENG-123"'),
+      }),
+      outputSchema: z.object({
+        transitions: z.array(z.object({ id: z.string(), name: z.string(), toStatus: z.string() })),
+      }),
+      request: input => ({
+        method: 'GET',
+        path: jiraPath(input.cloudId, `issue/${encodeURIComponent(input.issueKey)}/transitions`),
+      }),
+      transform: raw => {
+        const data = asRecord(raw);
+        return {
+          transitions: (Array.isArray(data.transitions) ? data.transitions.map(asRecord) : []).map(transition => ({
+            id: String(transition.id ?? ''),
+            name: String(transition.name ?? ''),
+            toStatus: String(asRecord(transition.to).name ?? ''),
+          })),
+        };
+      },
+    }),
+
+    jira_transition_issue: defineProxyTool(context, {
+      id: 'jira_transition_issue',
+      description:
+        'Move a Jira issue through a workflow transition (changes its status). Get valid transition ids from jira_list_transitions.',
+      inputSchema: z.object({
+        cloudId: cloudIdInput,
+        issueKey: z.string().describe('Issue key like "ENG-123"'),
+        transitionId: z.string().describe('Transition id (from jira_list_transitions)'),
+      }),
+      outputSchema: z.object({ transitioned: z.boolean() }),
+      request: input => ({
+        method: 'POST',
+        path: jiraPath(input.cloudId, `issue/${encodeURIComponent(input.issueKey)}/transitions`),
+        body: { transition: { id: input.transitionId } },
+      }),
+      transform: () => ({ transitioned: true }),
+    }),
+
+    jira_add_comment: defineProxyTool(context, {
+      id: 'jira_add_comment',
+      description: 'Add a comment to a Jira issue. Plain text is wrapped into Atlassian Document Format automatically.',
+      inputSchema: z.object({
+        cloudId: cloudIdInput,
+        issueKey: z.string().describe('Issue key like "ENG-123"'),
+        body: z.string().describe('Comment text (plain text)'),
+      }),
+      outputSchema: z.object({ comment: z.object({ id: z.string(), created: z.string() }) }),
+      request: input => ({
+        method: 'POST',
+        path: jiraPath(input.cloudId, `issue/${encodeURIComponent(input.issueKey)}/comment`),
+        body: { body: adfDocument(input.body) },
+      }),
+      transform: raw => {
+        const data = asRecord(raw);
+        return { comment: { id: String(data.id ?? ''), created: String(data.created ?? '') } };
+      },
+    }),
+
+    jira_list_comments: defineProxyTool(context, {
+      id: 'jira_list_comments',
+      description: 'List comments on a Jira issue as plain text.',
+      inputSchema: z.object({
+        cloudId: cloudIdInput,
+        issueKey: z.string().describe('Issue key like "ENG-123"'),
+        startAt: z.number().int().min(0).optional().describe('Offset for pagination (default 0)'),
+        ...paginationInput,
+      }),
+      outputSchema: z.object({
+        comments: z.array(z.object({ id: z.string(), author: z.string(), body: z.string(), created: z.string() })),
+        total: z.number(),
+      }),
+      request: input => ({
+        method: 'GET',
+        path: jiraPath(input.cloudId, `issue/${encodeURIComponent(input.issueKey)}/comment`),
+        query: { startAt: input.startAt, maxResults: input.limit ?? 25 },
+      }),
+      transform: raw => {
+        const data = asRecord(raw);
+        return {
+          comments: (Array.isArray(data.comments) ? data.comments.map(asRecord) : []).map(comment => ({
+            id: String(comment.id ?? ''),
+            author: String(asRecord(comment.author).displayName ?? ''),
+            body: adfText(comment.body).trim(),
+            created: String(comment.created ?? ''),
+          })),
+          total: typeof data.total === 'number' ? data.total : 0,
+        };
+      },
+    }),
+
+    jira_list_projects: defineProxyTool(context, {
+      id: 'jira_list_projects',
+      description: 'List Jira projects in the site, optionally filtered by a name/key query.',
+      inputSchema: z.object({
+        cloudId: cloudIdInput,
+        query: z.string().optional().describe('Filter projects by name or key'),
+        startAt: z.number().int().min(0).optional().describe('Offset for pagination (default 0)'),
+        ...paginationInput,
+      }),
+      outputSchema: z.object({
+        projects: z.array(z.object({ id: z.string(), key: z.string(), name: z.string() })),
+        total: z.number(),
+        isLast: z.boolean(),
+      }),
+      request: input => ({
+        method: 'GET',
+        path: jiraPath(input.cloudId, 'project/search'),
+        query: { query: input.query, startAt: input.startAt, maxResults: input.limit ?? 25 },
+      }),
+      transform: raw => {
+        const data = asRecord(raw);
+        return {
+          projects: (Array.isArray(data.values) ? data.values.map(asRecord) : []).map(project => ({
+            id: String(project.id ?? ''),
+            key: String(project.key ?? ''),
+            name: String(project.name ?? ''),
+          })),
+          total: typeof data.total === 'number' ? data.total : 0,
+          isLast: data.isLast === true,
+        };
+      },
+    }),
+  } satisfies ToolsInput;
+
+  return applyAllowTools(tools, options?.allowTools);
+}

--- a/packages/connect/src/providers/jira.ts
+++ b/packages/connect/src/providers/jira.ts
@@ -203,11 +203,11 @@ export function createJiraTools(options?: ProviderToolsOptions): ToolsInput {
         .object({
           cloudId: cloudIdInput,
           issueKey: z.string().describe('Issue key like "ENG-123"'),
-          summary: z.string().optional().describe('New summary'),
-          description: z.string().optional().describe('New plain-text description'),
-          assigneeAccountId: z.string().optional().describe('Atlassian account id of the new assignee'),
+          summary: z.string().min(1).optional().describe('New summary'),
+          description: z.string().min(1).optional().describe('New plain-text description'),
+          assigneeAccountId: z.string().min(1).optional().describe('Atlassian account id of the new assignee'),
           labels: z.array(z.string()).optional().describe('Replacement labels'),
-          priority: z.string().optional().describe('New priority name'),
+          priority: z.string().min(1).optional().describe('New priority name'),
         })
         .refine(
           input =>

--- a/packages/connect/src/providers/linear.ts
+++ b/packages/connect/src/providers/linear.ts
@@ -1,0 +1,462 @@
+import type { ToolsInput } from '@mastra/core/agent';
+import { z } from 'zod';
+
+import type { ProxyRequestOptions } from '../client.js';
+import { MastraConnectError } from '../errors.js';
+import type { ProviderToolsOptions } from '../toolset.js';
+import { applyAllowTools, defineProxyTool } from '../toolset.js';
+
+const ENV_VAR = 'MASTRA_LINEAR_CONNECTION_ID';
+
+// Linear's API is GraphQL-only: every tool POSTs a curated query/mutation to
+// the proxy path `graphql`.
+function graphql(query: string, variables: Record<string, unknown>): ProxyRequestOptions {
+  return { method: 'POST', path: 'graphql', body: { query, variables } };
+}
+
+interface GraphQLResponse {
+  data?: Record<string, unknown>;
+  errors?: { message?: string }[];
+}
+
+/** Unwraps a GraphQL response; GraphQL errors arrive in a 200 body and must still throw. */
+function unwrap(raw: unknown): Record<string, unknown> {
+  const response = (raw ?? {}) as GraphQLResponse;
+  if (Array.isArray(response.errors) && response.errors.length > 0) {
+    const message = response.errors
+      .map(error => (typeof error?.message === 'string' ? error.message : 'Unknown GraphQL error'))
+      .join('; ');
+    throw new MastraConnectError('proxy_error', `Linear GraphQL error: ${message}`, { detail: message });
+  }
+  if (!response.data || typeof response.data !== 'object') {
+    throw new MastraConnectError('proxy_error', 'Linear returned an empty GraphQL response.');
+  }
+  return response.data;
+}
+
+const issueFields = `
+  id
+  identifier
+  title
+  description
+  priority
+  url
+  createdAt
+  updatedAt
+  state { id name type }
+  assignee { id name }
+  team { id key name }
+`;
+
+const issueSchema = z.object({
+  id: z.string(),
+  identifier: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  priority: z.number().nullable(),
+  url: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  state: z.object({ id: z.string(), name: z.string(), type: z.string() }).nullable(),
+  assignee: z.object({ id: z.string(), name: z.string() }).nullable(),
+  team: z.object({ id: z.string(), key: z.string(), name: z.string() }).nullable(),
+});
+
+type Issue = z.infer<typeof issueSchema>;
+
+function shapeIssue(node: Record<string, unknown>): Issue {
+  const state = node.state as { id?: string; name?: string; type?: string } | null | undefined;
+  const assignee = node.assignee as { id?: string; name?: string } | null | undefined;
+  const team = node.team as { id?: string; key?: string; name?: string } | null | undefined;
+  return {
+    id: String(node.id ?? ''),
+    identifier: String(node.identifier ?? ''),
+    title: String(node.title ?? ''),
+    description: typeof node.description === 'string' ? node.description : null,
+    priority: typeof node.priority === 'number' ? node.priority : null,
+    url: String(node.url ?? ''),
+    createdAt: String(node.createdAt ?? ''),
+    updatedAt: String(node.updatedAt ?? ''),
+    state: state?.id ? { id: state.id, name: state.name ?? '', type: state.type ?? '' } : null,
+    assignee: assignee?.id ? { id: assignee.id, name: assignee.name ?? '' } : null,
+    team: team?.id ? { id: team.id, key: team.key ?? '', name: team.name ?? '' } : null,
+  };
+}
+
+function nodesOf(data: Record<string, unknown>, key: string): Record<string, unknown>[] {
+  const connection = data[key] as { nodes?: unknown } | undefined;
+  return Array.isArray(connection?.nodes) ? (connection.nodes as Record<string, unknown>[]) : [];
+}
+
+const pageInfoOf = (data: Record<string, unknown>, key: string): { hasNextPage: boolean; endCursor: string | null } => {
+  const connection = data[key] as { pageInfo?: { hasNextPage?: unknown; endCursor?: unknown } } | undefined;
+  return {
+    hasNextPage: connection?.pageInfo?.hasNextPage === true,
+    endCursor: typeof connection?.pageInfo?.endCursor === 'string' ? connection.pageInfo.endCursor : null,
+  };
+};
+
+const paginationInput = {
+  limit: z.number().int().min(1).max(50).optional().describe('Max results to return (1-50, default 25)'),
+  after: z.string().optional().describe('Pagination cursor from a previous page (endCursor)'),
+};
+
+const pageInfoSchema = z.object({ hasNextPage: z.boolean(), endCursor: z.string().nullable() });
+
+/**
+ * Curated Linear toolset executing through the platform connection proxy.
+ * All tools resolve the connection from `options.connectionId` or
+ * MASTRA_LINEAR_CONNECTION_ID at execute time.
+ */
+export function createLinearTools(options?: ProviderToolsOptions): ToolsInput {
+  const context = { envVar: ENV_VAR, options };
+
+  const tools = {
+    linear_list_teams: defineProxyTool(context, {
+      id: 'linear_list_teams',
+      description: 'List teams in the Linear workspace with their ids, keys, and names.',
+      inputSchema: z.object({ ...paginationInput }),
+      outputSchema: z.object({
+        teams: z.array(z.object({ id: z.string(), key: z.string(), name: z.string() })),
+        pageInfo: pageInfoSchema,
+      }),
+      request: input =>
+        graphql(
+          `
+            query Teams($first: Int!, $after: String) {
+              teams(first: $first, after: $after) {
+                nodes {
+                  id
+                  key
+                  name
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+          `,
+          { first: input.limit ?? 25, after: input.after ?? null },
+        ),
+      transform: raw => {
+        const data = unwrap(raw);
+        return {
+          teams: nodesOf(data, 'teams').map(node => ({
+            id: String(node.id ?? ''),
+            key: String(node.key ?? ''),
+            name: String(node.name ?? ''),
+          })),
+          pageInfo: pageInfoOf(data, 'teams'),
+        };
+      },
+    }),
+
+    linear_list_issues: defineProxyTool(context, {
+      id: 'linear_list_issues',
+      description:
+        'List issues in the Linear workspace, optionally filtered by team key, assignee email, or workflow state name.',
+      inputSchema: z.object({
+        teamKey: z.string().optional().describe('Filter by team key (e.g. "ENG")'),
+        assigneeEmail: z.string().optional().describe('Filter by assignee email'),
+        stateName: z.string().optional().describe('Filter by workflow state name (e.g. "In Progress")'),
+        ...paginationInput,
+      }),
+      outputSchema: z.object({ issues: z.array(issueSchema), pageInfo: pageInfoSchema }),
+      request: input => {
+        const filter: Record<string, unknown> = {};
+        if (input.teamKey) filter.team = { key: { eq: input.teamKey } };
+        if (input.assigneeEmail) filter.assignee = { email: { eq: input.assigneeEmail } };
+        if (input.stateName) filter.state = { name: { eq: input.stateName } };
+        return graphql(
+          `query Issues($filter: IssueFilter, $first: Int!, $after: String) {
+            issues(filter: $filter, first: $first, after: $after) {
+              nodes { ${issueFields} }
+              pageInfo { hasNextPage endCursor }
+            }
+          }`,
+          { filter, first: input.limit ?? 25, after: input.after ?? null },
+        );
+      },
+      transform: raw => {
+        const data = unwrap(raw);
+        return { issues: nodesOf(data, 'issues').map(shapeIssue), pageInfo: pageInfoOf(data, 'issues') };
+      },
+    }),
+
+    linear_get_issue: defineProxyTool(context, {
+      id: 'linear_get_issue',
+      description: 'Get a single Linear issue by id or identifier (e.g. "ENG-123").',
+      inputSchema: z.object({
+        id: z.string().describe('Issue id (UUID) or identifier like "ENG-123"'),
+      }),
+      outputSchema: z.object({ issue: issueSchema }),
+      request: input =>
+        graphql(
+          `query Issue($id: String!) {
+            issue(id: $id) { ${issueFields} }
+          }`,
+          { id: input.id },
+        ),
+      transform: raw => {
+        const data = unwrap(raw);
+        const issue = data.issue as Record<string, unknown> | null | undefined;
+        if (!issue) {
+          throw new MastraConnectError('proxy_error', 'Linear issue not found.');
+        }
+        return { issue: shapeIssue(issue) };
+      },
+    }),
+
+    linear_search_issues: defineProxyTool(context, {
+      id: 'linear_search_issues',
+      description: 'Full-text search Linear issues by title and description.',
+      inputSchema: z.object({
+        query: z.string().describe('Search terms'),
+        ...paginationInput,
+      }),
+      outputSchema: z.object({ issues: z.array(issueSchema), pageInfo: pageInfoSchema }),
+      request: input =>
+        graphql(
+          `query SearchIssues($term: String!, $first: Int!, $after: String) {
+            searchIssues(term: $term, first: $first, after: $after) {
+              nodes { ${issueFields} }
+              pageInfo { hasNextPage endCursor }
+            }
+          }`,
+          { term: input.query, first: input.limit ?? 25, after: input.after ?? null },
+        ),
+      transform: raw => {
+        const data = unwrap(raw);
+        return {
+          issues: nodesOf(data, 'searchIssues').map(shapeIssue),
+          pageInfo: pageInfoOf(data, 'searchIssues'),
+        };
+      },
+    }),
+
+    linear_create_issue: defineProxyTool(context, {
+      id: 'linear_create_issue',
+      description: 'Create a Linear issue in a team.',
+      inputSchema: z.object({
+        teamId: z.string().describe('Team id (from linear_list_teams)'),
+        title: z.string().describe('Issue title'),
+        description: z.string().optional().describe('Issue description (Markdown)'),
+        assigneeId: z.string().optional().describe('Assignee user id (from linear_list_users)'),
+        priority: z
+          .number()
+          .int()
+          .min(0)
+          .max(4)
+          .optional()
+          .describe('Priority: 0 none, 1 urgent, 2 high, 3 normal, 4 low'),
+        stateId: z.string().optional().describe('Workflow state id'),
+      }),
+      outputSchema: z.object({ issue: issueSchema }),
+      request: input =>
+        graphql(
+          `mutation CreateIssue($input: IssueCreateInput!) {
+            issueCreate(input: $input) {
+              success
+              issue { ${issueFields} }
+            }
+          }`,
+          {
+            input: {
+              teamId: input.teamId,
+              title: input.title,
+              description: input.description,
+              assigneeId: input.assigneeId,
+              priority: input.priority,
+              stateId: input.stateId,
+            },
+          },
+        ),
+      transform: raw => {
+        const data = unwrap(raw);
+        const payload = data.issueCreate as { success?: unknown; issue?: Record<string, unknown> } | undefined;
+        if (payload?.success !== true || !payload.issue) {
+          throw new MastraConnectError('proxy_error', 'Linear issue creation failed.');
+        }
+        return { issue: shapeIssue(payload.issue) };
+      },
+    }),
+
+    linear_update_issue: defineProxyTool(context, {
+      id: 'linear_update_issue',
+      description: 'Update a Linear issue (title, description, assignee, priority, or workflow state).',
+      inputSchema: z.object({
+        id: z.string().describe('Issue id (UUID)'),
+        title: z.string().optional().describe('New title'),
+        description: z.string().optional().describe('New description (Markdown)'),
+        assigneeId: z.string().optional().describe('New assignee user id'),
+        priority: z
+          .number()
+          .int()
+          .min(0)
+          .max(4)
+          .optional()
+          .describe('Priority: 0 none, 1 urgent, 2 high, 3 normal, 4 low'),
+        stateId: z.string().optional().describe('New workflow state id'),
+      }),
+      outputSchema: z.object({ issue: issueSchema }),
+      request: input =>
+        graphql(
+          `mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) {
+            issueUpdate(id: $id, input: $input) {
+              success
+              issue { ${issueFields} }
+            }
+          }`,
+          {
+            id: input.id,
+            input: {
+              title: input.title,
+              description: input.description,
+              assigneeId: input.assigneeId,
+              priority: input.priority,
+              stateId: input.stateId,
+            },
+          },
+        ),
+      transform: raw => {
+        const data = unwrap(raw);
+        const payload = data.issueUpdate as { success?: unknown; issue?: Record<string, unknown> } | undefined;
+        if (payload?.success !== true || !payload.issue) {
+          throw new MastraConnectError('proxy_error', 'Linear issue update failed.');
+        }
+        return { issue: shapeIssue(payload.issue) };
+      },
+    }),
+
+    linear_add_comment: defineProxyTool(context, {
+      id: 'linear_add_comment',
+      description: 'Add a comment to a Linear issue.',
+      inputSchema: z.object({
+        issueId: z.string().describe('Issue id (UUID)'),
+        body: z.string().describe('Comment body (Markdown)'),
+      }),
+      outputSchema: z.object({
+        comment: z.object({ id: z.string(), body: z.string(), url: z.string() }),
+      }),
+      request: input =>
+        graphql(
+          `
+            mutation AddComment($input: CommentCreateInput!) {
+              commentCreate(input: $input) {
+                success
+                comment {
+                  id
+                  body
+                  url
+                }
+              }
+            }
+          `,
+          { input: { issueId: input.issueId, body: input.body } },
+        ),
+      transform: raw => {
+        const data = unwrap(raw);
+        const payload = data.commentCreate as
+          | { success?: unknown; comment?: { id?: unknown; body?: unknown; url?: unknown } }
+          | undefined;
+        if (payload?.success !== true || !payload.comment) {
+          throw new MastraConnectError('proxy_error', 'Linear comment creation failed.');
+        }
+        return {
+          comment: {
+            id: String(payload.comment.id ?? ''),
+            body: String(payload.comment.body ?? ''),
+            url: String(payload.comment.url ?? ''),
+          },
+        };
+      },
+    }),
+
+    linear_list_projects: defineProxyTool(context, {
+      id: 'linear_list_projects',
+      description: 'List projects in the Linear workspace.',
+      inputSchema: z.object({ ...paginationInput }),
+      outputSchema: z.object({
+        projects: z.array(z.object({ id: z.string(), name: z.string(), state: z.string(), url: z.string() })),
+        pageInfo: pageInfoSchema,
+      }),
+      request: input =>
+        graphql(
+          `
+            query Projects($first: Int!, $after: String) {
+              projects(first: $first, after: $after) {
+                nodes {
+                  id
+                  name
+                  state
+                  url
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+          `,
+          { first: input.limit ?? 25, after: input.after ?? null },
+        ),
+      transform: raw => {
+        const data = unwrap(raw);
+        return {
+          projects: nodesOf(data, 'projects').map(node => ({
+            id: String(node.id ?? ''),
+            name: String(node.name ?? ''),
+            state: String(node.state ?? ''),
+            url: String(node.url ?? ''),
+          })),
+          pageInfo: pageInfoOf(data, 'projects'),
+        };
+      },
+    }),
+
+    linear_list_users: defineProxyTool(context, {
+      id: 'linear_list_users',
+      description: 'List users in the Linear workspace with their ids, names, and emails.',
+      inputSchema: z.object({ ...paginationInput }),
+      outputSchema: z.object({
+        users: z.array(z.object({ id: z.string(), name: z.string(), email: z.string(), active: z.boolean() })),
+        pageInfo: pageInfoSchema,
+      }),
+      request: input =>
+        graphql(
+          `
+            query Users($first: Int!, $after: String) {
+              users(first: $first, after: $after) {
+                nodes {
+                  id
+                  name
+                  email
+                  active
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+          `,
+          { first: input.limit ?? 25, after: input.after ?? null },
+        ),
+      transform: raw => {
+        const data = unwrap(raw);
+        return {
+          users: nodesOf(data, 'users').map(node => ({
+            id: String(node.id ?? ''),
+            name: String(node.name ?? ''),
+            email: String(node.email ?? ''),
+            active: node.active === true,
+          })),
+          pageInfo: pageInfoOf(data, 'users'),
+        };
+      },
+    }),
+  } satisfies ToolsInput;
+
+  return applyAllowTools(tools, options?.allowTools);
+}

--- a/packages/connect/src/providers/notion.ts
+++ b/packages/connect/src/providers/notion.ts
@@ -155,7 +155,7 @@ export function createNotionTools(options?: ProviderToolsOptions): ToolsInput {
     notion_create_page: defineProxyTool(context, {
       id: 'notion_create_page',
       description:
-        'Create a Notion page under a parent page or database. For a page parent, provide title and optional plain-text paragraphs; for a database parent, provide properties matching the database schema (including its title column).',
+        'Create a Notion page under a parent page or database. For a page parent, provide title (and optional plain-text paragraphs); for a database parent, provide properties matching the database schema (including its title column). Content paragraphs are appended as children for both parent kinds.',
       inputSchema: z
         .object({
           parentPageId: z.string().optional().describe('Parent page id (exactly one parent is required)'),
@@ -177,6 +177,12 @@ export function createNotionTools(options?: ProviderToolsOptions): ToolsInput {
         })
         .refine(input => !input.parentDatabaseId || Object.keys(input.properties ?? {}).length > 0, {
           message: 'properties (matching the database schema) are required when the parent is a database.',
+        })
+        .refine(input => !input.parentPageId || input.properties === undefined, {
+          message: 'properties only apply to database parents; page parents take title.',
+        })
+        .refine(input => !input.parentDatabaseId || input.title === undefined, {
+          message: 'title only applies to page parents; for database parents set the title column inside properties.',
         }),
       outputSchema: z.object({ page: pageSchema }),
       request: input => {
@@ -206,9 +212,12 @@ export function createNotionTools(options?: ProviderToolsOptions): ToolsInput {
           properties: z.record(z.string(), z.unknown()).optional().describe('Raw Notion properties object to set'),
           archived: z.boolean().optional().describe('Set true to archive the page, false to restore it'),
         })
-        .refine(input => input.properties !== undefined || input.archived !== undefined, {
-          message: 'Provide properties and/or archived to update.',
-        }),
+        .refine(
+          input =>
+            (input.properties !== undefined && Object.keys(input.properties).length > 0) ||
+            input.archived !== undefined,
+          { message: 'Provide non-empty properties and/or archived to update.' },
+        ),
       outputSchema: z.object({ page: pageSchema }),
       request: input => ({
         method: 'PATCH',

--- a/packages/connect/src/providers/notion.ts
+++ b/packages/connect/src/providers/notion.ts
@@ -155,31 +155,41 @@ export function createNotionTools(options?: ProviderToolsOptions): ToolsInput {
     notion_create_page: defineProxyTool(context, {
       id: 'notion_create_page',
       description:
-        'Create a Notion page under a parent page or database. Provide title and optional plain-text paragraphs; pass raw Notion properties for database pages with typed columns.',
+        'Create a Notion page under a parent page or database. For a page parent, provide title and optional plain-text paragraphs; for a database parent, provide properties matching the database schema (including its title column).',
       inputSchema: z
         .object({
           parentPageId: z.string().optional().describe('Parent page id (exactly one parent is required)'),
           parentDatabaseId: z.string().optional().describe('Parent database id (exactly one parent is required)'),
-          title: z.string().describe('Page title'),
+          title: z.string().optional().describe('Page title (required when the parent is a page)'),
           content: z.array(z.string()).optional().describe('Plain-text paragraphs to add as page content'),
           properties: z
             .record(z.string(), z.unknown())
             .optional()
-            .describe('Raw Notion properties object (merged over the title) for database pages'),
+            .describe(
+              'Raw Notion properties object matching the database schema (required when the parent is a database)',
+            ),
         })
         .refine(input => !input.parentPageId !== !input.parentDatabaseId, {
           message: 'Provide exactly one of parentPageId or parentDatabaseId.',
+        })
+        .refine(input => !input.parentPageId || Boolean(input.title?.trim()), {
+          message: 'title is required when the parent is a page.',
+        })
+        .refine(input => !input.parentDatabaseId || Object.keys(input.properties ?? {}).length > 0, {
+          message: 'properties (matching the database schema) are required when the parent is a database.',
         }),
       outputSchema: z.object({ page: pageSchema }),
       request: input => {
-        const titleValue = [{ type: 'text', text: { content: input.title } }];
+        const properties = input.parentPageId
+          ? { title: { title: [{ type: 'text', text: { content: input.title } }] } }
+          : input.properties;
         return {
           method: 'POST',
           path: 'v1/pages',
           headers,
           body: {
             parent: input.parentPageId ? { page_id: input.parentPageId } : { database_id: input.parentDatabaseId },
-            properties: { title: { title: titleValue }, ...(input.properties ?? {}) },
+            properties,
             children: input.content?.map(paragraph),
           },
         };
@@ -190,11 +200,15 @@ export function createNotionTools(options?: ProviderToolsOptions): ToolsInput {
     notion_update_page_properties: defineProxyTool(context, {
       id: 'notion_update_page_properties',
       description: 'Update property values of a Notion page (raw Notion properties object), or archive/unarchive it.',
-      inputSchema: z.object({
-        pageId: z.string().describe('Page id (UUID)'),
-        properties: z.record(z.string(), z.unknown()).optional().describe('Raw Notion properties object to set'),
-        archived: z.boolean().optional().describe('Set true to archive the page, false to restore it'),
-      }),
+      inputSchema: z
+        .object({
+          pageId: z.string().describe('Page id (UUID)'),
+          properties: z.record(z.string(), z.unknown()).optional().describe('Raw Notion properties object to set'),
+          archived: z.boolean().optional().describe('Set true to archive the page, false to restore it'),
+        })
+        .refine(input => input.properties !== undefined || input.archived !== undefined, {
+          message: 'Provide properties and/or archived to update.',
+        }),
       outputSchema: z.object({ page: pageSchema }),
       request: input => ({
         method: 'PATCH',

--- a/packages/connect/src/providers/notion.ts
+++ b/packages/connect/src/providers/notion.ts
@@ -1,0 +1,349 @@
+import type { ToolsInput } from '@mastra/core/agent';
+import { z } from 'zod';
+
+import type { ProviderToolsOptions } from '../toolset.js';
+import { applyAllowTools, defineProxyTool } from '../toolset.js';
+
+const ENV_VAR = 'MASTRA_NOTION_CONNECTION_ID';
+
+/**
+ * Pinned deliberately: the 2025-09 Notion API restructures database querying
+ * around data sources; this is the stable, widely-documented surface for v1.
+ */
+const NOTION_VERSION = '2022-06-28';
+
+const headers = { 'Notion-Version': NOTION_VERSION };
+
+const paginationInput = {
+  limit: z.number().int().min(1).max(50).optional().describe('Max results to return (1-50, default 25)'),
+  after: z.string().optional().describe('Pagination cursor from a previous page (nextCursor)'),
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+function listOf(raw: unknown): { results: Record<string, unknown>[]; nextCursor: string | null; hasMore: boolean } {
+  const data = asRecord(raw);
+  const results = Array.isArray(data.results) ? data.results.map(asRecord) : [];
+  return {
+    results,
+    nextCursor: typeof data.next_cursor === 'string' ? data.next_cursor : null,
+    hasMore: data.has_more === true,
+  };
+}
+
+/** Joins the plain_text of a Notion rich text array. */
+function plainText(richText: unknown): string {
+  if (!Array.isArray(richText)) return '';
+  return richText
+    .map(item => {
+      const text = asRecord(item).plain_text;
+      return typeof text === 'string' ? text : '';
+    })
+    .join('');
+}
+
+/** Extracts a human-readable title from a page or database object. */
+function titleOf(item: Record<string, unknown>): string {
+  if (Array.isArray(item.title)) return plainText(item.title);
+  for (const prop of Object.values(asRecord(item.properties))) {
+    const record = asRecord(prop);
+    if (record.type === 'title') return plainText(record.title);
+  }
+  return '';
+}
+
+const pageSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  title: z.string(),
+  archived: z.boolean(),
+  properties: z.record(z.string(), z.unknown()),
+});
+
+function shapePage(page: Record<string, unknown>) {
+  return {
+    id: String(page.id ?? ''),
+    url: String(page.url ?? ''),
+    title: titleOf(page),
+    archived: page.archived === true,
+    properties: asRecord(page.properties),
+  };
+}
+
+const blockSchema = z.object({ id: z.string(), type: z.string(), text: z.string(), hasChildren: z.boolean() });
+
+function shapeBlock(block: Record<string, unknown>) {
+  const type = String(block.type ?? '');
+  const content = asRecord(block[type]);
+  return {
+    id: String(block.id ?? ''),
+    type,
+    text: plainText(content.rich_text),
+    hasChildren: block.has_children === true,
+  };
+}
+
+/** Wraps plain text in a minimal Notion paragraph block. */
+function paragraph(text: string) {
+  return {
+    object: 'block',
+    type: 'paragraph',
+    paragraph: { rich_text: [{ type: 'text', text: { content: text } }] },
+  };
+}
+
+/**
+ * Curated Notion toolset executing through the platform connection proxy.
+ * All tools resolve the connection from `options.connectionId` or
+ * MASTRA_NOTION_CONNECTION_ID at execute time. Requests pin
+ * Notion-Version 2022-06-28.
+ */
+export function createNotionTools(options?: ProviderToolsOptions): ToolsInput {
+  const context = { envVar: ENV_VAR, options };
+
+  const tools = {
+    notion_search: defineProxyTool(context, {
+      id: 'notion_search',
+      description: 'Search Notion pages and databases shared with the integration by title.',
+      inputSchema: z.object({
+        query: z.string().optional().describe('Search terms; omit to list everything accessible'),
+        filter: z.enum(['page', 'database']).optional().describe('Restrict results to pages or databases'),
+        ...paginationInput,
+      }),
+      outputSchema: z.object({
+        results: z.array(z.object({ id: z.string(), object: z.string(), url: z.string(), title: z.string() })),
+        nextCursor: z.string().nullable(),
+        hasMore: z.boolean(),
+      }),
+      request: input => ({
+        method: 'POST',
+        path: 'v1/search',
+        headers,
+        body: {
+          query: input.query,
+          filter: input.filter ? { property: 'object', value: input.filter } : undefined,
+          page_size: input.limit ?? 25,
+          start_cursor: input.after,
+        },
+      }),
+      transform: raw => {
+        const { results, nextCursor, hasMore } = listOf(raw);
+        return {
+          results: results.map(item => ({
+            id: String(item.id ?? ''),
+            object: String(item.object ?? ''),
+            url: String(item.url ?? ''),
+            title: titleOf(item),
+          })),
+          nextCursor,
+          hasMore,
+        };
+      },
+    }),
+
+    notion_get_page: defineProxyTool(context, {
+      id: 'notion_get_page',
+      description: 'Get a Notion page by id, including its property values.',
+      inputSchema: z.object({ pageId: z.string().describe('Page id (UUID)') }),
+      outputSchema: z.object({ page: pageSchema }),
+      request: input => ({ method: 'GET', path: `v1/pages/${encodeURIComponent(input.pageId)}`, headers }),
+      transform: raw => ({ page: shapePage(asRecord(raw)) }),
+    }),
+
+    notion_create_page: defineProxyTool(context, {
+      id: 'notion_create_page',
+      description:
+        'Create a Notion page under a parent page or database. Provide title and optional plain-text paragraphs; pass raw Notion properties for database pages with typed columns.',
+      inputSchema: z
+        .object({
+          parentPageId: z.string().optional().describe('Parent page id (exactly one parent is required)'),
+          parentDatabaseId: z.string().optional().describe('Parent database id (exactly one parent is required)'),
+          title: z.string().describe('Page title'),
+          content: z.array(z.string()).optional().describe('Plain-text paragraphs to add as page content'),
+          properties: z
+            .record(z.string(), z.unknown())
+            .optional()
+            .describe('Raw Notion properties object (merged over the title) for database pages'),
+        })
+        .refine(input => !input.parentPageId !== !input.parentDatabaseId, {
+          message: 'Provide exactly one of parentPageId or parentDatabaseId.',
+        }),
+      outputSchema: z.object({ page: pageSchema }),
+      request: input => {
+        const titleValue = [{ type: 'text', text: { content: input.title } }];
+        return {
+          method: 'POST',
+          path: 'v1/pages',
+          headers,
+          body: {
+            parent: input.parentPageId ? { page_id: input.parentPageId } : { database_id: input.parentDatabaseId },
+            properties: { title: { title: titleValue }, ...(input.properties ?? {}) },
+            children: input.content?.map(paragraph),
+          },
+        };
+      },
+      transform: raw => ({ page: shapePage(asRecord(raw)) }),
+    }),
+
+    notion_update_page_properties: defineProxyTool(context, {
+      id: 'notion_update_page_properties',
+      description: 'Update property values of a Notion page (raw Notion properties object), or archive/unarchive it.',
+      inputSchema: z.object({
+        pageId: z.string().describe('Page id (UUID)'),
+        properties: z.record(z.string(), z.unknown()).optional().describe('Raw Notion properties object to set'),
+        archived: z.boolean().optional().describe('Set true to archive the page, false to restore it'),
+      }),
+      outputSchema: z.object({ page: pageSchema }),
+      request: input => ({
+        method: 'PATCH',
+        path: `v1/pages/${encodeURIComponent(input.pageId)}`,
+        headers,
+        body: { properties: input.properties, archived: input.archived },
+      }),
+      transform: raw => ({ page: shapePage(asRecord(raw)) }),
+    }),
+
+    notion_get_block_children: defineProxyTool(context, {
+      id: 'notion_get_block_children',
+      description: 'List the child blocks of a Notion page or block, with their plain-text content.',
+      inputSchema: z.object({
+        blockId: z.string().describe('Page or block id (UUID)'),
+        ...paginationInput,
+      }),
+      outputSchema: z.object({
+        blocks: z.array(blockSchema),
+        nextCursor: z.string().nullable(),
+        hasMore: z.boolean(),
+      }),
+      request: input => ({
+        method: 'GET',
+        path: `v1/blocks/${encodeURIComponent(input.blockId)}/children`,
+        headers,
+        query: { page_size: input.limit ?? 25, start_cursor: input.after },
+      }),
+      transform: raw => {
+        const { results, nextCursor, hasMore } = listOf(raw);
+        return { blocks: results.map(shapeBlock), nextCursor, hasMore };
+      },
+    }),
+
+    notion_append_block_children: defineProxyTool(context, {
+      id: 'notion_append_block_children',
+      description: 'Append plain-text paragraphs (or raw Notion blocks) to a Notion page or block.',
+      inputSchema: z
+        .object({
+          blockId: z.string().describe('Page or block id (UUID)'),
+          paragraphs: z.array(z.string()).optional().describe('Plain-text paragraphs to append'),
+          blocks: z.array(z.record(z.string(), z.unknown())).optional().describe('Raw Notion block objects to append'),
+        })
+        .refine(input => (input.paragraphs?.length ?? 0) + (input.blocks?.length ?? 0) > 0, {
+          message: 'Provide paragraphs or blocks to append.',
+        }),
+      outputSchema: z.object({ blocks: z.array(blockSchema) }),
+      request: input => ({
+        method: 'PATCH',
+        path: `v1/blocks/${encodeURIComponent(input.blockId)}/children`,
+        headers,
+        body: { children: [...(input.paragraphs?.map(paragraph) ?? []), ...(input.blocks ?? [])] },
+      }),
+      transform: raw => ({ blocks: listOf(raw).results.map(shapeBlock) }),
+    }),
+
+    notion_query_database: defineProxyTool(context, {
+      id: 'notion_query_database',
+      description:
+        'Query pages in a Notion database, optionally with a raw Notion filter/sorts (see Notion API docs for their shape).',
+      inputSchema: z.object({
+        databaseId: z.string().describe('Database id (UUID)'),
+        filter: z.record(z.string(), z.unknown()).optional().describe('Raw Notion filter object'),
+        sorts: z.array(z.record(z.string(), z.unknown())).optional().describe('Raw Notion sorts array'),
+        ...paginationInput,
+      }),
+      outputSchema: z.object({
+        pages: z.array(pageSchema),
+        nextCursor: z.string().nullable(),
+        hasMore: z.boolean(),
+      }),
+      request: input => ({
+        method: 'POST',
+        path: `v1/databases/${encodeURIComponent(input.databaseId)}/query`,
+        headers,
+        body: {
+          filter: input.filter,
+          sorts: input.sorts,
+          page_size: input.limit ?? 25,
+          start_cursor: input.after,
+        },
+      }),
+      transform: raw => {
+        const { results, nextCursor, hasMore } = listOf(raw);
+        return { pages: results.map(shapePage), nextCursor, hasMore };
+      },
+    }),
+
+    notion_get_database: defineProxyTool(context, {
+      id: 'notion_get_database',
+      description: 'Get a Notion database by id, including its title and column names/types.',
+      inputSchema: z.object({ databaseId: z.string().describe('Database id (UUID)') }),
+      outputSchema: z.object({
+        database: z.object({
+          id: z.string(),
+          url: z.string(),
+          title: z.string(),
+          properties: z.record(z.string(), z.object({ type: z.string() })),
+        }),
+      }),
+      request: input => ({ method: 'GET', path: `v1/databases/${encodeURIComponent(input.databaseId)}`, headers }),
+      transform: raw => {
+        const database = asRecord(raw);
+        const properties: Record<string, { type: string }> = {};
+        for (const [name, prop] of Object.entries(asRecord(database.properties))) {
+          properties[name] = { type: String(asRecord(prop).type ?? '') };
+        }
+        return {
+          database: {
+            id: String(database.id ?? ''),
+            url: String(database.url ?? ''),
+            title: titleOf(database),
+            properties,
+          },
+        };
+      },
+    }),
+
+    notion_create_comment: defineProxyTool(context, {
+      id: 'notion_create_comment',
+      description: 'Add a plain-text comment to a Notion page (or an existing discussion thread).',
+      inputSchema: z
+        .object({
+          pageId: z.string().optional().describe('Page id to start a new comment thread on'),
+          discussionId: z.string().optional().describe('Existing discussion id to reply to'),
+          body: z.string().describe('Comment text'),
+        })
+        .refine(input => !input.pageId !== !input.discussionId, {
+          message: 'Provide exactly one of pageId or discussionId.',
+        }),
+      outputSchema: z.object({ comment: z.object({ id: z.string(), discussionId: z.string() }) }),
+      request: input => ({
+        method: 'POST',
+        path: 'v1/comments',
+        headers,
+        body: {
+          parent: input.pageId ? { page_id: input.pageId } : undefined,
+          discussion_id: input.discussionId,
+          rich_text: [{ type: 'text', text: { content: input.body } }],
+        },
+      }),
+      transform: raw => {
+        const comment = asRecord(raw);
+        return {
+          comment: { id: String(comment.id ?? ''), discussionId: String(comment.discussion_id ?? '') },
+        };
+      },
+    }),
+  } satisfies ToolsInput;
+
+  return applyAllowTools(tools, options?.allowTools);
+}

--- a/packages/connect/src/providers/snowflake.ts
+++ b/packages/connect/src/providers/snowflake.ts
@@ -1,0 +1,228 @@
+import type { ToolsInput } from '@mastra/core/agent';
+import { z } from 'zod';
+
+import type { ProviderToolsOptions } from '../toolset.js';
+import { applyAllowTools, defineProxyTool } from '../toolset.js';
+
+const ENV_VAR = 'MASTRA_SNOWFLAKE_CONNECTION_ID';
+
+/**
+ * Nango's `snowflake` provider templates the account host
+ * (`https://${connectionConfig.snowflake_account_url}`) into the proxy base
+ * URL, so tool paths are relative to the account root (`api/v2/statements`).
+ * OAuth bearer auth is injected by the proxy; the
+ * X-Snowflake-Authorization-Token-Type header is only needed for key-pair
+ * JWT auth, not OAuth.
+ */
+
+/**
+ * Snowflake identifiers are interpolated into generated SQL (SHOW/DESCRIBE
+ * wrappers), so they are validated at the schema layer and must never
+ * contain quotes or special characters.
+ */
+const identifier = z
+  .string()
+  .min(1)
+  .regex(/^[A-Za-z_][A-Za-z0-9_$]*$/, 'Must be a valid unquoted identifier: letters, digits, _, $ (no quotes/spaces)');
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+const statementOutput = z.object({
+  statementHandle: z.string(),
+  /** RUNNING / QUEUED / SUCCESS / SUCCESS_WITH_MESSAGES / FAILED_WITH_ERROR / ABORTING / NO_DATA / ... */
+  status: z.string(),
+  message: z.string(),
+  columns: z.array(z.string()),
+  /** Result rows as column-name → string-value records (empty until the statement completes). */
+  rows: z.array(z.record(z.string(), z.unknown())),
+  numRows: z.number(),
+});
+
+type StatementOutput = z.infer<typeof statementOutput>;
+
+/** Shapes a Snowflake SQL API v2 response, keying rows by column name. */
+function shapeStatement(raw: unknown): StatementOutput {
+  const data = asRecord(raw);
+  const metadata = asRecord(data.resultSetMetaData);
+  const columns = (Array.isArray(metadata.rowType) ? metadata.rowType.map(asRecord) : []).map(col =>
+    String(col.name ?? ''),
+  );
+  const rows = (Array.isArray(data.data) ? data.data : [])
+    .filter(Array.isArray)
+    .map(row => Object.fromEntries(row.map((value, index) => [columns[index] ?? `column_${index}`, value])));
+  return {
+    statementHandle: String(data.statementHandle ?? ''),
+    status: String(data.statementStatus ?? ''),
+    message: String(data.message ?? ''),
+    columns,
+    rows,
+    numRows: typeof metadata.numRows === 'number' ? metadata.numRows : rows.length,
+  };
+}
+
+/** Pulls the `name` column out of a SHOW statement's shaped rows. */
+function namesFrom(statement: StatementOutput): string[] {
+  return statement.rows.map(row => String(row.name ?? '')).filter(Boolean);
+}
+
+/**
+ * Curated Snowflake toolset executing through the platform connection proxy
+ * (Snowflake SQL API v2). All tools resolve the connection from
+ * `options.connectionId` or MASTRA_SNOWFLAKE_CONNECTION_ID at execute time.
+ * Long-running statements return with status RUNNING; poll
+ * `snowflake_get_statement_status` with the statementHandle until it
+ * completes.
+ */
+export function createSnowflakeTools(options?: ProviderToolsOptions): ToolsInput {
+  const context = { envVar: ENV_VAR, options };
+
+  const tools = {
+    snowflake_execute_sql: defineProxyTool(context, {
+      id: 'snowflake_execute_sql',
+      description:
+        'Execute a SQL statement on Snowflake via the SQL API. Returns results immediately for fast statements; if status is RUNNING/QUEUED, poll snowflake_get_statement_status with the statementHandle.',
+      inputSchema: z.object({
+        statement: z.string().describe('SQL statement to execute'),
+        warehouse: z.string().describe('Warehouse to run the statement in'),
+        database: z.string().describe('Database context'),
+        schema: z.string().describe('Schema context'),
+        timeout: z.number().int().min(1).optional().describe('Server-side timeout in seconds'),
+      }),
+      outputSchema: statementOutput,
+      request: input => ({
+        method: 'POST',
+        path: 'api/v2/statements',
+        body: {
+          statement: input.statement,
+          warehouse: input.warehouse,
+          database: input.database,
+          schema: input.schema,
+          timeout: input.timeout,
+        },
+      }),
+      transform: shapeStatement,
+    }),
+
+    snowflake_get_statement_status: defineProxyTool(context, {
+      id: 'snowflake_get_statement_status',
+      description:
+        'Get the status and (once complete) the results of an async Snowflake statement. For partitioned results, fetch one partition per call.',
+      inputSchema: z.object({
+        statementHandle: z.string().describe('Handle returned by snowflake_execute_sql'),
+        partition: z.number().int().min(1).optional().describe('1-based partition index of a partitioned result set'),
+      }),
+      outputSchema: statementOutput,
+      request: input => ({
+        method: 'GET',
+        path: `api/v2/statements/${encodeURIComponent(input.statementHandle)}`,
+        query: { partition: input.partition },
+      }),
+      transform: shapeStatement,
+    }),
+
+    snowflake_cancel_statement: defineProxyTool(context, {
+      id: 'snowflake_cancel_statement',
+      description: 'Cancel a running Snowflake statement by its statement handle.',
+      inputSchema: z.object({
+        statementHandle: z.string().describe('Handle returned by snowflake_execute_sql'),
+      }),
+      outputSchema: z.object({ status: z.string(), message: z.string() }),
+      request: input => ({
+        method: 'POST',
+        path: `api/v2/statements/${encodeURIComponent(input.statementHandle)}/cancel`,
+        body: {},
+      }),
+      transform: raw => {
+        const data = asRecord(raw);
+        return { status: String(data.statementStatus ?? ''), message: String(data.message ?? '') };
+      },
+    }),
+
+    snowflake_list_databases: defineProxyTool(context, {
+      id: 'snowflake_list_databases',
+      description: 'List databases visible in the connection context (SHOW DATABASES).',
+      inputSchema: z.object({
+        warehouse: z.string().describe('Warehouse to run the statement in'),
+      }),
+      outputSchema: z.object({ databases: z.array(z.string()) }),
+      request: input => ({
+        method: 'POST',
+        path: 'api/v2/statements',
+        body: { statement: 'SHOW DATABASES LIMIT 50', warehouse: input.warehouse },
+      }),
+      transform: raw => ({ databases: namesFrom(shapeStatement(raw)) }),
+    }),
+
+    snowflake_list_tables: defineProxyTool(context, {
+      id: 'snowflake_list_tables',
+      description: 'List tables in a database schema (SHOW TABLES IN <database>.<schema>).',
+      inputSchema: z.object({
+        warehouse: z.string().describe('Warehouse to run the statement in'),
+        database: identifier.describe('Database name (unquoted identifier)'),
+        schema: identifier.describe('Schema name (unquoted identifier)'),
+      }),
+      outputSchema: z.object({ tables: z.array(z.string()) }),
+      request: input => ({
+        method: 'POST',
+        path: 'api/v2/statements',
+        body: {
+          statement: `SHOW TABLES IN ${input.database}.${input.schema} LIMIT 50`,
+          warehouse: input.warehouse,
+          database: input.database,
+          schema: input.schema,
+        },
+      }),
+      transform: raw => ({ tables: namesFrom(shapeStatement(raw)) }),
+    }),
+
+    snowflake_describe_table: defineProxyTool(context, {
+      id: 'snowflake_describe_table',
+      description: "Describe a table's columns and types (DESCRIBE TABLE <database>.<schema>.<table>).",
+      inputSchema: z.object({
+        warehouse: z.string().describe('Warehouse to run the statement in'),
+        database: identifier.describe('Database name (unquoted identifier)'),
+        schema: identifier.describe('Schema name (unquoted identifier)'),
+        table: identifier.describe('Table name (unquoted identifier)'),
+      }),
+      outputSchema: z.object({
+        columns: z.array(
+          z.object({
+            name: z.string(),
+            type: z.string(),
+            kind: z.string(),
+            nullable: z.boolean(),
+            default: z.unknown(),
+            comment: z.string(),
+          }),
+        ),
+      }),
+      request: input => ({
+        method: 'POST',
+        path: 'api/v2/statements',
+        body: {
+          statement: `DESCRIBE TABLE ${input.database}.${input.schema}.${input.table}`,
+          warehouse: input.warehouse,
+          database: input.database,
+          schema: input.schema,
+        },
+      }),
+      transform: raw => {
+        const statement = shapeStatement(raw);
+        return {
+          columns: statement.rows.map(row => ({
+            name: String(row.name ?? ''),
+            type: String(row.type ?? ''),
+            kind: String(row.kind ?? ''),
+            nullable: String(row['null?'] ?? '').toUpperCase() !== 'N',
+            default: row.default ?? null,
+            comment: String(row.comment ?? ''),
+          })),
+        };
+      },
+    }),
+  } satisfies ToolsInput;
+
+  return applyAllowTools(tools, options?.allowTools);
+}

--- a/packages/connect/src/registry.ts
+++ b/packages/connect/src/registry.ts
@@ -1,5 +1,6 @@
 import type { ToolsInput } from '@mastra/core/agent';
 
+import { createLinearTools } from './providers/linear.js';
 import type { ProviderToolsOptions } from './toolset.js';
 
 export type ProviderKey =
@@ -25,7 +26,13 @@ export interface ProviderRegistration {
  * Providers with shipped toolsets. Later segments add entries; `connect()`
  * warns and skips platform connections whose integrationId is not listed here.
  */
-export const PROVIDERS: Partial<Record<ProviderKey, ProviderRegistration>> = {};
+export const PROVIDERS: Partial<Record<ProviderKey, ProviderRegistration>> = {
+  linear: {
+    integrationId: 'linear',
+    envVar: 'MASTRA_LINEAR_CONNECTION_ID',
+    createTools: createLinearTools,
+  },
+};
 
 export function findProviderByIntegrationId(
   integrationId: string,

--- a/packages/connect/src/registry.ts
+++ b/packages/connect/src/registry.ts
@@ -3,6 +3,7 @@ import type { ToolsInput } from '@mastra/core/agent';
 import { createJiraTools } from './providers/jira.js';
 import { createLinearTools } from './providers/linear.js';
 import { createNotionTools } from './providers/notion.js';
+import { createSnowflakeTools } from './providers/snowflake.js';
 import type { ProviderToolsOptions } from './toolset.js';
 
 export type ProviderKey =
@@ -43,6 +44,11 @@ export const PROVIDERS: Partial<Record<ProviderKey, ProviderRegistration>> = {
     integrationId: 'jira',
     envVar: 'MASTRA_JIRA_CONNECTION_ID',
     createTools: createJiraTools,
+  },
+  snowflake: {
+    integrationId: 'snowflake',
+    envVar: 'MASTRA_SNOWFLAKE_CONNECTION_ID',
+    createTools: createSnowflakeTools,
   },
 };
 

--- a/packages/connect/src/registry.ts
+++ b/packages/connect/src/registry.ts
@@ -1,5 +1,6 @@
 import type { ToolsInput } from '@mastra/core/agent';
 
+import { createJiraTools } from './providers/jira.js';
 import { createLinearTools } from './providers/linear.js';
 import { createNotionTools } from './providers/notion.js';
 import type { ProviderToolsOptions } from './toolset.js';
@@ -37,6 +38,11 @@ export const PROVIDERS: Partial<Record<ProviderKey, ProviderRegistration>> = {
     integrationId: 'notion',
     envVar: 'MASTRA_NOTION_CONNECTION_ID',
     createTools: createNotionTools,
+  },
+  jira: {
+    integrationId: 'jira',
+    envVar: 'MASTRA_JIRA_CONNECTION_ID',
+    createTools: createJiraTools,
   },
 };
 

--- a/packages/connect/src/registry.ts
+++ b/packages/connect/src/registry.ts
@@ -1,6 +1,7 @@
 import type { ToolsInput } from '@mastra/core/agent';
 
 import { createLinearTools } from './providers/linear.js';
+import { createNotionTools } from './providers/notion.js';
 import type { ProviderToolsOptions } from './toolset.js';
 
 export type ProviderKey =
@@ -31,6 +32,11 @@ export const PROVIDERS: Partial<Record<ProviderKey, ProviderRegistration>> = {
     integrationId: 'linear',
     envVar: 'MASTRA_LINEAR_CONNECTION_ID',
     createTools: createLinearTools,
+  },
+  notion: {
+    integrationId: 'notion',
+    envVar: 'MASTRA_NOTION_CONNECTION_ID',
+    createTools: createNotionTools,
   },
 };
 


### PR DESCRIPTION
Adds the OAuth-connected provider wave to `@mastra/connect` (stacked on #22992, which introduces the package and its platform client). `@mastra/connect` turns Mastra-platform integration connections into agent toolsets with zero credential handling — every tool executes through the platform connection proxy (`/v2/connections/:connectionId/proxy/*`), so provider tokens never enter the app.

**What's in this PR**

- `createLinearTools()` — 9 GraphQL tools for Linear (teams, issues list/get/search/create/update, comments, projects, users). GraphQL-errors-in-200 responses map to `proxy_error`; pagination capped at 50.
- `createNotionTools()` — 9 tools over the Notion REST API pinned to `Notion-Version: 2022-06-28`: search, page get/create/update, block children get/append, database query/get, comments. Cross-field invariants (exactly-one parent, non-empty appends) live in the input schemas.
- `createJiraTools()` — 10 tools over Jira Cloud REST v3. Because the Atlassian cloud id is not part of the Nango base URL, `jira_get_accessible_resources` discovers cloud ids and every issue/project tool takes a `cloudId` input (paths are `ex/jira/{cloudId}/rest/api/3/...`). Plain-text descriptions/comments are wrapped into Atlassian Document Format; JQL search uses POST to avoid URL-length limits.
- `createSnowflakeTools()` — 6 tools over the Snowflake SQL API v2: execute SQL, statement status/cancel, list databases/tables, describe table. Identifiers interpolated into SHOW/DESCRIBE SQL are validated at the schema layer against `/^[A-Za-z_][A-Za-z0-9_$]*$/` (injection attempts are rejected before any request is built); SHOW queries cap at `LIMIT 50` to respect the proxy's 10 MB response cap.
- Registry entries + exports for all four providers, so `connect()` discovers them. `allowTools`, env-var fallback (`MASTRA_<PROVIDER>_CONNECTION_ID`), and lazy connection resolution behave identically across every toolset.
- Changeset (minor) with a usage example.

All tool construction is lazy (no env vars needed at build time); connection ids resolve at execute time. Notion database-parent page creation requires caller-supplied `properties` matching the database schema — no synthesized property keys are injected, so databases whose title column isn't named "title" work.

**Test plan**

- `pnpm --filter @mastra/connect test` — 122 tests / 8 files, all mocked fetch (no live network): proxy URL/method/header/body assertions, allowTools filtering, env-var fallback, `missing_connection_id` mapping, Notion schema rejections, Jira ADF wrap/flatten, Snowflake identifier-injection rejection (asserts no fetch fires).
- `npx tsc --noEmit` in the package, `pnpm --filter @mastra/connect lint`, and `pnpm turbo build --filter @mastra/connect` all green.
- Three rounds of adversarial review; all must-fixes resolved.

Base: #22992 (`feat/connect-core`) — review after that PR lands or as a stacked diff.
