### PR TITLE
fix(skills): publish stored skill drafts from storage snapshots

### DIFF
--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -150,7 +150,12 @@ export { createSkillTools, formatSkillActivation } from './skills';
 
 // Skill Publishing
 export type { SkillPublishResult } from './skills';
-export { collectSkillForPublish, publishSkillFromSource } from './skills';
+export {
+  collectSkillForPublish,
+  collectSkillForPublishFromFiles,
+  publishSkillFromSource,
+  publishSkillFromFiles,
+} from './skills';
 
 // Skill Source
 export type { SkillSource, SkillSourceEntry, SkillSourceStat } from './skills';

--- a/packages/core/src/workspace/skills/publish.ts
+++ b/packages/core/src/workspace/skills/publish.ts
@@ -251,18 +251,44 @@ export function parseSkillSnapshotFromFiles(files: SkillSnapshotFile[]): Omit<St
 }
 
 /**
- * Collect a skill from a SkillSource for publishing.
- * Walks the skill directory, hashes all files, parses SKILL.md frontmatter,
- * and returns everything needed to create a new version.
- *
- * @param source - The SkillSource to read from (live filesystem or any other source)
- * @param skillPath - Path to the skill directory (containing SKILL.md)
+ * Flatten a nested `StorageSkillFileNode` tree into walked file entries.
+ * Binary files are detected by MIME type; their `content` is expected to be
+ * base64-encoded (matching the round-trip from filesystem publish).
+ * Text files are treated as UTF-8 strings — content is never guessed as binary.
  */
