### PR TITLE
fix(core): harden background task execution

### DIFF
--- a/.changeset/fresh-subagents-share-owners.md
+++ b/.changeset/fresh-subagents-share-owners.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Clean up background tasks whose initial dispatch is rejected: mark still-pending tasks failed, discard their invocation context, and free local capacity for queued work. Preserve tasks already claimed by a worker when a transport reports an ambiguous publication failure. Add regression coverage for async dynamic subagent selection across independent Mastra instances sharing storage with `recoverStaleTasksOnStart: false`, and for resume publication failures.

--- a/.changeset/fresh-subagents-share-owners.md
+++ b/.changeset/fresh-subagents-share-owners.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Clean up background tasks whose initial dispatch is rejected: mark still-pending tasks failed, discard their invocation context, and free local capacity for queued work. Preserve tasks already claimed by a worker when a transport reports an ambiguous publication failure. Add regression coverage for async dynamic subagent selection across independent Mastra instances sharing storage with `recoverStaleTasksOnStart: false`, and for resume publication failures.
+Fixed background tasks whose initial dispatch is rejected by marking still-pending tasks as failed and freeing local capacity for queued work. Tasks already claimed by a worker are preserved when a transport reports an ambiguous publication failure.

--- a/.changeset/lazy-jobs-train.md
+++ b/.changeset/lazy-jobs-train.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': patch
+---
+
+Fixed background task result serialization so primitive values round-trip correctly through LibSQL storage.

--- a/.changeset/puny-regions-laugh.md
+++ b/.changeset/puny-regions-laugh.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved background task execution across multiple processes with process-affine routing, safer cancellation, configurable stale-task recovery, and reliable local concurrency cleanup.

--- a/.changeset/puny-regions-laugh.md
+++ b/.changeset/puny-regions-laugh.md
@@ -2,4 +2,17 @@
 '@mastra/core': patch
 ---
 
-Improved background task execution across multiple processes with process-affine routing, safer cancellation, configurable stale-task recovery, and reliable local concurrency cleanup.
+Improved background task execution across multiple processes. Invocation-bound tasks stay on the process that owns their executor, cancellation reliably reaches local work, and queued tasks continue after dispatch failures.
+
+**Stale task recovery**
+
+Startup recovery remains enabled by default. Disable it when multiple live managers share storage and task ownership cannot be verified across processes:
+
+```ts
+const mastra = new Mastra({
+  backgroundTasks: {
+    enabled: true,
+    recoverStaleTasksOnStart: false,
+  },
+});
+```

--- a/packages/core/src/agent/__tests__/dynamic-subagent-background-ownership.test.ts
+++ b/packages/core/src/agent/__tests__/dynamic-subagent-background-ownership.test.ts
@@ -5,6 +5,8 @@ import { RequestContext } from '../../request-context';
 import { MockStore } from '../../storage';
 import { Agent } from '../agent';
 
+const WAIT_TIMEOUT_MS = 10_000;
+
 it('keeps asynchronously selected subagents on their owning instance with distinct request contexts', async () => {
   const storage = new MockStore();
   const instances: Mastra[] = [];
@@ -86,35 +88,44 @@ it('keeps asynchronously selected subagents on their owning instance with distin
   try {
     const origin = await makeInstance();
     await delegate(origin.supervisor, 'A');
-    await vi.waitFor(() => expect(executions).toEqual(['A']));
+    await vi.waitFor(() => expect(executions).toEqual(['A']), { timeout: WAIT_TIMEOUT_MS });
     await delegate(origin.supervisor, 'B');
     expect(await tasks()).toEqual(expect.arrayContaining([expect.objectContaining({ runId: 'B', status: 'pending' })]));
     const remote = await makeInstance();
     await delegate(remote.supervisor, 'C');
-    await vi.waitFor(async () =>
-      expect(await tasks()).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ runId: 'A', status: 'running' }),
-          expect.objectContaining({ runId: 'B', status: 'pending' }),
-          expect.objectContaining({ runId: 'C', status: 'completed', result: expect.objectContaining({ text: 'C' }) }),
-        ]),
-      ),
+    await vi.waitFor(
+      async () =>
+        expect(await tasks()).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ runId: 'A', status: 'running' }),
+            expect.objectContaining({ runId: 'B', status: 'pending' }),
+            expect.objectContaining({
+              runId: 'C',
+              status: 'completed',
+              result: expect.objectContaining({ text: 'C' }),
+            }),
+          ]),
+        ),
+      { timeout: WAIT_TIMEOUT_MS },
     );
     expect(executions).toEqual(['A', 'C']);
     release();
-    await vi.waitFor(async () => {
-      const completed = await tasks();
-      expect(completed).toHaveLength(3);
-      for (const selected of ['A', 'B', 'C']) {
-        expect(completed).toContainEqual(
-          expect.objectContaining({
-            runId: selected,
-            status: 'completed',
-            result: expect.objectContaining({ text: selected }),
-          }),
-        );
-      }
-    });
+    await vi.waitFor(
+      async () => {
+        const completed = await tasks();
+        expect(completed).toHaveLength(3);
+        for (const selected of ['A', 'B', 'C']) {
+          expect(completed).toContainEqual(
+            expect.objectContaining({
+              runId: selected,
+              status: 'completed',
+              result: expect.objectContaining({ text: selected }),
+            }),
+          );
+        }
+      },
+      { timeout: WAIT_TIMEOUT_MS },
+    );
     expect(executions).toEqual(['A', 'C', 'B']);
   } finally {
     release();

--- a/packages/core/src/agent/__tests__/dynamic-subagent-background-ownership.test.ts
+++ b/packages/core/src/agent/__tests__/dynamic-subagent-background-ownership.test.ts
@@ -1,0 +1,126 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { expect, it, vi } from 'vitest';
+import { Mastra } from '../../mastra';
+import { RequestContext } from '../../request-context';
+import { MockStore } from '../../storage';
+import { Agent } from '../agent';
+
+it('keeps asynchronously selected subagents on their owning instance with distinct request contexts', async () => {
+  const storage = new MockStore();
+  const instances: Mastra[] = [];
+  let release!: () => void;
+  const gate = new Promise<void>(resolve => {
+    release = resolve;
+  });
+  const executions: string[] = [];
+
+  function makeSupervisor() {
+    return new Agent({
+      id: 'supervisor',
+      name: 'supervisor',
+      instructions: 'Delegate to helper.',
+      model: new MockLanguageModelV2({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'tool-call', toolCallId: 'delegate', toolName: 'agent-helper', input: '{"prompt":"hi"}' },
+            { type: 'finish', finishReason: 'tool-calls', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+          ]),
+        }),
+      }),
+      agents: async ({ requestContext }) => {
+        const selected = requestContext.get('selected') as string;
+        return {
+          helper: new Agent({
+            id: `helper-${selected}`,
+            name: 'helper',
+            description: 'Selected helper.',
+            instructions: 'Reply.',
+            model: new MockLanguageModelV2({
+              doStream: async () => {
+                executions.push(selected);
+                if (selected === 'A') await gate;
+                return {
+                  stream: convertArrayToReadableStream([
+                    { type: 'stream-start', warnings: [] },
+                    { type: 'text-start', id: 'answer' },
+                    { type: 'text-delta', id: 'answer', delta: selected },
+                    { type: 'text-end', id: 'answer' },
+                    {
+                      type: 'finish',
+                      finishReason: 'stop',
+                      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                    },
+                  ]),
+                };
+              },
+            }),
+          }),
+        };
+      },
+      backgroundTasks: { tools: { helper: { enabled: true } } },
+    });
+  }
+
+  async function makeInstance() {
+    const supervisor = makeSupervisor();
+    const instance = new Mastra({
+      logger: false,
+      storage,
+      agents: { supervisor },
+      backgroundTasks: { enabled: true, globalConcurrency: 1, perAgentConcurrency: 1, recoverStaleTasksOnStart: false },
+    });
+    instances.push(instance);
+    await instance.startWorkers();
+    return { instance, supervisor };
+  }
+
+  async function delegate(supervisor: Agent, selected: string) {
+    const requestContext = new RequestContext<{ selected: string }>();
+    requestContext.set('selected', selected);
+    const stream = await supervisor.stream('Delegate.', { requestContext, runId: selected, maxSteps: 1 });
+    await stream.consumeStream();
+  }
+
+  const tasks = async () => (await instances[0]!.backgroundTaskManager!.listTasks({})).tasks;
+  try {
+    const origin = await makeInstance();
+    await delegate(origin.supervisor, 'A');
+    await vi.waitFor(() => expect(executions).toEqual(['A']));
+    await delegate(origin.supervisor, 'B');
+    expect(await tasks()).toEqual(expect.arrayContaining([expect.objectContaining({ runId: 'B', status: 'pending' })]));
+    const remote = await makeInstance();
+    await delegate(remote.supervisor, 'C');
+    await vi.waitFor(async () =>
+      expect(await tasks()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ runId: 'A', status: 'running' }),
+          expect.objectContaining({ runId: 'B', status: 'pending' }),
+          expect.objectContaining({ runId: 'C', status: 'completed', result: expect.objectContaining({ text: 'C' }) }),
+        ]),
+      ),
+    );
+    expect(executions).toEqual(['A', 'C']);
+    release();
+    await vi.waitFor(async () => {
+      const completed = await tasks();
+      expect(completed).toHaveLength(3);
+      for (const selected of ['A', 'B', 'C']) {
+        expect(completed).toContainEqual(
+          expect.objectContaining({
+            runId: selected,
+            status: 'completed',
+            result: expect.objectContaining({ text: selected }),
+          }),
+        );
+      }
+    });
+    expect(executions).toEqual(['A', 'C', 'B']);
+  } finally {
+    release();
+    for (const instance of instances) {
+      await instance.backgroundTaskManager?.shutdown();
+      await instance.stopWorkers();
+    }
+  }
+});

--- a/packages/core/src/background-tasks/manager-lifecycle.test.ts
+++ b/packages/core/src/background-tasks/manager-lifecycle.test.ts
@@ -40,6 +40,19 @@ class NeverSubscribePubSub extends EventEmitterPubSub {
   }
 }
 
