### PR TITLE
fix(core): bundle ESM-only tokenx into CJS output for Jest consumers

### DIFF
--- a/e2e-tests/pkg-outputs/bundle.test.ts
+++ b/e2e-tests/pkg-outputs/bundle.test.ts
@@ -105,6 +105,31 @@ describe.for(
 // Native optional dependencies should not be bundled
 // =============================================================================
 
+describe('@mastra/core ESM-only runtime deps', () => {
+  const corePkg = allPackages.find(pkg => pkg.packageJson.name === '@mastra/core');
+  if (!corePkg) throw new Error('@mastra/core not found in workspace packages');
+  const coreDistDir = join(corePkg.dir, 'dist');
+
+  const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  // Pure-ESM dependencies must be bundled into published CJS chunks. Top-level
+  // require() of these packages breaks Jest's default CommonJS runtime.
+  const esmOnlyRuntimeDeps = ['tokenx', 'p-map', '@sindresorhus/slugify'];
+
+  it.for(esmOnlyRuntimeDeps.map(dep => [dep]))('%s should not be required from CJS chunks', async ([dep]) => {
+    const jsFiles = await globby(join(coreDistDir, '**/*.cjs'));
+    expect(jsFiles.length).toBeGreaterThan(0);
+
+    for (const file of jsFiles) {
+      const content = await readFile(file, 'utf-8');
+      if (!content.includes(dep)) continue;
+
+      const staticRequire = new RegExp(`(?<!\\.)require\\(["']${escapeRegExp(dep)}["']\\)`, 'm');
+      expect(content, `${file} has a static require() of ${dep}`).not.toMatch(staticRequire);
+    }
+  });
+});
+
 describe('@mastra/core native optional deps', () => {
   const corePkg = allPackages.find(pkg => pkg.packageJson.name === '@mastra/core');
   if (!corePkg) throw new Error('@mastra/core not found in workspace packages');

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -121,6 +121,11 @@ export default defineConfig({
       '@internal/auth',
       '@internal/core',
       '@internal/voice',
+      // ESM-only runtime deps must be bundled into CJS output so Jest/CJS consumers
+      // don't hit top-level require() of packages with no CommonJS build.
+      '@sindresorhus/slugify',
+      'p-map',
+      'tokenx',
     ],
   },
   onSuccess: async () => {

--- a/packages/memory/tsdown.config.ts
+++ b/packages/memory/tsdown.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   treeshake: true,
   sourcemap: true,
   deps: {
-    alwaysBundle: ['@internal/ai-sdk-v4', '@internal/ai-sdk-v5', '@internal/ai-v6'],
+    alwaysBundle: ['@internal/ai-sdk-v4', '@internal/ai-sdk-v5', '@internal/ai-v6', 'tokenx'],
   },
   onSuccess: async () => {
     await generateTypes(process.cwd(), new Set(['@internal/ai-sdk-v4', '@internal/ai-sdk-v5']));


### PR DESCRIPTION
## Summary

Fixes #22609

Published `@mastra/core` CJS chunks externalized `tokenx` (and other pure-ESM runtime deps like `p-map` and `@sindresorhus/slugify`), causing Jest's default CommonJS runtime to fail when loading `@mastra/core/agent` or processors.

This bundles those ESM-only dependencies into the CJS output via `deps.alwaysBundle` in tsdown, so CJS/Jest consumers no longer hit top-level `require()` of packages with no CommonJS build.

## Changes

- **`packages/core/tsdown.config.ts`** — add `tokenx`, `p-map`, and `@sindresorhus/slugify` to `alwaysBundle`
- **`packages/memory/tsdown.config.ts`** — add `tokenx` to `alwaysBundle`
- **`e2e-tests/pkg-outputs/bundle.test.ts`** — regression test asserting no static `require()` of ESM-only deps in published `*.cjs` chunks

## Verification

- Built `@mastra/core` and confirmed no `require('tokenx')` / `require('p-map')` / `require('@sindresorhus/slugify')` in `dist/**/*.cjs`
- Reproduced the original Jest failure with published `@mastra/core@latest`, then confirmed the fix with a packed tarball:
  - `require('@mastra/core/agent').Agent` — passes
  - `require('@mastra/core/processors').TokenLimiter` — passes
- pkg-outputs regression test for ESM-only runtime deps passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Some Mastra packages used libraries that only support modern JavaScript, which caused failures in older CommonJS tools such as Jest. This PR packages those libraries directly into the CommonJS output and adds a test to prevent the issue from returning.

## Changes

- Bundle `tokenx`, `p-map`, and `@sindresorhus/slugify` in `@mastra/core` CommonJS output.
- Bundle `tokenx` in `@mastra/memory` CommonJS output.
- Add a regression test that checks generated core `.cjs` files for static `require()` calls to these ESM-only dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->