### PR TITLE
fix(factory): make the eager sandbox start typecheck

### DIFF
--- a/.changeset/factory-eager-start-typecheck.md
+++ b/.changeset/factory-eager-start-typecheck.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed a type error in the eager sandbox start path that broke `tsc --noEmit` for the package.

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -455,7 +455,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
     const fireEagerStart = () => {
       if (!startEagerly) return;
       startEagerly = false;
-      sessionEntry.sandbox.start?.().catch(error => {
+      void Promise.resolve(sessionEntry.sandbox.start?.()).catch((error: unknown) => {
         console.warn(`[factory] Eager sandbox start for session ${session.id} failed:`, error);
       });
     };


### PR DESCRIPTION
## Summary
`@mastra/factory` has failed `tsc --noEmit` since #22577 merged: `WorkspaceSandbox.start` is optional and may return `void`, so `sessionEntry.sandbox.start?.().catch(...)` at `workspace.ts:458` does not typecheck. No CI job runs the factory package typecheck, so it was not caught.

Wrap the call in `Promise.resolve` so the rejection handler applies whatever the sandbox returns. Behavior is unchanged.

## Test plan
- [x] `pnpm --filter @mastra/factory exec tsc --noEmit` exit 0 (was 2 errors)
- [x] `workspace.test.ts` eager-start cases pass; the only failure is the pre-existing `terminal-handoff` skill assertion that also fails on `main`
- [x] lint, oxfmt clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The sandbox can start either immediately or later. This change makes both cases safe for TypeScript and keeps the same runtime behavior.

## Changes

- Wraps the optional `WorkspaceSandbox.start()` result with `Promise.resolve`.
- Preserves rejection handling for synchronous and asynchronous starts.
- Adds a patch changeset for `@mastra/factory`.

## Validation

- Factory typecheck passes.
- Eager-start tests pass.
- Linting and formatting are clean.
- One pre-existing `terminal-handoff` skill assertion still fails on `main`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->