+class ResultGatedPubSub extends EventEmitterPubSub {
+  readonly subscribeStarted = deferred();
+  readonly subscribeGate = deferred();
+
+  override async subscribe(topic: string, cb: EventCallback, options?: SubscribeOptions): Promise<void> {
+    if (topic === 'background-tasks-result') {
+      this.subscribeStarted.resolve();
+      await this.subscribeGate.promise;
+    }
+    await super.subscribe(topic, cb, options);
+  }
+}
+
 class CapturingPubSub extends EventEmitterPubSub {
   dispatchCallback?: EventCallback;
 
@@ -98,6 +111,27 @@ describe('BackgroundTaskManager lifecycle', () => {
       await mastra.shutdown();
       mastra.__unregisterHooks();
     }
+  });
+
+  it('releases every subscription when shutdown starts during the final initialization step', async () => {
+    const emitter = new EventEmitter();
+    const pubsub = new ResultGatedPubSub(emitter);
+    const manager = new BackgroundTaskManager({ enabled: true, recoverStaleTasksOnStart: false });
+
+    const initPromise = manager.init(pubsub);
+    await pubsub.subscribeStarted.promise;
+    const shutdownPromise = manager.shutdown();
+    pubsub.subscribeGate.resolve();
+
+    await Promise.all([initPromise, shutdownPromise]);
+    expect(emitter.eventNames()).toEqual([]);
+    await pubsub.close();
+  });
+
+  it('preserves resolved defaults when optional config values are explicitly undefined', () => {
+    const manager = new BackgroundTaskManager({ enabled: true, recoverStaleTasksOnStart: undefined });
+
+    expect((manager as any).config.recoverStaleTasksOnStart).toBe(true);
   });
 
   it('allows shutdown before initialization', async () => {
@@ -416,6 +450,136 @@ describe('BackgroundTaskManager lifecycle', () => {
     expect(ack).toHaveBeenCalledOnce();
     await manager.shutdown();
     await pubsub.close();
+    await mastra.shutdown();
+    mastra.__unregisterHooks();
+  });
+
+  it('fails and acknowledges a claimed dispatch when Mastra is not registered', async () => {
+    const pubsub = new CapturingPubSub();
+    const manager = new BackgroundTaskManager({ enabled: true, recoverStaleTasksOnStart: false });
+    const mockStore = new MockStore();
+    const storage = await mockStore.getStore('backgroundTasks');
+    if (!storage) throw new Error('Background task storage is unavailable');
+    vi.spyOn(manager, 'getStorage').mockResolvedValue(storage);
+    await manager.init(pubsub);
+
+    const task = makeRunningTask({ status: 'pending', startedAt: undefined });
+    await storage.createTask(task);
+    const ack = vi.fn(async () => {});
+    const event: Event = {
+      type: 'task.dispatch',
+      id: 'event-1',
+      data: { taskId: task.id },
+      runId: task.id,
+      createdAt: new Date(),
+    };
+
+    await pubsub.dispatchCallback!(event, ack);
+
+    expect(await storage.getTask(task.id)).toMatchObject({
+      status: 'failed',
+      error: { message: 'Mastra is not registered with this background task manager' },
+    });
+    expect(ack).toHaveBeenCalledOnce();
+    await manager.shutdown();
+    await pubsub.close();
+  });
+
+  it('does not overwrite cancellation when workflow startup fails', async () => {
+    const pubsub = new CapturingPubSub();
+    const manager = new BackgroundTaskManager({ enabled: true, recoverStaleTasksOnStart: false });
+    await manager.init(pubsub);
+
+    const task = makeRunningTask({ status: 'pending', startedAt: undefined });
+    let currentTask = task;
+    const updateTask = vi.fn(
+      async (
+        _taskId: string,
+        update: Partial<BackgroundTask>,
+        options?: { expectedStatus?: BackgroundTask['status'] },
+      ) => {
+        if (options?.expectedStatus === 'pending') {
+          currentTask = { ...currentTask, ...update };
+          return true;
+        }
+        currentTask = { ...currentTask, status: 'cancelled' };
+        return false;
+      },
+    );
+    const publish = vi.spyOn(pubsub, 'publish');
+    manager.__registerMastra({
+      getStorage: () => ({
+        getStore: async () => ({
+          getTask: async () => currentTask,
+          updateTask,
+          listTasks: async () => ({ tasks: [] }),
+        }),
+      }),
+      __getInternalWorkflow: () => ({
+        createRun: async () => {
+          throw new Error('workflow startup failed');
+        },
+      }),
+    } as unknown as Mastra);
+    const ack = vi.fn(async () => {});
+    const event: Event = {
+      type: 'task.dispatch',
+      id: 'event-1',
+      data: { taskId: task.id },
+      runId: task.id,
+      createdAt: new Date(),
+    };
+
+    await pubsub.dispatchCallback!(event, ack);
+
+    expect(updateTask).toHaveBeenLastCalledWith(task.id, expect.objectContaining({ status: 'failed' }), {
+      expectedStatus: 'running',
+    });
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'task.failed' }));
+    expect(ack).toHaveBeenCalledOnce();
+    await manager.shutdown();
+    await pubsub.close();
+  });
+
+  it('releases a reserved slot when a resumed task is no longer suspended', async () => {
+    const manager = new BackgroundTaskManager({ enabled: true });
+    vi.spyOn(manager, 'getStorage').mockResolvedValue({
+      getTask: async () => makeRunningTask({ status: 'completed' }),
+    } as any);
+    (manager as any).localReservations.set('task-1', 'agent-1');
+    const event: Event = {
+      type: 'task.resume',
+      id: 'event-1',
+      data: { taskId: 'task-1', resumeData: {} },
+      runId: 'task-1',
+      createdAt: new Date(),
+    };
+
+    await expect((manager as any).handleResume(event)).resolves.toBe(true);
+
+    expect((manager as any).localReservations.has('task-1')).toBe(false);
+    await manager.shutdown();
+  });
+
+  it('logs dispatch failures while draining instead of rejecting', async () => {
+    const mastra = new Mastra({ logger: false, storage: new MockStore(), workers: false });
+    const warn = vi.spyOn(mastra.getLogger(), 'warn');
+    const manager = new BackgroundTaskManager({ enabled: true });
+    manager.__registerMastra(mastra);
+    vi.spyOn(manager, 'getStorage').mockResolvedValue({
+      getTask: async () => makeRunningTask({ status: 'pending', startedAt: undefined }),
+    } as any);
+    const error = new Error('dispatch failed');
+    vi.spyOn(manager as any, 'dispatch').mockRejectedValue(error);
+    manager.registerTaskContext('task-1', { executor: { execute: vi.fn() } });
+    (manager as any).localPendingTaskIds.add('task-1');
+
+    await expect((manager as any).drainPending()).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith('background-task dispatch failed while draining task-1:', error);
+    expect((manager as any).localPendingTaskIds.has('task-1')).toBe(true);
+    expect((manager as any).localReservations.has('task-1')).toBe(false);
+    await manager.shutdown();
     await mastra.shutdown();
     mastra.__unregisterHooks();
   });

