### PR TITLE
fix(memory): retry buffered observation persistence

### DIFF
--- a/.changeset/six-taxes-dress.md
+++ b/.changeset/six-taxes-dress.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed observational memory buffering so transient database connection timeouts are retried instead of failing the buffer operation.

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -916,6 +916,9 @@ export class InMemoryMemory extends MemoryStorage {
       throw new Error(`Observational memory record not found: ${id}`);
     }
 
+    const existingChunks = Array.isArray(record.bufferedObservationChunks) ? record.bufferedObservationChunks : [];
+    if (existingChunks.some(existing => existing.cycleId === chunk.cycleId)) return;
+
     // Create a new chunk with generated id and timestamp
     const newChunk: BufferedObservationChunk = {
       id: `ombuf-${crypto.randomUUID()}`,
@@ -934,7 +937,6 @@ export class InMemoryMemory extends MemoryStorage {
     };
 
     // Add chunk to the array
-    const existingChunks = Array.isArray(record.bufferedObservationChunks) ? record.bufferedObservationChunks : [];
     record.bufferedObservationChunks = [...existingChunks, newChunk];
 
     if (input.lastBufferedAtTime) {

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
@@ -909,6 +909,24 @@ describe('buffer()', () => {
     expect(result.buffered).toBe(true);
   });
 
+  it('retries a transient database connection timeout while persisting buffered observations', async () => {
+    const om = createOM(storage, { messageTokens: 500, bufferTokens: 0.2 });
+    const messages = createBulkMessages(5, threadId);
+    const updateBufferedObservations = storage.updateBufferedObservations.bind(storage);
+    const updateSpy = vi
+      .spyOn(storage, 'updateBufferedObservations')
+      .mockRejectedValueOnce(new Error('Connection terminated due to connection timeout'))
+      .mockImplementation(updateBufferedObservations);
+
+    const result = await om.buffer({ threadId, messages });
+    expect(result.buffered).toBe(true);
+    await om.waitForBuffering(threadId, undefined, 5000);
+
+    expect(updateSpy).toHaveBeenCalledTimes(2);
+    const status = await om.getStatus({ threadId });
+    expect(status.bufferedChunkCount).toBe(1);
+  });
+
   it('should not buffer when no unobserved messages exist', async () => {
     const om = createOM(storage, { messageTokens: 500, bufferTokens: 0.2 });
     // No messages in storage

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
@@ -913,10 +913,10 @@ describe('buffer()', () => {
     const om = createOM(storage, { messageTokens: 500, bufferTokens: 0.2 });
     const messages = createBulkMessages(5, threadId);
     const updateBufferedObservations = storage.updateBufferedObservations.bind(storage);
-    const updateSpy = vi
-      .spyOn(storage, 'updateBufferedObservations')
-      .mockRejectedValueOnce(new Error('Connection terminated due to connection timeout'))
-      .mockImplementation(updateBufferedObservations);
+    const updateSpy = vi.spyOn(storage, 'updateBufferedObservations').mockImplementationOnce(async input => {
+      await updateBufferedObservations(input);
+      throw new Error('Connection terminated due to connection timeout');
+    });
 
     const result = await om.buffer({ threadId, messages });
     expect(result.buffered).toBe(true);

--- a/packages/memory/src/processors/observational-memory/__tests__/retry.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/retry.test.ts
@@ -19,6 +19,7 @@ describe('isTransientLLMError', () => {
     expect(isTransientLLMError(new Error('socket hang up'))).toBe(true);
     expect(isTransientLLMError(new Error('connection closed'))).toBe(true);
     expect(isTransientLLMError(new Error('Request timeout'))).toBe(true);
+    expect(isTransientLLMError(new Error('Connection terminated due to connection timeout'))).toBe(true);
   });
 
   it('matches retryable HTTP statuses', () => {

--- a/packages/memory/src/processors/observational-memory/observation-strategies/async-buffer.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/async-buffer.ts
@@ -13,6 +13,7 @@ import { getBufferedChunks, combineObservationsForBuffering } from '../message-u
 import { wrapInObservationGroup } from '../observation-groups';
 import { buildMessageRange } from '../observational-memory';
 import { formatMessagesForObserver } from '../observer-agent';
+import { withRetry } from '../retry';
 import { ObservationStrategy } from './base';
 import type { StrategyDeps } from './base';
 import type { ObservationRunOpts, ObserverOutput, ProcessedObservation } from './types';
@@ -142,23 +143,27 @@ export class AsyncBufferObservationStrategy extends ObservationStrategy {
 
     const { record, threadId, resourceId, messages } = this.opts;
     const messageTokens = await this.tokenCounter.countMessagesAsync(messages);
-    await this.storage.updateBufferedObservations({
-      id: record.id,
-      chunk: {
-        cycleId: this.cycleId,
-        observations: processed.observations,
-        tokenCount: processed.observationTokens,
-        messageIds: processed.observedMessageIds,
-        messageTokens,
-        lastObservedAt: processed.lastObservedAt,
-        suggestedContinuation: processed.suggestedContinuation,
-        currentTask: processed.currentTask,
-        threadTitle: processed.threadTitle,
-        extractedValues: processed.extractedValues,
-        extractionFailures: processed.extractionFailures,
-      },
-      lastBufferedAtTime: processed.lastObservedAt,
-    });
+    await withRetry(
+      () =>
+        this.storage.updateBufferedObservations({
+          id: record.id,
+          chunk: {
+            cycleId: this.cycleId,
+            observations: processed.observations,
+            tokenCount: processed.observationTokens,
+            messageIds: processed.observedMessageIds,
+            messageTokens,
+            lastObservedAt: processed.lastObservedAt,
+            suggestedContinuation: processed.suggestedContinuation,
+            currentTask: processed.currentTask,
+            threadTitle: processed.threadTitle,
+            extractedValues: processed.extractedValues,
+            extractionFailures: processed.extractionFailures,
+          },
+          lastBufferedAtTime: processed.lastObservedAt,
+        }),
+      { label: 'persist-buffered-observations', abortSignal: this.opts.abortSignal },
+    );
 
     await this.indexObservationGroups(processed.observations, threadId, resourceId, processed.lastObservedAt);
 

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -2314,6 +2314,11 @@ export class MemoryLibSQL extends MemoryStorage {
             }
           }
 
+          if (existingChunks.some(existing => existing.cycleId === input.chunk.cycleId)) {
+            await tx.commit();
+            return;
+          }
+
           // Create new chunk with ID and timestamp
           const newChunk: BufferedObservationChunk = {
             id: `ombuf-${randomUUID()}`,

--- a/stores/mysql/src/storage/domains/memory/index.ts
+++ b/stores/mysql/src/storage/domains/memory/index.ts
@@ -2146,6 +2146,10 @@ export class MemoryMySQL extends MemoryStorage {
         }
 
         const existingChunks = parseBufferedChunks(currentRows[0]!.bufferedObservationChunks);
+        if (existingChunks.some(existing => existing.cycleId === input.chunk.cycleId)) {
+          await connection.commit();
+          return;
+        }
 
         const newChunk: BufferedObservationChunk = {
           id: `ombuf-${randomUUID()}`,

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -2797,16 +2797,23 @@ export class MemoryPG extends MemoryStorage {
         extractionFailures: input.chunk.extractionFailures,
       };
 
-      // Append chunk to existing array using JSONB concatenation
+      // Append the chunk only if this cycle has not already been persisted by a previous attempt.
       const lastBufferedAtTime = input.lastBufferedAtTime ? input.lastBufferedAtTime.toISOString() : null;
       const result = await this.#db.client.query(
         `UPDATE ${tableName} SET
-          "bufferedObservationChunks" = COALESCE("bufferedObservationChunks", '[]'::jsonb) || $1::jsonb,
-          "lastBufferedAtTime" = COALESCE($2, "lastBufferedAtTime"),
-          "updatedAt" = $3,
-          "updatedAtZ" = $4
-        WHERE id = $5`,
-        [JSON.stringify([newChunk]), lastBufferedAtTime, nowStr, nowStr, input.id],
+          "bufferedObservationChunks" = CASE
+            WHEN EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements(COALESCE("bufferedObservationChunks", '[]'::jsonb)) AS chunk
+              WHERE chunk->>'cycleId' = $2
+            ) THEN COALESCE("bufferedObservationChunks", '[]'::jsonb)
+            ELSE COALESCE("bufferedObservationChunks", '[]'::jsonb) || $1::jsonb
+          END,
+          "lastBufferedAtTime" = COALESCE($3, "lastBufferedAtTime"),
+          "updatedAt" = $4,
+          "updatedAtZ" = $5
+        WHERE id = $6`,
+        [JSON.stringify([newChunk]), input.chunk.cycleId, lastBufferedAtTime, nowStr, nowStr, input.id],
       );
 
       if (result.rowCount === 0) {


### PR DESCRIPTION
Observational memory buffering could fail immediately when PostgreSQL briefly terminated a connection while persisting a buffered observation chunk. This retries transient persistence failures using the existing observational-memory retry policy, while preserving abort behavior.\n\nBefore, a transient database disconnect ended buffering with an error. After, the persistence operation retries and completes when the connection recovers.\n\nVerified with 206 focused memory tests, the memory package TypeScript check, and Prettier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If the database briefly disconnects while saving buffered observations, the system now tries again instead of failing immediately. It also prevents the same observation cycle from being saved twice when the first save succeeded before the disconnect.

## Changes

- Added retry handling to `AsyncBufferObservationStrategy.persist`.
- Reused the existing observational-memory retry policy.
- Preserved abort behavior and passed the configured abort signal.
- Prevented duplicate buffered observation cycles across PostgreSQL, MySQL, LibSQL, and in-memory storage.
- Added tests for transient connection timeouts and retry behavior.
- Added a patch changeset for `@mastra/memory`.

## Validation

- 206 focused memory tests passed.
- Memory package TypeScript check passed.
- Prettier passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->