### PR TITLE
feat(core): add consumer groups to UnixSocketPubSub

### DIFF
--- a/.changeset/unix-socket-consumer-groups.md
+++ b/.changeset/unix-socket-consumer-groups.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added consumer group support to UnixSocketPubSub. Named groups now deliver each message once per group with round-robin selection among group members, matching the subscribe group contract that BackgroundTaskManager already relies on. Ungrouped subscriptions keep fan-out behavior, reconnects preserve group membership, and locally delivered messages support bounded nack retry.

--- a/.changeset/unix-socket-consumer-groups.md
+++ b/.changeset/unix-socket-consumer-groups.md
@@ -2,4 +2,20 @@
 '@mastra/core': patch
 ---
 
-Added consumer group support to UnixSocketPubSub. Named groups now deliver each message once per group with round-robin selection among group members, matching the subscribe group contract that BackgroundTaskManager already relies on. Ungrouped subscriptions keep fan-out behavior, reconnects preserve group membership, and locally delivered messages support bounded nack retry.
+Added consumer groups to `UnixSocketPubSub`.
+
+**Usage**
+
+```typescript
+// Every ungrouped subscriber receives each message.
+await pubsub.subscribe('events', handleAllEvents);
+
+// One subscriber in the group receives each message.
+await pubsub.subscribe('events', handleWorkerEvent, { group: 'workers' });
+```
+
+**Behavior**
+
+- Delivers each message once per named group and rotates delivery among available group members.
+- Restores group membership when a client reconnects.
+- Retries rejected local deliveries a bounded number of times.

--- a/packages/core/src/events/unix-socket-pubsub.test.ts
+++ b/packages/core/src/events/unix-socket-pubsub.test.ts
@@ -69,6 +69,111 @@ describe('UnixSocketPubSub', () => {
     expect(secondCb.mock.calls[0]![0].type).toBe('hello');
   });
 
