### PR TITLE
docs(platform): document Studio auth on Mastra platform

### DIFF
--- a/docs/src/content/en/docs/mastra-platform/studio.mdx
+++ b/docs/src/content/en/docs/mastra-platform/studio.mdx
@@ -48,6 +48,40 @@ A deploy transitions through **queued → uploading → starting → running** o
 
 See the [`mastra deploy` CLI reference](/reference/cli/mastra#mastra-deploy) for the full list of flags and CI/CD usage.
 
+## Authentication
+
+Every Studio deploy on Mastra platform is protected by platform auth. Members of your platform organization sign in with their platform account, and no one else can access the deployed Studio. You don't need to configure anything to get this behavior.
+
+Platform auth applies to the Studio UI only. Your server's API routes are governed by your own [`server.auth`](/docs/studio/auth) configuration, or remain open if you haven't set one.
+
+### Roles and permissions
+
+Platform auth maps your organization roles to Studio permissions:
+
+| Platform role | Studio permissions |
+| - | - |
+| `admin` | Full access (`*`) |
+| `member` | Read and execute |
+| `viewer` | Read-only |
+
+To customize this mapping, set `roleMapping` on `studio.rbac` in your Mastra configuration. When present, your mapping replaces the platform defaults. See [Role-based access control](/docs/studio/auth#role-based-access-control) for the permission format.
+
+### Bring your own auth
+
+To use your own auth provider for the deployed Studio instead of platform auth, set an environment variable on the project:
+
+```bash
+MASTRA_PLATFORM_STUDIO_AUTH=disabled
+```
+
+Add it to the env file you deploy with, or store it on the project through the dashboard, then redeploy. With platform auth disabled, the deploy leaves your auth and RBAC configuration untouched. Your own provider drives the Studio login flow, exactly like a self-hosted deploy. Studio requests fall back to `server.auth` when `studio.auth` isn't set, so configuring either one protects the deployment.
+
+:::warning
+Disabling platform auth turns off platform account logins. If you disable it without configuring your own auth provider, the deployed Studio and all API routes are publicly accessible.
+:::
+
+If you keep platform auth enabled and also configure your own `studio.auth`, both providers validate tokens, but the login screen only offers the platform sign-in flow. To sign in through your own provider, disable platform auth.
+
 ## Environment files
 
 A local env file is optional. When a `.env` or `.env.*` file is present in the project directory, the deploy bundles its environment variables.

--- a/docs/src/content/en/docs/mastra-platform/studio.mdx
+++ b/docs/src/content/en/docs/mastra-platform/studio.mdx
@@ -61,7 +61,7 @@ Platform auth maps your organization roles to Studio permissions:
 | Platform role | Studio permissions |
 | - | - |
 | `admin` | Full access (`*`) |
-| `member` | Read and execute |
+| `member` | Read, execute, and write workflows |
 | `viewer` | Read-only |
 
 To customize this mapping, set `roleMapping` on `studio.rbac` in your Mastra configuration. When present, your mapping replaces the platform defaults. See [Role-based access control](/docs/studio/auth#role-based-access-control) for the permission format.
@@ -74,7 +74,7 @@ To use your own auth provider for the deployed Studio instead of platform auth, 
 MASTRA_PLATFORM_STUDIO_AUTH=disabled
 ```
 
-Add it to the env file you deploy with, or store it on the project through the dashboard, then redeploy. With platform auth disabled, the deploy leaves your auth and RBAC configuration untouched. Your own provider drives the Studio login flow, exactly like a self-hosted deploy. Studio requests fall back to `server.auth` when `studio.auth` isn't set, so configuring either one protects the deployment.
+Add it to the env file you deploy with, or store it on the project through the dashboard, then redeploy. With platform auth disabled, the deploy leaves your auth and RBAC configuration untouched. Your own provider drives the Studio login flow, exactly like a self-hosted deploy. `studio.auth` protects the Studio UI, while `server.auth` protects your API routes. Studio requests fall back to `server.auth` when `studio.auth` isn't set.
 
 :::warning
 Disabling platform auth turns off platform account logins. If you disable it without configuring your own auth provider, the deployed Studio and all API routes are publicly accessible.

--- a/docs/src/content/en/docs/mastra-platform/studio.mdx
+++ b/docs/src/content/en/docs/mastra-platform/studio.mdx
@@ -61,7 +61,7 @@ Platform auth maps your organization roles to Studio permissions:
 | Platform role | Studio permissions |
 | - | - |
 | `admin` | Full access (`*`) |
-| `member` | Read, execute, and write workflows |
+| `member` | Read and execute |
 | `viewer` | Read-only |
 
 To customize this mapping, set `roleMapping` on `studio.rbac` in your Mastra configuration. When present, your mapping replaces the platform defaults. See [Role-based access control](/docs/studio/auth#role-based-access-control) for the permission format.

--- a/docs/src/content/en/docs/mastra-platform/studio.mdx
+++ b/docs/src/content/en/docs/mastra-platform/studio.mdx
@@ -50,7 +50,7 @@ See the [`mastra deploy` CLI reference](/reference/cli/mastra#mastra-deploy) for
 
 ## Authentication
 
-Every Studio deploy on Mastra platform is protected by platform auth. Members of your platform organization sign in with their platform account, and no one else can access the deployed Studio. You don't need to configure anything to get this behavior.
+By default, every Studio deploy on Mastra platform is protected by platform auth. Members of your platform organization sign in with their platform account, and no one else can access the deployed Studio. You don't need to configure anything to get this behavior.
 
 Platform auth applies to the Studio UI only. Your server's API routes are governed by your own [`server.auth`](/docs/studio/auth) configuration, or remain open if you haven't set one.
 

--- a/docs/src/content/en/docs/studio/auth.mdx
+++ b/docs/src/content/en/docs/studio/auth.mdx
@@ -12,7 +12,7 @@ When you configure [authentication](/docs/auth/overview) on your Mastra server, 
 Without authentication, Studio and all API routes are publicly accessible.
 
 :::note
-Studio deployed on Mastra platform works differently. The platform injects its own auth so only your organization members can sign in, and your `server.auth` applies to API routes only. See [Authentication on Mastra platform](/docs/mastra-platform/studio#authentication).
+Studio deployed on Mastra platform works differently. By default, the platform injects its own auth so only your organization members can sign in, and your `server.auth` applies to API routes only. Set `MASTRA_PLATFORM_STUDIO_AUTH=disabled` to opt out. See [Authentication on Mastra platform](/docs/mastra-platform/studio#authentication).
 :::
 
 ## When to use Studio Auth

--- a/docs/src/content/en/docs/studio/auth.mdx
+++ b/docs/src/content/en/docs/studio/auth.mdx
@@ -11,6 +11,10 @@ When you configure [authentication](/docs/auth/overview) on your Mastra server, 
 
 Without authentication, Studio and all API routes are publicly accessible.
 
+:::note
+Studio deployed on Mastra platform works differently. The platform injects its own auth so only your organization members can sign in, and your `server.auth` applies to API routes only. See [Authentication on Mastra platform](/docs/mastra-platform/studio#authentication).
+:::
+
 ## When to use Studio Auth
 
 - Multiple team members need to interact with agents, workflows, and tools through a shared Studio deployment.


### PR DESCRIPTION
## Summary

Documents how Studio authentication works when deployed on Mastra platform. Previously, none of this behavior was documented:

- Every Studio deploy is protected by platform auth by default — only platform organization members can sign in, with no configuration needed.
- Platform auth gates the Studio UI only; API routes are governed by the user's own `server.auth` (or remain open).
- Platform roles map to Studio permissions (admin/member/viewer table), and a user-supplied `studio.rbac.roleMapping` replaces the defaults.
- Setting `MASTRA_PLATFORM_STUDIO_AUTH=disabled` opts out of platform auth so the user's own provider drives the Studio login flow, with a warning that a deploy with no auth configured at all becomes publicly accessible.
- When both platform auth and a user's `studio.auth` are configured, both validate tokens but only the platform sign-in flow appears on the login screen.

Also adds a note to the self-hosted Studio auth page pointing to the platform behavior, since "one configuration secures both Studio and API routes" doesn't hold on platform deploys.

All behavior verified against the deploy wrapper source and `CompositeAuth` in `packages/_internals/auth`.

## Test plan

- `pnpm validate` and `pnpm build` pass in `docs/`
- Reviewed rendered pages locally via `pnpm dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR explains how Mastra Platform protects deployed Studio pages. It also explains how to configure permissions, use custom authentication, or make Studio public.

## Changes

- Documented default platform authentication for Studio deployments.
- Clarified that platform authentication protects the Studio UI, while `server.auth` protects API routes.
- Documented platform role mappings:
  - `admin`: `*`
  - `member`: `*:read`, `*:execute`
  - `viewer`: `*:read`
  - `_default`: no permissions
- Documented custom role mapping and behavior when platform authentication and `studio.auth` are both configured.
- Documented `MASTRA_PLATFORM_STUDIO_AUTH=disabled` and the required redeployment.
- Added a warning about public access when authentication is disabled without a replacement.
- Added a link from the self-hosted Studio authentication page to platform-specific behavior.
- Recorded successful `pnpm validate`, `pnpm build`, and local rendered-page review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->