### PR TITLE
feat(playground-ui): render absent theme-flow buckets with a neutral fill

### DIFF
--- a/.changeset/absent-node-styling.md
+++ b/.changeset/absent-node-styling.md
@@ -1,0 +1,6 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/client-js': patch
+---
+
+Render absent trace-signal buckets in the theme flow with a neutral fill. The intelligence theme-flow API now emits an 'absent' passthrough node for cohort traces that never produced a stage's signal (e.g. sentiment); these buckets render muted instead of taking a theme hue, stay non-drillable, and are typed via the new 'absent' node kind on ThemeNode.

--- a/client-sdks/client-js/src/agent-learning.ts
+++ b/client-sdks/client-js/src/agent-learning.ts
@@ -96,7 +96,11 @@ export type ThemeNode =
     }
   | {
       nodeId: string;
-      kind: 'noise' | 'other';
+      /**
+       * 'absent' is a passthrough bucket for cohort traces that never produced
+       * this stage's signal (labeled "None observed" by the server).
+       */
+      kind: 'noise' | 'other' | 'absent';
       label: string;
       description?: string;
       traceCount: number;

--- a/packages/playground-ui/src/ds/components/SankeyChart/index.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/index.ts
@@ -2,7 +2,14 @@ export { Sankey, useSankey } from './sankey-context';
 export type { SankeyControlColumn, SankeyControls, SankeyProps } from './sankey-context';
 export { SankeyChart } from './sankey-chart';
 export type { SankeyChartProps } from './sankey-chart';
-export { buildSankeyHueMap, hashHue, nodeColor, nodeColorVivid } from './sankeyColor';
+export {
+  buildSankeyHueMap,
+  hashHue,
+  nodeColor,
+  nodeColorMuted,
+  nodeColorMutedVivid,
+  nodeColorVivid,
+} from './sankeyColor';
 export {
   buildSankeyChartGraph,
   getSankeyChartCurveSelection,

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SankeyChart } from './sankey-chart';
 import type { SankeyChartNodeSelection } from './sankey-chart-utils';
 import { Sankey, useSankey } from './sankey-context';
-import { buildSankeyHueMap, nodeColor, nodeColorVivid } from './sankeyColor';
+import { buildSankeyHueMap, nodeColor, nodeColorMuted, nodeColorMutedVivid, nodeColorVivid } from './sankeyColor';
 
 afterEach(() => {
   cleanup();
@@ -606,6 +606,28 @@ describe('SankeyChart', () => {
     expect(container.querySelector(`rect[fill="${nodeColor(hueMap.Search ?? 0)}"]`)).not.toBeNull();
     expect(container.querySelector(`stop[stop-color="${nodeColor(hueMap.Search ?? 0)}"]`)).not.toBeNull();
     expect(container.querySelector(`stop[stop-color="${nodeColorVivid(hueMap.EU ?? 0)}"]`)).not.toBeNull();
+  });
+
+  describe('when the caller marks nodes as muted', () => {
+    it('renders muted nodes and their ribbon endpoints with the neutral fill', async () => {
+      const { container } = render(
+        <Sankey data={data} columns={columns} getNodeMuted={nodeId => nodeId === 'Lost'}>
+          <SankeyChart onCurveClick={() => {}} />
+        </Sankey>,
+      );
+      const hueMap = buildSankeyHueMap(['Search', 'Referral', 'EU', 'US', 'Won', 'Lost']);
+
+      await screen.findAllByRole('button', { name: 'Select Sankey curve' });
+
+      // The muted node ignores its hue; every other node keeps hue coloring.
+      expect(container.querySelectorAll(`rect[fill="${nodeColorMuted()}"]`)).toHaveLength(1);
+      expect(container.querySelector(`rect[fill="${nodeColor(hueMap.Lost ?? 0)}"]`)).toBeNull();
+      expect(container.querySelector(`rect[fill="${nodeColor(hueMap.Won ?? 0)}"]`)).not.toBeNull();
+      // Ribbons into the muted node fade to the neutral fill at that endpoint.
+      expect(container.querySelector(`stop[stop-color="${nodeColorMuted()}"]`)).not.toBeNull();
+      expect(container.querySelector(`stop[stop-color="${nodeColorMutedVivid()}"]`)).not.toBeNull();
+      expect(container.querySelector(`stop[stop-color="${nodeColor(hueMap.Lost ?? 0)}"]`)).toBeNull();
+    });
   });
 
   describe('when the caller provides column hues', () => {

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -16,7 +16,7 @@ import type {
 } from './sankey-chart-utils';
 import { useSankeyRenderContext } from './sankey-context';
 import { SankeyPortalTooltip } from './sankey-portal-tooltip';
-import { nodeColor, nodeColorVivid } from './sankeyColor';
+import { nodeColor, nodeColorMuted, nodeColorMutedVivid, nodeColorVivid } from './sankeyColor';
 import { useSankeyChartMeasurements } from './use-sankey-chart-measurements';
 import { useSankeyGeometryTransition } from './use-sankey-geometry-transition';
 import { useSankeyHoverTooltip } from './use-sankey-hover-tooltip';
@@ -53,7 +53,7 @@ export function SankeyChart({
   hideColumnLabels = false,
   geometryTransitionKey,
 }: SankeyChartProps) {
-  const { graph, enabledColumns, hueMap, usesFixedGeometry } = useSankeyRenderContext();
+  const { graph, enabledColumns, hueMap, mutedNodeIds, usesFixedGeometry } = useSankeyRenderContext();
   const { chartContainerRef, fixedGeometry, labelWidths } = useSankeyChartMeasurements({
     graph,
     height,
@@ -117,6 +117,7 @@ export function SankeyChart({
                     y={nodeGeometry?.y ?? props.y}
                     height={nodeGeometry?.height ?? props.height}
                     hueMap={hueMap}
+                    muted={node !== undefined && mutedNodeIds.has(String(node.value))}
                     columnLabel={node?.column.label}
                     columnDescription={node ? getColumnDescription?.(node.column) : undefined}
                     label={node?.label}
@@ -154,6 +155,7 @@ export function SankeyChart({
                     sourceWidth={linkGeometry?.sourceWidth}
                     targetWidth={linkGeometry?.targetWidth}
                     hueMap={hueMap}
+                    mutedNodeIds={mutedNodeIds}
                     highlighted={String(props.payload.source.name ?? '') === activeSourceName}
                     displayValue={link?.displayValue}
                     layoutValue={link?.value}
@@ -196,6 +198,7 @@ type SankeyLinkRendererProps = {
 
 type SankeyNodeProps = SankeyNodeRendererProps & {
   hueMap: Record<string, number>;
+  muted: boolean;
   columnLabel?: string;
   columnDescription?: string;
   label?: string;
@@ -219,6 +222,7 @@ function SankeyNode({
   height,
   payload,
   hueMap,
+  muted,
   columnLabel,
   columnDescription,
   label,
@@ -259,6 +263,7 @@ function SankeyNode({
   const textAnchor = isFirstColumn ? 'start' : isLastColumn ? 'end' : 'middle';
   const labelX = isFirstColumn ? x : isLastColumn ? x + width : x + width / 2;
   const hue = hueMap[name] ?? 0;
+  const fill = muted ? nodeColorMuted() : nodeColor(hue);
   const handleKeyDown = (event: KeyboardEvent<SVGGElement>) => {
     if (event.key !== 'Enter' && event.key !== ' ') return;
     event.preventDefault();
@@ -306,7 +311,7 @@ function SankeyNode({
       >
         {/* The custom tooltip covers described nodes; a native title there would stack a second popup. */}
         {description ? null : <title>{displayLabel}</title>}
-        <rect x={x} y={visibleY} width={width} height={visibleHeight} rx={3} fill={nodeColor(hue)} />
+        <rect x={x} y={visibleY} width={width} height={visibleHeight} rx={3} fill={fill} />
         <text
           x={labelX}
           y={y - 24}
@@ -397,6 +402,7 @@ function scaleSankeyDimension(size: number, displayValue: number | undefined, la
 
 type SankeyLinkProps = SankeyLinkRendererProps & {
   hueMap: Record<string, number>;
+  mutedNodeIds: ReadonlySet<string>;
   highlighted: boolean;
   displayValue?: number;
   layoutValue?: number;
@@ -418,6 +424,7 @@ function SankeyLink({
   index,
   payload,
   hueMap,
+  mutedNodeIds,
   highlighted,
   displayValue,
   layoutValue,
@@ -439,6 +446,14 @@ function SankeyLink({
   ].join(' ');
   const sourceName = String(payload.source.name ?? '');
   const targetName = String(payload.target.name ?? '');
+  const sourceColor = mutedNodeIds.has(sourceName) ? nodeColorMuted() : nodeColor(hueMap[sourceName] ?? 0);
+  const targetColor = mutedNodeIds.has(targetName) ? nodeColorMuted() : nodeColor(hueMap[targetName] ?? 0);
+  const sourceColorVivid = mutedNodeIds.has(sourceName)
+    ? nodeColorMutedVivid()
+    : nodeColorVivid(hueMap[sourceName] ?? 0);
+  const targetColorVivid = mutedNodeIds.has(targetName)
+    ? nodeColorMutedVivid()
+    : nodeColorVivid(hueMap[targetName] ?? 0);
   const gradientId = `sankey-grad-${index}`;
   const vividGradientId = `${gradientId}-vivid`;
   const handleKeyDown = (event: KeyboardEvent<SVGPathElement>) => {
@@ -451,12 +466,12 @@ function SankeyLink({
     <g>
       <defs>
         <linearGradient id={gradientId} gradientUnits="userSpaceOnUse" x1={sourceX} x2={targetX}>
-          <stop offset="0%" stopColor={nodeColor(hueMap[sourceName] ?? 0)} />
-          <stop offset="100%" stopColor={nodeColor(hueMap[targetName] ?? 0)} />
+          <stop offset="0%" stopColor={sourceColor} />
+          <stop offset="100%" stopColor={targetColor} />
         </linearGradient>
         <linearGradient id={vividGradientId} gradientUnits="userSpaceOnUse" x1={sourceX} x2={targetX}>
-          <stop offset="0%" stopColor={nodeColorVivid(hueMap[sourceName] ?? 0)} />
-          <stop offset="100%" stopColor={nodeColorVivid(hueMap[targetName] ?? 0)} />
+          <stop offset="0%" stopColor={sourceColorVivid} />
+          <stop offset="100%" stopColor={targetColorVivid} />
         </linearGradient>
       </defs>
       <path

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-context.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-context.tsx
@@ -18,6 +18,8 @@ export type SankeyProps = {
   getRecordNodeLabel?: (record: SankeyChartRecord, column: SankeyChartColumn) => string;
   getRecordNodeValue?: (record: SankeyChartRecord, column: SankeyChartColumn) => number;
   getColumnHue?: (column: SankeyChartColumn) => number;
+  /** Muted nodes render with a neutral fill instead of their column hue. */
+  getNodeMuted?: (nodeId: string, column: SankeyChartColumn) => boolean;
 };
 
 export type SankeyControlColumn = SankeyChartColumn & {
@@ -34,6 +36,7 @@ type SankeyRenderContext = {
   graph: SankeyChartGraph;
   enabledColumns: Array<SankeyChartColumn>;
   hueMap: Record<string, number>;
+  mutedNodeIds: ReadonlySet<string>;
   usesFixedGeometry: boolean;
 };
 
@@ -54,6 +57,7 @@ export function Sankey({
   getRecordNodeLabel,
   getRecordNodeValue,
   getColumnHue,
+  getNodeMuted,
 }: SankeyProps) {
   const columnIds = columns.map(column => column.id);
   const [internalOrder, setInternalOrder] = useState(columnIds);
@@ -76,6 +80,11 @@ export function Sankey({
       String(node.value),
       getColumnHue?.(node.column) ?? defaultHueMap[String(node.value)] ?? 0,
     ]),
+  );
+  const mutedNodeIds = new Set(
+    graph.nodes
+      .filter(node => getNodeMuted?.(String(node.value), node.column) === true)
+      .map(node => String(node.value)),
   );
 
   const setVisibleColumns = (nextIds: Array<string>) => {
@@ -109,7 +118,7 @@ export function Sankey({
   return (
     <SankeyControlsContext.Provider value={{ columns: controlColumns, toggleColumn, reorderColumns }}>
       <SankeyRenderContext.Provider
-        value={{ graph, enabledColumns, hueMap, usesFixedGeometry: getRecordLayoutWeight !== undefined }}
+        value={{ graph, enabledColumns, hueMap, mutedNodeIds, usesFixedGeometry: getRecordLayoutWeight !== undefined }}
       >
         {children}
       </SankeyRenderContext.Provider>

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankeyColor.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankeyColor.ts
@@ -29,6 +29,15 @@ export function nodeColorVivid(hue: number) {
   return supportsOklch() ? `oklch(74% 0.18 ${normalizedHue})` : `hsl(${normalizedHue} 55% 68%)`;
 }
 
+/** Near-neutral fill for muted nodes (e.g. absent buckets), hue-free by design. */
+export function nodeColorMuted() {
+  return supportsOklch() ? 'oklch(52% 0.012 260)' : 'hsl(240 4% 46%)';
+}
+
+export function nodeColorMutedVivid() {
+  return supportsOklch() ? 'oklch(60% 0.014 260)' : 'hsl(240 5% 55%)';
+}
+
 export function buildSankeyHueMap(names: string[]) {
   // Not pre-sorted: the relaxation loop below re-sorts on every iteration.
   const entries = [...new Set(names)].map(name => ({ name, hue: hashHue(name) }));

--- a/packages/playground-ui/src/ee/signals/__tests__/fixtures/theme-flow.ts
+++ b/packages/playground-ui/src/ee/signals/__tests__/fixtures/theme-flow.ts
@@ -275,6 +275,65 @@ export const themeFlowResponse: ThemeFlowResponse = {
   ],
 };
 
+/** Outcome stage splits between a real theme and the absent passthrough bucket. */
+export const absentStageThemeFlowResponse: ThemeFlowResponse = {
+  snapshot: themeFlowResponse.snapshot,
+  stages: [
+    {
+      signalName: 'goal',
+      traceCount: 40,
+      nodes: [
+        {
+          nodeId: 'goal-support',
+          kind: 'theme',
+          // Numeric: drillable theme ids are numeric server ids.
+          themeId: '901',
+          label: 'Resolve support request',
+          traceCount: 40,
+          stageShare: 1,
+        },
+      ],
+    },
+    {
+      signalName: 'outcome',
+      traceCount: 40,
+      nodes: [
+        {
+          nodeId: 'outcome-resolved',
+          kind: 'theme',
+          themeId: '902',
+          label: 'Request resolved',
+          traceCount: 25,
+          stageShare: 0.625,
+        },
+        {
+          nodeId: 'outcome-absent',
+          kind: 'absent',
+          label: 'None observed',
+          traceCount: 15,
+          stageShare: 0.375,
+        },
+      ],
+    },
+  ],
+  links: [
+    {
+      sourceNodeId: 'goal-support',
+      targetNodeId: 'outcome-resolved',
+      traceCount: 25,
+      sourceShare: 0.625,
+      targetShare: 1,
+    },
+    {
+      sourceNodeId: 'goal-support',
+      targetNodeId: 'outcome-absent',
+      traceCount: 15,
+      sourceShare: 0.375,
+      targetShare: 1,
+    },
+  ],
+};
+
 export const fourStageThemeFlowResponse: ThemeFlowResponse = {
   snapshot: {
     snapshotId: 'snapshot-4',

--- a/packages/playground-ui/src/ee/signals/__tests__/sankey-signals.test.tsx
+++ b/packages/playground-ui/src/ee/signals/__tests__/sankey-signals.test.tsx
@@ -20,6 +20,7 @@ import { SignalsErrorState } from '../signals-error-state';
 import { SignalsLoadingSkeleton } from '../signals-loading-skeleton';
 import type { ThemeFlowResponse } from '../types';
 import {
+  absentStageThemeFlowResponse,
   duplicateLabelThemeFlowResponse,
   earlierThemeFlowResponse,
   emptyThemeSnapshotsResponse,
@@ -36,7 +37,7 @@ import {
   themeSnapshotsResponse,
   unlinkedGoalStageThemeFlowResponse,
 } from './fixtures/theme-flow';
-import { buildSankeyChartGraph } from '@/ds/components/SankeyChart';
+import { buildSankeyChartGraph, nodeColorMuted } from '@/ds/components/SankeyChart';
 import { server } from '@/test/msw-server';
 
 const BASE_URL = window.location.origin;
@@ -422,6 +423,35 @@ describe('SankeySignals', () => {
       await screen.findByRole('region', { name: 'Trace signal theme flow' });
       expect(columnHeaderLabels()).toEqual(['OUTCOME', 'BEHAVIOR', 'SENTIMENT']);
       expect(screen.queryByLabelText('Reorder Goal')).toBeNull();
+    });
+  });
+
+  describe('when a stage holds an absent passthrough bucket', () => {
+    it('renders the bucket neutral, labeled, and inert', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
+          HttpResponse.json(themeSnapshotsResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, () =>
+          HttpResponse.json(absentStageThemeFlowResponse),
+        ),
+      );
+
+      const { container } = renderSankeySignals();
+
+      const flowRegion = await screen.findByRole('region', { name: 'Trace signal theme flow' });
+      const absentLabel = within(flowRegion)
+        .getAllByText('None observed')
+        .find(element => element.tagName === 'text');
+      expect(absentLabel).not.toBeUndefined();
+      // The bucket drops its column hue for the neutral fill; themed nodes keep hues.
+      expect(container.querySelectorAll(`rect[fill="${nodeColorMuted()}"]`)).toHaveLength(1);
+      expect(container.querySelector(`stop[stop-color="${nodeColorMuted()}"]`)).not.toBeNull();
+      // Absence is not drillable: the bucket never becomes a button.
+      const absentNode = within(flowRegion).getByLabelText('None observed: 15 traces (38%)');
+      expect(absentNode.getAttribute('role')).toBeNull();
+      const themedNode = within(flowRegion).getByLabelText('Request resolved: 25 traces (63%)');
+      expect(themedNode.getAttribute('role')).toBe('button');
     });
   });
 

--- a/packages/playground-ui/src/ee/signals/flow-card.tsx
+++ b/packages/playground-ui/src/ee/signals/flow-card.tsx
@@ -30,6 +30,11 @@ export function FlowCard({
   reorderDisabled: boolean;
 }) {
   const linkedColumnIds = new Set(columns.map(column => column.id));
+  // Absent buckets (cohort traces that never produced this stage's signal)
+  // render neutral so they read as "no data", not as another theme.
+  const absentNodeIds = new Set(
+    stages.flatMap(stage => stage.nodes.filter(node => node.kind === 'absent').map(node => node.nodeId)),
+  );
   const stageSignalNames = stages.map(stage => stage.signalName).filter(signalName => linkedColumnIds.has(signalName));
   const optimisticSignalNames = signalOrder.filter(signalName => linkedColumnIds.has(signalName));
   const optimisticSignalSet = new Set(optimisticSignalNames);
@@ -77,6 +82,7 @@ export function FlowCard({
             columns={chartColumns}
             columnOrder={chartColumns.map(column => column.id)}
             getColumnHue={column => getSignalHue(column.id)}
+            getNodeMuted={nodeId => absentNodeIds.has(nodeId)}
             getRecordNodeId={getSignalRecordNodeId}
             getRecordNodeLabel={getSignalRecordNodeLabel}
             getRecordNodeValue={getSignalRecordNodeValue}


### PR DESCRIPTION
## Summary

The trace-intelligence theme-flow API now emits an `absent` passthrough node kind for cohort traces that never produced a stage's signal (common for sparse signals like sentiment, where most traces legitimately report "none observed"). Without dedicated styling these buckets take a theme hue and read as just another theme.

- **SankeyChart**: new `getNodeMuted` prop; muted nodes and their ribbon endpoints render with a hue-free neutral fill (`nodeColorMuted` / `nodeColorMutedVivid`), while column headers keep their signal hue.
- **FlowCard**: marks `kind === 'absent'` nodes as muted; they keep the server-provided "None observed" label and stay non-drillable.
- **client-js**: `ThemeNode` kind union gains `'absent'` (compile-time only, backward compatible).

## Test plan

- New SankeyChart test: muted nodes and ribbon endpoints use the neutral fill; unmuted nodes keep hue coloring.
- New SankeySignals test with an absent-stage flow fixture: bucket renders neutral, labeled "None observed", and is inert (no button role) while themed nodes stay clickable.
- Full signals + SankeyChart suites: 376/376 pass; typecheck clean for playground-ui and client-js.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Some flow stages have no signal data. This PR displays those stages in neutral colors and prevents users from opening them, while keeping normal themed stages unchanged.

## Changes

- Added muted Sankey node and ribbon colors with Oklch and HSL fallbacks.
- Added optional `getNodeMuted` support to `SankeyChart`.
- Updated `FlowCard` to:
  - Treat `absent` nodes as muted.
  - Keep the “None observed” label.
  - Disable drilling into absent nodes.
- Extended `ThemeNode.kind` with `'absent'`.
- Added fixtures and tests for muted Sankey rendering and absent-stage behavior.
- Added patch changesets for `@mastra/playground-ui` and `@mastra/client-js`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->