--- a/packages/core/src/background-tasks/manager-lifecycle.test.ts
+++ b/packages/core/src/background-tasks/manager-lifecycle.test.ts
@@ -55,9 +55,11 @@ class ResultGatedPubSub extends EventEmitterPubSub {
 
 class CapturingPubSub extends EventEmitterPubSub {
   dispatchCallback?: EventCallback;
+  resultCallback?: EventCallback;
 
   override async subscribe(topic: string, cb: EventCallback, options?: SubscribeOptions): Promise<void> {
     if (topic === 'background-tasks') this.dispatchCallback = cb;
+    if (topic === 'background-tasks-result') this.resultCallback = cb;
     await super.subscribe(topic, cb, options);
   }
 }
@@ -452,6 +454,145 @@ describe('BackgroundTaskManager lifecycle', () => {
     await pubsub.close();
     await mastra.shutdown();
     mastra.__unregisterHooks();
+  });
+
+  it('acknowledges completed results and cleans up when the global completion callback rejects', async () => {
+    const pubsub = new CapturingPubSub();
+    const mockStore = new MockStore();
+    const mastra = new Mastra({ logger: false, storage: mockStore, workers: false });
+    const error = new Error('completion callback failed');
+    const manager = new BackgroundTaskManager({
+      enabled: true,
+      recoverStaleTasksOnStart: false,
+      onTaskComplete: async () => {
+        throw error;
+      },
+    });
+    manager.__registerMastra(mastra);
+    const warn = vi.spyOn(mastra.getLogger(), 'warn');
+    const drainPending = vi.spyOn(manager as any, 'drainPending').mockResolvedValue(undefined);
+    const storage = await mockStore.getStore('backgroundTasks');
+    if (!storage) throw new Error('Background task storage is unavailable');
+    const task = makeRunningTask({ status: 'completed', completedAt: new Date(), result: { ok: true } });
+    await storage.createTask(task);
+    manager.registerTaskContext(task.id, { executor: { execute: vi.fn() } });
+
+    try {
+      await manager.init(pubsub);
+      const ack = vi.fn(async () => {});
+      const event: Event = {
+        type: 'task.completed',
+        id: 'event-1',
+        data: { ...task, taskId: task.id },
+        runId: task.runId,
+        createdAt: new Date(),
+      };
+
+      await expect(pubsub.resultCallback!(event, ack)).resolves.toBeUndefined();
+
+      expect(warn).toHaveBeenCalledWith(`background-task completion callback failed for ${task.id}:`, error);
+      expect(manager.taskContexts.has(task.id)).toBe(false);
+      expect(drainPending).toHaveBeenCalledOnce();
+      expect(ack).toHaveBeenCalledOnce();
+    } finally {
+      await manager.shutdown();
+      await pubsub.close();
+      await mastra.shutdown();
+      mastra.__unregisterHooks();
+    }
+  });
+
+  it('acknowledges failed results and cleans up when the global failure callback rejects', async () => {
+    const pubsub = new CapturingPubSub();
+    const mockStore = new MockStore();
+    const mastra = new Mastra({ logger: false, storage: mockStore, workers: false });
+    const error = new Error('failure callback failed');
+    const manager = new BackgroundTaskManager({
+      enabled: true,
+      recoverStaleTasksOnStart: false,
+      onTaskFailed: async () => {
+        throw error;
+      },
+    });
+    manager.__registerMastra(mastra);
+    const warn = vi.spyOn(mastra.getLogger(), 'warn');
+    const drainPending = vi.spyOn(manager as any, 'drainPending').mockResolvedValue(undefined);
+    const storage = await mockStore.getStore('backgroundTasks');
+    if (!storage) throw new Error('Background task storage is unavailable');
+    const task = makeRunningTask({
+      status: 'failed',
+      completedAt: new Date(),
+      error: { message: 'task failed' },
+    });
+    await storage.createTask(task);
+    manager.registerTaskContext(task.id, { executor: { execute: vi.fn() } });
+
+    try {
+      await manager.init(pubsub);
+      const ack = vi.fn(async () => {});
+      const event: Event = {
+        type: 'task.failed',
+        id: 'event-1',
+        data: { ...task, taskId: task.id },
+        runId: task.runId,
+        createdAt: new Date(),
+      };
+
+      await expect(pubsub.resultCallback!(event, ack)).resolves.toBeUndefined();
+
+      expect(warn).toHaveBeenCalledWith(`background-task failure callback failed for ${task.id}:`, error);
+      expect(manager.taskContexts.has(task.id)).toBe(false);
+      expect(drainPending).toHaveBeenCalledOnce();
+      expect(ack).toHaveBeenCalledOnce();
+    } finally {
+      await manager.shutdown();
+      await pubsub.close();
+      await mastra.shutdown();
+      mastra.__unregisterHooks();
+    }
+  });
+
+  it('acknowledges and cleans up before propagating a per-task completion callback rejection', async () => {
+    const pubsub = new CapturingPubSub();
+    const mockStore = new MockStore();
+    const mastra = new Mastra({ logger: false, storage: mockStore, workers: false });
+    const manager = new BackgroundTaskManager({ enabled: true, recoverStaleTasksOnStart: false });
+    manager.__registerMastra(mastra);
+    const drainPending = vi.spyOn(manager as any, 'drainPending').mockResolvedValue(undefined);
+    const storage = await mockStore.getStore('backgroundTasks');
+    if (!storage) throw new Error('Background task storage is unavailable');
+    const task = makeRunningTask({ status: 'completed', completedAt: new Date(), result: { ok: true } });
+    const error = new Error('per-task callback failed');
+    await storage.createTask(task);
+    manager.registerTaskContext(task.id, {
+      executor: { execute: vi.fn() },
+      onComplete: async () => {
+        throw error;
+      },
+    });
+
+    try {
+      await manager.init(pubsub);
+      const ack = vi.fn(async () => {});
+      const event: Event = {
+        type: 'task.completed',
+        id: 'event-1',
+        data: { ...task, taskId: task.id },
+        runId: task.runId,
+        createdAt: new Date(),
+      };
+
+      await expect(pubsub.resultCallback!(event, ack)).rejects.toThrow(error);
+
+      expect(manager.taskContexts.has(task.id)).toBe(false);
+      expect(drainPending).toHaveBeenCalledOnce();
+      expect(ack).toHaveBeenCalledOnce();
+    } finally {
+      await manager.shutdown();
+      await pubsub.close();
+      await mastra.shutdown();
+      mastra.__unregisterHooks();
+    }
   });
 
   it('fails and acknowledges a claimed dispatch when Mastra is not registered', async () => {

--- a/packages/core/src/background-tasks/manager-lifecycle.test.ts
+++ b/packages/core/src/background-tasks/manager-lifecycle.test.ts
@@ -725,6 +725,32 @@ describe('BackgroundTaskManager lifecycle', () => {
     mastra.__unregisterHooks();
   });
 
+  it('logs storage failures while draining instead of rejecting', async () => {
+    const mastra = new Mastra({ logger: false, storage: new MockStore(), workers: false });
+    const warn = vi.spyOn(mastra.getLogger(), 'warn');
+    const manager = new BackgroundTaskManager({ enabled: true });
+    manager.__registerMastra(mastra);
+    const error = new Error('storage failed');
+    vi.spyOn(manager, 'getStorage').mockResolvedValue({
+      getTask: async () => {
+        throw error;
+      },
+    } as any);
+    (manager as any).localPendingTaskIds.add('task-1');
+
+    try {
+      await expect((manager as any).drainPending()).resolves.toBeUndefined();
+
+      expect(warn).toHaveBeenCalledWith('background-task queue drain failed:', error);
+      expect((manager as any).localPendingTaskIds.has('task-1')).toBe(true);
+      expect((manager as any).drainingPending).toBe(false);
+    } finally {
+      await manager.shutdown();
+      await mastra.shutdown();
+      mastra.__unregisterHooks();
+    }
+  });
+
   it('still restarts an explicitly restarted running task', async () => {
     const pubsub = new CapturingPubSub();
     const manager = new BackgroundTaskManager({ enabled: true });

--- a/packages/core/src/background-tasks/manager-unix-socket.test.ts
+++ b/packages/core/src/background-tasks/manager-unix-socket.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { UnixSocketPubSub } from '../events/unix-socket-pubsub';
+import { Mastra } from '../mastra';
+import { MockStore } from '../storage';
+import { BackgroundTaskManager } from './manager';
+
+describe('BackgroundTaskManager with UnixSocketPubSub', () => {
+  const managers: BackgroundTaskManager[] = [];
+  const mastras: Mastra[] = [];
+  const pubsubs: UnixSocketPubSub[] = [];
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    await Promise.allSettled(managers.splice(0).map(manager => manager.shutdown()));
+    await Promise.allSettled(pubsubs.splice(0).map(pubsub => pubsub.close()));
+    await Promise.allSettled(mastras.splice(0).map(mastra => mastra.stopWorkers()));
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('dispatches a task through UnixSocketPubSub', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'mastra-background-task-uds-'));
+    const pubsub = new UnixSocketPubSub(join(tempDir, 'events.sock'));
+    const storage = new MockStore();
+    const mastra = new Mastra({ logger: false, storage });
+    const manager = new BackgroundTaskManager({ enabled: true, defaultTimeoutMs: 5_000 });
+    pubsubs.push(pubsub);
+    mastras.push(mastra);
+    managers.push(manager);
+
+    manager.__registerMastra(mastra);
+    await mastra.startWorkers();
+    await manager.init(pubsub);
+
+    const execute = vi.fn().mockResolvedValue('unix-result');
+    manager.registerStaticExecutor('read-only-tool', { execute });
+    const { task } = await manager.enqueue({
+      toolName: 'read-only-tool',
+      toolCallId: 'call-1',
+      args: {},
+      agentId: 'agent-1',
+      runId: 'run-1',
+    });
+
+    await vi.waitFor(async () => {
+      await expect(manager.getTask(task.id)).resolves.toMatchObject({ status: 'completed', result: 'unix-result' });
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps invocation-bound executors on their originating manager', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'mastra-background-task-affinity-'));
+    const socketPath = join(tempDir, 'events.sock');
+    const storage = new MockStore();
+    const originMastra = new Mastra({ logger: false, storage });
+    const remoteMastra = new Mastra({ logger: false, storage });
+    const originPubsub = new UnixSocketPubSub(socketPath);
+    const remotePubsub = new UnixSocketPubSub(socketPath);
+    const originManager = new BackgroundTaskManager({ enabled: true, recoverStaleTasksOnStart: false });
+    const remoteManager = new BackgroundTaskManager({ enabled: true, recoverStaleTasksOnStart: false });
+    managers.push(originManager, remoteManager);
+    mastras.push(originMastra, remoteMastra);
+    pubsubs.push(originPubsub, remotePubsub);
+
+    originManager.__registerMastra(originMastra);
+    remoteManager.__registerMastra(remoteMastra);
+    await Promise.all([originMastra.startWorkers(), remoteMastra.startWorkers()]);
+    await Promise.all([originManager.init(originPubsub), remoteManager.init(remotePubsub)]);
+
+    const originExecute = vi.fn().mockResolvedValue('origin-result');
+    const remoteExecute = vi.fn().mockResolvedValue('remote-result');
+    remoteManager.registerStaticExecutor('read-only-tool', { execute: remoteExecute });
+
+    const { task } = await originManager.enqueue(
+      { toolName: 'read-only-tool', toolCallId: 'call-1', args: {}, agentId: 'agent-1', runId: 'run-1' },
+      { executor: { execute: originExecute } },
+    );
+
+    await vi.waitFor(async () => {
+      await expect(originManager.getTask(task.id)).resolves.toMatchObject({
+        status: 'completed',
+        result: 'origin-result',
+      });
+    });
+    expect(originExecute).toHaveBeenCalledTimes(1);
+    expect(remoteExecute).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/background-tasks/manager-unix-socket.test.ts
+++ b/packages/core/src/background-tasks/manager-unix-socket.test.ts
@@ -9,6 +9,8 @@ import { Mastra } from '../mastra';
 import { MockStore } from '../storage';
 import { BackgroundTaskManager } from './manager';
 
+const WAIT_TIMEOUT_MS = 10_000;
+
 describe('BackgroundTaskManager with UnixSocketPubSub', () => {
   const managers: BackgroundTaskManager[] = [];
   const mastras: Mastra[] = [];
@@ -49,9 +51,12 @@ describe('BackgroundTaskManager with UnixSocketPubSub', () => {
       runId: 'run-1',
     });
 
-    await vi.waitFor(async () => {
-      await expect(manager.getTask(task.id)).resolves.toMatchObject({ status: 'completed', result: 'unix-result' });
-    });
+    await vi.waitFor(
+      async () => {
+        await expect(manager.getTask(task.id)).resolves.toMatchObject({ status: 'completed', result: 'unix-result' });
+      },
+      { timeout: WAIT_TIMEOUT_MS },
+    );
     expect(execute).toHaveBeenCalledTimes(1);
   });
 
@@ -81,9 +86,12 @@ describe('BackgroundTaskManager with UnixSocketPubSub', () => {
       agentId: 'agent',
       runId: 'portable',
     });
-    await vi.waitFor(async () => {
-      expect(await producer.getTask(task.id)).toMatchObject({ status: 'completed', result: 'remote-result' });
-    });
+    await vi.waitFor(
+      async () => {
+        expect(await producer.getTask(task.id)).toMatchObject({ status: 'completed', result: 'remote-result' });
+      },
+      { timeout: WAIT_TIMEOUT_MS },
+    );
     expect(execute).toHaveBeenCalledTimes(1);
   });
 
@@ -115,12 +123,15 @@ describe('BackgroundTaskManager with UnixSocketPubSub', () => {
       { executor: { execute: originExecute } },
     );
 
-    await vi.waitFor(async () => {
-      await expect(originManager.getTask(task.id)).resolves.toMatchObject({
-        status: 'completed',
-        result: 'origin-result',
-      });
-    });
+    await vi.waitFor(
+      async () => {
+        await expect(originManager.getTask(task.id)).resolves.toMatchObject({
+          status: 'completed',
+          result: 'origin-result',
+        });
+      },
+      { timeout: WAIT_TIMEOUT_MS },
+    );
     expect(originExecute).toHaveBeenCalledTimes(1);
     expect(remoteExecute).not.toHaveBeenCalled();
   });

--- a/packages/core/src/background-tasks/manager-unix-socket.test.ts
+++ b/packages/core/src/background-tasks/manager-unix-socket.test.ts
@@ -55,6 +55,38 @@ describe('BackgroundTaskManager with UnixSocketPubSub', () => {
     expect(execute).toHaveBeenCalledTimes(1);
   });
 
+  it('executes a producer-only manager’s portable task on a remote static worker', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'mastra-background-task-portable-'));
+    const socketPath = join(tempDir, 'events.sock');
+    const storage = new MockStore();
+    const producerMastra = new Mastra({ logger: false, storage });
+    const workerMastra = new Mastra({ logger: false, storage });
+    const producerPubsub = new UnixSocketPubSub(socketPath);
+    const workerPubsub = new UnixSocketPubSub(socketPath);
+    const producer = new BackgroundTaskManager({ enabled: true, mode: 'producer', recoverStaleTasksOnStart: false });
+    const worker = new BackgroundTaskManager({ enabled: true, mode: 'worker', recoverStaleTasksOnStart: false });
+    managers.push(producer, worker);
+    mastras.push(producerMastra, workerMastra);
+    pubsubs.push(producerPubsub, workerPubsub);
+    producer.__registerMastra(producerMastra);
+    worker.__registerMastra(workerMastra);
+    await Promise.all([producerMastra.startWorkers(), workerMastra.startWorkers()]);
+    await Promise.all([producer.init(producerPubsub), worker.init(workerPubsub)]);
+    const execute = vi.fn().mockResolvedValue('remote-result');
+    worker.registerStaticExecutor('portable-tool', { execute });
+    const { task } = await producer.enqueue({
+      toolName: 'portable-tool',
+      toolCallId: 'portable',
+      args: {},
+      agentId: 'agent',
+      runId: 'portable',
+    });
+    await vi.waitFor(async () => {
+      expect(await producer.getTask(task.id)).toMatchObject({ status: 'completed', result: 'remote-result' });
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps invocation-bound executors on their originating manager', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'mastra-background-task-affinity-'));
     const socketPath = join(tempDir, 'events.sock');

--- a/packages/core/src/background-tasks/manager.test.ts
+++ b/packages/core/src/background-tasks/manager.test.ts
@@ -290,6 +290,67 @@ describe('BackgroundTaskManager', () => {
       resolvers.forEach(r => r());
     });
 
+    it('does not let abandoned shared running rows block process-affine tasks', async () => {
+      const backgroundTasksStore = await testStorage.getStore('backgroundTasks');
+      for (let i = 0; i < 3; i++) {
+        await backgroundTasksStore!.createTask({
+          id: `abandoned-${i}`,
+          status: 'running',
+          toolName: 'remote-tool',
+          toolCallId: `remote-call-${i}`,
+          args: {},
+          agentId: 'remote-agent',
+          runId: `remote-run-${i}`,
+          retryCount: 0,
+          maxRetries: 0,
+          timeoutMs: 5000,
+          createdAt: new Date(),
+          startedAt: new Date(),
+        });
+      }
+
+      const executeFn = vi.fn().mockResolvedValue('local-result');
+      const { task } = await manager.enqueue(
+        { toolName: 'local-tool', toolCallId: 'local-call', args: {}, agentId: 'local-agent', runId: 'local-run' },
+        ctx(executeFn),
+      );
+
+      await tick();
+      expect((await manager.getTask(task.id))?.status).toBe('completed');
+      expect(executeFn).toHaveBeenCalledOnce();
+    });
+
+    it('continues to apply persisted concurrency limits to portable tasks', async () => {
+      const backgroundTasksStore = await testStorage.getStore('backgroundTasks');
+      for (let i = 0; i < 3; i++) {
+        await backgroundTasksStore!.createTask({
+          id: `portable-blocker-${i}`,
+          status: 'running',
+          toolName: 'remote-tool',
+          toolCallId: `remote-call-${i}`,
+          args: {},
+          agentId: 'remote-agent',
+          runId: `remote-run-${i}`,
+          retryCount: 0,
+          maxRetries: 0,
+          timeoutMs: 5000,
+          createdAt: new Date(),
+          startedAt: new Date(),
+        });
+      }
+
+      const { task } = await manager.enqueue({
+        toolName: 'portable-tool',
+        toolCallId: 'portable-call',
+        args: {},
+        agentId: 'portable-agent',
+        runId: 'portable-run',
+      });
+
+      await tick();
+      expect((await manager.getTask(task.id))?.status).toBe('pending');
+    });
+
     it('backpressure reject throws on limit', async () => {
       const { mgr: rejectManager, cleanup } = await makeLocalManager({
         enabled: true,
@@ -622,6 +683,29 @@ describe('BackgroundTaskManager', () => {
       await cleanup();
     });
 
+    it('invokes onTaskCancelled callback', async () => {
+      const onCancelled = vi.fn();
+      const { mgr, cleanup } = await makeLocalManager({ enabled: true, onTaskCancelled: onCancelled });
+      const executeFn = vi.fn().mockImplementation(
+        (_args: any, opts: { abortSignal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            opts.abortSignal.addEventListener('abort', () => reject(new Error('Task cancelled')));
+          }),
+      );
+      const { task } = await mgr.enqueue(
+        { toolName: 'tool', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'run-1' },
+        ctx(executeFn),
+      );
+      await tick();
+
+      await mgr.cancel(task.id);
+      await tick();
+
+      expect(onCancelled).toHaveBeenCalledTimes(1);
+      expect(onCancelled.mock.calls[0]![0].status).toBe('cancelled');
+      await cleanup();
+    });
+
     it('invokes per-task onComplete callback', async () => {
       const onComplete = vi.fn();
       const executeFn = vi.fn().mockResolvedValue('ok');
@@ -908,6 +992,44 @@ describe('BackgroundTaskManager', () => {
   });
 
   describe('recovery on startup', () => {
+    it('leaves running tasks untouched when startup recovery is disabled', async () => {
+      const seedStorage = new MockStore();
+      const bgStore = await seedStorage.getStore('backgroundTasks');
+      const startedAt = new Date(Date.now() - 60_000);
+      await bgStore!.createTask({
+        id: 'live-elsewhere',
+        status: 'running',
+        toolName: 't',
+        toolCallId: 'c',
+        args: {},
+        agentId: 'a',
+        runId: 'r',
+        retryCount: 0,
+        maxRetries: 0,
+        timeoutMs: 5000,
+        createdAt: new Date(),
+        startedAt,
+      });
+
+      const local = new Mastra({
+        logger: false,
+        storage: seedStorage,
+        backgroundTasks: { enabled: true, recoverStaleTasksOnStart: false },
+      });
+      await local.startWorkers();
+
+      try {
+        await tick(150);
+        await expect(local.backgroundTaskManager!.getTask('live-elsewhere')).resolves.toMatchObject({
+          status: 'running',
+          startedAt,
+        });
+      } finally {
+        await local.backgroundTaskManager?.shutdown();
+        await local.stopWorkers();
+      }
+    });
+
     it('recovers stale running tasks with retries available', async () => {
       // Pre-seed storage with a task in 'running' status as if a previous
       // process crashed mid-execution. A fresh manager.init() should flip
@@ -1392,6 +1514,37 @@ describe('BackgroundTaskManager', () => {
       });
 
       // Complete the task — should get live completion event
+      resolver('late-result');
+      await tick();
+
+      const live = await reader.read();
+      expect(live.value).toMatchObject({
+        type: 'background-task-completed',
+        payload: { toolName: 'tool', result: 'late-result' },
+      });
+
+      abortController.abort();
+    });
+
+    it('can subscribe to live events without importing existing running tasks', async () => {
+      let resolver!: (val: string) => void;
+      await manager.enqueue(
+        { toolName: 'tool', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'run-1' },
+        ctx(
+          vi.fn().mockImplementation(
+            () =>
+              new Promise<string>(resolve => {
+                resolver = resolve;
+              }),
+          ),
+        ),
+      );
+      await tick();
+
+      const abortController = new AbortController();
+      const stream = manager.stream({ abortSignal: abortController.signal, includeExisting: false });
+      const reader = stream.getReader();
+
       resolver('late-result');
       await tick();
 

--- a/packages/core/src/background-tasks/manager.test.ts
+++ b/packages/core/src/background-tasks/manager.test.ts
@@ -77,6 +77,163 @@ describe('BackgroundTaskManager', () => {
     await backgroundTasksStore?.dangerouslyClearAll();
   });
 
+  describe('shared-storage ownership', () => {
+    it('releases resume reservations on publish failure and tolerates worker-start failure', async () => {
+      const local = await makeLocalManager({ enabled: true, globalConcurrency: 1, perAgentConcurrency: 1 });
+      const execute = vi.fn(async (_args, opts) => {
+        if (!opts.resumeData) return opts.suspend({ waiting: true });
+        return opts.resumeData;
+      });
+      try {
+        const { task } = await local.mgr.enqueue(
+          { toolName: 'agent-helper', toolCallId: 'suspend', args: {}, agentId: 'parent', runId: 'suspend' },
+          ctx(execute),
+        );
+        await vi.waitFor(async () => expect((await local.mgr.getTask(task.id))?.status).toBe('suspended'));
+        vi.spyOn(local.isolatedPubsub, 'publish').mockRejectedValueOnce(new Error('resume publish failed'));
+        await expect(local.mgr.resume(task.id, { ok: true })).rejects.toThrow('resume publish failed');
+        expect((await local.mgr.getTask(task.id))?.status).toBe('suspended');
+        const { task: next } = await local.mgr.enqueue(
+          { toolName: 'agent-helper', toolCallId: 'next', args: {}, agentId: 'parent', runId: 'next' },
+          ctx(async () => 'next'),
+        );
+        await vi.waitFor(async () => expect((await local.mgr.getTask(next.id))?.status).toBe('completed'));
+        vi.spyOn(local.localMastra, '__ensureExecutionWorkersStarted').mockRejectedValueOnce(
+          new Error('startup failed'),
+        );
+        await local.mgr.resume(task.id, { ok: true });
+        await vi.waitFor(async () =>
+          expect(await local.mgr.getTask(task.id)).toMatchObject({ status: 'completed', result: { ok: true } }),
+        );
+        expect(execute).toHaveBeenCalledTimes(2);
+      } finally {
+        await local.cleanup();
+      }
+    });
+
+    it('leaves another live manager’s running and queued invocation contexts untouched', async () => {
+      const config = { enabled: true, globalConcurrency: 1, perAgentConcurrency: 1, recoverStaleTasksOnStart: false };
+      const origin = await makeLocalManager(config);
+      let release!: () => void;
+      const gate = new Promise<void>(resolve => {
+        release = resolve;
+      });
+      const first = vi.fn(async () => {
+        await gate;
+        return 'request-A';
+      });
+      const second = vi.fn(async () => 'request-B');
+      let remote: Awaited<ReturnType<typeof makeLocalManager>> | undefined;
+      try {
+        const { task: running } = await origin.mgr.enqueue(
+          { toolName: 'agent-helper', toolCallId: 'a', args: {}, agentId: 'parent', runId: 'a' },
+          ctx(first),
+        );
+        await vi.waitFor(async () => expect((await origin.mgr.getTask(running.id))?.status).toBe('running'));
+        const { task: queued } = await origin.mgr.enqueue(
+          { toolName: 'agent-helper', toolCallId: 'b', args: {}, agentId: 'parent', runId: 'b' },
+          ctx(second),
+        );
+        remote = await makeLocalManager(config);
+        const remoteExecute = vi.fn(async () => 'remote');
+        const { task: remoteTask } = await remote.mgr.enqueue(
+          { toolName: 'agent-helper', toolCallId: 'c', args: {}, agentId: 'parent', runId: 'c' },
+          ctx(remoteExecute),
+        );
+        await vi.waitFor(async () => expect((await remote!.mgr.getTask(remoteTask.id))?.status).toBe('completed'));
+        expect((await origin.mgr.getTask(running.id))?.status).toBe('running');
+        expect((await origin.mgr.getTask(queued.id))?.status).toBe('pending');
+        expect(second).not.toHaveBeenCalled();
+        release();
+        await vi.waitFor(async () => {
+          expect(await origin.mgr.getTask(running.id)).toMatchObject({ status: 'completed', result: 'request-A' });
+          expect(await origin.mgr.getTask(queued.id)).toMatchObject({ status: 'completed', result: 'request-B' });
+        });
+        expect(first).toHaveBeenCalledTimes(1);
+        expect(second).toHaveBeenCalledTimes(1);
+        expect(remoteExecute).toHaveBeenCalledTimes(1);
+      } finally {
+        release();
+        await origin.cleanup();
+        await remote?.cleanup();
+      }
+    });
+
+    it('preserves a claimed invocation when publication reports failure after delivery', async () => {
+      const local = await makeLocalManager({ enabled: true, globalConcurrency: 1, perAgentConcurrency: 1 });
+      let release!: () => void;
+      const gate = new Promise<void>(resolve => {
+        release = resolve;
+      });
+      let started!: () => void;
+      const executing = new Promise<void>(resolve => {
+        started = resolve;
+      });
+      const publish = local.isolatedPubsub.publish.bind(local.isolatedPubsub);
+      vi.spyOn(local.isolatedPubsub, 'publish').mockImplementationOnce(async (...args) => {
+        await publish(...args);
+        await executing;
+        throw new Error('acknowledgement lost');
+      });
+      try {
+        await expect(
+          local.mgr.enqueue(
+            { toolName: 'agent-helper', toolCallId: 'claimed', args: {}, agentId: 'parent', runId: 'claimed' },
+            ctx(async () => {
+              started();
+              await gate;
+              return 'claimed';
+            }),
+          ),
+        ).rejects.toThrow('acknowledgement lost');
+        const { task: queued } = await local.mgr.enqueue(
+          { toolName: 'agent-helper', toolCallId: 'queued', args: {}, agentId: 'parent', runId: 'queued' },
+          ctx(async () => 'queued'),
+        );
+        expect((await local.mgr.getTask(queued.id))?.status).toBe('pending');
+        release();
+        await vi.waitFor(async () => {
+          expect((await local.mgr.listTasks({ runId: 'claimed' })).tasks[0]).toMatchObject({
+            status: 'completed',
+            result: 'claimed',
+          });
+          expect(await local.mgr.getTask(queued.id)).toMatchObject({ status: 'completed', result: 'queued' });
+        });
+      } finally {
+        release();
+        await local.cleanup();
+      }
+    });
+
+    it('cleans up an invocation when dispatch publication rejects and allows the next enqueue', async () => {
+      const local = await makeLocalManager({ enabled: true, globalConcurrency: 1, perAgentConcurrency: 1 });
+      const execute = vi.fn(async () => 'next');
+      const deregister = vi.spyOn(local.mgr, 'deregisterTaskContext');
+      const publish = vi.spyOn(local.isolatedPubsub, 'publish').mockRejectedValueOnce(new Error('publish failed'));
+      try {
+        await expect(
+          local.mgr.enqueue(
+            { toolName: 'agent-helper', toolCallId: 'failed', args: {}, agentId: 'parent', runId: 'failed' },
+            ctx(execute),
+          ),
+        ).rejects.toThrow('publish failed');
+        const { tasks } = await local.mgr.listTasks({ runId: 'failed' });
+        expect(tasks).toHaveLength(1);
+        expect(tasks[0]?.status).toBe('failed');
+        expect(deregister).toHaveBeenCalledWith(tasks[0]!.id);
+        const { task } = await local.mgr.enqueue(
+          { toolName: 'agent-helper', toolCallId: 'next', args: {}, agentId: 'parent', runId: 'next' },
+          ctx(execute),
+        );
+        await vi.waitFor(async () => expect((await local.mgr.getTask(task.id))?.status).toBe('completed'));
+        expect(execute).toHaveBeenCalledTimes(1);
+      } finally {
+        publish.mockRestore();
+        await local.cleanup();
+      }
+    });
+  });
+
   describe('enqueue and execute', () => {
     it('enqueues a task, executes it, and completes', async () => {
       const executeFn = vi.fn().mockResolvedValue({ data: 'hello' });

--- a/packages/core/src/background-tasks/manager.test.ts
+++ b/packages/core/src/background-tasks/manager.test.ts
@@ -79,7 +79,12 @@ describe('BackgroundTaskManager', () => {
 
   describe('shared-storage ownership', () => {
     it('releases resume reservations on publish failure and tolerates worker-start failure', async () => {
-      const local = await makeLocalManager({ enabled: true, globalConcurrency: 1, perAgentConcurrency: 1 });
+      const local = await makeLocalManager({
+        enabled: true,
+        globalConcurrency: 1,
+        perAgentConcurrency: 1,
+        recoverStaleTasksOnStart: false,
+      });
       const execute = vi.fn(async (_args, opts) => {
         if (!opts.resumeData) return opts.suspend({ waiting: true });
         return opts.resumeData;
@@ -160,7 +165,12 @@ describe('BackgroundTaskManager', () => {
     });
 
     it('preserves a claimed invocation when publication reports failure after delivery', async () => {
-      const local = await makeLocalManager({ enabled: true, globalConcurrency: 1, perAgentConcurrency: 1 });
+      const local = await makeLocalManager({
+        enabled: true,
+        globalConcurrency: 1,
+        perAgentConcurrency: 1,
+        recoverStaleTasksOnStart: false,
+      });
       let release!: () => void;
       const gate = new Promise<void>(resolve => {
         release = resolve;
@@ -206,7 +216,12 @@ describe('BackgroundTaskManager', () => {
     });
 
     it('cleans up an invocation when dispatch publication rejects and allows the next enqueue', async () => {
-      const local = await makeLocalManager({ enabled: true, globalConcurrency: 1, perAgentConcurrency: 1 });
+      const local = await makeLocalManager({
+        enabled: true,
+        globalConcurrency: 1,
+        perAgentConcurrency: 1,
+        recoverStaleTasksOnStart: false,
+      });
       const execute = vi.fn(async () => 'next');
       const deregister = vi.spyOn(local.mgr, 'deregisterTaskContext');
       const publish = vi.spyOn(local.isolatedPubsub, 'publish').mockRejectedValueOnce(new Error('publish failed'));
@@ -849,18 +864,55 @@ describe('BackgroundTaskManager', () => {
             opts.abortSignal.addEventListener('abort', () => reject(new Error('Task cancelled')));
           }),
       );
-      const { task } = await mgr.enqueue(
-        { toolName: 'tool', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'run-1' },
-        ctx(executeFn),
+
+      try {
+        const { task } = await mgr.enqueue(
+          { toolName: 'tool', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'run-1' },
+          ctx(executeFn),
+        );
+        await tick();
+
+        await mgr.cancel(task.id);
+        await tick();
+
+        expect(onCancelled).toHaveBeenCalledTimes(1);
+        expect(onCancelled.mock.calls[0]![0].status).toBe('cancelled');
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('continues cancellation when onTaskCancelled rejects', async () => {
+      const callbackError = new Error('callback failed');
+      const onCancelled = vi.fn().mockRejectedValue(callbackError);
+      const { mgr, cleanup, localMastra } = await makeLocalManager({ enabled: true, onTaskCancelled: onCancelled });
+      const warn = vi.spyOn(localMastra.getLogger(), 'warn');
+      const executeFn = vi.fn().mockImplementation(
+        (_args: any, opts: { abortSignal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            opts.abortSignal.addEventListener('abort', () => reject(new Error('Task cancelled')));
+          }),
       );
-      await tick();
 
-      await mgr.cancel(task.id);
-      await tick();
+      try {
+        const { task } = await mgr.enqueue(
+          { toolName: 'tool', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'run-1' },
+          ctx(executeFn),
+        );
+        await tick();
 
-      expect(onCancelled).toHaveBeenCalledTimes(1);
-      expect(onCancelled.mock.calls[0]![0].status).toBe('cancelled');
-      await cleanup();
+        await expect(mgr.cancel(task.id)).resolves.toBeUndefined();
+        await tick();
+
+        expect(onCancelled).toHaveBeenCalledOnce();
+        expect(warn).toHaveBeenCalledWith(
+          `background-task cancellation callback failed for ${task.id}:`,
+          callbackError,
+        );
+        expect(mgr.taskContexts.has(task.id)).toBe(false);
+      } finally {
+        await cleanup();
+      }
     });
 
     it('invokes per-task onComplete callback', async () => {

--- a/packages/core/src/background-tasks/manager.ts
+++ b/packages/core/src/background-tasks/manager.ts
@@ -24,8 +24,13 @@ const SHUTDOWN_ABORT_MESSAGE = 'Background task manager is shutting down';
 
 export class BackgroundTaskManager {
   private pubsub!: PubSub;
+  private readonly workerId = randomUUID();
+  private readonly processAffineDispatchTopic = `${TOPIC_DISPATCH}:${this.workerId}`;
   config: Required<
-    Pick<BackgroundTaskManagerConfig, 'globalConcurrency' | 'perAgentConcurrency' | 'backpressure' | 'defaultTimeoutMs'>
+    Pick<
+      BackgroundTaskManagerConfig,
+      'globalConcurrency' | 'perAgentConcurrency' | 'backpressure' | 'defaultTimeoutMs' | 'recoverStaleTasksOnStart'
+    >
   > &
     BackgroundTaskManagerConfig;
 
@@ -45,6 +50,17 @@ export class BackgroundTaskManager {
   // Track active AbortControllers for running tasks (for cancellation + timeout)
   /** @internal — read by the workflow-engine step bodies in workflow.ts */
   activeAbortControllers: Map<string, AbortController> = new Map();
+
+  // Process-affine executors are runtime closures and cannot participate in
+  // storage-wide concurrency accounting without persisted ownership/leases.
+  // Keep their admission and queue ownership local to the manager that owns
+  // the closure so abandoned rows from another process cannot block them.
+  // TODO: Replace this POC boundary with persisted ownership, leases,
+  // heartbeats, atomic claims, and fenced terminal writes before treating
+  // process-affine work as recoverable across worker crashes.
+  private localReservations = new Map<string, string>();
+  private localPendingTaskIds = new Set<string>();
+  private drainingPending = false;
 
   // Pubsub callbacks (kept for unsubscribe)
   private workerCallback?: EventCallback;
@@ -79,6 +95,7 @@ export class BackgroundTaskManager {
       perAgentConcurrency: config.perAgentConcurrency ?? 5,
       backpressure: config.backpressure ?? 'queue',
       defaultTimeoutMs: config.defaultTimeoutMs ?? 300_000,
+      recoverStaleTasksOnStart: config.recoverStaleTasksOnStart ?? true,
       ...config,
     };
   }
@@ -168,9 +185,20 @@ export class BackgroundTaskManager {
       }
 
       await this.pubsub.subscribe(TOPIC_DISPATCH, this.workerCallback, { group: WORKER_GROUP });
+      await this.pubsub.subscribe(this.processAffineDispatchTopic, this.workerCallback);
+
       if (this.shuttingDown) {
-        await this.#releaseLateInitSubscriptions([[TOPIC_DISPATCH, this.workerCallback]]);
+        await this.#releaseLateInitSubscriptions([
+          [TOPIC_DISPATCH, this.workerCallback],
+          [this.processAffineDispatchTopic, this.workerCallback],
+        ]);
         return;
+      }
+
+      if (this.config.recoverStaleTasksOnStart) {
+        // Recover stale tasks from a previous process — only workers should
+        // attempt recovery since they own execution.
+        await this.recoverStaleTasks();
       }
     }
 
@@ -183,12 +211,6 @@ export class BackgroundTaskManager {
       lateSubscriptions.push([TOPIC_RESULT, this.resultCallback]);
       await this.#releaseLateInitSubscriptions(lateSubscriptions);
       return;
-    }
-
-    if (!isProducerOnly) {
-      // Recover stale tasks from a previous process — only workers should
-      // attempt recovery since they own execution.
-      await this.recoverStaleTasks();
     }
 
     // Start periodic cleanup if configured
@@ -305,10 +327,16 @@ export class BackgroundTaskManager {
     const storage = await this.getStorage();
     await storage.createTask(task);
 
-    const canRun = await this.checkConcurrency(task.agentId);
+    const isProcessAffine = Boolean(context);
+    const canRun = isProcessAffine ? this.reserveLocalSlot(task) : await this.checkConcurrency(task.agentId);
 
     if (canRun) {
-      await this.dispatch(task);
+      try {
+        await this.dispatch(task);
+      } catch (error) {
+        if (isProcessAffine) this.releaseLocalSlot(task.id);
+        throw error;
+      }
       return { task };
     }
 
@@ -326,7 +354,10 @@ export class BackgroundTaskManager {
 
       case 'queue':
       default:
-        // Task stays pending in storage, will be dispatched when a slot opens
+        // Queue ownership stays local. A persisted pending row does not carry
+        // enough information to distinguish an invocation-bound closure from
+        // a portable static executor in another process.
+        this.localPendingTaskIds.add(task.id);
         return { task };
     }
   }
@@ -350,6 +381,7 @@ export class BackgroundTaskManager {
       }
 
       const previousStatus = task.status;
+      const isProcessAffine = this.taskContexts.has(taskId);
       const cancelled = await storage.updateTask(
         taskId,
         { status: 'cancelled', completedAt: new Date() },
@@ -359,6 +391,11 @@ export class BackgroundTaskManager {
         task = await storage.getTask(taskId);
         if (!task) return;
         continue;
+      }
+
+      if (previousStatus === 'pending') {
+        this.localPendingTaskIds.delete(taskId);
+        this.releaseLocalSlot(taskId);
       }
 
       if (previousStatus === 'running') {
@@ -385,12 +422,16 @@ export class BackgroundTaskManager {
       }
 
       const cancelledTask = await storage.getTask(taskId);
-      if (cancelledTask) await this.publishLifecycleEvent('task.cancelled', cancelledTask);
+      if (cancelledTask) {
+        await this.publishLifecycleEvent('task.cancelled', cancelledTask);
+        await this.config.onTaskCancelled?.(cancelledTask);
+      }
       this.deregisterTaskContext(taskId);
 
       if (previousStatus === 'running') {
-        // Also publish cancel on dispatch topic for distributed worker abort
-        await this.pubsub.publish(TOPIC_DISPATCH, {
+        // Route cancellation to the same process that owns an invocation-bound executor.
+        const dispatchTopic = isProcessAffine ? this.processAffineDispatchTopic : TOPIC_DISPATCH;
+        await this.pubsub.publish(dispatchTopic, {
           type: 'task.cancel',
           data: { taskId },
           runId: taskId,
@@ -428,7 +469,8 @@ export class BackgroundTaskManager {
       throw new Error(`Cannot resume task in status '${task.status}' (expected 'suspended')`);
     }
 
-    const canRun = await this.checkConcurrency(task.agentId);
+    const isProcessAffine = this.taskContexts.has(taskId);
+    const canRun = isProcessAffine ? this.reserveLocalSlot(task) : await this.checkConcurrency(task.agentId);
     if (!canRun) {
       // Resume sits outside the queue/fallback-sync paths — there's no
       // synchronous caller to fall back to, and silently leaving the task
@@ -441,15 +483,19 @@ export class BackgroundTaskManager {
     // lazy worker start for the library-mode process-restart case.
     await this.#ensureExecutionWorkersStarted();
 
-    // Hand off to the worker subscriber. `task.resume` rides the same
-    // `TOPIC_DISPATCH` + `WORKER_GROUP` exactly-once channel as
-    // `task.dispatch`, so any worker (including a different process from
-    // the one that suspended the task) can pick it up.
-    await this.pubsub.publish(TOPIC_DISPATCH, {
-      type: 'task.resume',
-      data: { taskId, resumeData },
-      runId: taskId,
-    });
+    // Resume invocation-bound executors on their owning manager. A task
+    // without local context remains portable through the shared worker group.
+    const dispatchTopic = isProcessAffine ? this.processAffineDispatchTopic : TOPIC_DISPATCH;
+    try {
+      await this.pubsub.publish(dispatchTopic, {
+        type: 'task.resume',
+        data: { taskId, resumeData },
+        runId: taskId,
+      });
+    } catch (error) {
+      if (isProcessAffine) this.releaseLocalSlot(taskId);
+      throw error;
+    }
 
     return task;
   }
@@ -484,7 +530,8 @@ export class BackgroundTaskManager {
       this.registerTaskContext(task.id, context);
     }
 
-    const canRun = await this.checkConcurrency(task.agentId);
+    const isProcessAffine = this.taskContexts.has(taskId);
+    const canRun = isProcessAffine ? this.reserveLocalSlot(task) : await this.checkConcurrency(task.agentId);
     if (!canRun) {
       // Restart sits outside the queue/fallback-sync paths — there's no
       // synchronous caller to fall back to, and silently leaving the task
@@ -493,7 +540,12 @@ export class BackgroundTaskManager {
       throw new Error(`Concurrency limit reached, cannot restart task "${taskId}" — retry once a slot is available`);
     }
 
-    await this.dispatch(task, true);
+    try {
+      await this.dispatch(task, true);
+    } catch (error) {
+      if (isProcessAffine) this.releaseLocalSlot(taskId);
+      throw error;
+    }
 
     return task;
   }
@@ -611,10 +663,11 @@ export class BackgroundTaskManager {
     resourceId?: string;
     taskId?: string;
     abortSignal?: AbortSignal;
+    includeExisting?: boolean;
   }): ReadableStream<Record<string, unknown>> {
     const manager = this;
     const pubsub = this.pubsub;
-    const { agentId, runId, threadId, resourceId, abortSignal, taskId } = options ?? {};
+    const { agentId, runId, threadId, resourceId, abortSignal, taskId, includeExisting = true } = options ?? {};
 
     const EVENT_STATUS_MAP: Record<string, BackgroundTaskStatus> = {
       'task.running': 'running',
@@ -698,18 +751,24 @@ export class BackgroundTaskManager {
           }
         };
 
-        void pubsub.subscribe(TOPIC_RESULT, handler);
+        await pubsub.subscribe(TOPIC_RESULT, handler);
 
-        abortSignal?.addEventListener('abort', () => {
+        const close = () => {
           void pubsub.unsubscribe(TOPIC_RESULT, handler);
           try {
             controller.close();
           } catch {
             // Already closed
           }
-        });
+        };
+        if (abortSignal?.aborted) {
+          close();
+          return;
+        }
+        abortSignal?.addEventListener('abort', close, { once: true });
 
         // 2. Emit snapshot of existing in-flight tasks (running + suspended).
+        if (!includeExisting) return;
         try {
           const storage = await manager.getStorage();
           if (taskId) {
@@ -815,7 +874,10 @@ export class BackgroundTaskManager {
     }
 
     const subscriptions: Array<[string, EventCallback]> = [];
-    if (this.workerCallback) subscriptions.push([TOPIC_DISPATCH, this.workerCallback]);
+    if (this.workerCallback) {
+      subscriptions.push([TOPIC_DISPATCH, this.workerCallback]);
+      subscriptions.push([this.processAffineDispatchTopic, this.workerCallback]);
+    }
     if (this.resultCallback) subscriptions.push([TOPIC_RESULT, this.resultCallback]);
     const unsubscribeResults = await this.#waitForShutdownStep(
       'background task subscription cleanup',
@@ -838,6 +900,8 @@ export class BackgroundTaskManager {
     this.#abortActiveControllers();
 
     this.taskContexts.clear();
+    this.localReservations.clear();
+    this.localPendingTaskIds.clear();
     this.staticExecutors.clear();
     if (this.initPromise) {
       await this.#waitForShutdownStep('background task pubsub flush', this.pubsub.flush());
@@ -953,10 +1017,11 @@ export class BackgroundTaskManager {
     if (this.shuttingDown) return;
     await this.#ensureExecutionWorkersStarted();
 
-    // Publish `task.dispatch` on `TOPIC_DISPATCH` with `WORKER_GROUP`, so
-    // exactly one worker handles the task. `handleDispatch` flips the
-    // task to running and starts the per-task workflow run.
-    await this.pubsub.publish(TOPIC_DISPATCH, {
+    // Invocation-bound executors are closures owned by this manager and cannot
+    // run in another process. Static executors remain portable and use the
+    // shared competing-consumer topic.
+    const dispatchTopic = this.taskContexts.has(task.id) ? this.processAffineDispatchTopic : TOPIC_DISPATCH;
+    await this.pubsub.publish(dispatchTopic, {
       type: 'task.dispatch',
       data: {
         taskId: task.id,
@@ -989,6 +1054,7 @@ export class BackgroundTaskManager {
     const task = await storage.getTask(taskId);
     if (this.shuttingDown) return false;
     if (!task || task.status === 'cancelled') {
+      this.releaseLocalSlot(taskId);
       this.deregisterTaskContext(taskId);
       return true;
     }
@@ -1026,7 +1092,12 @@ export class BackgroundTaskManager {
     // Fire-and-forget the workflow run; the workflow step body owns
     // executor invocation, retries, and suspend/resume. The local
     // execution hook still runs here so callers see `onExecution` fire.
-    if (this.#mastra) {
+    if (!this.#mastra) {
+      this.releaseLocalSlot(taskId);
+      return false;
+    }
+
+    try {
       if (runningTask) void this.runLocalExecutionHook(runningTask);
       const workflow = this.#mastra.__getInternalWorkflow(BACKGROUND_TASK_WORKFLOW_ID);
       const prevWorkflowRun = isRestart ? await workflow.getWorkflowRunById(taskId) : undefined;
@@ -1047,9 +1118,19 @@ export class BackgroundTaskManager {
             ?.error(`background-task workflow ${shouldRestart ? 'restart' : 'start'} failed for ${taskId}:`, err);
         })
         .finally(() => {
-          // Free the concurrency slot once the run terminates.
+          this.releaseLocalSlot(taskId);
           void this.drainPending();
         });
+    } catch (error) {
+      this.releaseLocalSlot(taskId);
+      await storage.updateTask(taskId, {
+        status: 'failed',
+        error: { message: error instanceof Error ? error.message : String(error) },
+        completedAt: new Date(),
+      });
+      const failedTask = await storage.getTask(taskId);
+      if (failedTask) await this.publishLifecycleEvent('task.failed', failedTask);
+      void this.drainPending();
     }
     return true;
   }
@@ -1108,7 +1189,7 @@ export class BackgroundTaskManager {
         this.#mastra?.getLogger?.()?.error(`background-task workflow resume failed for ${taskId}:`, err);
       })
       .finally(() => {
-        // Mirror dispatch's drain — resuming frees a slot when it terminates.
+        this.releaseLocalSlot(taskId);
         void this.drainPending();
       });
     return true;
@@ -1333,8 +1414,11 @@ export class BackgroundTaskManager {
         }
       }
 
-      // Clean up context after terminal result
+      // Clean up context after terminal result and admit the next task owned
+      // by this manager. Portable tasks may have completed on another process,
+      // so the result fan-out is the origin manager's queue-drain signal.
       this.deregisterTaskContext(taskId);
+      void this.drainPending();
     }
   }
 
@@ -1383,6 +1467,24 @@ export class BackgroundTaskManager {
     });
   }
 
+  private reserveLocalSlot(task: Pick<BackgroundTask, 'id' | 'agentId'>): boolean {
+    if (this.localReservations.has(task.id)) return true;
+    if (this.localReservations.size >= this.config.globalConcurrency) return false;
+
+    let agentRunning = 0;
+    for (const agentId of this.localReservations.values()) {
+      if (agentId === task.agentId) agentRunning++;
+    }
+    if (agentRunning >= this.config.perAgentConcurrency) return false;
+
+    this.localReservations.set(task.id, task.agentId);
+    return true;
+  }
+
+  private releaseLocalSlot(taskId: string): void {
+    this.localReservations.delete(taskId);
+  }
+
   private async checkConcurrency(agentId: string): Promise<boolean> {
     const storage = await this.getStorage();
     const globalRunning = await storage.getRunningCount();
@@ -1399,18 +1501,33 @@ export class BackgroundTaskManager {
   }
 
   private async drainPending(): Promise<void> {
-    if (this.shuttingDown) return;
-    const storage = await this.getStorage();
-    const { tasks: pending } = await storage.listTasks({
-      status: 'pending',
-      orderBy: 'createdAt',
-      orderDirection: 'asc',
-    });
+    if (this.drainingPending || this.shuttingDown) return;
+    this.drainingPending = true;
 
-    for (const task of pending) {
-      if (await this.checkConcurrency(task.agentId)) {
-        await this.dispatch(task);
+    try {
+      const storage = await this.getStorage();
+      for (const taskId of [...this.localPendingTaskIds]) {
+        const task = await storage.getTask(taskId);
+        if (!task || task.status !== 'pending') {
+          this.localPendingTaskIds.delete(taskId);
+          continue;
+        }
+
+        const isProcessAffine = this.taskContexts.has(taskId);
+        const canRun = isProcessAffine ? this.reserveLocalSlot(task) : await this.checkConcurrency(task.agentId);
+        if (!canRun) continue;
+
+        this.localPendingTaskIds.delete(taskId);
+        try {
+          await this.dispatch(task);
+        } catch (error) {
+          if (isProcessAffine) this.releaseLocalSlot(taskId);
+          this.localPendingTaskIds.add(taskId);
+          throw error;
+        }
       }
+    } finally {
+      this.drainingPending = false;
     }
   }
 

--- a/packages/core/src/background-tasks/manager.ts
+++ b/packages/core/src/background-tasks/manager.ts
@@ -91,12 +91,12 @@ export class BackgroundTaskManager {
 
   constructor(config: BackgroundTaskManagerConfig = { enabled: false }) {
     this.config = {
+      ...config,
       globalConcurrency: config.globalConcurrency ?? 10,
       perAgentConcurrency: config.perAgentConcurrency ?? 5,
       backpressure: config.backpressure ?? 'queue',
       defaultTimeoutMs: config.defaultTimeoutMs ?? 300_000,
       recoverStaleTasksOnStart: config.recoverStaleTasksOnStart ?? true,
-      ...config,
     };
   }
 
@@ -205,9 +205,12 @@ export class BackgroundTaskManager {
     await this.pubsub.subscribe(TOPIC_RESULT, this.resultCallback);
     if (this.shuttingDown) {
       // Producer mode never registers a worker callback, so only include the
-      // dispatch subscription when it actually exists.
+      // dispatch subscriptions when they actually exist.
       const lateSubscriptions: Array<[string, EventCallback]> = [];
-      if (this.workerCallback) lateSubscriptions.push([TOPIC_DISPATCH, this.workerCallback]);
+      if (this.workerCallback) {
+        lateSubscriptions.push([TOPIC_DISPATCH, this.workerCallback]);
+        lateSubscriptions.push([this.processAffineDispatchTopic, this.workerCallback]);
+      }
       lateSubscriptions.push([TOPIC_RESULT, this.resultCallback]);
       await this.#releaseLateInitSubscriptions(lateSubscriptions);
       return;
@@ -437,7 +440,13 @@ export class BackgroundTaskManager {
       const cancelledTask = await storage.getTask(taskId);
       if (cancelledTask) {
         await this.publishLifecycleEvent('task.cancelled', cancelledTask);
-        await this.config.onTaskCancelled?.(cancelledTask);
+        try {
+          await this.config.onTaskCancelled?.(cancelledTask);
+        } catch (error) {
+          this.#mastra
+            ?.getLogger?.()
+            ?.warn(`background-task cancellation callback failed for ${taskId}:`, error as any);
+        }
       }
       this.deregisterTaskContext(taskId);
 
@@ -1107,7 +1116,21 @@ export class BackgroundTaskManager {
     // execution hook still runs here so callers see `onExecution` fire.
     if (!this.#mastra) {
       this.releaseLocalSlot(taskId);
-      return false;
+      const markedFailed = await storage.updateTask(
+        taskId,
+        {
+          status: 'failed',
+          error: { message: 'Mastra is not registered with this background task manager' },
+          completedAt: new Date(),
+        },
+        { expectedStatus: 'running' },
+      );
+      if (markedFailed) {
+        const failedTask = await storage.getTask(taskId);
+        if (failedTask?.status === 'failed') await this.publishLifecycleEvent('task.failed', failedTask);
+      }
+      void this.drainPending();
+      return true;
     }
 
     try {
@@ -1136,13 +1159,19 @@ export class BackgroundTaskManager {
         });
     } catch (error) {
       this.releaseLocalSlot(taskId);
-      await storage.updateTask(taskId, {
-        status: 'failed',
-        error: { message: error instanceof Error ? error.message : String(error) },
-        completedAt: new Date(),
-      });
-      const failedTask = await storage.getTask(taskId);
-      if (failedTask) await this.publishLifecycleEvent('task.failed', failedTask);
+      const markedFailed = await storage.updateTask(
+        taskId,
+        {
+          status: 'failed',
+          error: { message: error instanceof Error ? error.message : String(error) },
+          completedAt: new Date(),
+        },
+        { expectedStatus: 'running' },
+      );
+      if (markedFailed) {
+        const failedTask = await storage.getTask(taskId);
+        if (failedTask?.status === 'failed') await this.publishLifecycleEvent('task.failed', failedTask);
+      }
       void this.drainPending();
     }
     return true;
@@ -1167,6 +1196,8 @@ export class BackgroundTaskManager {
       // Either gone or already resumed/cancelled by another worker. Drop the
       // event silently — the worker group ensures exactly-once delivery, but
       // the task may have moved on between publish and pickup.
+      this.releaseLocalSlot(taskId);
+      void this.drainPending();
       return true;
     }
 
@@ -1180,13 +1211,21 @@ export class BackgroundTaskManager {
       },
       { expectedStatus: 'suspended' },
     );
-    if (!resumed) return true;
+    if (!resumed) {
+      this.releaseLocalSlot(taskId);
+      void this.drainPending();
+      return true;
+    }
     const resumedTask = await storage.getTask(taskId);
     if (resumedTask) {
       await this.publishLifecycleEvent('task.resumed', resumedTask);
     }
 
-    if (!this.#mastra) return true;
+    if (!this.#mastra) {
+      this.releaseLocalSlot(taskId);
+      void this.drainPending();
+      return true;
+    }
     const workflow = this.#mastra.__getInternalWorkflow(BACKGROUND_TASK_WORKFLOW_ID);
     // `createRun({ runId })` reattaches to the existing snapshot when given a
     // stable runId — we don't want a fresh run.
@@ -1536,7 +1575,8 @@ export class BackgroundTaskManager {
         } catch (error) {
           if (isProcessAffine) this.releaseLocalSlot(taskId);
           this.localPendingTaskIds.add(taskId);
-          throw error;
+          this.#mastra?.getLogger?.()?.warn(`background-task dispatch failed while draining ${taskId}:`, error as any);
+          return;
         }
       }
     } finally {

--- a/packages/core/src/background-tasks/manager.ts
+++ b/packages/core/src/background-tasks/manager.ts
@@ -1602,6 +1602,8 @@ export class BackgroundTaskManager {
           return;
         }
       }
+    } catch (error) {
+      this.#mastra?.getLogger?.()?.warn('background-task queue drain failed:', error as any);
     } finally {
       this.drainingPending = false;
     }

--- a/packages/core/src/background-tasks/manager.ts
+++ b/packages/core/src/background-tasks/manager.ts
@@ -334,7 +334,20 @@ export class BackgroundTaskManager {
       try {
         await this.dispatch(task);
       } catch (error) {
-        if (isProcessAffine) this.releaseLocalSlot(task.id);
+        const failed = await storage.updateTask(
+          task.id,
+          {
+            status: 'failed',
+            error: { message: error instanceof Error ? error.message : String(error) },
+            completedAt: new Date(),
+          },
+          { expectedStatus: 'pending' },
+        );
+        if (failed) {
+          this.releaseLocalSlot(task.id);
+          this.deregisterTaskContext(task.id);
+          void this.drainPending();
+        }
         throw error;
       }
       return { task };

--- a/packages/core/src/background-tasks/manager.ts
+++ b/packages/core/src/background-tasks/manager.ts
@@ -135,7 +135,12 @@ export class BackgroundTaskManager {
     // to receive completion/failure notifications for dispatched tasks.
     this.resultCallback = async (event: Event, ack?: () => Promise<void>) => {
       if (event.type === 'task.completed' || event.type === 'task.failed') {
-        await this.handleResult(event);
+        try {
+          await this.handleResult(event);
+        } finally {
+          await ack?.();
+        }
+        return;
       }
       await ack?.();
     };
@@ -1396,10 +1401,12 @@ export class BackgroundTaskManager {
     const storage = await this.getStorage();
     const task = await storage.getTask(taskId);
 
-    if (task?.completedAt) {
-      // Look up per-task hooks
-      const ctx = this.taskContexts.get(taskId);
+    if (!task?.completedAt) return;
 
+    // Look up per-task hooks
+    const ctx = this.taskContexts.get(taskId);
+
+    try {
       if (event.type === 'task.completed') {
         ctx?.onChunk?.({
           type: 'background-task-completed',
@@ -1428,9 +1435,18 @@ export class BackgroundTaskManager {
           startedAt: task.startedAt!,
         });
 
-        if (task) {
-          await Promise.all([ctx?.onComplete?.(task), this.config.onTaskComplete?.(task)]);
-        }
+        await Promise.all([
+          ctx?.onComplete?.(task),
+          (async () => {
+            try {
+              await this.config.onTaskComplete?.(task);
+            } catch (error) {
+              this.#mastra
+                ?.getLogger?.()
+                ?.warn(`background-task completion callback failed for ${taskId}:`, error as any);
+            }
+          })(),
+        ]);
       }
 
       if (event.type === 'task.failed') {
@@ -1461,11 +1477,18 @@ export class BackgroundTaskManager {
           startedAt: task.startedAt!,
         });
 
-        if (task) {
-          await Promise.all([ctx?.onFailed?.(task), this.config.onTaskFailed?.(task)]);
-        }
+        await Promise.all([
+          ctx?.onFailed?.(task),
+          (async () => {
+            try {
+              await this.config.onTaskFailed?.(task);
+            } catch (error) {
+              this.#mastra?.getLogger?.()?.warn(`background-task failure callback failed for ${taskId}:`, error as any);
+            }
+          })(),
+        ]);
       }
-
+    } finally {
       // Clean up context after terminal result and admit the next task owned
       // by this manager. Portable tasks may have completed on another process,
       // so the result fan-out is the origin manager's queue-drain signal.

--- a/packages/core/src/background-tasks/types.ts
+++ b/packages/core/src/background-tasks/types.ts
@@ -185,6 +185,12 @@ export interface BackgroundTaskManagerConfig {
   /** Cleanup configuration for old task records */
   cleanup?: CleanupConfig;
   /**
+   * Whether to recover running and pending tasks during manager startup.
+   * Disable this when multiple live managers share storage until recovery can
+   * be fenced by persisted worker ownership and leases. Default: true.
+   */
+  recoverStaleTasksOnStart?: boolean;
+  /**
    * Minimum delay between chunk-based progress output events for each task, in ms.
    * Default: undefined (publish every progress chunk).
    */
@@ -200,6 +206,8 @@ export interface BackgroundTaskManagerConfig {
   onTaskComplete?: (task: BackgroundTask) => void | Promise<void>;
   /** Optional callback invoked when a task fails (in addition to stream + message list injection) */
   onTaskFailed?: (task: BackgroundTask) => void | Promise<void>;
+  /** Optional callback invoked when a task is cancelled */
+  onTaskCancelled?: (task: BackgroundTask) => void | Promise<void>;
 }
 
 // --- Tool-level and agent-level config ---

--- a/packages/core/src/background-tasks/workflow.test.ts
+++ b/packages/core/src/background-tasks/workflow.test.ts
@@ -35,6 +35,7 @@ describe('background-task workflow registration', () => {
     });
 
     expect(await waitForWorkflowRegistration(mastra, true)).toBe(true);
+    expect(mastra.__getInternalWorkflow(BACKGROUND_TASK_WORKFLOW_ID).engineType).toBe('default');
   });
 
   it('does not register the workflow when bg tasks are disabled', async () => {

--- a/packages/core/src/background-tasks/workflow.ts
+++ b/packages/core/src/background-tasks/workflow.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { InternalSpans } from '../observability';
-import type { SuspendOptions } from '../workflows';
 import { createStep, createWorkflow } from '../workflows';
+import type { SuspendOptions } from '../workflows';
 import type { BackgroundTaskManager } from './manager';
 import type { BackgroundTaskStatus } from './types';
 import { BACKGROUND_TASK_WORKFLOW_ID } from './workflow-id';
@@ -37,11 +37,11 @@ const WORKFLOW_STATUS_TO_PERSIST = ['suspended', 'pending', 'paused', 'waiting']
  * Builds the per-task workflow that owns executor + retries.
  *
  * Uses the standard (default) execution engine so the workflow runs entirely
- * in-process on whatever host calls `run.start()`. This is critical for
- * distributed deployments where the background-task worker must
- * execute tools locally — routing through the evented pipeline would send
- * step execution to the orchestration worker / API, which don't have the
- * internal workflow or task contexts registered.
+ * in-process on whichever background-task worker calls `run.start()`. This is
+ * critical for distributed deployments: routing through the evented pipeline
+ * would introduce another competing-consumer hop that could move execution to
+ * an orchestration worker or API process without the internal workflow or
+ * invocation-bound task context registered.
  *
  * Shape: outer workflow runs an inner `[run-attempt, classify-outcome]`
  * workflow inside a `dountil` loop. `run-attempt` invokes the executor and

--- a/stores/libsql/src/storage/domains/background-tasks/index.test.ts
+++ b/stores/libsql/src/storage/domains/background-tasks/index.test.ts
@@ -1,0 +1,68 @@
+import type { Client } from '@libsql/client';
+import { createClient } from '@libsql/client';
+import type { BackgroundTask } from '@mastra/core/background-tasks';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { BackgroundTasksLibSQL } from './index';
+
+const TEST_DB_URL = 'file::memory:?cache=shared';
+
+function createTask(id: string): BackgroundTask {
+  return {
+    id,
+    status: 'running',
+    toolName: 'view',
+    toolCallId: `call-${id}`,
+    args: { path: 'package.json' },
+    agentId: 'agent-1',
+    threadId: 'thread-1',
+    resourceId: 'resource-1',
+    runId: `run-${id}`,
+    retryCount: 0,
+    maxRetries: 0,
+    timeoutMs: 30_000,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+}
+
+describe('BackgroundTasksLibSQL', () => {
+  let client: Client;
+  let store: BackgroundTasksLibSQL;
+
+  beforeEach(async () => {
+    client = createClient({ url: TEST_DB_URL });
+    store = new BackgroundTasksLibSQL({ client, maxRetries: 1, initialBackoffMs: 10 });
+    await store.init();
+    await store.dangerouslyClearAll();
+  });
+
+  afterEach(() => {
+    client.close();
+  });
+
+  it('persists primitive and structured task results as JSON', async () => {
+    await store.createTask(createTask('string-result'));
+    await store.updateTask('string-result', {
+      status: 'completed',
+      result: 'package.json contents',
+      completedAt: new Date('2026-01-01T00:01:00.000Z'),
+    });
+
+    expect(await store.getTask('string-result')).toMatchObject({
+      status: 'completed',
+      result: 'package.json contents',
+    });
+
+    await store.createTask(createTask('object-result'));
+    await store.updateTask('object-result', {
+      status: 'completed',
+      result: { files: 3, ok: true },
+      completedAt: new Date('2026-01-01T00:02:00.000Z'),
+    });
+
+    expect(await store.getTask('object-result')).toMatchObject({
+      status: 'completed',
+      result: { files: 3, ok: true },
+    });
+  });
+});

--- a/stores/libsql/src/storage/domains/background-tasks/index.test.ts
+++ b/stores/libsql/src/storage/domains/background-tasks/index.test.ts
@@ -65,4 +65,19 @@ describe('BackgroundTasksLibSQL', () => {
       result: { files: 3, ok: true },
     });
   });
+
+  it.each([
+    ['function', () => {}],
+    ['symbol', Symbol('result')],
+  ])('rejects a defined %s result that JSON cannot serialize', async (_type, result) => {
+    await store.createTask(createTask('unserializable-result'));
+
+    await expect(store.updateTask('unserializable-result', { result })).rejects.toThrow(
+      'Failed to serialize background task value as JSON',
+    );
+    await expect(store.getTask('unserializable-result')).resolves.toMatchObject({
+      status: 'running',
+      result: undefined,
+    });
+  });
 });

--- a/stores/libsql/src/storage/domains/background-tasks/index.ts
+++ b/stores/libsql/src/storage/domains/background-tasks/index.ts
@@ -13,9 +13,8 @@ import type { SqliteClient as Client, SqliteInValue as InValue } from '../../db/
 import { buildSelectColumns } from '../../db/utils';
 import { runPrune, resolveTargets } from '../../retention';
 
-function serializeJson(v: unknown): any {
-  if (typeof v === 'object' && v != null) return JSON.stringify(v);
-  return v ?? null;
+function serializeJson(v: unknown): InValue {
+  return v === undefined ? null : JSON.stringify(v);
 }
 
 function parseJson(val: unknown): any {

--- a/stores/libsql/src/storage/domains/background-tasks/index.ts
+++ b/stores/libsql/src/storage/domains/background-tasks/index.ts
@@ -14,7 +14,18 @@ import { buildSelectColumns } from '../../db/utils';
 import { runPrune, resolveTargets } from '../../retention';
 
 function serializeJson(v: unknown): InValue {
-  return v === undefined ? null : JSON.stringify(v);
+  if (v === undefined) return null;
+
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(v);
+  } catch (error) {
+    throw new Error('Failed to serialize background task value as JSON', { cause: error });
+  }
+  if (serialized === undefined) {
+    throw new Error('Failed to serialize background task value as JSON');
+  }
+  return serialized;
 }
 
 function parseJson(val: unknown): any {


### PR DESCRIPTION
## Summary

Hardens background task execution across processes while keeping the changes contained to the existing background-task manager and storage implementation.

This PR is stacked on #23020 because its Unix socket integration test exercises consumer-group dispatch through `UnixSocketPubSub`.

### What changes

- Routes closure-backed task executors to the manager process that owns their runtime context instead of sending them through the shared worker group.
- Uses local admission accounting for process-affine work so stale rows from another process cannot consume local concurrency.
- Adds configurable stale-task recovery for deployments where multiple managers share storage.
- Makes cancellation status updates conditional, prevents late workflow completion from overwriting cancellation, aborts locally owned work, and notifies the owning process when needed.
- Releases local reservations and task contexts consistently across dispatch, resume, cancellation, failure, and shutdown paths.
- Allows task streams to omit the initial persisted snapshot and cleans up abort listeners when streams close.
- Preserves primitive background-task results in LibSQL instead of coercing them through object-only JSON serialization.

### Scope

This PR does not add execution dispositions, awaited calls, completion signals, agent delegation behavior, MastraCode UI, or docs. It is independently useful manager infrastructure and the foundation for those later changes.

## Test plan

- Core background-task unit suites: 6 files / 111 tests passing.
- Core events + background manager/lifecycle regression suite on the parent branch: 18 files / 323 tests passing.
- LibSQL background-task storage test: 1/1 passing.
- `@mastra/core` TypeScript check passing.
- `@mastra/libsql` build and lint passing.
- Formatting and `git diff --check` passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Background tasks now run in the correct process and recover safely after failures. Cancellation and stored results also behave correctly.

## Changes

- Route process-specific executors to their owning `BackgroundTaskManager`.
- Add local concurrency reservations, ownership tracking, and lifecycle cleanup.
- Add configurable stale-task recovery.
- Handle cancellation callbacks and prevent late completion from overwriting cancellation.
- Continue queue processing after dispatch, storage, or concurrency failures.
- Support streams without an initial snapshot and clean up abort listeners.
- Preserve dynamic subagent ownership across asynchronous execution.
- Preserve primitive background-task results in LibSQL.
- Add regression coverage for process routing, ownership, cancellation, recovery, streams, lifecycle failures, and LibSQL serialization.

## Public API

- Add `recoverStaleTasksOnStart` to `BackgroundTaskManagerConfig`.
- Add `onTaskCancelled` to `BackgroundTaskManagerConfig`.
- Add `includeExisting` to `BackgroundTaskManager.stream()` options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->