-export async function collectSkillForPublish(source: SkillSource, skillPath: string): Promise<SkillPublishResult> {
-  // 1. Walk the skill directory recursively, reading all files
-  const files = await walkSkillDirectory(source, skillPath);
+function flattenSkillFileNodes(nodes: StorageSkillFileNode[], prefix = ''): WalkedFile[] {
+  const files: WalkedFile[] = [];
 
-  // 2. Build tree entries and blob entries, deduplicating blobs by hash
+  for (const node of nodes) {
+    if (node.type === 'folder') {
+      if (node.children?.length) {
+        const childPrefix = prefix ? `${prefix}/${node.name}` : node.name;
+        files.push(...flattenSkillFileNodes(node.children, childPrefix));
+      }
+      continue;
+    }
+
+    if (node.content === undefined) continue;
+
+    const path = prefix ? `${prefix}/${node.name}` : node.name;
+    const mimeType = detectMimeType(node.name);
+    const isBinary = isBinaryMimeType(mimeType);
+
+    if (isBinary) {
+      const buf = Buffer.from(node.content, 'base64');
+      files.push({ path, content: buf, isBinary: true });
+    } else {
+      files.push({ path, content: node.content, isBinary: false });
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Build tree, blobs, snapshot, and UI file nodes from walked files.
+ */
+function buildPublishResultFromWalkedFiles(files: WalkedFile[], skillPathForErrors?: string): SkillPublishResult {
   const treeEntries: Record<string, SkillVersionTreeEntry> = {};
   const blobMap = new Map<string, StorageBlobEntry>();
   const now = new Date();
@@ -272,7 +298,6 @@ export async function collectSkillForPublish(source: SkillSource, skillPath: str
     const mimeType = detectMimeType(file.path);
 
     if (file.isBinary) {
-      // Binary file: store as base64-encoded string
       const buf = Buffer.isBuffer(file.content) ? file.content : Buffer.from(file.content as string);
       const size = buf.length;
       const base64Content = buf.toString('base64');
@@ -294,7 +319,6 @@ export async function collectSkillForPublish(source: SkillSource, skillPath: str
         });
       }
     } else {
-      // Text file: store as UTF-8 string
       const content = file.content as string;
       const size = Buffer.byteLength(content, 'utf-8');
 
@@ -320,19 +344,41 @@ export async function collectSkillForPublish(source: SkillSource, skillPath: str
   const blobs = Array.from(blobMap.values());
   const fileNodes = buildSkillFileNodes(files);
 
-  // 3. Parse SKILL.md frontmatter and discover references/scripts/assets paths
   let snapshot: Omit<StorageSkillSnapshotType, 'tree'>;
   try {
     snapshot = parseSkillSnapshotFromFiles(files);
   } catch (err) {
-    // Surface the skill path to make the error easier to debug
-    if (err instanceof Error && err.message.includes('SKILL.md not found')) {
-      throw new Error(`SKILL.md not found in ${skillPath}`);
+    if (err instanceof Error && err.message.includes('SKILL.md not found') && skillPathForErrors) {
+      throw new Error(`SKILL.md not found in ${skillPathForErrors}`);
     }
     throw err;
   }
 
   return { snapshot, tree, blobs, files: fileNodes };
+}
+
+/**
+ * Collect a skill from a SkillSource for publishing.
+ * Walks the skill directory, hashes all files, parses SKILL.md frontmatter,
+ * and returns everything needed to create a new version.
+ *
+ * @param source - The SkillSource to read from (live filesystem or any other source)
+ * @param skillPath - Path to the skill directory (containing SKILL.md)
+ */
+export async function collectSkillForPublish(source: SkillSource, skillPath: string): Promise<SkillPublishResult> {
+  const files = await walkSkillDirectory(source, skillPath);
+  return buildPublishResultFromWalkedFiles(files, skillPath);
+}
+
+/**
+ * Collect a skill from a stored `files` snapshot for publishing.
+ * Converts the nested file tree into content-addressable blobs and a tree manifest.
+ *
+ * @param fileNodes - Nested file tree from a stored skill version snapshot
+ */
+export function collectSkillForPublishFromFiles(fileNodes: StorageSkillFileNode[]): SkillPublishResult {
+  const files = flattenSkillFileNodes(fileNodes);
+  return buildPublishResultFromWalkedFiles(files);
 }
 
 /**
@@ -349,7 +395,22 @@ export async function publishSkillFromSource(
   blobStore: BlobStore,
 ): Promise<SkillPublishResult> {
   const result = await collectSkillForPublish(source, skillPath);
-  // Store blobs in batch
+  await blobStore.putMany(result.blobs);
+  return result;
+}
+
+/**
+ * Publish a skill from a stored `files` snapshot.
+ * Hashes files into the blob store and returns the tree manifest and snapshot.
+ *
+ * @param fileNodes - Nested file tree from a stored skill version snapshot
+ * @param blobStore - Where to store file blobs
+ */
+export async function publishSkillFromFiles(
+  fileNodes: StorageSkillFileNode[],
+  blobStore: BlobStore,
+): Promise<SkillPublishResult> {
+  const result = collectSkillForPublishFromFiles(fileNodes);
   await blobStore.putMany(result.blobs);
   return result;
 }

--- a/packages/core/src/workspace/skills/skill-versioning.test.ts
+++ b/packages/core/src/workspace/skills/skill-versioning.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { InMemoryBlobStore } from '../../storage/domains/blobs/inmemory';
 import type { SkillVersionTree, StorageBlobEntry } from '../../storage/types';
 import { CompositeVersionedSkillSource } from './composite-versioned-skill-source';
-import { collectSkillForPublish, publishSkillFromSource } from './publish';
+import { collectSkillForPublish, collectSkillForPublishFromFiles, publishSkillFromSource, publishSkillFromFiles } from './publish';
 import type { SkillSource, SkillSourceEntry, SkillSourceStat } from './skill-source';
 import { VersionedSkillSource } from './versioned-skill-source';
 import { WorkspaceSkillsImpl } from './workspace-skills';
@@ -291,6 +291,53 @@ describe('collectSkillForPublish', () => {
     expect(result.snapshot.compatibility).toBe('node>=18');
     expect(result.snapshot.metadata).toBeDefined();
     expect(result.snapshot.metadata!.author).toBe('test-user');
+  });
+});
+
+// =============================================================================
+// 2b. collectSkillForPublishFromFiles / publishSkillFromFiles
+// =============================================================================
+
+describe('collectSkillForPublishFromFiles', () => {
+  it('should publish from a nested storage file tree', async () => {
+    const skillMd = createSkillMd(
+      { name: 'stored-skill', description: 'From storage' },
+      '# Stored Skill\n\nPublished from snapshot.',
+    );
+    const fileNodes = [
+      { name: 'SKILL.md', type: 'file' as const, content: skillMd },
+      {
+        name: 'references',
+        type: 'folder' as const,
+        children: [{ name: 'notes.md', type: 'file' as const, content: '# Notes' }],
+      },
+    ];
+
+    const result = collectSkillForPublishFromFiles(fileNodes);
+
+    expect(result.snapshot.name).toBe('stored-skill');
+    expect(result.snapshot.instructions).toBe('# Stored Skill\n\nPublished from snapshot.');
+    expect(result.tree.entries['SKILL.md']).toBeDefined();
+    expect(result.tree.entries['references/notes.md']).toBeDefined();
+    expect(result.files).toHaveLength(2);
+  });
+
+  it('should throw if SKILL.md is missing from the stored snapshot', () => {
+    expect(() =>
+      collectSkillForPublishFromFiles([{ name: 'README.md', type: 'file', content: '# No skill file' }]),
+    ).toThrow('SKILL.md not found');
+  });
+
+  it('should store blobs via publishSkillFromFiles', async () => {
+    const skillMd = createSkillMd({ name: 'blob-skill', description: 'Blob test' }, '# Blob');
+    const blobStore = new InMemoryBlobStore();
+
+    const result = await publishSkillFromFiles([{ name: 'SKILL.md', type: 'file', content: skillMd }], blobStore);
+
+    for (const blob of result.blobs) {
+      const stored = await blobStore.get(blob.hash);
+      expect(stored).not.toBeNull();
+    }
   });
 });
 

--- a/packages/editor/src/namespaces/skill.ts
+++ b/packages/editor/src/namespaces/skill.ts
@@ -5,9 +5,10 @@ import type {
   StorageListSkillsOutput,
   StorageResolvedSkillType,
   StorageListSkillsResolvedOutput,
+  StorageSkillFileNode,
 } from '@mastra/core/storage';
 import type { SkillSource } from '@mastra/core/workspace';
-import { publishSkillFromSource } from '@mastra/core/workspace';
+import { publishSkillFromFiles, publishSkillFromSource } from '@mastra/core/workspace';
 
 import { CrudEditorNamespace } from './base';
 import type { StorageAdapter } from './base';
@@ -129,6 +130,57 @@ export class EditorSkillNamespace extends CrudEditorNamespace<
 
     // Invalidate any cached agents that reference this skill so they
     // re-hydrate with the updated version on next access.
+    this.editor.agent.invalidateAgentsReferencingSkill(skillId);
+
+    return resolved;
+  }
+
+  /**
+   * Publish a skill from a stored `files` snapshot.
+   * Hashes files into the blob store, creates a new tree-backed version,
+   * and sets activeVersionId.
+   */
+  async publishFromFiles(skillId: string, files: StorageSkillFileNode[]): Promise<StorageResolvedSkillType> {
+    this.ensureRegistered();
+
+    const storage = this.mastra?.getStorage();
+    if (!storage) throw new Error('Storage is not configured');
+
+    const skillStore = await storage.getStore('skills');
+    if (!skillStore) throw new Error('Skills storage domain is not available');
+
+    const blobStore = await this.editor.resolveBlobStore();
+    if (!blobStore)
+      throw new Error('No blob store is configured. Register one via new MastraEditor({ blobStores: [...] })');
+
+    const { snapshot, tree, files: publishedFiles } = await publishSkillFromFiles(files, blobStore);
+
+    const snapshotUpdate: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(snapshot)) {
+      if (value !== undefined) snapshotUpdate[key] = value;
+    }
+
+    await skillStore.update({
+      id: skillId,
+      ...snapshotUpdate,
+      tree,
+      files: publishedFiles,
+      status: 'published',
+    });
+
+    const latestVersion = await skillStore.getLatestVersion(skillId);
+    if (!latestVersion) {
+      throw new Error(`Failed to retrieve version after publishing skill "${skillId}"`);
+    }
+    await skillStore.update({
+      id: skillId,
+      activeVersionId: latestVersion.id,
+    });
+
+    const resolved = await skillStore.getByIdResolved(skillId);
+    if (!resolved) throw new Error(`Failed to resolve skill ${skillId} after publish`);
+
+    this.clearCache(skillId);
     this.editor.agent.invalidateAgentsReferencingSkill(skillId);
 
     return resolved;

--- a/packages/server/src/server/handlers/stored-skills.test.ts
+++ b/packages/server/src/server/handlers/stored-skills.test.ts
@@ -11,6 +11,7 @@ import {
   CREATE_STORED_SKILL_ROUTE,
   UPDATE_STORED_SKILL_ROUTE,
   DELETE_STORED_SKILL_ROUTE,
+  PUBLISH_STORED_SKILL_ROUTE,
 } from './stored-skills';
 
 // =============================================================================
@@ -37,6 +38,8 @@ interface MockSkillsStore {
   listResolved: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
   delete: ReturnType<typeof vi.fn>;
+  getVersion: ReturnType<typeof vi.fn>;
+  getLatestVersion: ReturnType<typeof vi.fn>;
 }
 
 function createMockSkillsStore(skillsData: Map<string, MockStoredSkill> = new Map()): MockSkillsStore {
@@ -100,6 +103,18 @@ function createMockSkillsStore(skillsData: Map<string, MockStoredSkill> = new Ma
     delete: vi.fn().mockImplementation(async (id: string) => {
       return skillsData.delete(id);
     }),
+    getVersion: vi.fn().mockResolvedValue(null),
+    getLatestVersion: vi.fn().mockResolvedValue(null),
+  };
+}
+
+interface MockBlobStore {
+  putMany: ReturnType<typeof vi.fn>;
+}
+
+function createMockBlobStore(): MockBlobStore {
+  return {
+    putMany: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -107,11 +122,14 @@ interface MockStorage {
   getStore: ReturnType<typeof vi.fn>;
 }
 
-function createMockStorage(skillsStore?: MockSkillsStore): MockStorage {
+function createMockStorage(skillsStore?: MockSkillsStore, blobStore?: MockBlobStore): MockStorage {
   return {
     getStore: vi.fn().mockImplementation(async (storeName: string) => {
       if (storeName === 'skills' && skillsStore) {
         return skillsStore;
+      }
+      if (storeName === 'blobs' && blobStore) {
+        return blobStore;
       }
       return null;
     }),
@@ -154,13 +172,15 @@ function createAuthenticatedContext(mastra: MockMastra, userId: string, permissi
 describe('Stored Skills Handlers', () => {
   let mockSkillsData: Map<string, MockStoredSkill>;
   let mockSkillsStore: MockSkillsStore;
+  let mockBlobStore: MockBlobStore;
   let mockStorage: MockStorage;
   let mockMastra: MockMastra;
 
   beforeEach(() => {
     mockSkillsData = new Map();
     mockSkillsStore = createMockSkillsStore(mockSkillsData);
-    mockStorage = createMockStorage(mockSkillsStore);
+    mockBlobStore = createMockBlobStore();
+    mockStorage = createMockStorage(mockSkillsStore, mockBlobStore);
     mockMastra = createMockMastra({ storage: mockStorage });
   });
 
@@ -748,6 +768,131 @@ describe('Stored Skills Handlers', () => {
       });
 
       expect(result).toMatchObject({ success: true });
+    });
+  });
+
+  describe('PUBLISH_STORED_SKILL_ROUTE', () => {
+    const skillMd = `---
+name: builder-skill
+description: A builder-authored skill
+---
+# Builder Skill
+
+Do builder things.`;
+
+    const versionFiles = [
+      { name: 'SKILL.md', type: 'file' as const, content: skillMd },
+      {
+        name: 'references',
+        type: 'folder' as const,
+        children: [{ name: 'notes.md', type: 'file' as const, content: '# Notes' }],
+      },
+    ];
+
+    beforeEach(() => {
+      mockSkillsData.set('builder-skill', {
+        id: 'builder-skill',
+        name: 'Builder Skill',
+        description: 'A builder-authored skill',
+        instructions: '# Builder Skill\n\nDo builder things.',
+        authorId: 'user-a',
+        visibility: 'private',
+        status: 'draft',
+      });
+
+      mockSkillsStore.getLatestVersion.mockResolvedValue({
+        id: 'version-1',
+        skillId: 'builder-skill',
+        files: versionFiles,
+      });
+      mockSkillsStore.getVersion.mockImplementation(async (id: string) => {
+        if (id === 'version-1') {
+          return { id: 'version-1', skillId: 'builder-skill', files: versionFiles };
+        }
+        return null;
+      });
+      mockSkillsStore.update.mockImplementation(async (updates: Record<string, unknown> & { id: string }) => {
+        const existing = mockSkillsData.get(updates.id);
+        if (!existing) return null;
+        const updated = { ...existing, ...updates };
+        mockSkillsData.set(updates.id, updated as MockStoredSkill);
+        if (updates.tree) {
+          mockSkillsStore.getLatestVersion.mockResolvedValue({
+            id: 'version-2',
+            skillId: updates.id,
+            files: versionFiles,
+            tree: updates.tree,
+          });
+        }
+        return updated;
+      });
+    });
+
+    it('should publish from a stored files snapshot when skillPath is omitted', async () => {
+      const result = await PUBLISH_STORED_SKILL_ROUTE.handler({
+        ...createAuthenticatedContext(mockMastra, 'user-a'),
+        storedSkillId: 'builder-skill',
+      });
+
+      expect(mockBlobStore.putMany).toHaveBeenCalled();
+      expect(mockSkillsStore.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'builder-skill',
+          status: 'published',
+          tree: expect.objectContaining({
+            entries: expect.objectContaining({
+              'SKILL.md': expect.any(Object),
+              'references/notes.md': expect.any(Object),
+            }),
+          }),
+        }),
+      );
+      expect(result).toMatchObject({
+        id: 'builder-skill',
+        status: 'published',
+      });
+    });
+
+    it('should publish a specific version when versionId is provided', async () => {
+      await PUBLISH_STORED_SKILL_ROUTE.handler({
+        ...createAuthenticatedContext(mockMastra, 'user-a'),
+        storedSkillId: 'builder-skill',
+        versionId: 'version-1',
+      });
+
+      expect(mockSkillsStore.getVersion).toHaveBeenCalledWith('version-1');
+      expect(mockBlobStore.putMany).toHaveBeenCalled();
+    });
+
+    it('should reject when the selected version has no files snapshot', async () => {
+      mockSkillsStore.getLatestVersion.mockResolvedValue({
+        id: 'version-empty',
+        skillId: 'builder-skill',
+        files: [],
+      });
+
+      await expect(
+        PUBLISH_STORED_SKILL_ROUTE.handler({
+          ...createAuthenticatedContext(mockMastra, 'user-a'),
+          storedSkillId: 'builder-skill',
+        }),
+      ).rejects.toThrow(HTTPException);
+    });
+
+    it('should reject when versionId does not belong to the skill', async () => {
+      mockSkillsStore.getVersion.mockResolvedValue({
+        id: 'other-version',
+        skillId: 'other-skill',
+        files: versionFiles,
+      });
+
+      await expect(
+        PUBLISH_STORED_SKILL_ROUTE.handler({
+          ...createAuthenticatedContext(mockMastra, 'user-a'),
+          storedSkillId: 'builder-skill',
+          versionId: 'other-version',
+        }),
+      ).rejects.toThrow(HTTPException);
     });
   });
 });

--- a/packages/server/src/server/handlers/stored-skills.ts
+++ b/packages/server/src/server/handlers/stored-skills.ts
@@ -1,4 +1,4 @@
-import type { StorageSkillFileNode } from '@mastra/core/storage';
+import type { SkillVersionTree, StorageSkillFileNode, StorageSkillSnapshotType } from '@mastra/core/storage';
 import { LocalSkillSource } from '@mastra/core/workspace';
 
 import { HTTPException } from '../http-exception';
@@ -569,10 +569,10 @@ export const PUBLISH_STORED_SKILL_ROUTE = createRoute({
   responseSchema: publishStoredSkillResponseSchema,
   summary: 'Publish stored skill',
   description:
-    'Snapshots the skill directory from the filesystem into content-addressable blob storage, creates a new version with a tree manifest, and marks the skill as published',
+    'Publishes a stored skill by snapshotting its version files into content-addressable blob storage, or from a server filesystem directory when skillPath is provided. Creates a new version with a tree manifest and marks the skill as published.',
   tags: ['Stored Skills'],
   requiresAuth: true,
-  handler: async ({ mastra, requestContext, storedSkillId, skillPath }) => {
+  handler: async ({ mastra, requestContext, storedSkillId, skillPath, versionId }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -590,14 +590,12 @@ export const PUBLISH_STORED_SKILL_ROUTE = createRoute({
         throw new HTTPException(500, { message: 'Blob storage domain is not available' });
       }
 
-      // Verify skill exists. Skill metadata lives on the resolved snapshot.
       const existing = await skillStore.getByIdResolved(storedSkillId);
       if (!existing) {
         throw new HTTPException(404, { message: `Stored skill with id ${storedSkillId} not found` });
       }
       assertStoredResourceScope(existing, await getStoredResourceScope(mastra, requestContext));
 
-      // Throws 404 if the caller isn't the owner, admin, or `stored-skills:write[:<id>]` holder.
       assertWriteAccess({
         requestContext,
         resource: 'stored-skills',
@@ -606,49 +604,82 @@ export const PUBLISH_STORED_SKILL_ROUTE = createRoute({
         record: existing,
       });
 
-      // Validate skillPath to prevent path traversal
-      const path = await import('node:path');
-      const fs = await import('node:fs/promises');
-      const resolvedPath = path.default.resolve(skillPath);
-      const allowedBase = path.default.resolve(process.env.SKILLS_BASE_DIR || process.cwd());
-      if (!resolvedPath.startsWith(allowedBase + path.default.sep) && resolvedPath !== allowedBase) {
-        throw new HTTPException(400, {
-          message: `skillPath must be within the allowed directory: ${allowedBase}`,
-        });
-      }
+      let snapshot: Omit<StorageSkillSnapshotType, 'tree'>;
+      let tree: SkillVersionTree;
+      let files: StorageSkillFileNode[];
 
-      // Verify the source directory exists and contains a SKILL.md before attempting
-      // to publish, so callers get a 400 with context instead of a raw 500/ENOENT.
-      try {
-        const stat = await fs.stat(resolvedPath);
-        if (!stat.isDirectory()) {
-          throw new HTTPException(400, { message: `skillPath is not a directory: ${resolvedPath}` });
-        }
-      } catch (err) {
-        if (err instanceof HTTPException) throw err;
-        if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      if (skillPath) {
+        const path = await import('node:path');
+        const fs = await import('node:fs/promises');
+        const resolvedPath = path.default.resolve(skillPath);
+        const allowedBase = path.default.resolve(process.env.SKILLS_BASE_DIR || process.cwd());
+        if (!resolvedPath.startsWith(allowedBase + path.default.sep) && resolvedPath !== allowedBase) {
           throw new HTTPException(400, {
-            message: `skillPath does not exist on the server filesystem: ${resolvedPath}. Create the skill directory (with a SKILL.md) before publishing, or use a skill that was materialized to disk.`,
+            message: `skillPath must be within the allowed directory: ${allowedBase}`,
           });
         }
-        throw err;
-      }
-      try {
-        await fs.stat(path.default.join(resolvedPath, 'SKILL.md'));
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
-          throw new HTTPException(400, {
-            message: `skillPath is missing SKILL.md: ${resolvedPath}`,
+
+        try {
+          const stat = await fs.stat(resolvedPath);
+          if (!stat.isDirectory()) {
+            throw new HTTPException(400, { message: `skillPath is not a directory: ${resolvedPath}` });
+          }
+        } catch (err) {
+          if (err instanceof HTTPException) throw err;
+          if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
+            throw new HTTPException(400, {
+              message: `skillPath does not exist on the server filesystem: ${resolvedPath}. Create the skill directory (with a SKILL.md) before publishing, or use a skill that was materialized to disk.`,
+            });
+          }
+          throw err;
+        }
+        try {
+          await fs.stat(path.default.join(resolvedPath, 'SKILL.md'));
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
+            throw new HTTPException(400, {
+              message: `skillPath is missing SKILL.md: ${resolvedPath}`,
+            });
+          }
+          throw err;
+        }
+
+        const source = new LocalSkillSource();
+        const { publishSkillFromSource } = await import('@mastra/core/workspace');
+
+        ({ snapshot, tree, files } = await publishSkillFromSource(source, resolvedPath, blobStore));
+      } else {
+        const version = versionId
+          ? await skillStore.getVersion(versionId)
+          : await skillStore.getLatestVersion(storedSkillId);
+
+        if (!version || version.skillId !== storedSkillId) {
+          throw new HTTPException(404, {
+            message: versionId
+              ? `Version ${versionId} not found for skill ${storedSkillId}`
+              : `No versions found for skill ${storedSkillId}`,
           });
         }
-        throw err;
+
+        if (!version.files || version.files.length === 0) {
+          throw new HTTPException(400, {
+            message:
+              'The selected skill version has no files snapshot to publish. Update the skill with a files tree containing SKILL.md, or provide skillPath to publish from the server filesystem.',
+          });
+        }
+
+        const { publishSkillFromFiles } = await import('@mastra/core/workspace');
+        try {
+          ({ snapshot, tree, files } = await publishSkillFromFiles(version.files, blobStore));
+        } catch (err) {
+          if (err instanceof Error && err.message.includes('SKILL.md not found')) {
+            throw new HTTPException(400, {
+              message: 'The stored skill version is missing SKILL.md in its files snapshot.',
+            });
+          }
+          throw err;
+        }
       }
-
-      // Use LocalSkillSource to read from the server filesystem
-      const source = new LocalSkillSource();
-      const { publishSkillFromSource } = await import('@mastra/core/workspace');
-
-      const { snapshot, tree, files } = await publishSkillFromSource(source, resolvedPath, blobStore);
 
       // Strip undefined keys from the snapshot before passing to update(). The
       // storage layer treats "field present" as "field changed"; forwarding

--- a/packages/server/src/server/schemas/stored-skills.ts
+++ b/packages/server/src/server/schemas/stored-skills.ts
@@ -212,8 +212,23 @@ export const deleteStoredSkillResponseSchema = z.object({
 // Publish / Rollback Schemas
 // ============================================================================
 
-export const publishStoredSkillBodySchema = z.object({
-  skillPath: z.string().describe('Path to the skill directory on the server filesystem (containing SKILL.md)'),
-});
+export const publishStoredSkillBodySchema = z
+  .object({
+    skillPath: z
+      .string()
+      .optional()
+      .describe(
+        'Path to the skill directory on the server filesystem (containing SKILL.md). When omitted, publishes from the stored skill version snapshot.',
+      ),
+    versionId: z
+      .string()
+      .optional()
+      .describe(
+        'Version ID to publish from storage. Defaults to the latest version when skillPath is omitted. Cannot be combined with skillPath.',
+      ),
+  })
+  .refine(data => !(data.skillPath && data.versionId), {
+    message: 'Provide skillPath or versionId, not both',
+  });
 
 export const publishStoredSkillResponseSchema = storedSkillSchema;


### PR DESCRIPTION
## Description

Fixes #22562.

Builder- and registry-authored stored skills keep their content in `files` snapshots on version rows, but the only publish path required a server filesystem `skillPath`. That left storage-only drafts unpublishable and could produce a misleading published-but-unresolvable state when `activeVersionId` was set without a `tree` manifest.

This PR adds a storage-backed publish path that converts a selected `files` snapshot into blobs plus a tree manifest, creates a new immutable published version, and activates it.

### Changes

- **Core**: add `collectSkillForPublishFromFiles()` and `publishSkillFromFiles()` to convert nested `StorageSkillFileNode[]` trees into content-addressable blobs and tree manifests.
- **API**: make `skillPath` optional on `POST /stored/skills/:storedSkillId/publish`; when omitted, publish from the stored version snapshot (`versionId` optional, defaults to latest).
- **Editor**: add `EditorSkillNamespace.publishFromFiles()` for programmatic publish from stored snapshots.

### Behavior

- `skillPath` provided → existing filesystem publish flow (unchanged).
- `skillPath` omitted → publish from storage using `versionId` or the latest version.
- `skillPath` and `versionId` cannot be combined.
- Text files are treated as UTF-8; binary files are detected by MIME type and expected to be base64-encoded in the stored snapshot (matching filesystem publish round-trip).

## Related issue(s)

Fixes #22562

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Skills saved in storage can now be published without first copying them to the server filesystem. The publish flow turns stored files into the blobs and file tree required to run the skill.

## Summary

- Added storage-backed publishing with `collectSkillForPublishFromFiles` and `publishSkillFromFiles`.
- Added `EditorSkillNamespace.publishFromFiles()`.
- Updated the publish API to accept an optional `versionId` and use the latest stored version by default.
- Preserved filesystem publishing through `skillPath`.
- Rejected requests that provide both `skillPath` and `versionId`.
- Added validation for file snapshots, version ownership, and `SKILL.md`.
- Added binary file decoding and UTF-8 handling for stored files.
- Added tests for nested file trees, blob storage, version selection, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->