+  it('round-robins local subscribers in the same group', async () => {
+    const path = await socketPath();
+    const pubsub = new UnixSocketPubSub(path);
+    pubsubs.push(pubsub);
+
+    const firstCb = vi.fn();
+    const secondCb = vi.fn();
+    await pubsub.subscribe('topic-a', firstCb, { group: 'workers' });
+    await pubsub.subscribe('topic-a', secondCb, { group: 'workers' });
+
+    await pubsub.publish('topic-a', makeEvent({ type: 'first' }));
+    await pubsub.publish('topic-a', makeEvent({ type: 'second' }));
+
+    expect(firstCb).toHaveBeenCalledTimes(1);
+    expect(secondCb).toHaveBeenCalledTimes(1);
+  });
+
+  it('fans out to ungrouped subscribers and selects one process per group', async () => {
+    const path = await socketPath();
+    const broker = new UnixSocketPubSub(path);
+    const clientA = new UnixSocketPubSub(path);
+    const clientB = new UnixSocketPubSub(path);
+    pubsubs.push(broker, clientA, clientB);
+
+    const brokerFanout = vi.fn();
+    const clientFanout = vi.fn();
+    const brokerWorker = vi.fn();
+    const clientAWorker = vi.fn();
+    const clientBWorker = vi.fn();
+    await broker.subscribe('topic-a', brokerFanout);
+    await clientA.subscribe('topic-a', clientFanout);
+    await broker.subscribe('topic-a', brokerWorker, { group: 'workers' });
+    await clientA.subscribe('topic-a', clientAWorker, { group: 'workers' });
+    await clientB.subscribe('topic-a', clientBWorker, { group: 'workers' });
+
+    for (let index = 0; index < 6; index++) {
+      await broker.publish('topic-a', makeEvent({ type: `event-${index}` }));
+    }
+
+    await waitFor(() => {
+      expect(brokerFanout).toHaveBeenCalledTimes(6);
+      expect(clientFanout).toHaveBeenCalledTimes(6);
+      expect(brokerWorker).toHaveBeenCalledTimes(2);
+      expect(clientAWorker).toHaveBeenCalledTimes(2);
+      expect(clientBWorker).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('delivers once to each independent group on a topic', async () => {
+    const path = await socketPath();
+    const broker = new UnixSocketPubSub(path);
+    const client = new UnixSocketPubSub(path);
+    pubsubs.push(broker, client);
+
+    const workers = vi.fn();
+    const auditors = vi.fn();
+    await broker.subscribe('topic-a', workers, { group: 'workers' });
+    await client.subscribe('topic-a', auditors, { group: 'auditors' });
+
+    await broker.publish('topic-a', makeEvent({ type: 'grouped' }));
+
+    await waitFor(() => {
+      expect(workers).toHaveBeenCalledTimes(1);
+      expect(auditors).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('removes a remote group membership only after its last local subscriber unsubscribes', async () => {
+    const path = await socketPath();
+    const broker = new UnixSocketPubSub(path);
+    const client = new UnixSocketPubSub(path);
+    pubsubs.push(broker, client);
+
+    const first = vi.fn();
+    const second = vi.fn();
+    await client.subscribe('topic-a', first, { group: 'workers' });
+    await client.subscribe('topic-a', second, { group: 'workers' });
+    await client.unsubscribe('topic-a', first);
+
+    await broker.publish('topic-a', makeEvent({ type: 'still-subscribed' }));
+    await waitFor(() => expect(second).toHaveBeenCalledTimes(1));
+
+    await client.unsubscribe('topic-a', second);
+    await broker.publish('topic-a', makeEvent({ type: 'unsubscribed' }));
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps localOnly grouped delivery within the publishing instance', async () => {
+    const path = await socketPath();
+    const broker = new UnixSocketPubSub(path);
+    const client = new UnixSocketPubSub(path);
+    pubsubs.push(broker, client);
+
+    const brokerWorker = vi.fn();
+    const clientWorker = vi.fn();
+    await broker.subscribe('topic-a', brokerWorker, { group: 'workers' });
+    await client.subscribe('topic-a', clientWorker, { group: 'workers' });
+
+    await client.publish('topic-a', makeEvent({ type: 'local-grouped' }), { localOnly: true });
+
+    expect(clientWorker).toHaveBeenCalledTimes(1);
+    expect(brokerWorker).not.toHaveBeenCalled();
+  });
+
   it('relays client-published events back to the publishing client', async () => {
     const path = await socketPath();
     const broker = new UnixSocketPubSub(path);
@@ -608,6 +713,26 @@ describe('UnixSocketPubSub', () => {
     await waitFor(() => {
       expect(follower.isBroker).toBe(true);
       expect(cb).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('preserves grouped subscriptions when a follower becomes the broker', async () => {
+    const path = await socketPath();
+    const broker = new UnixSocketPubSub(path);
+    const follower = new UnixSocketPubSub(path);
+    pubsubs.push(broker, follower);
+
+    const worker = vi.fn();
+    await broker.subscribe('topic-a', vi.fn(), { group: 'workers' });
+    await follower.subscribe('topic-a', worker, { group: 'workers' });
+
+    await broker.close();
+    pubsubs.splice(pubsubs.indexOf(broker), 1);
+    await follower.publish('topic-a', makeEvent({ type: 'after-grouped-close' }));
+
+    await waitFor(() => {
+      expect(follower.isBroker).toBe(true);
+      expect(worker).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/core/src/events/unix-socket-pubsub.test.ts
+++ b/packages/core/src/events/unix-socket-pubsub.test.ts
@@ -675,6 +675,82 @@ describe('UnixSocketPubSub', () => {
     });
   });
 
+  it('keeps the final callback active until the broker acknowledges unsubscribe', async () => {
+    const path = await socketPath();
+    const sockets = new Set<net.Socket>();
+    let acknowledgeUnsubscribe: (() => void) | undefined;
+    let unsubscribeReceivedResolve: (() => void) | undefined;
+    const unsubscribeReceived = new Promise<void>(resolve => {
+      unsubscribeReceivedResolve = resolve;
+    });
+    const event = {
+      ...makeEvent({ type: 'during-unsubscribe' }),
+      id: 'event-1',
+      createdAt: new Date().toISOString(),
+      deliveryAttempt: 1,
+    };
+    const server = net.createServer((socket: net.Socket) => {
+      sockets.add(socket);
+      socket.on('close', () => sockets.delete(socket));
+      socket.setEncoding('utf8');
+      let pending = '';
+      socket.on('data', (chunk: string) => {
+        pending += chunk;
+        const lines = pending.split('\n');
+        pending = lines.pop() ?? '';
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          const frame = JSON.parse(line);
+          if (frame.type === 'subscribe') {
+            socket.write(`${JSON.stringify({ type: 'subscribed', topic: frame.topic, group: frame.group })}\n`);
+          } else if (frame.type === 'unsubscribe') {
+            acknowledgeUnsubscribe = () => {
+              socket.write(`${JSON.stringify({ type: 'unsubscribed', topic: frame.topic, group: frame.group })}\n`);
+            };
+            socket.write(`${JSON.stringify({ type: 'event', topic: frame.topic, group: frame.group, event })}\n`);
+            unsubscribeReceivedResolve?.();
+          }
+        }
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(path, () => resolve());
+    });
+    const pubsub = new UnixSocketPubSub(path);
+    pubsubs.push(pubsub);
+    const cb = vi.fn();
+
+    try {
+      await pubsub.subscribe('topic-a', cb, { group: 'workers' });
+
+      let unsubscribeCompleted = false;
+      const unsubscribe = pubsub.unsubscribe('topic-a', cb).then(() => {
+        unsubscribeCompleted = true;
+      });
+      await unsubscribeReceived;
+      await waitFor(() => expect(cb).toHaveBeenCalledTimes(1));
+      expect(unsubscribeCompleted).toBe(false);
+
+      const replacement = vi.fn();
+      await pubsub.subscribe('topic-a', replacement, { group: 'workers' });
+      expect(acknowledgeUnsubscribe).toBeTypeOf('function');
+      acknowledgeUnsubscribe!();
+      await unsubscribe;
+      expect(unsubscribeCompleted).toBe(true);
+
+      for (const socket of sockets) {
+        socket.write(`${JSON.stringify({ type: 'event', topic: 'topic-a', group: 'workers', event })}\n`);
+      }
+      await waitFor(() => expect(replacement).toHaveBeenCalledTimes(1));
+      expect(cb).toHaveBeenCalledTimes(1);
+    } finally {
+      await pubsub.close();
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+
   it('rejects subscribe when the broker disconnects before acknowledging', async () => {
     const path = await socketPath();
     const server = net.createServer((socket: net.Socket) => {

--- a/packages/core/src/events/unix-socket-pubsub.test.ts
+++ b/packages/core/src/events/unix-socket-pubsub.test.ts
@@ -86,6 +86,52 @@ describe('UnixSocketPubSub', () => {
     expect(secondCb).toHaveBeenCalledTimes(1);
   });
 
+  it('treats an empty group name as a group', async () => {
+    const path = await socketPath();
+    const broker = new UnixSocketPubSub(path);
+    const client = new UnixSocketPubSub(path);
+    pubsubs.push(broker, client);
+
+    const brokerCb = vi.fn();
+    const clientCb = vi.fn();
+    await broker.subscribe('topic-a', brokerCb, { group: '' });
+    await client.subscribe('topic-a', clientCb, { group: '' });
+
+    for (let index = 0; index < 4; index++) {
+      await broker.publish('topic-a', makeEvent({ type: `event-${index}` }));
+    }
+
+    await waitFor(() => {
+      expect(brokerCb).toHaveBeenCalledTimes(2);
+      expect(clientCb).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('resets group rotation after the membership ends', async () => {
+    const path = await socketPath();
+    const pubsub = new UnixSocketPubSub(path);
+    pubsubs.push(pubsub);
+
+    const firstCb = vi.fn();
+    const secondCb = vi.fn();
+    await pubsub.subscribe('topic-a', firstCb, { group: 'workers' });
+    await pubsub.subscribe('topic-a', secondCb, { group: 'workers' });
+    await pubsub.publish('topic-a', makeEvent({ type: 'before-reset' }));
+    expect(firstCb).toHaveBeenCalledTimes(1);
+
+    await pubsub.unsubscribe('topic-a', firstCb);
+    await pubsub.unsubscribe('topic-a', secondCb);
+
+    const nextFirstCb = vi.fn();
+    const nextSecondCb = vi.fn();
+    await pubsub.subscribe('topic-a', nextFirstCb, { group: 'workers' });
+    await pubsub.subscribe('topic-a', nextSecondCb, { group: 'workers' });
+    await pubsub.publish('topic-a', makeEvent({ type: 'after-reset' }));
+
+    expect(nextFirstCb).toHaveBeenCalledTimes(1);
+    expect(nextSecondCb).not.toHaveBeenCalled();
+  });
+
   it('fans out to ungrouped subscribers and selects one process per group', async () => {
     const path = await socketPath();
     const broker = new UnixSocketPubSub(path);

--- a/packages/core/src/events/unix-socket-pubsub.test.ts
+++ b/packages/core/src/events/unix-socket-pubsub.test.ts
@@ -190,8 +190,13 @@ describe('UnixSocketPubSub', () => {
 
     const first = vi.fn();
     const second = vi.fn();
+    await broker.publish('bootstrap', makeEvent());
+    expect(broker.isBroker).toBe(true);
+
     await client.subscribe('topic-a', first, { group: 'workers' });
     await client.subscribe('topic-a', second, { group: 'workers' });
+    expect(client.isBroker).toBe(false);
+
     await client.unsubscribe('topic-a', first);
 
     await broker.publish('topic-a', makeEvent({ type: 'still-subscribed' }));

--- a/packages/core/src/events/unix-socket-pubsub.test.ts
+++ b/packages/core/src/events/unix-socket-pubsub.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { encode } from './codec';
 import type { Event } from './types';
 import { UnixSocketPubSub } from './unix-socket-pubsub';
 
@@ -762,7 +763,7 @@ describe('UnixSocketPubSub', () => {
     const event = {
       ...makeEvent({ type: 'during-unsubscribe' }),
       id: 'event-1',
-      createdAt: new Date().toISOString(),
+      createdAt: new Date(),
       deliveryAttempt: 1,
     };
     const server = net.createServer((socket: net.Socket) => {
@@ -783,7 +784,9 @@ describe('UnixSocketPubSub', () => {
             acknowledgeUnsubscribe = () => {
               socket.write(`${JSON.stringify({ type: 'unsubscribed', topic: frame.topic, group: frame.group })}\n`);
             };
-            socket.write(`${JSON.stringify({ type: 'event', topic: frame.topic, group: frame.group, event })}\n`);
+            socket.write(
+              `${JSON.stringify(encode({ type: 'event', topic: frame.topic, group: frame.group, event }))}\n`,
+            );
             unsubscribeReceivedResolve?.();
           }
         }
@@ -816,7 +819,7 @@ describe('UnixSocketPubSub', () => {
       expect(unsubscribeCompleted).toBe(true);
 
       for (const socket of sockets) {
-        socket.write(`${JSON.stringify({ type: 'event', topic: 'topic-a', group: 'workers', event })}\n`);
+        socket.write(`${JSON.stringify(encode({ type: 'event', topic: 'topic-a', group: 'workers', event }))}\n`);
       }
       await waitFor(() => expect(replacement).toHaveBeenCalledTimes(1));
       expect(cb).toHaveBeenCalledTimes(1);

--- a/packages/core/src/events/unix-socket-pubsub.test.ts
+++ b/packages/core/src/events/unix-socket-pubsub.test.ts
@@ -675,6 +675,82 @@ describe('UnixSocketPubSub', () => {
     });
   });
 
+  it('waits for an in-flight broker registration before completing overlapping subscriptions', async () => {
+    const path = await socketPath();
+    const sockets = new Set<net.Socket>();
+    let acknowledgeSubscribe: (() => void) | undefined;
+    let subscribeReceivedResolve: (() => void) | undefined;
+    const subscribeReceived = new Promise<void>(resolve => {
+      subscribeReceivedResolve = resolve;
+    });
+    const server = net.createServer((socket: net.Socket) => {
+      sockets.add(socket);
+      socket.on('close', () => sockets.delete(socket));
+      socket.setEncoding('utf8');
+      let pending = '';
+      socket.on('data', (chunk: string) => {
+        pending += chunk;
+        const lines = pending.split('\n');
+        pending = lines.pop() ?? '';
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          const frame = JSON.parse(line);
+          if (frame.type !== 'subscribe') continue;
+          const acknowledge = () => {
+            socket.write(`${JSON.stringify({ type: 'subscribed', topic: frame.topic, group: frame.group })}\n`);
+          };
+          if (frame.topic === 'topic-a') {
+            acknowledgeSubscribe = acknowledge;
+            subscribeReceivedResolve?.();
+          } else {
+            acknowledge();
+          }
+        }
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(path, () => resolve());
+    });
+    const pubsub = new UnixSocketPubSub(path);
+    pubsubs.push(pubsub);
+
+    try {
+      await pubsub.subscribe('bootstrap', vi.fn());
+
+      let firstCompleted = false;
+      const first = pubsub.subscribe('topic-a', vi.fn(), { group: 'workers' }).then(() => {
+        firstCompleted = true;
+      });
+      await subscribeReceived;
+
+      const secondCallback = vi.fn();
+      let secondCompleted = false;
+      const second = pubsub.subscribe('topic-a', secondCallback, { group: 'workers' }).then(() => {
+        secondCompleted = true;
+      });
+      let duplicateCompleted = false;
+      const duplicate = pubsub.subscribe('topic-a', secondCallback, { group: 'workers' }).then(() => {
+        duplicateCompleted = true;
+      });
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(firstCompleted).toBe(false);
+      expect(secondCompleted).toBe(false);
+      expect(duplicateCompleted).toBe(false);
+      expect(acknowledgeSubscribe).toBeTypeOf('function');
+      acknowledgeSubscribe!();
+      await Promise.all([first, second, duplicate]);
+      expect(firstCompleted).toBe(true);
+      expect(secondCompleted).toBe(true);
+      expect(duplicateCompleted).toBe(true);
+    } finally {
+      await pubsub.close();
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+
   it('keeps the final callback active until the broker acknowledges unsubscribe', async () => {
     const path = await socketPath();
     const sockets = new Set<net.Socket>();

--- a/packages/core/src/events/unix-socket-pubsub.ts
+++ b/packages/core/src/events/unix-socket-pubsub.ts
@@ -10,13 +10,20 @@ import type { PubSubDeliveryMode } from './pubsub';
 import type { Event, EventCallback, SubscribeOptions } from './types';
 
 type ClientFrame =
-  | { type: 'subscribe'; topic: string }
-  | { type: 'unsubscribe'; topic: string }
+  | { type: 'subscribe'; topic: string; group?: string }
+  | { type: 'unsubscribe'; topic: string; group?: string }
   | { type: 'publish'; topic: string; event: Omit<Event, 'id' | 'createdAt'>; localOnly?: boolean }
   | { type: 'ack'; id?: string }
   | { type: 'nack'; id?: string };
 
-type ServerFrame = { type: 'event'; topic: string; event: Event } | { type: 'subscribed'; topic: string };
+type ServerFrame =
+  | { type: 'event'; topic: string; event: Event; group?: string }
+  | { type: 'subscribed'; topic: string; group?: string };
+
+type LocalSubscription = {
+  callback: EventCallback;
+  group?: string;
+};
 
 type UnixSocketPubSubOptions = {
   maxRemoteClientQueuedBytes?: number;
@@ -133,6 +140,10 @@ function nextTick(): Promise<void> {
   return new Promise(resolve => setImmediate(resolve));
 }
 
+function membershipKey(topic: string, group?: string): string {
+  return JSON.stringify([topic, group ?? null]);
+}
+
 function readFrames(socket: net.Socket, onFrame: (frame: any) => void, maxFrameBytes: number) {
   // Accumulate raw bytes and only decode complete lines so byte accounting is
   // exact and multi-byte UTF-8 sequences split across chunks stay intact.
@@ -208,7 +219,9 @@ export class UnixSocketPubSub extends PubSub {
   #isBroker = false;
   #closed = false;
   #starting?: Promise<void>;
-  #callbacks = new Map<string, Set<EventCallback>>();
+  #subscriptions = new Map<string, Map<EventCallback, LocalSubscription>>();
+  #localGroupCursors = new Map<string, number>();
+  #brokerGroupCursors = new Map<string, number>();
   #subscribeWaiters = new Map<string, SubscribeWaiter[]>();
   #brokerClients = new Map<net.Socket, BrokerClient>();
   #pendingWrites = new Set<Promise<void>>();
@@ -279,41 +292,50 @@ export class UnixSocketPubSub extends PubSub {
   }
 
   async subscribe(topic: string, cb: EventCallback, options?: SubscribeOptions): Promise<void> {
-    if (options?.group) {
-      throw new Error('UnixSocketPubSub does not support grouped subscriptions yet');
+    const subscriptions = this.#subscriptions.get(topic) ?? new Map<EventCallback, LocalSubscription>();
+    const existing = subscriptions.get(cb);
+    if (existing && existing.group === options?.group) return;
+    if (existing) {
+      await this.unsubscribe(topic, cb);
     }
 
-    const callbacks = this.#callbacks.get(topic) ?? new Set<EventCallback>();
-    const hadCallback = callbacks.has(cb);
+    const group = options?.group;
+    const hadMembership = this.#hasLocalMembership(topic, group);
     const wasConnected = Boolean(this.#clientSocket && !this.#clientSocket.destroyed);
-    callbacks.add(cb);
-    this.#callbacks.set(topic, callbacks);
+    subscriptions.set(cb, { callback: cb, group });
+    this.#subscriptions.set(topic, subscriptions);
 
     try {
       await this.#ensureStarted();
-      if (!this.#isBroker && !hadCallback && wasConnected) {
-        await this.#sendSubscribeToBroker(topic);
+      if (!this.#isBroker && !hadMembership && wasConnected) {
+        await this.#sendSubscribeToBroker(topic, group);
       }
     } catch (error) {
-      if (!hadCallback) {
-        callbacks.delete(cb);
-        if (callbacks.size === 0) {
-          this.#callbacks.delete(topic);
-        }
+      subscriptions.delete(cb);
+      if (subscriptions.size === 0) {
+        this.#subscriptions.delete(topic);
       }
       throw error;
     }
   }
 
   async unsubscribe(topic: string, cb: EventCallback): Promise<void> {
-    const callbacks = this.#callbacks.get(topic);
-    callbacks?.delete(cb);
-    if (callbacks?.size === 0) {
-      this.#callbacks.delete(topic);
-      if (!this.#isBroker && this.#clientSocket && !this.#clientSocket.destroyed) {
-        await this.#sendToBroker({ type: 'unsubscribe', topic });
-        await nextTick();
-      }
+    const subscriptions = this.#subscriptions.get(topic);
+    const subscription = subscriptions?.get(cb);
+    if (!subscription) return;
+
+    subscriptions!.delete(cb);
+    if (subscriptions!.size === 0) {
+      this.#subscriptions.delete(topic);
+    }
+    if (
+      !this.#hasLocalMembership(topic, subscription.group) &&
+      !this.#isBroker &&
+      this.#clientSocket &&
+      !this.#clientSocket.destroyed
+    ) {
+      await this.#sendToBroker({ type: 'unsubscribe', topic, group: subscription.group });
+      await nextTick();
     }
   }
 
@@ -321,17 +343,43 @@ export class UnixSocketPubSub extends PubSub {
     await Promise.allSettled([...this.#pendingWrites]);
   }
 
+  #hasLocalMembership(topic: string, group?: string): boolean {
+    return [...(this.#subscriptions.get(topic)?.values() ?? [])].some(subscription => subscription.group === group);
+  }
+
+  #localGroups(topic: string): string[] {
+    return [
+      ...new Set(
+        [...(this.#subscriptions.get(topic)?.values() ?? [])]
+          .map(subscription => subscription.group)
+          .filter((group): group is string => Boolean(group)),
+      ),
+    ];
+  }
+
   async close(): Promise<void> {
     this.#closed = true;
-    this.#callbacks.clear();
+    this.#subscriptions.clear();
+    this.#localGroupCursors.clear();
+    this.#brokerGroupCursors.clear();
 
     this.#clientSocket?.destroy();
     this.#clientSocket = undefined;
     this.#rejectSubscribeWaiters(new Error('UnixSocketPubSub is closed'));
 
-    for (const client of [...this.#brokerClients.values()]) {
-      this.#removeBrokerClient(client);
-    }
+    const clientClosures = [...this.#brokerClients.values()].map(
+      client =>
+        new Promise<void>(resolve => {
+          if (client.socket.destroyed) {
+            this.#removeBrokerClient(client);
+            resolve();
+            return;
+          }
+          client.socket.once('close', resolve);
+          this.#removeBrokerClient(client);
+        }),
+    );
+    await Promise.allSettled(clientClosures);
 
     if (this.#server) {
       await new Promise<void>(resolve => this.#server?.close(() => resolve()));
@@ -459,8 +507,11 @@ export class UnixSocketPubSub extends PubSub {
   }
 
   async #resubscribeClient() {
-    for (const topic of this.#callbacks.keys()) {
-      await this.#sendSubscribeToBroker(topic);
+    for (const [topic, subscriptions] of this.#subscriptions) {
+      const groups = new Set([...subscriptions.values()].map(subscription => subscription.group));
+      for (const group of groups) {
+        await this.#sendSubscribeToBroker(topic, group);
+      }
     }
   }
 
@@ -551,38 +602,39 @@ export class UnixSocketPubSub extends PubSub {
     }
   }
 
-  async #sendSubscribeToBroker(topic: string): Promise<void> {
+  async #sendSubscribeToBroker(topic: string, group?: string): Promise<void> {
+    const key = membershipKey(topic, group);
     let waiter: SubscribeWaiter | undefined;
     const subscribed = new Promise<void>((resolve, reject) => {
       waiter = { resolve, reject };
-      const waiters = this.#subscribeWaiters.get(topic) ?? [];
+      const waiters = this.#subscribeWaiters.get(key) ?? [];
       waiters.push(waiter);
-      this.#subscribeWaiters.set(topic, waiters);
+      this.#subscribeWaiters.set(key, waiters);
     });
     try {
-      await this.#sendToBroker({ type: 'subscribe', topic });
+      await this.#sendToBroker({ type: 'subscribe', topic, group });
     } catch (error) {
-      this.#removeSubscribeWaiter(topic, waiter);
+      this.#removeSubscribeWaiter(key, waiter);
       throw error;
     }
     await subscribed;
   }
 
-  #removeSubscribeWaiter(topic: string, waiter: SubscribeWaiter | undefined) {
+  #removeSubscribeWaiter(key: string, waiter: SubscribeWaiter | undefined) {
     if (!waiter) return;
-    const waiters = this.#subscribeWaiters.get(topic);
+    const waiters = this.#subscribeWaiters.get(key);
     if (!waiters) return;
     const nextWaiters = waiters.filter(item => item !== waiter);
     if (nextWaiters.length === 0) {
-      this.#subscribeWaiters.delete(topic);
+      this.#subscribeWaiters.delete(key);
       return;
     }
-    this.#subscribeWaiters.set(topic, nextWaiters);
+    this.#subscribeWaiters.set(key, nextWaiters);
   }
 
-  #settleSubscribeWaiters(topic: string, error?: Error) {
-    const waiters = this.#subscribeWaiters.get(topic);
-    this.#subscribeWaiters.delete(topic);
+  #settleSubscribeWaiters(key: string, error?: Error) {
+    const waiters = this.#subscribeWaiters.get(key);
+    this.#subscribeWaiters.delete(key);
     if (error) {
       waiters?.forEach(waiter => waiter.reject(error));
       return;
@@ -609,10 +661,14 @@ export class UnixSocketPubSub extends PubSub {
       frame => {
         const clientFrame = frame as ClientFrame;
         if (clientFrame.type === 'subscribe') {
-          client.subscriptions.add(clientFrame.topic);
-          this.#enqueueBrokerClientWrite(client, { type: 'subscribed', topic: clientFrame.topic });
+          client.subscriptions.add(membershipKey(clientFrame.topic, clientFrame.group));
+          this.#enqueueBrokerClientWrite(client, {
+            type: 'subscribed',
+            topic: clientFrame.topic,
+            ...(clientFrame.group !== undefined ? { group: clientFrame.group } : {}),
+          });
         } else if (clientFrame.type === 'unsubscribe') {
-          client.subscriptions.delete(clientFrame.topic);
+          client.subscriptions.delete(membershipKey(clientFrame.topic, clientFrame.group));
         } else if (clientFrame.type === 'publish') {
           void this.#publishFromBroker(clientFrame.topic, clientFrame.event, client, clientFrame.localOnly);
         }
@@ -666,13 +722,17 @@ export class UnixSocketPubSub extends PubSub {
 
   #handleServerFrame(frame: ServerFrame) {
     if (frame.type === 'subscribed') {
-      this.#settleSubscribeWaiters(frame.topic);
+      this.#settleSubscribeWaiters(membershipKey(frame.topic, frame.group));
       return;
     }
     if (frame.type !== 'event') return;
     // `createdAt` is already a Date — the codec rehydrates it during JSON.parse
     // in `readFrames`. No ad-hoc conversion needed.
-    this.#deliverLocal(frame.topic, frame.event);
+    if (frame.group) {
+      this.#deliverLocalGroup(frame.topic, frame.group, frame.event);
+    } else {
+      this.#deliverLocalFanout(frame.topic, frame.event);
+    }
   }
 
   async #publishFromBroker(
@@ -688,58 +748,95 @@ export class UnixSocketPubSub extends PubSub {
       deliveryAttempt: 1,
     };
 
-    this.#deliverLocal(topic, brokerEvent);
+    this.#deliverLocalFanout(topic, brokerEvent);
 
-    // Skip serialization entirely when no remote clients could receive the event.
-    if (this.#brokerClients.size === 0) return;
-
-    // `localOnly` events are scoped to the publishing instance.
-    // When the publisher is the broker, the `#deliverLocal` above is enough.
-    // When the publisher is a remote client, relay the event back ONLY to
-    // that client so its subscription callback fires, but do NOT fan out to
-    // other clients — their WEP would just drop the event via `#ownsWorkflow`
-    // and the multi-MB payload would waste socket/kernel buffer for nothing.
+    // `localOnly` events are scoped to the publishing instance. Client-side
+    // localOnly publishes bypass the broker entirely, so this branch only
+    // protects compatibility with older clients that may still send the flag.
     if (localOnly) {
-      if (sourceClient && sourceClient.subscriptions.has(topic) && !sourceClient.socket.destroyed) {
+      if (sourceClient && sourceClient.subscriptions.has(membershipKey(topic)) && !sourceClient.socket.destroyed) {
         this.#enqueueBrokerClientWrite(sourceClient, { type: 'event', topic, event: brokerEvent });
       }
       return;
     }
 
-    let frame: ServerFrame | undefined;
+    const fanoutFrame: ServerFrame = { type: 'event', topic, event: brokerEvent };
     for (const client of this.#brokerClients.values()) {
-      if (!client.subscriptions.has(topic) || client.socket.destroyed) continue;
-      // Lazily build the frame only when we know at least one client needs it.
-      frame ??= { type: 'event', topic, event: brokerEvent };
-      this.#enqueueBrokerClientWrite(client, frame);
+      if (!client.subscriptions.has(membershipKey(topic)) || client.socket.destroyed) continue;
+      this.#enqueueBrokerClientWrite(client, fanoutFrame);
+    }
+
+    const groups = new Set(this.#localGroups(topic));
+    for (const client of this.#brokerClients.values()) {
+      for (const subscription of client.subscriptions) {
+        const [subscriptionTopic, group] = JSON.parse(subscription) as [string, string | null];
+        if (subscriptionTopic === topic && group) groups.add(group);
+      }
+    }
+
+    for (const group of groups) {
+      const members: Array<'local' | BrokerClient> = [];
+      if (this.#hasLocalMembership(topic, group)) members.push('local');
+      for (const client of this.#brokerClients.values()) {
+        if (client.subscriptions.has(membershipKey(topic, group)) && !client.socket.destroyed) members.push(client);
+      }
+      if (members.length === 0) continue;
+      const key = membershipKey(topic, group);
+      const cursor = this.#brokerGroupCursors.get(key) ?? 0;
+      const member = members[cursor % members.length]!;
+      this.#brokerGroupCursors.set(key, (cursor + 1) % members.length);
+      if (member === 'local') {
+        this.#deliverLocalGroup(topic, group, brokerEvent);
+      } else {
+        this.#enqueueBrokerClientWrite(member, { type: 'event', topic, event: brokerEvent, group });
+      }
     }
   }
 
   #deliverLocal(topic: string, event: Event) {
-    const callbacks = this.#callbacks.get(topic);
-    if (!callbacks) return;
-    for (const cb of callbacks) {
-      this.#invokeLocalCallback(topic, event, cb, 0);
+    this.#deliverLocalFanout(topic, event);
+    for (const group of this.#localGroups(topic)) {
+      this.#deliverLocalGroup(topic, group, event);
     }
   }
 
-  #invokeLocalCallback(topic: string, event: Event, cb: EventCallback, attempt: number) {
+  #deliverLocalFanout(topic: string, event: Event) {
+    for (const subscription of this.#subscriptions.get(topic)?.values() ?? []) {
+      if (subscription.group) continue;
+      this.#invokeLocalCallback(topic, event, subscription.callback, subscription.group, 0);
+    }
+  }
+
+  #deliverLocalGroup(topic: string, group: string, event: Event) {
+    const members = [...(this.#subscriptions.get(topic)?.values() ?? [])].filter(
+      subscription => subscription.group === group,
+    );
+    if (members.length === 0) return;
+    const key = membershipKey(topic, group);
+    const cursor = this.#localGroupCursors.get(key) ?? 0;
+    const member = members[cursor % members.length]!;
+    this.#localGroupCursors.set(key, (cursor + 1) % members.length);
+    this.#invokeLocalCallback(topic, event, member.callback, group, 0);
+  }
+
+  #invokeLocalCallback(topic: string, event: Event, cb: EventCallback, group: string | undefined, attempt: number) {
     let nacked = false;
     const nack = async () => {
       if (nacked || this.#closed) return;
       nacked = true;
       if (attempt >= MAX_LOCAL_REDELIVERIES) return;
-      const stillSubscribed = this.#callbacks.get(topic)?.has(cb);
-      if (!stillSubscribed) return;
+      const currentSubscription = this.#subscriptions.get(topic)?.get(cb);
+      if (!currentSubscription || currentSubscription.group !== group) return;
       const timer = setTimeout(
         () => {
           if (this.#closed) return;
-          if (!this.#callbacks.get(topic)?.has(cb)) return;
+          const currentSubscription = this.#subscriptions.get(topic)?.get(cb);
+          if (!currentSubscription || currentSubscription.group !== group) return;
           const redeliveredEvent: Event = {
             ...event,
             deliveryAttempt: (event.deliveryAttempt ?? 1) + 1,
           };
-          this.#invokeLocalCallback(topic, redeliveredEvent, cb, attempt + 1);
+          this.#invokeLocalCallback(topic, redeliveredEvent, cb, group, attempt + 1);
         },
         REDELIVERY_DELAY_MS * (attempt + 1),
       );

--- a/packages/core/src/events/unix-socket-pubsub.ts
+++ b/packages/core/src/events/unix-socket-pubsub.ts
@@ -929,7 +929,7 @@ export class UnixSocketPubSub extends PubSub {
 
   async #handlePromotedBrokerFrame(frame: ClientFrame) {
     if (frame.type === 'subscribe') {
-      this.#settleSubscribeWaiters(frame.topic);
+      this.#settleSubscribeWaiters(membershipKey(frame.topic, frame.group));
     } else if (frame.type === 'publish') {
       await this.#publishFromBroker(frame.topic, frame.event);
     }

--- a/packages/core/src/events/unix-socket-pubsub.ts
+++ b/packages/core/src/events/unix-socket-pubsub.ts
@@ -18,7 +18,8 @@ type ClientFrame =
 
 type ServerFrame =
   | { type: 'event'; topic: string; event: Event; group?: string }
-  | { type: 'subscribed'; topic: string; group?: string };
+  | { type: 'subscribed'; topic: string; group?: string }
+  | { type: 'unsubscribed'; topic: string; group?: string };
 
 type LocalSubscription = {
   callback: EventCallback;
@@ -43,7 +44,7 @@ type BrokerClient = {
   queuedBytes: number;
 };
 
-type SubscribeWaiter = {
+type MembershipWaiter = {
   resolve: () => void;
   reject: (error: Error) => void;
 };
@@ -136,10 +137,6 @@ function writeFrame(socket: net.Socket, frame: ClientFrame | ServerFrame): Promi
   return writeSerializedFrame(socket, serializeFrame(frame));
 }
 
-function nextTick(): Promise<void> {
-  return new Promise(resolve => setImmediate(resolve));
-}
-
 function membershipKey(topic: string, group?: string): string {
   return JSON.stringify([topic, group ?? null]);
 }
@@ -222,7 +219,8 @@ export class UnixSocketPubSub extends PubSub {
   #subscriptions = new Map<string, Map<EventCallback, LocalSubscription>>();
   #localGroupCursors = new Map<string, number>();
   #brokerGroupCursors = new Map<string, number>();
-  #subscribeWaiters = new Map<string, SubscribeWaiter[]>();
+  #subscribeWaiters = new Map<string, MembershipWaiter[]>();
+  #unsubscribeWaiters = new Map<string, MembershipWaiter[]>();
   #brokerClients = new Map<net.Socket, BrokerClient>();
   #pendingWrites = new Set<Promise<void>>();
   #recovering?: Promise<void>;
@@ -322,20 +320,28 @@ export class UnixSocketPubSub extends PubSub {
   async unsubscribe(topic: string, cb: EventCallback): Promise<void> {
     const subscriptions = this.#subscriptions.get(topic);
     const subscription = subscriptions?.get(cb);
-    if (!subscription) return;
+    if (!subscriptions || !subscription) return;
 
-    subscriptions!.delete(cb);
-    if (subscriptions!.size === 0) {
+    const membershipWillEnd = ![...subscriptions.values()].some(
+      candidate => candidate.callback !== cb && candidate.group === subscription.group,
+    );
+    if (membershipWillEnd && !this.#isBroker && this.#clientSocket && !this.#clientSocket.destroyed) {
+      await this.#sendUnsubscribeToBroker(topic, subscription.group);
+      const membershipReplaced = [...subscriptions.values()].some(
+        candidate => candidate.callback !== cb && candidate.group === subscription.group,
+      );
+      if (membershipReplaced) {
+        await this.#sendSubscribeToBroker(topic, subscription.group);
+      }
+    }
+
+    subscriptions.delete(cb);
+    if (subscriptions.size === 0) {
       this.#subscriptions.delete(topic);
     }
-    const membershipEnded = !this.#hasLocalMembership(topic, subscription.group);
-    if (membershipEnded && subscription.group !== undefined) {
+    if (membershipWillEnd && subscription.group !== undefined) {
       this.#localGroupCursors.delete(membershipKey(topic, subscription.group));
       this.#evictBrokerGroupCursor(topic, subscription.group);
-    }
-    if (membershipEnded && !this.#isBroker && this.#clientSocket && !this.#clientSocket.destroyed) {
-      await this.#sendToBroker({ type: 'unsubscribe', topic, group: subscription.group });
-      await nextTick();
     }
   }
 
@@ -365,7 +371,7 @@ export class UnixSocketPubSub extends PubSub {
 
     this.#clientSocket?.destroy();
     this.#clientSocket = undefined;
-    this.#rejectSubscribeWaiters(new Error('UnixSocketPubSub is closed'));
+    this.#rejectMembershipWaiters(new Error('UnixSocketPubSub is closed'));
 
     const clientClosures = [...this.#brokerClients.values()].map(
       client =>
@@ -518,7 +524,7 @@ export class UnixSocketPubSub extends PubSub {
   #handleClientDisconnect(socket: net.Socket, error: Error) {
     if (this.#clientSocket !== socket) return;
     this.#clientSocket = undefined;
-    this.#rejectSubscribeWaiters(error);
+    this.#rejectMembershipWaiters(error);
     if (!this.#closed) {
       void this.#recoverClientConnection();
     }
@@ -603,38 +609,53 @@ export class UnixSocketPubSub extends PubSub {
   }
 
   async #sendSubscribeToBroker(topic: string, group?: string): Promise<void> {
-    const key = membershipKey(topic, group);
-    let waiter: SubscribeWaiter | undefined;
-    const subscribed = new Promise<void>((resolve, reject) => {
-      waiter = { resolve, reject };
-      const waiters = this.#subscribeWaiters.get(key) ?? [];
-      waiters.push(waiter);
-      this.#subscribeWaiters.set(key, waiters);
-    });
-    try {
-      await this.#sendToBroker({ type: 'subscribe', topic, group });
-    } catch (error) {
-      this.#removeSubscribeWaiter(key, waiter);
-      throw error;
-    }
-    await subscribed;
+    await this.#sendMembershipFrameToBroker({ type: 'subscribe', topic, group }, this.#subscribeWaiters);
   }
 
-  #removeSubscribeWaiter(key: string, waiter: SubscribeWaiter | undefined) {
+  async #sendUnsubscribeToBroker(topic: string, group?: string): Promise<void> {
+    await this.#sendMembershipFrameToBroker({ type: 'unsubscribe', topic, group }, this.#unsubscribeWaiters);
+  }
+
+  async #sendMembershipFrameToBroker(
+    frame: Extract<ClientFrame, { type: 'subscribe' | 'unsubscribe' }>,
+    waiterMap: Map<string, MembershipWaiter[]>,
+  ): Promise<void> {
+    const key = membershipKey(frame.topic, frame.group);
+    let waiter: MembershipWaiter | undefined;
+    const acknowledged = new Promise<void>((resolve, reject) => {
+      waiter = { resolve, reject };
+      const waiters = waiterMap.get(key) ?? [];
+      waiters.push(waiter);
+      waiterMap.set(key, waiters);
+    });
+    try {
+      await this.#sendToBroker(frame);
+    } catch (error) {
+      this.#removeMembershipWaiter(waiterMap, key, waiter);
+      throw error;
+    }
+    await acknowledged;
+  }
+
+  #removeMembershipWaiter(
+    waiterMap: Map<string, MembershipWaiter[]>,
+    key: string,
+    waiter: MembershipWaiter | undefined,
+  ) {
     if (!waiter) return;
-    const waiters = this.#subscribeWaiters.get(key);
+    const waiters = waiterMap.get(key);
     if (!waiters) return;
     const nextWaiters = waiters.filter(item => item !== waiter);
     if (nextWaiters.length === 0) {
-      this.#subscribeWaiters.delete(key);
+      waiterMap.delete(key);
       return;
     }
-    this.#subscribeWaiters.set(key, nextWaiters);
+    waiterMap.set(key, nextWaiters);
   }
 
-  #settleSubscribeWaiters(key: string, error?: Error) {
-    const waiters = this.#subscribeWaiters.get(key);
-    this.#subscribeWaiters.delete(key);
+  #settleMembershipWaiters(waiterMap: Map<string, MembershipWaiter[]>, key: string, error?: Error) {
+    const waiters = waiterMap.get(key);
+    waiterMap.delete(key);
     if (error) {
       waiters?.forEach(waiter => waiter.reject(error));
       return;
@@ -642,9 +663,11 @@ export class UnixSocketPubSub extends PubSub {
     waiters?.forEach(waiter => waiter.resolve());
   }
 
-  #rejectSubscribeWaiters(error: Error) {
-    for (const topic of this.#subscribeWaiters.keys()) {
-      this.#settleSubscribeWaiters(topic, error);
+  #rejectMembershipWaiters(error: Error) {
+    for (const waiterMap of [this.#subscribeWaiters, this.#unsubscribeWaiters]) {
+      for (const key of waiterMap.keys()) {
+        this.#settleMembershipWaiters(waiterMap, key, error);
+      }
     }
   }
 
@@ -672,6 +695,11 @@ export class UnixSocketPubSub extends PubSub {
           if (clientFrame.group !== undefined) {
             this.#evictBrokerGroupCursor(clientFrame.topic, clientFrame.group);
           }
+          this.#enqueueBrokerClientWrite(client, {
+            type: 'unsubscribed',
+            topic: clientFrame.topic,
+            ...(clientFrame.group !== undefined ? { group: clientFrame.group } : {}),
+          });
         } else if (clientFrame.type === 'publish') {
           void this.#publishFromBroker(clientFrame.topic, clientFrame.event, client, clientFrame.localOnly);
         }
@@ -737,7 +765,11 @@ export class UnixSocketPubSub extends PubSub {
 
   #handleServerFrame(frame: ServerFrame) {
     if (frame.type === 'subscribed') {
-      this.#settleSubscribeWaiters(membershipKey(frame.topic, frame.group));
+      this.#settleMembershipWaiters(this.#subscribeWaiters, membershipKey(frame.topic, frame.group));
+      return;
+    }
+    if (frame.type === 'unsubscribed') {
+      this.#settleMembershipWaiters(this.#unsubscribeWaiters, membershipKey(frame.topic, frame.group));
       return;
     }
     if (frame.type !== 'event') return;
@@ -944,7 +976,9 @@ export class UnixSocketPubSub extends PubSub {
 
   async #handlePromotedBrokerFrame(frame: ClientFrame) {
     if (frame.type === 'subscribe') {
-      this.#settleSubscribeWaiters(membershipKey(frame.topic, frame.group));
+      this.#settleMembershipWaiters(this.#subscribeWaiters, membershipKey(frame.topic, frame.group));
+    } else if (frame.type === 'unsubscribe') {
+      this.#settleMembershipWaiters(this.#unsubscribeWaiters, membershipKey(frame.topic, frame.group));
     } else if (frame.type === 'publish') {
       await this.#publishFromBroker(frame.topic, frame.event);
     }

--- a/packages/core/src/events/unix-socket-pubsub.ts
+++ b/packages/core/src/events/unix-socket-pubsub.ts
@@ -328,12 +328,12 @@ export class UnixSocketPubSub extends PubSub {
     if (subscriptions!.size === 0) {
       this.#subscriptions.delete(topic);
     }
-    if (
-      !this.#hasLocalMembership(topic, subscription.group) &&
-      !this.#isBroker &&
-      this.#clientSocket &&
-      !this.#clientSocket.destroyed
-    ) {
+    const membershipEnded = !this.#hasLocalMembership(topic, subscription.group);
+    if (membershipEnded && subscription.group !== undefined) {
+      this.#localGroupCursors.delete(membershipKey(topic, subscription.group));
+      this.#evictBrokerGroupCursor(topic, subscription.group);
+    }
+    if (membershipEnded && !this.#isBroker && this.#clientSocket && !this.#clientSocket.destroyed) {
       await this.#sendToBroker({ type: 'unsubscribe', topic, group: subscription.group });
       await nextTick();
     }
@@ -352,7 +352,7 @@ export class UnixSocketPubSub extends PubSub {
       ...new Set(
         [...(this.#subscriptions.get(topic)?.values() ?? [])]
           .map(subscription => subscription.group)
-          .filter((group): group is string => Boolean(group)),
+          .filter((group): group is string => group !== undefined),
       ),
     ];
   }
@@ -669,6 +669,9 @@ export class UnixSocketPubSub extends PubSub {
           });
         } else if (clientFrame.type === 'unsubscribe') {
           client.subscriptions.delete(membershipKey(clientFrame.topic, clientFrame.group));
+          if (clientFrame.group !== undefined) {
+            this.#evictBrokerGroupCursor(clientFrame.topic, clientFrame.group);
+          }
         } else if (clientFrame.type === 'publish') {
           void this.#publishFromBroker(clientFrame.topic, clientFrame.event, client, clientFrame.localOnly);
         }
@@ -709,10 +712,22 @@ export class UnixSocketPubSub extends PubSub {
     void write.finally(() => this.#pendingWrites.delete(write));
   }
 
+  #evictBrokerGroupCursor(topic: string, group: string) {
+    const key = membershipKey(topic, group);
+    if (this.#hasLocalMembership(topic, group)) return;
+    if ([...this.#brokerClients.values()].some(client => client.subscriptions.has(key))) return;
+    this.#brokerGroupCursors.delete(key);
+  }
+
   #removeBrokerClient(client: BrokerClient) {
     if (this.#brokerClients.get(client.socket) !== client) return;
+    const subscriptions = [...client.subscriptions];
     this.#brokerClients.delete(client.socket);
     client.subscriptions.clear();
+    for (const subscription of subscriptions) {
+      const [topic, group] = JSON.parse(subscription) as [string, string | null];
+      if (group !== null) this.#evictBrokerGroupCursor(topic, group);
+    }
     client.queuedBytes = 0;
     client.writeChain = Promise.resolve();
     if (!client.socket.destroyed) {
@@ -728,7 +743,7 @@ export class UnixSocketPubSub extends PubSub {
     if (frame.type !== 'event') return;
     // `createdAt` is already a Date — the codec rehydrates it during JSON.parse
     // in `readFrames`. No ad-hoc conversion needed.
-    if (frame.group) {
+    if (frame.group !== undefined) {
       this.#deliverLocalGroup(frame.topic, frame.group, frame.event);
     } else {
       this.#deliverLocalFanout(frame.topic, frame.event);
@@ -770,7 +785,7 @@ export class UnixSocketPubSub extends PubSub {
     for (const client of this.#brokerClients.values()) {
       for (const subscription of client.subscriptions) {
         const [subscriptionTopic, group] = JSON.parse(subscription) as [string, string | null];
-        if (subscriptionTopic === topic && group) groups.add(group);
+        if (subscriptionTopic === topic && group !== null) groups.add(group);
       }
     }
 
@@ -802,7 +817,7 @@ export class UnixSocketPubSub extends PubSub {
 
   #deliverLocalFanout(topic: string, event: Event) {
     for (const subscription of this.#subscriptions.get(topic)?.values() ?? []) {
-      if (subscription.group) continue;
+      if (subscription.group !== undefined) continue;
       this.#invokeLocalCallback(topic, event, subscription.callback, subscription.group, 0);
     }
   }

--- a/packages/core/src/events/unix-socket-pubsub.ts
+++ b/packages/core/src/events/unix-socket-pubsub.ts
@@ -292,7 +292,16 @@ export class UnixSocketPubSub extends PubSub {
   async subscribe(topic: string, cb: EventCallback, options?: SubscribeOptions): Promise<void> {
     const subscriptions = this.#subscriptions.get(topic) ?? new Map<EventCallback, LocalSubscription>();
     const existing = subscriptions.get(cb);
-    if (existing && existing.group === options?.group) return;
+    if (existing && existing.group === options?.group) {
+      await this.#ensureStarted();
+      if (!this.#isBroker) {
+        await this.#waitForPendingMembershipAcknowledgement(
+          this.#subscribeWaiters,
+          membershipKey(topic, existing.group),
+        );
+      }
+      return;
+    }
     if (existing) {
       await this.unsubscribe(topic, cb);
     }
@@ -305,8 +314,12 @@ export class UnixSocketPubSub extends PubSub {
 
     try {
       await this.#ensureStarted();
-      if (!this.#isBroker && !hadMembership && wasConnected) {
-        await this.#sendSubscribeToBroker(topic, group);
+      if (!this.#isBroker && wasConnected) {
+        if (hadMembership) {
+          await this.#waitForPendingMembershipAcknowledgement(this.#subscribeWaiters, membershipKey(topic, group));
+        } else {
+          await this.#sendSubscribeToBroker(topic, group);
+        }
       }
     } catch (error) {
       subscriptions.delete(cb);
@@ -621,36 +634,25 @@ export class UnixSocketPubSub extends PubSub {
     waiterMap: Map<string, MembershipWaiter[]>,
   ): Promise<void> {
     const key = membershipKey(frame.topic, frame.group);
-    let waiter: MembershipWaiter | undefined;
     const acknowledged = new Promise<void>((resolve, reject) => {
-      waiter = { resolve, reject };
       const waiters = waiterMap.get(key) ?? [];
-      waiters.push(waiter);
+      waiters.push({ resolve, reject });
       waiterMap.set(key, waiters);
     });
     try {
       await this.#sendToBroker(frame);
     } catch (error) {
-      this.#removeMembershipWaiter(waiterMap, key, waiter);
-      throw error;
+      this.#settleMembershipWaiters(waiterMap, key, error instanceof Error ? error : new Error(String(error)));
     }
     await acknowledged;
   }
 
-  #removeMembershipWaiter(
-    waiterMap: Map<string, MembershipWaiter[]>,
-    key: string,
-    waiter: MembershipWaiter | undefined,
-  ) {
-    if (!waiter) return;
+  #waitForPendingMembershipAcknowledgement(waiterMap: Map<string, MembershipWaiter[]>, key: string): Promise<void> {
     const waiters = waiterMap.get(key);
-    if (!waiters) return;
-    const nextWaiters = waiters.filter(item => item !== waiter);
-    if (nextWaiters.length === 0) {
-      waiterMap.delete(key);
-      return;
-    }
-    waiterMap.set(key, nextWaiters);
+    if (!waiters) return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      waiters.push({ resolve, reject });
+    });
   }
 
   #settleMembershipWaiters(waiterMap: Map<string, MembershipWaiter[]>, key: string, error?: Error) {


### PR DESCRIPTION
## Summary

`UnixSocketPubSub` now implements consumer groups. `BackgroundTaskManager` already subscribes to its dispatch topic with `{ group: WORKER_GROUP }`, but the unix socket transport silently ignored the option — every connected process received every dispatch instead of exactly one worker per group. This PR makes the transport honor the contract the rest of the codebase already depends on.

### Behavior

- **Named groups**: each published message is delivered once per group, with round-robin selection among the group's members (both broker-side across processes and locally within a process).
- **Ungrouped subscriptions**: unchanged fan-out to every subscriber.
- **Reconnects**: group membership is re-established when a client reconnects to the broker.
- **`localOnly`**: still bypasses the broker entirely.
- **Nack retry**: locally delivered messages get bounded retry on handler failure.

### Non-goals

Durability, broker-owned in-flight acknowledgements, crash requeue, cross-process nack rerouting, and exactly-once delivery are explicitly out of scope. This is minimum viable group semantics for the existing `subscribe(topic, cb, { group })` API.

## Test plan

- `src/events/unix-socket-pubsub.test.ts`: 28 tests covering group delivery, round-robin, reconnect, unsubscribe, localOnly, and nack retry.
- Full `src/events/` suite (incl. multiprocess broker-election, codec roundtrip, and localOnly multiprocess tests) plus `src/background-tasks/manager.test.ts` and `manager-lifecycle.test.ts` against this transport: 18 files / 323 tests passing.
- `tsc --noEmit` clean on `@mastra/core`.

This is the first extraction from #19960 (native background tools); it stands alone and has no behavioral impact on code that doesn't use groups on this transport.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This change lets multiple processes share work from the same subscription group. Each message goes to one group member, while ungrouped subscriptions receive every message.

## What changed

- Added `{ group }` support to `UnixSocketPubSub`.
- Added round-robin delivery across processes and within a process.
- Preserved fan-out behavior for ungrouped subscriptions.
- Preserved `localOnly` behavior.
- Restored group membership after reconnects and broker failover.
- Removed group cursors after the final member leaves, including disconnected clients.
- Added bounded retries for failed local handlers.
- Made remote unsubscribe wait for broker acknowledgement.
- Restored broker membership when a replacement subscription joins during unsubscribe.
- Added tests for routing, empty groups, cleanup, reconnects, failover, `localOnly`, retries, duplicate subscriptions, and unsubscribe races.
- Added a patch changeset for `@mastra/core`.

## Validation

- 323 tests passed across 18 files.
- TypeScript compilation passed for `@mastra/core`.
- Formatting and lint checks passed for `@mastra/core`.

Durability, broker-owned acknowledgements, crash requeue, cross-process nack rerouting, and exactly-once delivery remain out of scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->