### PR TITLE
feat(observability): support feedback trace predicates

### DIFF
--- a/.changeset/eager-houses-stop.md
+++ b/.changeset/eager-houses-stop.md
@@ -1,0 +1,12 @@
+---
+'@mastra/duckdb': minor
+---
+
+Added DuckDB support for filtering traces by related feedback.
+
+```typescript
+await mastraClient.queryTraces({
+  timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z' },
+  where: { feedback: { some: { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'rating' } } } },
+})
+```

--- a/.changeset/eager-houses-stop.md
+++ b/.changeset/eager-houses-stop.md
@@ -2,11 +2,11 @@
 '@mastra/duckdb': minor
 ---
 
-Added DuckDB support for filtering traces by related feedback.
+Added DuckDB support for filtering traces by related feedback. Repeated writes for one `feedbackId` now retain the latest record for feedback predicates.
 
 ```typescript
 await mastraClient.queryTraces({
   timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z' },
   where: { feedback: { some: { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'rating' } } } },
-})
+});
 ```

--- a/.changeset/large-years-tap.md
+++ b/.changeset/large-years-tap.md
@@ -1,0 +1,12 @@
+---
+'@mastra/pg': minor
+---
+
+Added PostgreSQL support for filtering traces by related feedback.
+
+```typescript
+await mastraClient.queryTraces({
+  timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z' },
+  where: { feedback: { none: { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'clinical-review' } } } },
+})
+```

--- a/.changeset/large-years-tap.md
+++ b/.changeset/large-years-tap.md
@@ -2,7 +2,7 @@
 '@mastra/pg': minor
 ---
 
-Added PostgreSQL support for filtering traces by related feedback.
+Added PostgreSQL support for filtering traces by related feedback. Repeated writes for one `feedbackId`, including writes with the same timestamp and repeated IDs in one batch, now retain the last accepted record for feedback predicates.
 
 ```typescript
 await mastraClient.queryTraces({

--- a/.changeset/large-years-tap.md
+++ b/.changeset/large-years-tap.md
@@ -8,5 +8,5 @@ Added PostgreSQL support for filtering traces by related feedback.
 await mastraClient.queryTraces({
   timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z' },
   where: { feedback: { none: { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'clinical-review' } } } },
-})
+});
 ```

--- a/.changeset/ninety-parks-leave.md
+++ b/.changeset/ninety-parks-leave.md
@@ -1,0 +1,12 @@
+---
+'@mastra/core': minor
+---
+
+Added feedback predicates to advanced trace queries.
+
+```typescript
+await mastraClient.queryTraces({
+  timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z' },
+  where: { feedback: { some: { op: 'lt', left: { path: 'value' }, right: { literal: 0 } } } },
+})
+```

--- a/.changeset/ninety-parks-leave.md
+++ b/.changeset/ninety-parks-leave.md
@@ -8,5 +8,5 @@ Added feedback predicates to advanced trace queries.
 await mastraClient.queryTraces({
   timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z' },
   where: { feedback: { some: { op: 'lt', left: { path: 'value' }, right: { literal: 0 } } } },
-})
+});
 ```

--- a/.changeset/tidy-flowers-mate.md
+++ b/.changeset/tidy-flowers-mate.md
@@ -1,0 +1,12 @@
+---
+'@mastra/clickhouse': minor
+---
+
+Added ClickHouse support for filtering traces by related feedback.
+
+```typescript
+await mastraClient.queryTraces({
+  timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z' },
+  where: { feedback: { some: { op: 'eq', left: { path: 'feedbackSource' }, right: { literal: 'clinician' } } } },
+})
+```

--- a/.changeset/tidy-flowers-mate.md
+++ b/.changeset/tidy-flowers-mate.md
@@ -8,5 +8,5 @@ Added ClickHouse support for filtering traces by related feedback.
 await mastraClient.queryTraces({
   timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z' },
   where: { feedback: { some: { op: 'eq', left: { path: 'feedbackSource' }, right: { literal: 'clinician' } } } },
-})
+});
 ```

--- a/.changeset/tidy-flowers-mate.md
+++ b/.changeset/tidy-flowers-mate.md
@@ -2,7 +2,7 @@
 '@mastra/clickhouse': minor
 ---
 
-Added ClickHouse support for filtering traces by related feedback.
+Added ClickHouse support for filtering traces by related feedback. Durable per-feedback write versions make the last accepted write current before trace correlation, independently of caller timestamps. Existing version-0 rows retain latest-timestamp ordering until their first post-migration replacement.
 
 ```typescript
 await mastraClient.queryTraces({

--- a/.changeset/tricky-zebras-care.md
+++ b/.changeset/tricky-zebras-care.md
@@ -1,0 +1,12 @@
+---
+'@mastra/client-js': minor
+---
+
+Added feedback predicates to `queryTraces`.
+
+```typescript
+await client.queryTraces({
+  timeRange,
+  where: { feedback: { some: { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'rating' } } } },
+});
+```

--- a/.changeset/tricky-zebras-care.md
+++ b/.changeset/tricky-zebras-care.md
@@ -6,7 +6,10 @@ Added feedback predicates to `queryTraces`.
 
 ```typescript
 await client.queryTraces({
-  timeRange,
+  timeRange: {
+    from: '2026-08-01T00:00:00.000Z',
+    to: '2026-08-08T00:00:00.000Z',
+  },
   where: { feedback: { some: { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'rating' } } } },
 });
 ```

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -75,6 +75,15 @@ type Shared_Auxiliary_588 =
         | {
             none: Shared_Auxiliary_606;
           };
+    }
+  | {
+      feedback:
+        | {
+            some: Shared_Auxiliary_606;
+          }
+        | {
+            none: Shared_Auxiliary_606;
+          };
     };
 
 type Shared_Auxiliary_606 =
@@ -119,7 +128,7 @@ type Shared_Auxiliary_606 =
       arg: Shared_Auxiliary_606;
     };
 
-type Shared_Auxiliary_1143 =
+type Shared_Auxiliary_1146 =
   | {
       op: 'eq' | 'ne' | 'lt' | 'lte' | 'gt' | 'gte';
       left:
@@ -164,19 +173,19 @@ type Shared_Auxiliary_1143 =
     }
   | {
       op: 'and' | 'or';
-      args: Shared_Auxiliary_1143[];
+      args: Shared_Auxiliary_1146[];
     }
   | {
       op: 'not';
-      arg: Shared_Auxiliary_1143;
+      arg: Shared_Auxiliary_1146;
     };
 
-type Shared_Auxiliary_1283 = {
+type Shared_Auxiliary_1286 = {
   id?: string | undefined;
   name: string;
   type: 'file' | 'folder';
   content?: string | undefined;
-  children?: Shared_Auxiliary_1283[] | undefined;
+  children?: Shared_Auxiliary_1286[] | undefined;
 };
 
 type Shared_Type_0 = {
@@ -2609,7 +2618,7 @@ type Shared_Type_111 = {
       }
     | undefined;
   steps: Shared_Type_106;
-  predicates: Shared_Auxiliary_1143[];
+  predicates: Shared_Auxiliary_1146[];
 };
 
 type Shared_Type_112 = {
@@ -2632,7 +2641,7 @@ type Shared_Type_112 = {
         description?: string | undefined;
       };
   loopType: 'dowhile' | 'dountil';
-  predicate: Shared_Auxiliary_1143;
+  predicate: Shared_Auxiliary_1146;
 };
 
 type Shared_Type_113 =
@@ -2986,7 +2995,7 @@ type Shared_Type_126 = {
   /** List of asset file paths */
   assets?: string[] | undefined;
   /** Full file tree structure for the skill */
-  files?: Shared_Auxiliary_1283[] | undefined;
+  files?: Shared_Auxiliary_1286[] | undefined;
   /** Additional metadata for the skill */
   metadata?:
     | {
@@ -16878,7 +16887,7 @@ export type PostStoredSkills_Body = {
   /** List of asset file paths */
   assets?: string[] | undefined;
   /** Full file tree structure for the skill */
-  files?: Shared_Auxiliary_1283[] | undefined;
+  files?: Shared_Auxiliary_1286[] | undefined;
   /** Additional metadata for the skill */
   metadata?:
     | {
@@ -16936,7 +16945,7 @@ export type PatchStoredSkillsStoredSkillId_Body = {
   /** List of asset file paths */
   assets?: (string[] | undefined) | undefined;
   /** Full file tree structure for the skill */
-  files?: (Shared_Auxiliary_1283[] | undefined) | undefined;
+  files?: (Shared_Auxiliary_1286[] | undefined) | undefined;
   /** Additional metadata for the skill */
   metadata?:
     | (

--- a/docs/src/content/en/reference/observability/tracing/trace-query.mdx
+++ b/docs/src/content/en/reference/observability/tracing/trace-query.mdx
@@ -115,6 +115,9 @@ Hono and Fastify enforce the request-body limit before JSON parsing. Express and
 | Score | `scorerId`, `scorerVersion`, `scoreSource`, `entityVersionId`, `parentEntityVersionId`, `rootEntityVersionId` | `eq`, `ne`, `in`, `notIn`, `exists`, `notExists` |
 | Score | `score`, `timestamp` | `eq`, `ne`, `in`, `notIn`, `lt`, `lte`, `gt`, `gte`, `exists`, `notExists` |
 | Score | `spanId` | `exists`, `notExists` |
+| Feedback | `feedbackType`, `feedbackSource`, `feedbackUserId`, `sourceId`, `entityVersionId`, `parentEntityVersionId`, `rootEntityVersionId` | `eq`, `ne`, `in`, `notIn`, `exists`, `notExists` |
+| Feedback | `value`, `timestamp` | `eq`, `ne`, `in`, `notIn`, `lt`, `lte`, `gt`, `gte`, `exists`, `notExists` |
+| Feedback | `comment` | `exists`, `notExists` |
 
 Compose predicates with `{ op: 'and', args: [...] }`, `{ op: 'or', args: [...] }`, and `{ op: 'not', arg: ... }`. Comparison predicates place a field reference on the left and a literal on the right. Membership predicates use a field reference in `value` and a homogeneous literal array in `set`.
 
@@ -273,6 +276,45 @@ const messageTrace = {
 The key must name one top-level property. Empty keys and nested paths are rejected. Metadata keys aren't trimmed, so leading and trailing whitespace remains part of the exact key identity. When metadata duplicates a canonical trace field, such as `resourceId`, `threadId`, or `environment`, prefer the canonical field because it uses the dedicated storage column. The `metadata.<key>` form remains available when you specifically need the value from the metadata object. Metadata and canonical values may differ.
 
 Metadata fields aren't available for grouping or field discovery.
+
+### Filter by feedback
+
+Every condition inside one `feedback.some` or `feedback.none` clause applies to the same current feedback record. `feedbackType` and `feedbackSource` are exact application-defined strings rather than built-in enums. This query finds traces with a numeric patient rating below zero:
+
+```typescript
+const negativePatientRating = {
+  feedback: {
+    some: {
+      op: 'and',
+      args: [
+        { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'rating' } },
+        { op: 'eq', left: { path: 'feedbackSource' }, right: { literal: 'patient' } },
+        { op: 'lt', left: { path: 'value' }, right: { literal: 0 } },
+      ],
+    },
+  },
+}
+```
+
+Strict stored-value types are the portable contract for feedback predicates. PostgreSQL and ClickHouse distinguish numeric `3` from textual `'3'` for equality and ordered comparisons. DuckDB currently persists feedback values as `VARCHAR`, so numeric-looking strings may be coerced for equality and ordered numeric predicates. OBS-306 will remove this DuckDB exception through typed persistence. Ordered operators require a finite numeric literal. `eq` and `ne` accept one string or number, while `in` and `notIn` require a non-empty set containing only strings or only numbers. `exists` and `notExists` test for either value type.
+
+Use `none` to select traces without a matching record. Traces with no feedback also match:
+
+```typescript
+const missingClinicianReview = {
+  feedback: {
+    none: {
+      op: 'and',
+      args: [
+        { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'clinical-review' } },
+        { op: 'eq', left: { path: 'feedbackSource' }, right: { literal: 'clinician' } },
+      ],
+    },
+  },
+}
+```
+
+Feedback `timestamp` predicates are independent of the root `timeRange`. Use `comment` only with `exists` or `notExists`. Comment contents aren't searchable. The deprecated feedback fields `source` and `userId` aren't available. Use `feedbackSource` and `feedbackUserId`.
 
 ## Responses
 

--- a/packages/core/src/storage/domains/observability/trace-query.test.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.test.ts
@@ -552,6 +552,128 @@ describe('planTraceQuery', () => {
     expect(error.issues[0]).toMatchObject({ code: 'field_not_allowed', path: ['where', 'spans', 'some', 'path'] });
   });
 
+  it('plans feedback predicates with typed values and field-specific semantics', () => {
+    const plan = planTraceQuery(
+      parsed({
+        ...baseRequest,
+        where: {
+          op: 'and',
+          args: [
+            {
+              feedback: {
+                some: {
+                  op: 'and',
+                  args: [
+                    { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'rating' } },
+                    { op: 'lt', left: { path: 'value' }, right: { literal: 0 } },
+                    { op: 'exists', path: 'comment' },
+                    {
+                      op: 'gte',
+                      left: { path: 'timestamp' },
+                      right: { literal: '2026-08-10T02:00:00+02:00' },
+                    },
+                  ],
+                },
+              },
+            },
+            { feedback: { none: { op: 'in', value: { path: 'value' }, set: ['bad', 'worse'] } } },
+          ],
+        },
+      }),
+    );
+
+    expect(plan.where).toEqual({
+      type: 'boolean',
+      operator: 'and',
+      args: [
+        {
+          type: 'relation',
+          collection: 'feedback',
+          quantifier: 'some',
+          predicate: {
+            type: 'boolean',
+            operator: 'and',
+            args: [
+              { type: 'comparison', field: 'feedbackType', operator: 'eq', value: 'rating' },
+              { type: 'comparison', field: 'value', operator: 'lt', value: 0 },
+              { type: 'presence', field: 'comment', operator: 'exists' },
+              { type: 'comparison', field: 'timestamp', operator: 'gte', value: '2026-08-10T00:00:00.000Z' },
+            ],
+          },
+        },
+        {
+          type: 'relation',
+          collection: 'feedback',
+          quantifier: 'none',
+          predicate: { type: 'membership', field: 'value', operator: 'in', values: ['bad', 'worse'] },
+        },
+      ],
+    });
+  });
+
+  it('validates feedback fields and strict value types', () => {
+    for (const field of [
+      'feedbackSource',
+      'feedbackUserId',
+      'sourceId',
+      'entityVersionId',
+      'parentEntityVersionId',
+      'rootEntityVersionId',
+    ]) {
+      expect(
+        planTraceQuery(
+          parsed({
+            ...baseRequest,
+            where: { feedback: { some: { op: 'eq', left: { path: field }, right: { literal: 'value' } } } },
+          }),
+        ).where,
+      ).toMatchObject({ type: 'relation', collection: 'feedback' });
+    }
+
+    for (const field of ['source', 'userId']) {
+      const error = validationError(() =>
+        planTraceQuery(
+          parsed({
+            ...baseRequest,
+            where: { feedback: { some: { op: 'exists', path: field } } },
+          }),
+        ),
+      );
+      expect(error.issues[0]).toMatchObject({
+        code: 'field_not_allowed',
+        path: ['where', 'feedback', 'some', 'path'],
+      });
+    }
+
+    const mixed = validationError(() =>
+      planTraceQuery(
+        parsed({
+          ...baseRequest,
+          where: { feedback: { some: { op: 'in', value: { path: 'value' }, set: [3, '3'] } } },
+        }),
+      ),
+    );
+    expect(mixed.issues[0]).toMatchObject({
+      code: 'invalid_literal',
+      path: ['where', 'feedback', 'some', 'set'],
+    });
+
+    for (const literal of ['3', true, null]) {
+      const error = validationError(() =>
+        planTraceQuery(
+          parsed({
+            ...baseRequest,
+            where: { feedback: { some: { op: 'lt', left: { path: 'value' }, right: { literal } } } },
+          }),
+        ),
+      );
+      expect(error.issues[0]).toMatchObject({
+        code: 'invalid_literal',
+        path: ['where', 'feedback', 'some', 'right', 'literal'],
+      });
+    }
+  });
+
   it('enforces field-specific operators and literal types', () => {
     const badErrorOperator = validationError(() =>
       planTraceQuery(

--- a/packages/core/src/storage/domains/observability/trace-query.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { z } from 'zod/v4';
+import type { FeedbackRecord } from './feedback';
 import type { ScoreRecord } from './scores';
 import type { SpanRecord } from './tracing';
 
@@ -229,17 +230,7 @@ export type TraceQueryField =
 type TraceQueryDerivedSpanField = 'model' | 'provider' | 'durationMs' | 'status';
 export type TraceQuerySpanField = keyof typeof SPAN_FIELD_RULES;
 export type TraceQueryScoreField = keyof typeof SCORE_FIELD_RULES;
-export type TraceQueryFeedbackField =
-  | 'feedbackType'
-  | 'feedbackSource'
-  | 'feedbackUserId'
-  | 'sourceId'
-  | 'entityVersionId'
-  | 'parentEntityVersionId'
-  | 'rootEntityVersionId'
-  | 'value'
-  | 'timestamp'
-  | 'comment';
+export type TraceQueryFeedbackField = keyof typeof FEEDBACK_FIELD_RULES;
 export type TraceQueryCanonicalField =
   | TraceQueryField
   | TraceQuerySpanField
@@ -419,7 +410,7 @@ const SCORE_FIELD_RULES = {
   rootEntityVersionId: { type: 'string', operators: STRING_OPERATORS },
 } as const satisfies Partial<Record<Extract<keyof ScoreRecord, string>, FieldRule>>;
 
-const FEEDBACK_FIELD_RULES: Record<TraceQueryFeedbackField, FieldRule> = {
+const FEEDBACK_FIELD_RULES = {
   feedbackType: { type: 'string', operators: STRING_OPERATORS },
   feedbackSource: { type: 'string', operators: STRING_OPERATORS },
   feedbackUserId: { type: 'string', operators: STRING_OPERATORS },
@@ -430,7 +421,7 @@ const FEEDBACK_FIELD_RULES: Record<TraceQueryFeedbackField, FieldRule> = {
   value: { type: 'stringOrNumber', operators: ORDERED_OPERATORS },
   timestamp: { type: 'timestamp', operators: ORDERED_OPERATORS },
   comment: { type: 'presence', operators: PRESENCE_OPERATORS },
-};
+} as const satisfies Partial<Record<Extract<keyof FeedbackRecord, string>, FieldRule>>;
 
 type PredicateContext = 'trace' | 'spans' | 'scores' | 'feedback';
 

--- a/packages/core/src/storage/domains/observability/trace-query.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.ts
@@ -102,6 +102,14 @@ export const traceQueryPredicateSchema: z.ZodType<TraceQueryPredicate> = z.lazy(
         ]),
       })
       .strict(),
+    z
+      .object({
+        feedback: z.union([
+          z.object({ some: traceQueryScalarPredicateSchema }).strict(),
+          z.object({ none: traceQueryScalarPredicateSchema }).strict(),
+        ]),
+      })
+      .strict(),
   ]),
 );
 
@@ -198,7 +206,8 @@ export type TraceQueryPredicate =
   | { op: 'and' | 'or'; args: TraceQueryPredicate[] }
   | { op: 'not'; arg: TraceQueryPredicate }
   | { spans: { some: TraceQueryScalarPredicate } | { none: TraceQueryScalarPredicate } }
-  | { scores: { some: TraceQueryScalarPredicate } | { none: TraceQueryScalarPredicate } };
+  | { scores: { some: TraceQueryScalarPredicate } | { none: TraceQueryScalarPredicate } }
+  | { feedback: { some: TraceQueryScalarPredicate } | { none: TraceQueryScalarPredicate } };
 
 export type TraceQueryRequest = z.input<typeof traceQueryRequestObjectSchema>;
 export type NormalizedTraceQueryRequest = z.output<typeof traceQueryRequestObjectSchema>;
@@ -220,7 +229,22 @@ export type TraceQueryField =
 type TraceQueryDerivedSpanField = 'model' | 'provider' | 'durationMs' | 'status';
 export type TraceQuerySpanField = keyof typeof SPAN_FIELD_RULES;
 export type TraceQueryScoreField = keyof typeof SCORE_FIELD_RULES;
-export type TraceQueryCanonicalField = TraceQueryField | TraceQuerySpanField | TraceQueryScoreField;
+export type TraceQueryFeedbackField =
+  | 'feedbackType'
+  | 'feedbackSource'
+  | 'feedbackUserId'
+  | 'sourceId'
+  | 'entityVersionId'
+  | 'parentEntityVersionId'
+  | 'rootEntityVersionId'
+  | 'value'
+  | 'timestamp'
+  | 'comment';
+export type TraceQueryCanonicalField =
+  | TraceQueryField
+  | TraceQuerySpanField
+  | TraceQueryScoreField
+  | TraceQueryFeedbackField;
 type TraceQueryMetadataKey = Extract<keyof NonNullable<SpanRecord['metadata']>, string>;
 export type TraceQueryMetadataField = `metadata.${TraceQueryMetadataKey}`;
 export type TraceQueryPredicateField = TraceQueryCanonicalField | TraceQueryMetadataField;
@@ -251,7 +275,7 @@ export type TrustedTraceQueryPredicate =
   | { type: 'not'; arg: TrustedTraceQueryPredicate }
   | {
       type: 'relation';
-      collection: 'spans' | 'scores';
+      collection: 'spans' | 'scores' | 'feedback';
       quantifier: 'some' | 'none';
       predicate: TrustedTraceQueryScalarPredicate;
     };
@@ -343,7 +367,7 @@ export function resolveTraceQueryTimeoutMs(timeoutMs = TRACE_QUERY_DEFAULT_TIMEO
 }
 
 interface FieldRule {
-  type: 'string' | 'number' | 'timestamp' | 'presence';
+  type: 'string' | 'number' | 'stringOrNumber' | 'timestamp' | 'presence';
   operators: ReadonlySet<string>;
   nonEmpty?: boolean;
 }
@@ -395,7 +419,20 @@ const SCORE_FIELD_RULES = {
   rootEntityVersionId: { type: 'string', operators: STRING_OPERATORS },
 } as const satisfies Partial<Record<Extract<keyof ScoreRecord, string>, FieldRule>>;
 
-type PredicateContext = 'trace' | 'spans' | 'scores';
+const FEEDBACK_FIELD_RULES: Record<TraceQueryFeedbackField, FieldRule> = {
+  feedbackType: { type: 'string', operators: STRING_OPERATORS },
+  feedbackSource: { type: 'string', operators: STRING_OPERATORS },
+  feedbackUserId: { type: 'string', operators: STRING_OPERATORS },
+  sourceId: { type: 'string', operators: STRING_OPERATORS },
+  entityVersionId: { type: 'string', operators: STRING_OPERATORS },
+  parentEntityVersionId: { type: 'string', operators: STRING_OPERATORS },
+  rootEntityVersionId: { type: 'string', operators: STRING_OPERATORS },
+  value: { type: 'stringOrNumber', operators: ORDERED_OPERATORS },
+  timestamp: { type: 'timestamp', operators: ORDERED_OPERATORS },
+  comment: { type: 'presence', operators: PRESENCE_OPERATORS },
+};
+
+type PredicateContext = 'trace' | 'spans' | 'scores' | 'feedback';
 
 interface PlannerState {
   nodes: number;
@@ -439,7 +476,7 @@ function findPredicateComplexityIssue(input: unknown): Array<string | number> | 
       continue;
     }
 
-    for (const collection of ['scores', 'spans'] as const) {
+    for (const collection of ['feedback', 'scores', 'spans'] as const) {
       const clause = predicate[collection];
       if (!clause || typeof clause !== 'object') continue;
       for (const quantifier of ['none', 'some'] as const) {
@@ -599,7 +636,7 @@ function planPredicate(
     return undefined;
   }
 
-  if ('spans' in predicate || 'scores' in predicate) {
+  if ('spans' in predicate || 'scores' in predicate || 'feedback' in predicate) {
     state.relatedClauses += 1;
     if (state.relatedClauses > TRACE_QUERY_MAX_RELATED_CLAUSES) {
       addPredicateComplexityIssue(
@@ -616,8 +653,9 @@ function planPredicate(
       });
       return undefined;
     }
-    const collection = 'spans' in predicate ? 'spans' : 'scores';
-    const clause = 'spans' in predicate ? predicate.spans : predicate.scores;
+    const collection = 'spans' in predicate ? 'spans' : 'scores' in predicate ? 'scores' : 'feedback';
+    const clause =
+      'spans' in predicate ? predicate.spans : 'scores' in predicate ? predicate.scores : predicate.feedback;
     const quantifier = 'some' in clause ? 'some' : 'none';
     const nested = 'some' in clause ? clause.some : clause.none;
     const planned = planPredicate(nested, collection, [...path, collection, quantifier], depth + 1, state);
@@ -705,7 +743,7 @@ function planPredicate(
   const rule = getRule(field, context, rules, [...path, 'left', 'path'], state);
   if (!rule) return undefined;
   if (!rule.operators.has(comparison.op)) addOperatorIssue(comparison.op, field, [...path, 'op'], state);
-  const value = normalizeLiteral(comparison.right.literal, rule);
+  const value = normalizeLiteral(comparison.right.literal, rule, comparison.op);
   if (value === undefined) {
     state.issues.push({
       code: 'invalid_literal',
@@ -720,6 +758,7 @@ function planPredicate(
 function rulesForContext(context: PredicateContext): Record<string, FieldRule> {
   if (context === 'spans') return SPAN_FIELD_RULES;
   if (context === 'scores') return SCORE_FIELD_RULES;
+  if (context === 'feedback') return FEEDBACK_FIELD_RULES;
   return TRACE_FIELD_RULES;
 }
 
@@ -768,8 +807,18 @@ function normalizePath(path: string): string {
   return normalized;
 }
 
-function normalizeLiteral(value: TraceQueryLiteral, rule: FieldRule): string | number | undefined {
+function normalizeLiteral(
+  value: TraceQueryLiteral,
+  rule: FieldRule,
+  operator?: TraceQueryComparisonOperator,
+): string | number | undefined {
   if (rule.type === 'number') return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  if (rule.type === 'stringOrNumber') {
+    if (operator && !STRING_OPERATORS.has(operator)) {
+      return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+    }
+    return typeof value === 'string' || (typeof value === 'number' && Number.isFinite(value)) ? value : undefined;
+  }
   if (rule.type === 'timestamp') {
     const timestamp = timestampLiteralSchema.safeParse(value);
     return timestamp.success ? new Date(timestamp.data).toISOString() : undefined;
@@ -782,7 +831,10 @@ function normalizeLiteral(value: TraceQueryLiteral, rule: FieldRule): string | n
 
 function normalizeSet(values: TraceQueryLiteral[], rule: FieldRule): Array<string | number> | undefined {
   const normalized = values.map(value => normalizeLiteral(value, rule));
-  return normalized.some(value => value === undefined) ? undefined : (normalized as Array<string | number>);
+  if (normalized.some(value => value === undefined)) return undefined;
+  if (rule.type === 'stringOrNumber' && normalized.some(value => typeof value !== typeof normalized[0]))
+    return undefined;
+  return normalized as Array<string | number>;
 }
 
 function digestBinding(value: unknown): string {

--- a/packages/server/src/server/handlers/observability-trace-query.test.ts
+++ b/packages/server/src/server/handlers/observability-trace-query.test.ts
@@ -134,6 +134,73 @@ describe('QUERY_TRACES', () => {
     expect(response).not.toHaveProperty('matches');
   });
 
+  it('passes feedback predicates through without adding matching evidence', async () => {
+    const { mastra, observabilityStore } = createHarness();
+    const response = await QUERY_TRACES.handler(
+      params(mastra, {
+        timeRange: TIME_RANGE,
+        where: {
+          feedback: {
+            some: {
+              op: 'and',
+              args: [
+                { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'rating' } },
+                { op: 'lt', left: { path: 'value' }, right: { literal: 0 } },
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    expect(observabilityStore.queryTraces).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          type: 'relation',
+          collection: 'feedback',
+          quantifier: 'some',
+          predicate: expect.objectContaining({ type: 'boolean', operator: 'and' }),
+        }),
+      }),
+    );
+    expect(response).toEqual({ traces: [], page: { next: null } });
+    expect(response).not.toHaveProperty('feedback');
+    expect(response).not.toHaveProperty('matches');
+  });
+
+  it('rejects invalid feedback value types before touching storage', async () => {
+    const { mastra, observabilityStore, getStore } = createHarness();
+    const cases = [
+      {
+        predicate: { op: 'in', value: { path: 'value' }, set: [3, 'sensitive-3'] },
+        issue: { code: 'invalid_literal', path: ['where', 'feedback', 'some', 'set'] },
+      },
+      {
+        predicate: { op: 'lt', left: { path: 'value' }, right: { literal: 'sensitive-3' } },
+        issue: { code: 'invalid_literal', path: ['where', 'feedback', 'some', 'right', 'literal'] },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const error = await captureHttpException(
+        QUERY_TRACES.handler(
+          params(mastra, {
+            timeRange: TIME_RANGE,
+            where: { feedback: { some: testCase.predicate } },
+          }),
+        ),
+      );
+      expect(error.status).toBe(422);
+      const body = await error.getResponse().json();
+      expect(body).toMatchObject({ code: 'TRACE_QUERY_INVALID' });
+      expect(body.issues).toContainEqual(expect.objectContaining(testCase.issue));
+      expect(JSON.stringify(body)).not.toContain('sensitive');
+    }
+
+    expect(getStore).not.toHaveBeenCalled();
+    expect(observabilityStore.queryTraces).not.toHaveBeenCalled();
+  });
+
   it('preserves the shared canonical semantics and fixed response projections', async () => {
     const { mastra, observabilityStore } = createHarness();
     observabilityStore.queryTraces.mockImplementation(plan => evaluateTraceQuery(TRACE_QUERY_FIXTURE_DATA, plan));

--- a/stores/_test-utils/src/domains/observability-vnext/index.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/index.ts
@@ -165,7 +165,7 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
                 spans: TRACE_QUERY_FIXTURE_DATA.spans,
                 relatedSpans: [],
                 scores: TRACE_QUERY_FIXTURE_DATA.scores,
-                feedback: currentTraceQueryFeedbackFixture(),
+                feedback: TRACE_QUERY_FIXTURE_DATA.feedback,
               };
         const records: CreateSpanRecord[] = [...fixture.spans, ...fixture.relatedSpans]
           .filter(span => span.traceId !== null)

--- a/stores/_test-utils/src/domains/observability-vnext/index.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/index.ts
@@ -38,6 +38,8 @@ export interface ObservabilityVNextCapabilities {
    * not accept pending events or logical replacement writes.
    */
   traceQueryWriteModel?: 'current-record' | 'completion-only';
+  /** Whether feedback value predicates distinguish numbers from numeric-looking strings. Defaults to true. */
+  traceQueryStrictFeedbackValueTypes?: boolean;
 }
 
 export interface CreateObservabilityVNextTestsOptions {
@@ -105,6 +107,7 @@ function completionOnlyTraceQueryFixture() {
     spans: [...roots.values()].filter(root => !root.isPending),
     relatedSpans: [...spans.values()],
     scores: [...scores.values()],
+    feedback: TRACE_QUERY_FIXTURE_DATA.feedback,
   };
 }
 
@@ -156,6 +159,7 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
                 spans: TRACE_QUERY_FIXTURE_DATA.spans,
                 relatedSpans: [],
                 scores: TRACE_QUERY_FIXTURE_DATA.scores,
+                feedback: TRACE_QUERY_FIXTURE_DATA.feedback,
               };
         const records: CreateSpanRecord[] = [...fixture.spans, ...fixture.relatedSpans]
           .filter(span => span.traceId !== null)
@@ -206,7 +210,31 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
           });
         for (const score of scores) await storage.createScore({ score });
 
+        for (const feedback of fixture.feedback) {
+          await storage.createFeedback({
+            feedback: {
+              feedbackId: feedback.feedbackId,
+              traceId: feedback.traceId,
+              spanId: null,
+              timestamp: new Date(feedback.timestamp),
+              feedbackType: feedback.feedbackType,
+              feedbackSource: feedback.feedbackSource,
+              feedbackUserId: feedback.feedbackUserId,
+              sourceId: feedback.sourceId,
+              value: feedback.value,
+              comment: feedback.comment,
+              entityVersionId: feedback.entityVersionId,
+              parentEntityVersionId: feedback.parentEntityVersionId,
+              rootEntityVersionId: feedback.rootEntityVersionId,
+              metadata: null,
+            },
+          });
+        }
+
         for (const testCase of TRACE_QUERY_CONFORMANCE_CASES) {
+          if (testCase.requiresStrictFeedbackValueTypes && capabilities.traceQueryStrictFeedbackValueTypes === false) {
+            continue;
+          }
           const plan = planTraceQuery(parseTraceQueryRequest(testCase.request));
           const response = await storage.queryTraces(plan);
           expect(normalizeTraceQueryResponse(response), testCase.name).toEqual(testCase.expected);

--- a/stores/_test-utils/src/domains/observability-vnext/index.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/index.ts
@@ -14,6 +14,7 @@ import { VNEXT_BASE_DATE, makeSpan } from './data';
 import {
   normalizeTraceQueryResponse,
   TRACE_QUERY_CONFORMANCE_CASES,
+  TRACE_QUERY_FEEDBACK_REPLACEMENT_SCENARIOS,
   TRACE_QUERY_FIXTURE_DATA,
   TRACE_QUERY_ORDINAL_FIXTURE_DATA,
 } from './trace-query';
@@ -33,11 +34,11 @@ export interface ObservabilityVNextCapabilities {
   /** Whether this adapter implements the advanced trusted trace-query plan. */
   traceQuery?: boolean;
   /**
-   * The write model used to seed trace-query conformance fixtures. Completion-only
-   * adapters receive only each fixture's final completed record, because they do
-   * not accept pending events or logical replacement writes.
+   * The span write model used to seed trace-query conformance fixtures. Completion-only
+   * adapters receive only completed span records. Score and feedback history is always
+   * written unchanged so adapters must implement their own current-record semantics.
    */
-  traceQueryWriteModel?: 'current-record' | 'completion-only';
+  traceQuerySpanWriteModel?: 'event-sourced' | 'completion-only';
   /** Whether feedback value predicates distinguish numbers from numeric-looking strings. Defaults to true. */
   traceQueryStrictFeedbackValueTypes?: boolean;
 }
@@ -89,12 +90,6 @@ export interface CreateObservabilityVNextTestsOptions {
  * materialized views) so the assertion isn't racey. Adapters with synchronous
  * reads (InMemory, DuckDB) satisfy the predicate on the first call.
  */
-function currentTraceQueryFeedbackFixture() {
-  const feedback = new Map<string, (typeof TRACE_QUERY_FIXTURE_DATA.feedback)[number]>();
-  for (const record of TRACE_QUERY_FIXTURE_DATA.feedback) feedback.set(record.feedbackId, record);
-  return [...feedback.values()];
-}
-
 function completionOnlyTraceQueryFixture() {
   const roots = new Map<string | null, (typeof TRACE_QUERY_FIXTURE_DATA.spans)[number]>();
   const spans = new Map<string, (typeof TRACE_QUERY_FIXTURE_DATA.spans)[number]>();
@@ -106,14 +101,11 @@ function completionOnlyTraceQueryFixture() {
     }
   }
 
-  const scores = new Map<string, (typeof TRACE_QUERY_FIXTURE_DATA.scores)[number]>();
-  for (const score of TRACE_QUERY_FIXTURE_DATA.scores) scores.set(score.scoreId, score);
-
   return {
     spans: [...roots.values()].filter(root => !root.isPending),
     relatedSpans: [...spans.values()],
-    scores: [...scores.values()],
-    feedback: currentTraceQueryFeedbackFixture(),
+    scores: TRACE_QUERY_FIXTURE_DATA.scores,
+    feedback: TRACE_QUERY_FIXTURE_DATA.feedback,
   };
 }
 
@@ -159,7 +151,7 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
     if (capabilities.traceQuery) {
       it('matches the shared advanced trace-query conformance cases without merge assistance', async () => {
         const fixture =
-          capabilities.traceQueryWriteModel === 'completion-only'
+          capabilities.traceQuerySpanWriteModel === 'completion-only'
             ? completionOnlyTraceQueryFixture()
             : {
                 spans: TRACE_QUERY_FIXTURE_DATA.spans,
@@ -262,6 +254,71 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
         } while (after);
         expect(pagedTraceIds).toEqual(['trace-d', 'trace-c', 'trace-a', 'trace-b']);
         expect(new Set(pagedTraceIds).size).toBe(pagedTraceIds.length);
+      });
+
+      describe('feedback replacement conformance', () => {
+        for (const scenario of TRACE_QUERY_FEEDBACK_REPLACEMENT_SCENARIOS) {
+          it(scenario.name, async () => {
+            for (const span of scenario.fixture.spans) {
+              await storage.createSpan({
+                span: {
+                  traceId: span.traceId!,
+                  spanId: span.spanId,
+                  parentSpanId: span.parentSpanId,
+                  name: span.name,
+                  spanType: span.spanType as SpanType,
+                  isEvent: false,
+                  startedAt: new Date(span.startedAt),
+                  endedAt: span.endedAt ? new Date(span.endedAt) : null,
+                  threadId: span.threadId,
+                  resourceId: span.resourceId,
+                  entityType: span.entityType as EntityType,
+                  entityId: span.entityId,
+                  entityName: span.entityName,
+                  entityVersionId: span.entityVersionId,
+                  parentEntityVersionId: span.parentEntityVersionId,
+                  rootEntityVersionId: span.rootEntityVersionId,
+                  environment: span.environment,
+                  attributes: span.attributes,
+                  metadata: span.metadata,
+                  error: span.error as CreateSpanRecord['error'],
+                },
+              });
+            }
+
+            for (const write of scenario.writes) {
+              const feedbacks: CreateFeedbackRecord[] = write.feedback.map(feedback => ({
+                feedbackId: feedback.feedbackId,
+                traceId: feedback.traceId,
+                spanId: null,
+                timestamp: new Date(feedback.timestamp),
+                feedbackType: feedback.feedbackType,
+                feedbackSource: feedback.feedbackSource,
+                feedbackUserId: feedback.feedbackUserId,
+                sourceId: feedback.sourceId,
+                value: feedback.value,
+                comment: feedback.comment,
+                entityVersionId: feedback.entityVersionId,
+                parentEntityVersionId: feedback.parentEntityVersionId,
+                rootEntityVersionId: feedback.rootEntityVersionId,
+                metadata: null,
+              }));
+              if (write.method === 'batch') {
+                await storage.batchCreateFeedback({ feedbacks });
+              } else {
+                await storage.createFeedback({ feedback: feedbacks[0]! });
+              }
+            }
+
+            if (flushPendingMerges) await flushPendingMerges(storage);
+
+            for (const assertion of scenario.assertions) {
+              const plan = planTraceQuery(parseTraceQueryRequest(assertion.request));
+              const response = await storage.queryTraces(plan);
+              expect.soft(normalizeTraceQueryResponse(response), assertion.name).toEqual(assertion.expected);
+            }
+          });
+        }
       });
 
       it('paginates mixed-case and non-ASCII trace and thread IDs in ordinal order', async () => {

--- a/stores/_test-utils/src/domains/observability-vnext/index.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/index.ts
@@ -89,6 +89,12 @@ export interface CreateObservabilityVNextTestsOptions {
  * materialized views) so the assertion isn't racey. Adapters with synchronous
  * reads (InMemory, DuckDB) satisfy the predicate on the first call.
  */
+function currentTraceQueryFeedbackFixture() {
+  const feedback = new Map<string, (typeof TRACE_QUERY_FIXTURE_DATA.feedback)[number]>();
+  for (const record of TRACE_QUERY_FIXTURE_DATA.feedback) feedback.set(record.feedbackId, record);
+  return [...feedback.values()];
+}
+
 function completionOnlyTraceQueryFixture() {
   const roots = new Map<string | null, (typeof TRACE_QUERY_FIXTURE_DATA.spans)[number]>();
   const spans = new Map<string, (typeof TRACE_QUERY_FIXTURE_DATA.spans)[number]>();
@@ -107,7 +113,7 @@ function completionOnlyTraceQueryFixture() {
     spans: [...roots.values()].filter(root => !root.isPending),
     relatedSpans: [...spans.values()],
     scores: [...scores.values()],
-    feedback: TRACE_QUERY_FIXTURE_DATA.feedback,
+    feedback: currentTraceQueryFeedbackFixture(),
   };
 }
 
@@ -159,7 +165,7 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
                 spans: TRACE_QUERY_FIXTURE_DATA.spans,
                 relatedSpans: [],
                 scores: TRACE_QUERY_FIXTURE_DATA.scores,
-                feedback: TRACE_QUERY_FIXTURE_DATA.feedback,
+                feedback: currentTraceQueryFeedbackFixture(),
               };
         const records: CreateSpanRecord[] = [...fixture.spans, ...fixture.relatedSpans]
           .filter(span => span.traceId !== null)

--- a/stores/_test-utils/src/domains/observability-vnext/trace-query.test.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/trace-query.test.ts
@@ -6,6 +6,7 @@ import {
   evaluateTraceQueryRequest,
   normalizeTraceQueryResponse,
   TRACE_QUERY_CONFORMANCE_CASES,
+  TRACE_QUERY_FEEDBACK_REPLACEMENT_SCENARIOS,
   TRACE_QUERY_FIXTURE_DATA,
   TRACE_QUERY_ORDINAL_FIXTURE_DATA,
   TRACE_QUERY_TIED_TIMESTAMP_CASES,
@@ -30,6 +31,21 @@ describe('trace-query reference evaluator', () => {
       ).toEqual(testCase.expected);
     });
   }
+
+  describe('feedback replacement contract', () => {
+    for (const scenario of TRACE_QUERY_FEEDBACK_REPLACEMENT_SCENARIOS) {
+      it(scenario.name, () => {
+        for (const assertion of scenario.assertions) {
+          expect
+            .soft(
+              normalizeTraceQueryResponse(evaluateTraceQueryRequest(scenario.fixture, assertion.request)),
+              assertion.name,
+            )
+            .toEqual(assertion.expected);
+        }
+      });
+    }
+  });
 
   it('projects only fixed lightweight fields', () => {
     const response = evaluateTraceQueryRequest(TRACE_QUERY_FIXTURE_DATA, {

--- a/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
@@ -352,8 +352,8 @@ export const TRACE_QUERY_FIXTURE_DATA: TraceQueryFixtureData = {
     }),
   ],
   feedback: [
-    feedbackRecord(1, 'feedback-a-rating', 'trace-a', 'rating', 'patient', -1, {
-      timestamp: '2026-07-15T10:00:00.000Z',
+    feedbackRecord(1, 'feedback-a-rating', 'trace-a', 'rating', 'superseded-patient', -1, {
+      timestamp: '2026-07-14T10:00:00.000Z',
       feedbackUserId: 'patient-1',
       sourceId: 'survey-result-1',
       comment: 'Needs improvement',
@@ -1062,6 +1062,22 @@ export const TRACE_QUERY_CONFORMANCE_CASES: TraceQueryConformanceCase[] = [
     expected: [{ traceId: 'trace-b' }],
   },
   {
+    name: 'uses only the latest feedback record when its timestamp changes',
+    request: {
+      timeRange: fullRange,
+      where: {
+        feedback: {
+          some: {
+            op: 'eq',
+            left: { path: 'feedbackSource' },
+            right: { literal: 'superseded-patient' },
+          },
+        },
+      },
+    },
+    expected: [],
+  },
+  {
     name: 'preserves string feedback values without numeric coercion',
     request: {
       timeRange: fullRange,
@@ -1097,6 +1113,26 @@ export const TRACE_QUERY_CONFORMANCE_CASES: TraceQueryConformanceCase[] = [
       },
     },
     expected: [],
+  },
+  {
+    name: 'treats textual feedback as unequal to a numeric literal',
+    requiresStrictFeedbackValueTypes: true,
+    request: {
+      timeRange: fullRange,
+      where: {
+        feedback: {
+          some: {
+            op: 'and',
+            args: [
+              { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'rating' } },
+              { op: 'eq', left: { path: 'feedbackSource' }, right: { literal: 'patient' } },
+              { op: 'ne', left: { path: 'value' }, right: { literal: 3 } },
+            ],
+          },
+        },
+      },
+    },
+    expected: [{ traceId: 'trace-a' }, { traceId: 'trace-b' }],
   },
   {
     name: 'matches feedback lineage, user, and source fields',
@@ -1233,9 +1269,8 @@ function currentScores(scores: RawTraceQueryScore[]): RawTraceQueryScore[] {
 function currentFeedback(feedback: RawTraceQueryFeedback[]): RawTraceQueryFeedback[] {
   const records = new Map<string, RawTraceQueryFeedback>();
   for (const candidate of feedback) {
-    const key = `${candidate.feedbackId}\u0000${candidate.timestamp}`;
-    const current = records.get(key);
-    if (!current || candidate.cursorId > current.cursorId) records.set(key, candidate);
+    const current = records.get(candidate.feedbackId);
+    if (!current || candidate.cursorId > current.cursorId) records.set(candidate.feedbackId, candidate);
   }
   return [...records.values()];
 }

--- a/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
@@ -53,9 +53,26 @@ export interface RawTraceQueryScore {
   rootEntityVersionId: string | null;
 }
 
+export interface RawTraceQueryFeedback {
+  cursorId: number;
+  feedbackId: string;
+  traceId: string | null;
+  timestamp: string;
+  feedbackType: string;
+  feedbackSource: string;
+  feedbackUserId: string | null;
+  sourceId: string | null;
+  value: string | number;
+  comment: string | null;
+  entityVersionId: string | null;
+  parentEntityVersionId: string | null;
+  rootEntityVersionId: string | null;
+}
+
 export interface TraceQueryFixtureData {
   spans: RawTraceQuerySpan[];
   scores: RawTraceQueryScore[];
+  feedback: RawTraceQueryFeedback[];
 }
 
 const span = (
@@ -105,6 +122,31 @@ const scoreRecord = (
   scorerVersion: null,
   scoreSource: null,
   score,
+  entityVersionId: null,
+  parentEntityVersionId: null,
+  rootEntityVersionId: null,
+  ...overrides,
+});
+
+const feedbackRecord = (
+  cursorId: number,
+  feedbackId: string,
+  traceId: string | null,
+  feedbackType: string,
+  feedbackSource: string,
+  value: string | number,
+  overrides: Partial<RawTraceQueryFeedback> = {},
+): RawTraceQueryFeedback => ({
+  cursorId,
+  feedbackId,
+  traceId,
+  timestamp: '2026-08-10T00:00:00.000Z',
+  feedbackType,
+  feedbackSource,
+  feedbackUserId: null,
+  sourceId: null,
+  value,
+  comment: null,
   entityVersionId: null,
   parentEntityVersionId: null,
   rootEntityVersionId: null,
@@ -309,6 +351,41 @@ export const TRACE_QUERY_FIXTURE_DATA: TraceQueryFixtureData = {
       scoreSource: 'automated',
     }),
   ],
+  feedback: [
+    feedbackRecord(1, 'feedback-a-rating', 'trace-a', 'rating', 'patient', -1, {
+      timestamp: '2026-07-15T10:00:00.000Z',
+      feedbackUserId: 'patient-1',
+      sourceId: 'survey-result-1',
+      comment: 'Needs improvement',
+      entityVersionId: 'entity-v2',
+      parentEntityVersionId: 'parent-v2',
+      rootEntityVersionId: 'root-v1',
+    }),
+    feedbackRecord(2, 'feedback-a-rating', 'trace-a', 'rating', 'patient', -1, {
+      timestamp: '2026-07-15T10:00:00.000Z',
+      feedbackUserId: 'patient-1',
+      sourceId: 'survey-result-1',
+      comment: 'Needs improvement',
+      entityVersionId: 'entity-v2',
+      parentEntityVersionId: 'parent-v2',
+      rootEntityVersionId: 'root-v1',
+    }),
+    feedbackRecord(3, 'feedback-a-correction', 'trace-a', 'clinician-correction', 'clinician', 'Use 20 mg', {
+      timestamp: '2026-08-12T10:00:00.000Z',
+      feedbackUserId: 'clinician-1',
+    }),
+    feedbackRecord(4, 'feedback-b-review-type', 'trace-b', 'clinical-review', 'patient', 'reviewed'),
+    feedbackRecord(5, 'feedback-b-review-source', 'trace-b', 'rating', 'clinician', 3, {
+      timestamp: '2026-08-20T10:00:00.000Z',
+      sourceId: 'app-result-1',
+    }),
+    feedbackRecord(6, 'feedback-b-text-three', 'trace-b', 'rating', 'patient', '3'),
+    feedbackRecord(7, 'feedback-c-review', 'trace-c', 'clinical-review', 'clinician', 'approved', {
+      comment: 'Reviewed',
+    }),
+    feedbackRecord(8, 'feedback-uncorrelated', null, 'rating', 'patient', -5),
+    feedbackRecord(9, 'feedback-nonmatching-trace', 'trace-without-root', 'rating', 'patient', -5),
+  ],
 };
 
 const tiedStartedAt = '2026-08-20T10:00:00.000Z';
@@ -323,6 +400,7 @@ export const TRACE_QUERY_ORDINAL_FIXTURE_DATA: TraceQueryFixtureData = {
     span(204, 'Ω', 'root-omega', { threadId: 'Ω', startedAt: tiedStartedAt, endedAt: tiedEndedAt }),
   ],
   scores: [],
+  feedback: [],
 };
 
 export const TRACE_QUERY_TIED_TIMESTAMP_FIXTURE_DATA: TraceQueryFixtureData = {
@@ -359,6 +437,7 @@ export const TRACE_QUERY_TIED_TIMESTAMP_FIXTURE_DATA: TraceQueryFixtureData = {
     scoreRecord(100, 'score-tied', 'trace-tied', 'factuality', 0.9, { timestamp: tiedScoreTimestamp }),
     scoreRecord(101, 'score-tied', 'trace-tied', 'factuality', 0.2, { timestamp: tiedScoreTimestamp }),
   ],
+  feedback: [],
 };
 
 const fullRange = {
@@ -370,6 +449,7 @@ export interface TraceQueryConformanceCase {
   name: string;
   request: TraceQueryRequest;
   expected: Array<{ traceId: string } | { threadId: string }>;
+  requiresStrictFeedbackValueTypes?: boolean;
 }
 
 export const TRACE_QUERY_TIED_TIMESTAMP_CASES: TraceQueryConformanceCase[] = [
@@ -898,6 +978,148 @@ export const TRACE_QUERY_CONFORMANCE_CASES: TraceQueryConformanceCase[] = [
     expected: [{ traceId: 'trace-d' }],
   },
   {
+    name: 'matches negative numeric patient feedback outside the root time range',
+    request: {
+      timeRange: fullRange,
+      where: {
+        feedback: {
+          some: {
+            op: 'and',
+            args: [
+              { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'rating' } },
+              { op: 'eq', left: { path: 'feedbackSource' }, right: { literal: 'patient' } },
+              { op: 'lt', left: { path: 'value' }, right: { literal: 0 } },
+            ],
+          },
+        },
+      },
+    },
+    expected: [{ traceId: 'trace-a' }],
+  },
+  {
+    name: 'matches clinician correction feedback',
+    request: {
+      timeRange: fullRange,
+      where: {
+        feedback: {
+          some: {
+            op: 'and',
+            args: [
+              { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'clinician-correction' } },
+              { op: 'eq', left: { path: 'feedbackSource' }, right: { literal: 'clinician' } },
+            ],
+          },
+        },
+      },
+    },
+    expected: [{ traceId: 'trace-a' }],
+  },
+  {
+    name: 'anti-matches clinician review with same-record binding and includes traces without feedback',
+    request: {
+      timeRange: fullRange,
+      where: {
+        feedback: {
+          none: {
+            op: 'and',
+            args: [
+              { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'clinical-review' } },
+              { op: 'eq', left: { path: 'feedbackSource' }, right: { literal: 'clinician' } },
+            ],
+          },
+        },
+      },
+    },
+    expected: [{ traceId: 'trace-d' }, { traceId: 'trace-a' }, { traceId: 'trace-b' }],
+  },
+  {
+    name: 'matches feedback with comments',
+    request: { timeRange: fullRange, where: { feedback: { some: { op: 'exists', path: 'comment' } } } },
+    expected: [{ traceId: 'trace-c' }, { traceId: 'trace-a' }],
+  },
+  {
+    name: 'matches feedback without comments',
+    request: { timeRange: fullRange, where: { feedback: { some: { op: 'notExists', path: 'comment' } } } },
+    expected: [{ traceId: 'trace-a' }, { traceId: 'trace-b' }],
+  },
+  {
+    name: 'matches application-defined feedback sources in an independent feedback time range',
+    request: {
+      timeRange: fullRange,
+      where: {
+        feedback: {
+          some: {
+            op: 'and',
+            args: [
+              { op: 'eq', left: { path: 'feedbackSource' }, right: { literal: 'clinician' } },
+              { op: 'gte', left: { path: 'timestamp' }, right: { literal: '2026-08-15T00:00:00Z' } },
+              { op: 'lt', left: { path: 'timestamp' }, right: { literal: '2026-09-01T00:00:00Z' } },
+            ],
+          },
+        },
+      },
+    },
+    expected: [{ traceId: 'trace-b' }],
+  },
+  {
+    name: 'preserves string feedback values without numeric coercion',
+    request: {
+      timeRange: fullRange,
+      where: {
+        feedback: {
+          some: {
+            op: 'and',
+            args: [
+              { op: 'eq', left: { path: 'feedbackSource' }, right: { literal: 'patient' } },
+              { op: 'eq', left: { path: 'value' }, right: { literal: '3' } },
+            ],
+          },
+        },
+      },
+    },
+    expected: [{ traceId: 'trace-b' }],
+  },
+  {
+    name: 'does not coerce textual feedback values to numbers',
+    requiresStrictFeedbackValueTypes: true,
+    request: {
+      timeRange: fullRange,
+      where: {
+        feedback: {
+          some: {
+            op: 'and',
+            args: [
+              { op: 'eq', left: { path: 'feedbackSource' }, right: { literal: 'patient' } },
+              { op: 'eq', left: { path: 'value' }, right: { literal: 3 } },
+            ],
+          },
+        },
+      },
+    },
+    expected: [],
+  },
+  {
+    name: 'matches feedback lineage, user, and source fields',
+    request: {
+      timeRange: fullRange,
+      where: {
+        feedback: {
+          some: {
+            op: 'and',
+            args: [
+              { op: 'eq', left: { path: 'feedbackUserId' }, right: { literal: 'patient-1' } },
+              { op: 'eq', left: { path: 'sourceId' }, right: { literal: 'survey-result-1' } },
+              { op: 'eq', left: { path: 'entityVersionId' }, right: { literal: 'entity-v2' } },
+              { op: 'eq', left: { path: 'parentEntityVersionId' }, right: { literal: 'parent-v2' } },
+              { op: 'eq', left: { path: 'rootEntityVersionId' }, right: { literal: 'root-v1' } },
+            ],
+          },
+        },
+      },
+    },
+    expected: [{ traceId: 'trace-a' }],
+  },
+  {
     name: 'returns distinct non-null thread groups',
     request: { timeRange: fullRange, group: { by: ['threadId'] } },
     expected: [{ threadId: 'thread-1' }, { threadId: 'thread-2' }],
@@ -907,10 +1129,11 @@ export const TRACE_QUERY_CONFORMANCE_CASES: TraceQueryConformanceCase[] = [
 export function evaluateTraceQuery(data: TraceQueryFixtureData, plan: TrustedTraceQueryPlan): TraceQueryResponse {
   const spans = currentSpans(data.spans);
   const scores = currentScores(data.scores);
+  const feedback = currentFeedback(data.feedback);
   const roots = currentRoots(data.spans)
     .filter(root => !root.isPending && root.endedAt !== null)
     .filter(root => root.startedAt >= plan.timeRange.from && root.startedAt < plan.timeRange.to)
-    .filter(root => !plan.where || evaluateTracePredicate(plan.where, root, spans, scores));
+    .filter(root => !plan.where || evaluateTracePredicate(plan.where, root, spans, scores, feedback));
 
   if (plan.result === 'groups') {
     let groups = [...new Set(roots.map(root => root.threadId).filter((value): value is string => value !== null))].sort(
@@ -1007,14 +1230,26 @@ function currentScores(scores: RawTraceQueryScore[]): RawTraceQueryScore[] {
   return [...records.values()];
 }
 
+function currentFeedback(feedback: RawTraceQueryFeedback[]): RawTraceQueryFeedback[] {
+  const records = new Map<string, RawTraceQueryFeedback>();
+  for (const candidate of feedback) {
+    const key = `${candidate.feedbackId}\u0000${candidate.timestamp}`;
+    const current = records.get(key);
+    if (!current || candidate.cursorId > current.cursorId) records.set(key, candidate);
+  }
+  return [...records.values()];
+}
+
 function evaluateTracePredicate(
   predicate: TrustedTraceQueryPredicate,
   root: RawTraceQuerySpan,
   spans: RawTraceQuerySpan[],
   scores: RawTraceQueryScore[],
+  feedback: RawTraceQueryFeedback[],
 ): boolean {
   if (predicate.type === 'relation') {
-    const records = (predicate.collection === 'spans' ? spans : scores).filter(
+    const collection = predicate.collection === 'spans' ? spans : predicate.collection === 'scores' ? scores : feedback;
+    const records = collection.filter(
       record => root.traceId !== null && record.traceId !== null && record.traceId === root.traceId,
     );
     const matched = records.some(record =>
@@ -1027,16 +1262,16 @@ function evaluateTracePredicate(
   }
   if (predicate.type === 'boolean') {
     return predicate.operator === 'and'
-      ? predicate.args.every(arg => evaluateTracePredicate(arg, root, spans, scores))
-      : predicate.args.some(arg => evaluateTracePredicate(arg, root, spans, scores));
+      ? predicate.args.every(arg => evaluateTracePredicate(arg, root, spans, scores, feedback))
+      : predicate.args.some(arg => evaluateTracePredicate(arg, root, spans, scores, feedback));
   }
-  if (predicate.type === 'not') return !evaluateTracePredicate(predicate.arg, root, spans, scores);
+  if (predicate.type === 'not') return !evaluateTracePredicate(predicate.arg, root, spans, scores, feedback);
   return evaluateScalarPredicate(predicate, traceValues(root));
 }
 
 function evaluateScalarPredicate(
   predicate: TrustedTraceQueryScalarPredicate,
-  record: RawTraceQuerySpan | RawTraceQueryScore | Record<string, unknown>,
+  record: RawTraceQuerySpan | RawTraceQueryScore | RawTraceQueryFeedback | Record<string, unknown>,
 ): boolean {
   if (predicate.type === 'boolean') {
     return predicate.operator === 'and'
@@ -1053,6 +1288,7 @@ function evaluateScalarPredicate(
     return predicate.operator === 'in' ? included : !included;
   }
   if (missing) return predicate.operator === 'ne';
+  if (typeof value !== typeof predicate.value) return predicate.operator === 'ne';
   switch (predicate.operator) {
     case 'eq':
       return value === predicate.value;

--- a/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
@@ -1078,6 +1078,22 @@ export const TRACE_QUERY_CONFORMANCE_CASES: TraceQueryConformanceCase[] = [
     expected: [],
   },
   {
+    name: 'applies feedback none to only the latest record when its timestamp changes',
+    request: {
+      timeRange: fullRange,
+      where: {
+        feedback: {
+          none: {
+            op: 'eq',
+            left: { path: 'feedbackSource' },
+            right: { literal: 'superseded-patient' },
+          },
+        },
+      },
+    },
+    expected: [{ traceId: 'trace-d' }, { traceId: 'trace-c' }, { traceId: 'trace-a' }, { traceId: 'trace-b' }],
+  },
+  {
     name: 'preserves string feedback values without numeric coercion',
     request: {
       timeRange: fullRange,

--- a/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
@@ -5,6 +5,7 @@ import {
   planTraceQuery,
   type NormalizedTraceQueryRequest,
   type TraceQueryGroupResponse,
+  type TraceQueryPredicate,
   type TraceQueryRequest,
   type TraceQueryResponse,
   type TraceQueryTrace,
@@ -152,6 +153,481 @@ const feedbackRecord = (
   rootEntityVersionId: null,
   ...overrides,
 });
+
+export interface TraceQueryFeedbackReplacementWrite {
+  method: 'create' | 'batch';
+  feedback: RawTraceQueryFeedback[];
+}
+
+export interface TraceQueryFeedbackReplacementAssertion {
+  name: string;
+  request: TraceQueryRequest;
+  expected: Array<{ traceId: string }>;
+}
+
+export interface TraceQueryFeedbackReplacementScenario {
+  name: string;
+  fixture: TraceQueryFixtureData;
+  writes: TraceQueryFeedbackReplacementWrite[];
+  assertions: TraceQueryFeedbackReplacementAssertion[];
+}
+
+const feedbackReplacementRange = { from: '2026-08-01T00:00:00Z', to: '2026-09-01T00:00:00Z' };
+const feedbackReplacementWideRange = { from: '2026-07-01T00:00:00Z', to: '2026-08-01T00:00:00Z' };
+
+const feedbackReplacementRoot = (traceId: string, startedAt: string): RawTraceQuerySpan =>
+  span(1, traceId, `root-${traceId}`, {
+    startedAt,
+    endedAt: new Date(new Date(startedAt).getTime() + 1000).toISOString(),
+  });
+
+const feedbackReplacementRequest = (
+  traceId: string,
+  quantifier: 'some' | 'none',
+  predicate: TraceQueryPredicate,
+  timeRange = feedbackReplacementRange,
+): TraceQueryRequest => ({
+  timeRange,
+  where: {
+    op: 'and',
+    args: [
+      { op: 'eq', left: { path: 'traceId' }, right: { literal: traceId } },
+      { feedback: { [quantifier]: predicate } },
+    ],
+  },
+});
+
+const feedbackReplacementAssertions = (args: {
+  oldPredicate: TraceQueryPredicate;
+  currentPredicate: TraceQueryPredicate;
+  oldTraceId?: string;
+  currentTraceId?: string;
+  currentIsCorrelated?: boolean;
+  currentTimeRange?: { from: string; to: string };
+}): TraceQueryFeedbackReplacementAssertion[] => {
+  const oldTraceId = args.oldTraceId ?? 'feedback-replacement-a';
+  const currentTraceId = args.currentTraceId ?? oldTraceId;
+  const currentIsCorrelated = args.currentIsCorrelated ?? true;
+  return [
+    {
+      name: 'old predicate does not satisfy some',
+      request: feedbackReplacementRequest(oldTraceId, 'some', args.oldPredicate),
+      expected: [],
+    },
+    {
+      name: 'old predicate satisfies none',
+      request: feedbackReplacementRequest(oldTraceId, 'none', args.oldPredicate),
+      expected: [{ traceId: oldTraceId }],
+    },
+    {
+      name: 'current predicate satisfies some',
+      request: feedbackReplacementRequest(
+        currentTraceId,
+        'some',
+        args.currentPredicate,
+        args.currentTimeRange ?? feedbackReplacementRange,
+      ),
+      expected: currentIsCorrelated ? [{ traceId: currentTraceId }] : [],
+    },
+    {
+      name: 'current predicate does not satisfy none',
+      request: feedbackReplacementRequest(
+        currentTraceId,
+        'none',
+        args.currentPredicate,
+        args.currentTimeRange ?? feedbackReplacementRange,
+      ),
+      expected: currentIsCorrelated ? [] : [{ traceId: currentTraceId }],
+    },
+  ];
+};
+
+const feedbackSourcePredicate = (value: string): TraceQueryPredicate => ({
+  op: 'eq',
+  left: { path: 'feedbackSource' },
+  right: { literal: value },
+});
+
+const feedbackValuePredicate = (value: string | number): TraceQueryPredicate => ({
+  op: 'eq',
+  left: { path: 'value' },
+  right: { literal: value },
+});
+
+const feedbackReplacementScenario = (args: {
+  name: string;
+  roots?: RawTraceQuerySpan[];
+  writes: TraceQueryFeedbackReplacementWrite[];
+  assertions: TraceQueryFeedbackReplacementAssertion[];
+}): TraceQueryFeedbackReplacementScenario => ({
+  name: args.name,
+  fixture: {
+    spans: args.roots ?? [feedbackReplacementRoot('feedback-replacement-a', '2026-08-10T00:00:00.000Z')],
+    scores: [],
+    feedback: args.writes.flatMap(write => write.feedback),
+  },
+  writes: args.writes,
+  assertions: args.assertions,
+});
+
+const sequentialFeedbackWrites = (
+  oldRecord: RawTraceQueryFeedback,
+  currentRecord: RawTraceQueryFeedback,
+): TraceQueryFeedbackReplacementWrite[] => [
+  { method: 'create', feedback: [oldRecord] },
+  { method: 'create', feedback: [currentRecord] },
+];
+
+/**
+ * Feedback replacement contract:
+ * - feedbackId alone is the logical identity;
+ * - the last accepted sequential write, or last matching entry in one batch, is current;
+ * - caller timestamps do not define replacement order;
+ * - current selection happens globally before trace correlation and some/none evaluation;
+ * - exact retries are idempotent;
+ * - concurrent writes without an observable acceptance order are outside this deterministic contract.
+ */
+export const TRACE_QUERY_FEEDBACK_REPLACEMENT_SCENARIOS: TraceQueryFeedbackReplacementScenario[] = [
+  (() => {
+    const oldRecord = feedbackRecord(
+      1,
+      'feedback-replacement-later-timestamp',
+      'feedback-replacement-a',
+      'rating',
+      'old-later-timestamp',
+      1,
+      { timestamp: '2026-08-10T01:00:00.000Z' },
+    );
+    const currentRecord = feedbackRecord(
+      2,
+      oldRecord.feedbackId,
+      'feedback-replacement-a',
+      'rating',
+      'current-later-timestamp',
+      2,
+      { timestamp: '2026-08-10T02:00:00.000Z' },
+    );
+    return feedbackReplacementScenario({
+      name: 'sequential replacement with a later timestamp',
+      writes: sequentialFeedbackWrites(oldRecord, currentRecord),
+      assertions: feedbackReplacementAssertions({
+        oldPredicate: feedbackSourcePredicate(oldRecord.feedbackSource),
+        currentPredicate: feedbackSourcePredicate(currentRecord.feedbackSource),
+      }),
+    });
+  })(),
+  (() => {
+    const oldRecord = feedbackRecord(
+      1,
+      'feedback-replacement-backdated',
+      'feedback-replacement-a',
+      'rating',
+      'old-backdated',
+      1,
+      { timestamp: '2026-08-10T02:00:00.000Z' },
+    );
+    const currentRecord = feedbackRecord(
+      2,
+      oldRecord.feedbackId,
+      'feedback-replacement-a',
+      'rating',
+      'current-backdated',
+      2,
+      { timestamp: '2026-08-10T01:00:00.000Z' },
+    );
+    return feedbackReplacementScenario({
+      name: 'sequential replacement with an earlier timestamp',
+      writes: sequentialFeedbackWrites(oldRecord, currentRecord),
+      assertions: feedbackReplacementAssertions({
+        oldPredicate: feedbackSourcePredicate(oldRecord.feedbackSource),
+        currentPredicate: feedbackSourcePredicate(currentRecord.feedbackSource),
+      }),
+    });
+  })(),
+  (() => {
+    const oldRecord = feedbackRecord(
+      1,
+      'feedback-replacement-same-timestamp',
+      'feedback-replacement-a',
+      'rating',
+      'old-same-timestamp',
+      1,
+    );
+    const currentRecord = feedbackRecord(
+      2,
+      oldRecord.feedbackId,
+      'feedback-replacement-a',
+      'rating',
+      'current-same-timestamp',
+      2,
+    );
+    return feedbackReplacementScenario({
+      name: 'sequential replacement with the same timestamp',
+      writes: sequentialFeedbackWrites(oldRecord, currentRecord),
+      assertions: feedbackReplacementAssertions({
+        oldPredicate: feedbackSourcePredicate(oldRecord.feedbackSource),
+        currentPredicate: feedbackSourcePredicate(currentRecord.feedbackSource),
+      }),
+    });
+  })(),
+  (() => {
+    const record = feedbackRecord(
+      1,
+      'feedback-replacement-exact-retry',
+      'feedback-replacement-a',
+      'rating',
+      'exact-retry',
+      1,
+    );
+    const retry = { ...record, cursorId: 2 };
+    return feedbackReplacementScenario({
+      name: 'exact retry with the same timestamp and payload',
+      writes: sequentialFeedbackWrites(record, retry),
+      assertions: [
+        {
+          name: 'retried predicate satisfies some',
+          request: feedbackReplacementRequest(
+            'feedback-replacement-a',
+            'some',
+            feedbackSourcePredicate(record.feedbackSource),
+          ),
+          expected: [{ traceId: 'feedback-replacement-a' }],
+        },
+        {
+          name: 'retried predicate does not satisfy none',
+          request: feedbackReplacementRequest(
+            'feedback-replacement-a',
+            'none',
+            feedbackSourcePredicate(record.feedbackSource),
+          ),
+          expected: [],
+        },
+      ],
+    });
+  })(),
+  (() => {
+    const oldRecord = feedbackRecord(
+      1,
+      'feedback-replacement-one-batch',
+      'feedback-replacement-a',
+      'rating',
+      'old-one-batch',
+      1,
+      { timestamp: '2026-08-10T02:00:00.000Z' },
+    );
+    const currentRecord = feedbackRecord(
+      2,
+      oldRecord.feedbackId,
+      'feedback-replacement-a',
+      'rating',
+      'current-one-batch',
+      2,
+      { timestamp: '2026-08-10T01:00:00.000Z' },
+    );
+    return feedbackReplacementScenario({
+      name: 'repeated feedbackId in one batch uses the last entry',
+      writes: [{ method: 'batch', feedback: [oldRecord, currentRecord] }],
+      assertions: feedbackReplacementAssertions({
+        oldPredicate: feedbackSourcePredicate(oldRecord.feedbackSource),
+        currentPredicate: feedbackSourcePredicate(currentRecord.feedbackSource),
+      }),
+    });
+  })(),
+  (() => {
+    const oldRecord = feedbackRecord(
+      1,
+      'feedback-replacement-across-batches',
+      'feedback-replacement-a',
+      'rating',
+      'old-across-batches',
+      1,
+      { timestamp: '2026-08-10T02:00:00.000Z' },
+    );
+    const currentRecord = feedbackRecord(
+      2,
+      oldRecord.feedbackId,
+      'feedback-replacement-a',
+      'rating',
+      'current-across-batches',
+      2,
+      { timestamp: '2026-08-10T01:00:00.000Z' },
+    );
+    return feedbackReplacementScenario({
+      name: 'repeated feedbackId across batches uses the backdated final write',
+      writes: [
+        { method: 'batch', feedback: [oldRecord] },
+        { method: 'batch', feedback: [currentRecord] },
+      ],
+      assertions: feedbackReplacementAssertions({
+        oldPredicate: feedbackSourcePredicate(oldRecord.feedbackSource),
+        currentPredicate: feedbackSourcePredicate(currentRecord.feedbackSource),
+      }),
+    });
+  })(),
+  (() => {
+    const oldRecord = feedbackRecord(
+      1,
+      'feedback-replacement-number-to-text',
+      'feedback-replacement-a',
+      'rating',
+      'number-to-text',
+      7,
+      { timestamp: '2026-08-10T01:00:00.000Z' },
+    );
+    const currentRecord = feedbackRecord(
+      2,
+      oldRecord.feedbackId,
+      'feedback-replacement-a',
+      'rating',
+      'number-to-text',
+      'current-text',
+      { timestamp: '2026-08-10T02:00:00.000Z' },
+    );
+    return feedbackReplacementScenario({
+      name: 'numeric value replaced by a textual value',
+      writes: sequentialFeedbackWrites(oldRecord, currentRecord),
+      assertions: feedbackReplacementAssertions({
+        oldPredicate: feedbackValuePredicate(oldRecord.value),
+        currentPredicate: feedbackValuePredicate(currentRecord.value),
+      }),
+    });
+  })(),
+  (() => {
+    const oldRecord = feedbackRecord(
+      1,
+      'feedback-replacement-text-to-number',
+      'feedback-replacement-a',
+      'rating',
+      'text-to-number',
+      'old-text',
+      { timestamp: '2026-08-10T01:00:00.000Z' },
+    );
+    const currentRecord = feedbackRecord(
+      2,
+      oldRecord.feedbackId,
+      'feedback-replacement-a',
+      'rating',
+      'text-to-number',
+      8,
+      { timestamp: '2026-08-10T02:00:00.000Z' },
+    );
+    return feedbackReplacementScenario({
+      name: 'textual value replaced by a numeric value',
+      writes: sequentialFeedbackWrites(oldRecord, currentRecord),
+      assertions: feedbackReplacementAssertions({
+        oldPredicate: feedbackValuePredicate(oldRecord.value),
+        currentPredicate: feedbackValuePredicate(currentRecord.value),
+      }),
+    });
+  })(),
+  (() => {
+    const oldRecord = feedbackRecord(
+      1,
+      'feedback-replacement-comment',
+      'feedback-replacement-a',
+      'rating',
+      'comment-transition',
+      1,
+      { comment: 'old comment', timestamp: '2026-08-10T01:00:00.000Z' },
+    );
+    const currentRecord = feedbackRecord(
+      2,
+      oldRecord.feedbackId,
+      'feedback-replacement-a',
+      'rating',
+      'comment-transition',
+      2,
+      { comment: null, timestamp: '2026-08-10T02:00:00.000Z' },
+    );
+    return feedbackReplacementScenario({
+      name: 'present comment replaced by a missing comment',
+      writes: sequentialFeedbackWrites(oldRecord, currentRecord),
+      assertions: feedbackReplacementAssertions({
+        oldPredicate: { op: 'exists', path: 'comment' },
+        currentPredicate: { op: 'notExists', path: 'comment' },
+      }),
+    });
+  })(),
+  (() => {
+    const oldRecord = feedbackRecord(
+      1,
+      'feedback-replacement-moved-trace',
+      'feedback-replacement-a',
+      'rating',
+      'old-moved-trace',
+      1,
+      { timestamp: '2026-08-10T02:00:00.000Z' },
+    );
+    const currentRecord = feedbackRecord(
+      2,
+      oldRecord.feedbackId,
+      'feedback-replacement-b',
+      'rating',
+      'current-moved-trace',
+      2,
+      { timestamp: '2026-08-10T03:00:00.000Z' },
+    );
+    return feedbackReplacementScenario({
+      name: 'feedback moved from trace A to trace B outside the selected root range',
+      roots: [
+        feedbackReplacementRoot('feedback-replacement-a', '2026-08-10T00:00:00.000Z'),
+        feedbackReplacementRoot('feedback-replacement-b', '2026-07-10T00:00:00.000Z'),
+      ],
+      writes: sequentialFeedbackWrites(oldRecord, currentRecord),
+      assertions: feedbackReplacementAssertions({
+        oldPredicate: feedbackSourcePredicate(oldRecord.feedbackSource),
+        currentPredicate: feedbackSourcePredicate(currentRecord.feedbackSource),
+        currentTraceId: 'feedback-replacement-b',
+        currentTimeRange: feedbackReplacementWideRange,
+      }),
+    });
+  })(),
+  (() => {
+    const oldRecord = feedbackRecord(
+      1,
+      'feedback-replacement-trace-to-null',
+      'feedback-replacement-a',
+      'rating',
+      'old-trace-to-null',
+      1,
+      { timestamp: '2026-08-10T01:00:00.000Z' },
+    );
+    const currentRecord = feedbackRecord(2, oldRecord.feedbackId, null, 'rating', 'current-trace-to-null', 2, {
+      timestamp: '2026-08-10T02:00:00.000Z',
+    });
+    return feedbackReplacementScenario({
+      name: 'feedback moved from trace A to a null trace',
+      writes: sequentialFeedbackWrites(oldRecord, currentRecord),
+      assertions: feedbackReplacementAssertions({
+        oldPredicate: feedbackSourcePredicate(oldRecord.feedbackSource),
+        currentPredicate: feedbackSourcePredicate(currentRecord.feedbackSource),
+        currentIsCorrelated: false,
+      }),
+    });
+  })(),
+  (() => {
+    const oldRecord = feedbackRecord(1, 'feedback-replacement-null-to-trace', null, 'rating', 'old-null-to-trace', 1, {
+      timestamp: '2026-08-10T01:00:00.000Z',
+    });
+    const currentRecord = feedbackRecord(
+      2,
+      oldRecord.feedbackId,
+      'feedback-replacement-a',
+      'rating',
+      'current-null-to-trace',
+      2,
+      { timestamp: '2026-08-10T02:00:00.000Z' },
+    );
+    return feedbackReplacementScenario({
+      name: 'feedback moved from a null trace to trace A',
+      writes: sequentialFeedbackWrites(oldRecord, currentRecord),
+      assertions: feedbackReplacementAssertions({
+        oldPredicate: feedbackSourcePredicate(oldRecord.feedbackSource),
+        currentPredicate: feedbackSourcePredicate(currentRecord.feedbackSource),
+      }),
+    });
+  })(),
+];
 
 export const TRACE_QUERY_FIXTURE_DATA: TraceQueryFixtureData = {
   spans: [

--- a/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
@@ -765,7 +765,7 @@ FROM (
 }
 
 // ---------------------------------------------------------------------------
-// feedback_events — ReplacingMergeTree with feedbackId dedup
+// feedback_events — ReplacingMergeTree history with durable per-feedback write order
 // ---------------------------------------------------------------------------
 
 export const FEEDBACK_EVENTS_DDL = `
@@ -775,6 +775,7 @@ CREATE TABLE IF NOT EXISTS ${TABLE_FEEDBACK_EVENTS} (
 
   -- IDs
   feedbackId         String,
+  writeVersion       UInt64 DEFAULT 0,
   traceId            Nullable(String),
   spanId             Nullable(String),
   experimentId       Nullable(String),
@@ -1155,6 +1156,7 @@ export const ALL_MIGRATIONS: readonly MigrationEntry[] = [
   addColumn(TABLE_SCORE_EVENTS, 'parentEntityVersionId', 'Nullable(String)'),
   addColumn(TABLE_SCORE_EVENTS, 'rootEntityVersionId', 'Nullable(String)'),
   // Feedback
+  addColumn(TABLE_FEEDBACK_EVENTS, 'writeVersion', 'UInt64 DEFAULT 0'),
   addColumn(TABLE_FEEDBACK_EVENTS, 'entityVersionId', 'Nullable(String)'),
   addColumn(TABLE_FEEDBACK_EVENTS, 'reviewStatus', "LowCardinality(String) DEFAULT 'needs-review'"),
   addColumn(TABLE_FEEDBACK_EVENTS, 'parentEntityVersionId', 'Nullable(String)'),

--- a/stores/clickhouse/src/storage/domains/observability/v-next/deletion.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/deletion.test.ts
@@ -128,6 +128,7 @@ describe('ClickHouse deletion lifecycle', () => {
     query
       .mockResolvedValueOnce(queryResult([existingRow]))
       .mockResolvedValueOnce(queryResult([]))
+      .mockResolvedValueOnce(queryResult([{ feedbackId: 'feedback-1', writeVersion: '0' }]))
       .mockResolvedValueOnce(queryResult([{ found: 1 }]));
 
     await expect(
@@ -147,6 +148,13 @@ describe('ClickHouse deletion lifecycle', () => {
     );
     expect(query.mock.calls[1]?.[0].query).toContain("predicateType = 'itemIds'");
     expect(query.mock.calls[1]?.[0].query).toContain('has(predicateValues, {feedbackId:String})');
+    expect(query).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        query: expect.stringContaining('toString(max(writeVersion)) AS writeVersion'),
+        query_params: { feedbackIds: ['feedback-1'] },
+      }),
+    );
     expect(insert).toHaveBeenCalledTimes(2);
     expect(insert).toHaveBeenNthCalledWith(
       2,

--- a/stores/clickhouse/src/storage/domains/observability/v-next/feedback.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/feedback.ts
@@ -173,6 +173,32 @@ async function queryJson<T>(client: ClickHouseClient, query: string, params: Rec
 // Write
 // ============================================================================
 
+async function feedbackRowsWithWriteVersions(
+  client: ClickHouseClient,
+  feedbacks: BatchCreateFeedbackArgs['feedbacks'],
+) {
+  const identifiedFeedback = feedbacks.map(feedback => ({
+    ...feedback,
+    feedbackId: feedback.feedbackId ?? '',
+  }));
+  const feedbackIds = [...new Set(identifiedFeedback.map(feedback => feedback.feedbackId))];
+  const existingVersions = await queryJson<{ feedbackId: string; writeVersion: string }>(
+    client,
+    `SELECT feedbackId, toString(max(writeVersion)) AS writeVersion
+     FROM ${TABLE_FEEDBACK_EVENTS}
+     WHERE feedbackId IN ({feedbackIds:Array(String)})
+     GROUP BY feedbackId`,
+    { feedbackIds },
+  );
+  const versions = new Map(existingVersions.map(row => [row.feedbackId, BigInt(row.writeVersion)]));
+
+  return identifiedFeedback.map(feedback => {
+    const writeVersion = (versions.get(feedback.feedbackId) ?? 0n) + 1n;
+    versions.set(feedback.feedbackId, writeVersion);
+    return { ...feedbackRecordToRow(feedback), writeVersion: writeVersion.toString() };
+  });
+}
+
 export async function createFeedback(client: ClickHouseClient, args: CreateFeedbackArgs): Promise<void> {
   await batchCreateFeedback(client, { feedbacks: [args.feedback] });
 }
@@ -182,7 +208,7 @@ export async function batchCreateFeedback(client: ClickHouseClient, args: BatchC
 
   await client.insert({
     table: TABLE_FEEDBACK_EVENTS,
-    values: args.feedbacks.map(feedbackRecordToRow),
+    values: await feedbackRowsWithWriteVersions(client, args.feedbacks),
     format: 'JSONEachRow',
     clickhouse_settings: CH_INSERT_SETTINGS,
   });
@@ -288,7 +314,10 @@ export async function updateFeedbackReviewStatus(
 
   const existing = await queryJson<Record<string, any>>(
     client,
-    `SELECT * FROM ${TABLE_FEEDBACK_EVENTS} FINAL WHERE feedbackId = {feedbackId:String} LIMIT 1`,
+    `SELECT * FROM ${TABLE_FEEDBACK_EVENTS} FINAL
+     WHERE feedbackId = {feedbackId:String}
+     ORDER BY writeVersion DESC, timestamp DESC
+     LIMIT 1`,
     { feedbackId },
   );
   const existingRow = existing[0];
@@ -300,18 +329,8 @@ export async function updateFeedbackReviewStatus(
     throw feedbackNotFoundError(feedbackId);
   }
 
-  // ClickHouse is append-only in practice: never mutate a written row. Instead
-  // insert a replacement row with the same ReplacingMergeTree key
-  // (traceId, timestamp, feedbackId). Background merges collapse the
-  // duplicates keeping the last inserted row, and every read on this table
-  // uses FINAL so the latest version wins before merges happen.
   const updated = rowToFeedbackRecord({ ...existingRow, reviewStatus });
-  await client.insert({
-    table: TABLE_FEEDBACK_EVENTS,
-    values: [feedbackRecordToRow(updated)],
-    format: 'JSONEachRow',
-    clickhouse_settings: CH_INSERT_SETTINGS,
-  });
+  await batchCreateFeedback(client, { feedbacks: [updated] });
 
   if (await hasFeedbackDeletionRequest(client, feedbackId, existingRow.organizationId, existingRow.resourceId)) {
     await deleteFeedback(

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
@@ -55,7 +55,7 @@ createObservabilityVNextTests({
     label: 'ClickHouse vNext',
     preferredStrategy: 'insert-only',
     traceQuery: true,
-    traceQueryWriteModel: 'completion-only',
+    traceQuerySpanWriteModel: 'completion-only',
   },
   getStorage: async () => {
     if (!sharedSuiteStorage) {
@@ -2014,6 +2014,155 @@ LIMIT 1`,
         });
       });
 
+      it('retains changed-timestamp feedback versions as distinct physical rows', async () => {
+        const feedback = {
+          feedbackId: 'feedback-physical-supersession',
+          timestamp: new Date('2026-01-02T00:00:00Z'),
+          traceId: 'feedback-physical-trace',
+          spanId: null,
+          feedbackSource: 'old-physical-source',
+          feedbackType: 'rating',
+          value: 1,
+          comment: null,
+          experimentId: null,
+          sourceId: null,
+          metadata: null,
+        };
+        await storage.createFeedback({ feedback });
+        await storage.createFeedback({
+          feedback: {
+            ...feedback,
+            timestamp: new Date('2026-01-01T00:00:00Z'),
+            feedbackSource: 'current-physical-source',
+          },
+        });
+
+        const client = createClient({
+          url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+          username: process.env.CLICKHOUSE_USERNAME || 'default',
+          password: process.env.CLICKHOUSE_PASSWORD || 'password',
+        });
+        try {
+          const result = await client.query({
+            query: `SELECT feedbackSource, toString(writeVersion) AS writeVersion FROM ${TABLE_FEEDBACK_EVENTS} FINAL WHERE feedbackId = {feedbackId:String} ORDER BY timestamp`,
+            query_params: { feedbackId: feedback.feedbackId },
+            format: 'JSONEachRow',
+          });
+          expect(await result.json<{ feedbackSource: string; writeVersion: string }>()).toEqual([
+            { feedbackSource: 'current-physical-source', writeVersion: '2' },
+            { feedbackSource: 'old-physical-source', writeVersion: '1' },
+          ]);
+        } finally {
+          await client.close();
+        }
+      });
+
+      it('starts post-migration replacements at version 1 above legacy version-0 rows', async () => {
+        const client = createClient({
+          url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+          username: process.env.CLICKHOUSE_USERNAME || 'default',
+          password: process.env.CLICKHOUSE_PASSWORD || 'password',
+        });
+        const legacyFeedback = {
+          feedbackId: 'feedback-legacy-write-version',
+          timestamp: new Date('2026-01-02T00:00:00Z'),
+          traceId: 'feedback-legacy-trace',
+          spanId: null,
+          feedbackSource: 'legacy-current-by-timestamp',
+          feedbackType: 'rating',
+          value: 1,
+          comment: null,
+          experimentId: null,
+          sourceId: null,
+          metadata: null,
+        };
+        try {
+          await client.insert({
+            table: TABLE_FEEDBACK_EVENTS,
+            values: [
+              feedbackRecordToRow({
+                ...legacyFeedback,
+                timestamp: new Date('2026-01-01T00:00:00Z'),
+                feedbackSource: 'legacy-older-by-timestamp',
+              }),
+              feedbackRecordToRow(legacyFeedback),
+            ],
+            format: 'JSONEachRow',
+          });
+          await storage.createFeedback({
+            feedback: {
+              ...legacyFeedback,
+              timestamp: new Date('2025-12-31T00:00:00Z'),
+              feedbackSource: 'post-migration-current',
+            },
+          });
+
+          const result = await client.query({
+            query: `SELECT feedbackSource, toString(writeVersion) AS writeVersion FROM ${TABLE_FEEDBACK_EVENTS} FINAL WHERE feedbackId = {feedbackId:String} ORDER BY writeVersion, timestamp`,
+            query_params: { feedbackId: legacyFeedback.feedbackId },
+            format: 'JSONEachRow',
+          });
+          expect(await result.json<{ feedbackSource: string; writeVersion: string }>()).toEqual([
+            { feedbackSource: 'legacy-older-by-timestamp', writeVersion: '0' },
+            { feedbackSource: 'legacy-current-by-timestamp', writeVersion: '0' },
+            { feedbackSource: 'post-migration-current', writeVersion: '1' },
+          ]);
+        } finally {
+          await client.close();
+        }
+      });
+
+      it('updates review status on the current accepted feedback write', async () => {
+        const feedback = {
+          feedbackId: 'feedback-review-current-version',
+          timestamp: new Date('2026-01-02T00:00:00Z'),
+          traceId: 'feedback-review-trace',
+          spanId: null,
+          feedbackSource: 'superseded-review-source',
+          feedbackType: 'rating',
+          value: 1,
+          comment: null,
+          experimentId: null,
+          sourceId: null,
+          metadata: null,
+        };
+        await storage.createFeedback({ feedback });
+        await storage.createFeedback({
+          feedback: {
+            ...feedback,
+            timestamp: new Date('2026-01-01T00:00:00Z'),
+            feedbackSource: 'current-review-source',
+          },
+        });
+
+        const updated = await storage.updateFeedbackReviewStatus({
+          feedbackId: feedback.feedbackId,
+          reviewStatus: 'reviewed',
+        });
+        expect(updated).toMatchObject({
+          feedbackSource: 'current-review-source',
+          reviewStatus: 'reviewed',
+        });
+
+        const client = createClient({
+          url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+          username: process.env.CLICKHOUSE_USERNAME || 'default',
+          password: process.env.CLICKHOUSE_PASSWORD || 'password',
+        });
+        try {
+          const result = await client.query({
+            query: `SELECT feedbackSource, reviewStatus, toString(writeVersion) AS writeVersion FROM ${TABLE_FEEDBACK_EVENTS} FINAL WHERE feedbackId = {feedbackId:String} ORDER BY writeVersion DESC, timestamp DESC LIMIT 1`,
+            query_params: { feedbackId: feedback.feedbackId },
+            format: 'JSONEachRow',
+          });
+          expect(await result.json<{ feedbackSource: string; reviewStatus: string; writeVersion: string }>()).toEqual([
+            { feedbackSource: 'current-review-source', reviewStatus: 'reviewed', writeVersion: '3' },
+          ]);
+        } finally {
+          await client.close();
+        }
+      });
+
       it('filters by organizationId', async () => {
         const result = await storage.listFeedback({ filters: { organizationId: 'org-A' } });
         expect(result.feedback).toHaveLength(1);
@@ -2534,7 +2683,7 @@ LIMIT 1`,
   // ==========================================================================
 
   describe('feedback', () => {
-    it('maps every persisted feedback column', async () => {
+    it('maps every public feedback column while keeping writeVersion internal', async () => {
       const client = createClient({
         url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
         username: process.env.CLICKHOUSE_USERNAME || 'default',
@@ -2556,7 +2705,13 @@ LIMIT 1`,
           value: 0,
         });
 
-        expect(Object.keys(row).sort()).toEqual(columns.map(column => column.name).sort());
+        expect(row).not.toHaveProperty('writeVersion');
+        expect(Object.keys(row).sort()).toEqual(
+          columns
+            .map(column => column.name)
+            .filter(column => column !== 'writeVersion')
+            .sort(),
+        );
       } finally {
         await client.close();
       }
@@ -4503,6 +4658,21 @@ LIMIT 1`,
   describe('init idempotence', () => {
     // --- Unit tests for ALL_MIGRATIONS shape ---
 
+    it('includes durable feedback write versions in fresh and migrated schemas', () => {
+      const tableDdl = buildAllTableDDL().find(ddl =>
+        ddl.includes(`CREATE TABLE IF NOT EXISTS ${TABLE_FEEDBACK_EVENTS}`),
+      );
+      expect(tableDdl).toContain('writeVersion       UInt64 DEFAULT 0');
+      expect(
+        ALL_MIGRATIONS.find(
+          migration =>
+            migration.kind === 'column' &&
+            migration.table === TABLE_FEEDBACK_EVENTS &&
+            migration.name === 'writeVersion',
+        )?.sql,
+      ).toContain('ADD COLUMN IF NOT EXISTS writeVersion UInt64 DEFAULT 0');
+    });
+
     it('ALL_MIGRATIONS entries carry table + name consistent with their SQL', () => {
       expect(ALL_MIGRATIONS.length).toBeGreaterThan(0);
       for (const entry of ALL_MIGRATIONS) {
@@ -4625,9 +4795,10 @@ LIMIT 1`,
         password: process.env.CLICKHOUSE_PASSWORD || 'password',
       });
 
-      // Pick a migration we know is additive and safe to drop/re-add.
+      // writeVersion is additive: legacy feedback rows default to version 0
+      // until the first post-migration write supersedes them.
       const target = ALL_MIGRATIONS.find(
-        m => m.kind === 'column' && m.table === 'mastra_log_events' && m.name === 'entityVersionId',
+        m => m.kind === 'column' && m.table === TABLE_FEEDBACK_EVENTS && m.name === 'writeVersion',
       );
       expect(target).toBeDefined();
 

--- a/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.test.ts
@@ -195,6 +195,56 @@ describe('ClickHouse advanced trace query', () => {
     expect(repeated.match(/FROM current_scores s/g)).toHaveLength(2);
   });
 
+  it('compiles typed feedback relations with one correlated existence check per clause', () => {
+    const compiled = compileClickHouseTraceQuery(
+      plan({
+        where: {
+          op: 'and',
+          args: [
+            {
+              feedback: {
+                some: {
+                  op: 'and',
+                  args: [
+                    { op: 'eq', left: { path: 'feedbackType' }, right: { literal: "rating' OR 1" } },
+                    { op: 'lt', left: { path: 'value' }, right: { literal: 0 } },
+                    { op: 'gte', left: { path: 'timestamp' }, right: { literal: '2026-01-01T14:00:00+02:00' } },
+                    { op: 'exists', path: 'value' },
+                    { op: 'exists', path: 'comment' },
+                  ],
+                },
+              },
+            },
+            { feedback: { none: { op: 'in', value: { path: 'value' }, set: ['bad', 'worse'] } } },
+          ],
+        },
+      }),
+    );
+
+    expect(compiled.query.match(/current_feedback AS/g)).toHaveLength(1);
+    expect(compiled.query.match(/FROM current_feedback s/g)).toHaveLength(2);
+    expect(compiled.query).toContain('isNotNull(s.traceId)');
+    expect(compiled.query).toContain('s.traceId = r.traceId');
+    expect(compiled.query).toMatch(/s\.valueNumber < \{trace_query_\d+:Float64\}/);
+    expect(compiled.query).toMatch(/s\.valueString IN \(\{trace_query_\d+:String\}/);
+    expect(compiled.query).toContain('(isNotNull(s.valueString) OR isNotNull(s.valueNumber))');
+    expect(compiled.query).toContain('FROM mastra_feedback_events FINAL');
+    expect(compiled.query).not.toContain("rating' OR 1");
+    expect(Object.values(compiled.query_params)).toContain("rating' OR 1");
+    expect(Object.values(compiled.query_params)).toContain('2026-01-01 12:00:00.000');
+  });
+
+  it('emits feedback scope only when referenced', () => {
+    const traceOnly = compileClickHouseTraceQuery(plan()).query;
+    const feedbackOnly = compileClickHouseTraceQuery(
+      plan({ where: { feedback: { some: { op: 'exists', path: 'value' } } } }),
+    ).query;
+
+    expect(traceOnly).not.toContain('current_feedback AS');
+    expect(traceOnly).not.toContain('mastra_feedback_events');
+    expect(feedbackOnly.match(/current_feedback AS/g)).toHaveLength(1);
+  });
+
   it('uses total nullable semantics for negative predicates', () => {
     const compiled = compileClickHouseTraceQuery(
       plan({ where: { op: 'ne', left: { path: 'threadId' }, right: { literal: 'excluded' } } }),

--- a/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.test.ts
@@ -229,6 +229,8 @@ describe('ClickHouse advanced trace query', () => {
     expect(compiled.query).toMatch(/s\.valueString IN \(\{trace_query_\d+:String\}/);
     expect(compiled.query).toContain('(isNotNull(s.valueString) OR isNotNull(s.valueNumber))');
     expect(compiled.query).toContain('FROM mastra_feedback_events FINAL');
+    expect(compiled.query).toContain('ORDER BY feedbackId, timestamp DESC');
+    expect(compiled.query).toContain('LIMIT 1 BY feedbackId');
     expect(compiled.query).not.toContain("rating' OR 1");
     expect(Object.values(compiled.query_params)).toContain("rating' OR 1");
     expect(Object.values(compiled.query_params)).toContain('2026-01-01 12:00:00.000');

--- a/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.test.ts
@@ -228,9 +228,14 @@ describe('ClickHouse advanced trace query', () => {
     expect(compiled.query).toMatch(/s\.valueNumber < \{trace_query_\d+:Float64\}/);
     expect(compiled.query).toMatch(/s\.valueString IN \(\{trace_query_\d+:String\}/);
     expect(compiled.query).toContain('(isNotNull(s.valueString) OR isNotNull(s.valueNumber))');
-    expect(compiled.query).toContain('FROM mastra_feedback_events FINAL');
-    expect(compiled.query).toContain('ORDER BY feedbackId, timestamp DESC');
-    expect(compiled.query).toContain('LIMIT 1 BY feedbackId');
+    expect(compiled.query).toContain(`FROM (
+      SELECT *
+      FROM mastra_feedback_events FINAL
+      ORDER BY feedbackId, writeVersion DESC, timestamp DESC
+      LIMIT 1 BY feedbackId
+    ) AS current
+    WHERE isNotNull(traceId)
+      AND traceId IN (SELECT traceId FROM root_scope)`);
     expect(compiled.query).not.toContain("rating' OR 1");
     expect(Object.values(compiled.query_params)).toContain("rating' OR 1");
     expect(Object.values(compiled.query_params)).toContain('2026-01-01 12:00:00.000');

--- a/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.ts
@@ -2,6 +2,7 @@ import type { ClickHouseClient } from '@clickhouse/client';
 import * as coreStorage from '@mastra/core/storage';
 import type {
   TraceQueryCanonicalField,
+  TraceQueryFeedbackField,
   TraceQueryField,
   TraceQueryPredicateField,
   TraceQueryResponse,
@@ -12,7 +13,7 @@ import type {
   TrustedTraceQueryScalarPredicate,
 } from '@mastra/core/storage';
 
-import { TABLE_SCORE_EVENTS, TABLE_SPAN_EVENTS, TABLE_TRACE_ROOTS } from './ddl';
+import { TABLE_FEEDBACK_EVENTS, TABLE_SCORE_EVENTS, TABLE_SPAN_EVENTS, TABLE_TRACE_ROOTS } from './ddl';
 import { CH_SETTINGS } from './helpers';
 
 type ClickHouseParameterType = 'String' | 'Float64' | 'UInt64' | "DateTime64(3, 'UTC')";
@@ -64,6 +65,18 @@ const SCORE_FIELDS = {
   parentEntityVersionId: { sql: 's.parentEntityVersionId', parameterType: 'String' },
   rootEntityVersionId: { sql: 's.rootEntityVersionId', parameterType: 'String' },
 } satisfies FieldRegistry<TraceQueryScoreField>;
+
+const FEEDBACK_FIELDS = {
+  feedbackType: { sql: 's.feedbackType', parameterType: 'String' },
+  feedbackSource: { sql: 's.feedbackSource', parameterType: 'String' },
+  feedbackUserId: { sql: 's.feedbackUserId', parameterType: 'String' },
+  sourceId: { sql: 's.sourceId', parameterType: 'String' },
+  entityVersionId: { sql: 's.entityVersionId', parameterType: 'String' },
+  parentEntityVersionId: { sql: 's.parentEntityVersionId', parameterType: 'String' },
+  rootEntityVersionId: { sql: 's.rootEntityVersionId', parameterType: 'String' },
+  timestamp: { sql: 's.timestamp', parameterType: "DateTime64(3, 'UTC')" },
+  comment: { sql: 's.comment', parameterType: 'String' },
+} satisfies FieldRegistry<Exclude<TraceQueryFeedbackField, 'value'>>;
 
 const TRACE_SELECT = `
   r.traceId AS traceId,
@@ -149,10 +162,32 @@ function compileScalarPredicate<TField extends string>(
   return `ifNull(${field.sql} ${operator} ${parameter}, ${predicate.operator === 'ne' ? '1' : '0'})`;
 }
 
+function compileFeedbackScalarPredicate(
+  predicate: TrustedTraceQueryScalarPredicate,
+  parameters: ParameterBuilder,
+): string {
+  if (predicate.type === 'boolean') {
+    const parts = predicate.args.map(arg => `(${compileFeedbackScalarPredicate(arg, parameters)})`);
+    return parts.join(predicate.operator === 'and' ? ' AND ' : ' OR ');
+  }
+  if (predicate.type === 'not') return `NOT (${compileFeedbackScalarPredicate(predicate.arg, parameters)})`;
+  if (predicate.field !== 'value') return compileScalarPredicate(predicate, FEEDBACK_FIELDS, parameters);
+  if (predicate.type === 'presence') {
+    const present = `(isNotNull(s.valueString) OR isNotNull(s.valueNumber))`;
+    return predicate.operator === 'exists' ? present : `NOT ${present}`;
+  }
+  const sample = predicate.type === 'membership' ? predicate.values[0] : predicate.value;
+  const field =
+    typeof sample === 'number'
+      ? { value: { sql: 's.valueNumber', parameterType: 'Float64' as const } }
+      : { value: { sql: 's.valueString', parameterType: 'String' as const } };
+  return compileScalarPredicate(predicate, field, parameters);
+}
+
 function collectRelationCollections(
   predicate: TrustedTraceQueryPredicate | undefined,
-  collections = new Set<'spans' | 'scores'>(),
-): Set<'spans' | 'scores'> {
+  collections = new Set<'spans' | 'scores' | 'feedback'>(),
+): Set<'spans' | 'scores' | 'feedback'> {
   if (!predicate) return collections;
   if (predicate.type === 'relation') {
     collections.add(predicate.collection);
@@ -166,12 +201,24 @@ function collectRelationCollections(
 
 function compilePredicate(predicate: TrustedTraceQueryPredicate, parameters: ParameterBuilder): string {
   if (predicate.type === 'relation') {
-    const registry = predicate.collection === 'spans' ? SPAN_FIELDS : SCORE_FIELDS;
-    const table = predicate.collection === 'spans' ? 'current_spans' : 'current_scores';
-    const nested = compileScalarPredicate(predicate.predicate, registry, parameters);
+    const table =
+      predicate.collection === 'spans'
+        ? 'current_spans'
+        : predicate.collection === 'scores'
+          ? 'current_scores'
+          : 'current_feedback';
+    const nested =
+      predicate.collection === 'feedback'
+        ? compileFeedbackScalarPredicate(predicate.predicate, parameters)
+        : compileScalarPredicate(
+            predicate.predicate,
+            predicate.collection === 'spans' ? SPAN_FIELDS : SCORE_FIELDS,
+            parameters,
+          );
     const existence = `EXISTS (
       SELECT 1 FROM ${table} s
-      WHERE s.traceId = r.traceId
+      WHERE isNotNull(s.traceId)
+        AND s.traceId = r.traceId
         AND (${nested})
     )`;
     return predicate.quantifier === 'some' ? existence : `NOT ${existence}`;
@@ -259,6 +306,26 @@ export function compileClickHouseTraceQuery(plan: TrustedTraceQueryPlan): Compil
       AND traceId IN (SELECT traceId FROM root_scope)
     ORDER BY scoreId, timestamp DESC
     LIMIT 1 BY scoreId
+  )`);
+  }
+  if (relationCollections.has('feedback')) {
+    ctes.push(`current_feedback AS (
+    SELECT
+      traceId,
+      feedbackType,
+      feedbackSource,
+      feedbackUserId,
+      sourceId,
+      valueString,
+      valueNumber,
+      comment,
+      timestamp,
+      entityVersionId,
+      parentEntityVersionId,
+      rootEntityVersionId
+    FROM ${TABLE_FEEDBACK_EVENTS} FINAL
+    WHERE isNotNull(traceId)
+      AND traceId IN (SELECT traceId FROM root_scope)
   )`);
   }
 

--- a/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.ts
@@ -323,11 +323,14 @@ export function compileClickHouseTraceQuery(plan: TrustedTraceQueryPlan): Compil
       entityVersionId,
       parentEntityVersionId,
       rootEntityVersionId
-    FROM ${TABLE_FEEDBACK_EVENTS} FINAL
+    FROM (
+      SELECT *
+      FROM ${TABLE_FEEDBACK_EVENTS} FINAL
+      ORDER BY feedbackId, writeVersion DESC, timestamp DESC
+      LIMIT 1 BY feedbackId
+    ) AS current
     WHERE isNotNull(traceId)
       AND traceId IN (SELECT traceId FROM root_scope)
-    ORDER BY feedbackId, timestamp DESC
-    LIMIT 1 BY feedbackId
   )`);
   }
 

--- a/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.ts
@@ -326,6 +326,8 @@ export function compileClickHouseTraceQuery(plan: TrustedTraceQueryPlan): Compil
     FROM ${TABLE_FEEDBACK_EVENTS} FINAL
     WHERE isNotNull(traceId)
       AND traceId IN (SELECT traceId FROM root_scope)
+    ORDER BY feedbackId, timestamp DESC
+    LIMIT 1 BY feedbackId
   )`);
   }
 

--- a/stores/duckdb/src/storage/domains/observability/feedback.ts
+++ b/stores/duckdb/src/storage/domains/observability/feedback.ts
@@ -37,6 +37,50 @@ type LegacyFeedbackRecord = CreateFeedbackArgs['feedback'] & {
   userId?: string | null;
 };
 
+const FEEDBACK_UPSERT_COLUMNS = [
+  'timestamp',
+  'cursorId',
+  'traceId',
+  'spanId',
+  'experimentId',
+  'entityType',
+  'entityId',
+  'entityName',
+  'entityVersionId',
+  'parentEntityVersionId',
+  'parentEntityType',
+  'parentEntityId',
+  'parentEntityName',
+  'rootEntityVersionId',
+  'rootEntityType',
+  'rootEntityId',
+  'rootEntityName',
+  'userId',
+  'organizationId',
+  'resourceId',
+  'runId',
+  'sessionId',
+  'threadId',
+  'requestId',
+  'environment',
+  'executionSource',
+  'serviceName',
+  'feedbackUserId',
+  'sourceId',
+  'reviewStatus',
+  'feedbackSource',
+  'feedbackType',
+  'value',
+  'comment',
+  'tags',
+  'metadata',
+  'scope',
+] as const;
+
+const FEEDBACK_UPSERT_CLAUSE = `ON CONFLICT (feedbackId) DO UPDATE SET ${FEEDBACK_UPSERT_COLUMNS.map(
+  column => `${column} = excluded.${column}`,
+).join(', ')}`;
+
 const FEEDBACK_GROUP_BY_COLUMNS = new Set([
   'timestamp',
   'traceId',
@@ -302,7 +346,7 @@ export async function createFeedback(db: DuckDBConnection, args: CreateFeedbackA
        jsonV(f.metadata),
        jsonV(f.scope ?? null),
      ].join(', ')})
-     ON CONFLICT DO NOTHING`,
+     ${FEEDBACK_UPSERT_CLAUSE}`,
   );
 }
 
@@ -310,7 +354,8 @@ export async function createFeedback(db: DuckDBConnection, args: CreateFeedbackA
 export async function batchCreateFeedback(db: DuckDBConnection, args: BatchCreateFeedbackArgs): Promise<void> {
   if (args.feedbacks.length === 0) return;
 
-  const tuples = args.feedbacks.map(f => {
+  const currentFeedback = new Map(args.feedbacks.map(feedback => [feedback.feedbackId, feedback]));
+  const tuples = [...currentFeedback.values()].map(f => {
     const legacyFeedback = f as LegacyFeedbackRecord;
     const feedbackSource = legacyFeedback.feedbackSource ?? legacyFeedback.source ?? '';
     const feedbackUserId = legacyFeedback.feedbackUserId ?? legacyFeedback.userId ?? null;
@@ -364,7 +409,7 @@ export async function batchCreateFeedback(db: DuckDBConnection, args: BatchCreat
       feedbackUserId, sourceId, reviewStatus, feedbackSource, feedbackType, value, comment, tags, metadata, scope
     )
      VALUES ${tuples.join(',\n       ')}
-     ON CONFLICT DO NOTHING`,
+     ${FEEDBACK_UPSERT_CLAUSE}`,
   );
 }
 

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -19,6 +19,7 @@ createObservabilityVNextTests({
     label: 'DuckDB',
     preferredStrategy: 'event-sourced',
     traceQuery: true,
+    traceQueryStrictFeedbackValueTypes: false,
   },
   getStorage: async () => {
     sharedSuiteStore = new DuckDBStore({ path: ':memory:' });

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -2168,10 +2168,10 @@ describe('ObservabilityStorageDuckDB', () => {
   // ==========================================================================
 
   describe('feedback', () => {
-    it('replaces an existing feedbackId with the latest single write', async () => {
+    it('replaces an existing feedbackId with a backdated latest single write', async () => {
       const original = {
         feedbackId: 'feedback-supersession-single',
-        timestamp: new Date('2026-01-01T00:00:00Z'),
+        timestamp: new Date('2026-01-02T00:00:00Z'),
         traceId: 'trace-feedback-supersession-single',
         spanId: null,
         feedbackSource: 'superseded-patient',
@@ -2187,7 +2187,7 @@ describe('ObservabilityStorageDuckDB', () => {
       await storage.createFeedback({
         feedback: {
           ...original,
-          timestamp: new Date('2026-01-02T00:00:00Z'),
+          timestamp: new Date('2026-01-01T00:00:00Z'),
           feedbackSource: 'patient',
           value: 1,
           comment: 'new',
@@ -2198,7 +2198,7 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(result.feedback).toHaveLength(1);
       expect(result.feedback[0]).toMatchObject({
         feedbackId: original.feedbackId,
-        timestamp: new Date('2026-01-02T00:00:00Z'),
+        timestamp: new Date('2026-01-01T00:00:00Z'),
         feedbackSource: 'patient',
         value: 1,
         comment: 'new',

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -2168,6 +2168,82 @@ describe('ObservabilityStorageDuckDB', () => {
   // ==========================================================================
 
   describe('feedback', () => {
+    it('replaces an existing feedbackId with the latest single write', async () => {
+      const original = {
+        feedbackId: 'feedback-supersession-single',
+        timestamp: new Date('2026-01-01T00:00:00Z'),
+        traceId: 'trace-feedback-supersession-single',
+        spanId: null,
+        feedbackSource: 'superseded-patient',
+        feedbackType: 'rating',
+        value: -1,
+        comment: 'old',
+        experimentId: null,
+        feedbackUserId: 'patient-1',
+        sourceId: 'survey-1',
+        metadata: null,
+      };
+      await storage.createFeedback({ feedback: original });
+      await storage.createFeedback({
+        feedback: {
+          ...original,
+          timestamp: new Date('2026-01-02T00:00:00Z'),
+          feedbackSource: 'patient',
+          value: 1,
+          comment: 'new',
+        },
+      });
+
+      const result = await storage.listFeedback({ filters: { traceId: original.traceId } });
+      expect(result.feedback).toHaveLength(1);
+      expect(result.feedback[0]).toMatchObject({
+        feedbackId: original.feedbackId,
+        timestamp: new Date('2026-01-02T00:00:00Z'),
+        feedbackSource: 'patient',
+        value: 1,
+        comment: 'new',
+      });
+    });
+
+    it('retains the last repeated feedbackId in a batch', async () => {
+      const original = {
+        feedbackId: 'feedback-supersession-batch',
+        timestamp: new Date('2026-01-01T00:00:00Z'),
+        traceId: 'trace-feedback-supersession-batch',
+        spanId: null,
+        feedbackSource: 'superseded-patient',
+        feedbackType: 'rating',
+        value: -1,
+        comment: 'old',
+        experimentId: null,
+        feedbackUserId: 'patient-1',
+        sourceId: 'survey-1',
+        metadata: null,
+      };
+      await storage.batchCreateFeedback({
+        feedbacks: [
+          original,
+          {
+            ...original,
+            timestamp: new Date('2026-01-02T00:00:00Z'),
+            feedbackSource: 'patient',
+            value: 1,
+            comment: 'new',
+          },
+        ],
+      });
+
+      const result = await storage.listFeedback({ filters: { traceId: original.traceId } });
+      expect(result.feedback).toHaveLength(1);
+      expect(result.feedback[0]).toMatchObject({
+        feedbackId: original.feedbackId,
+        timestamp: new Date('2026-01-02T00:00:00Z'),
+        feedbackSource: 'patient',
+        value: 1,
+        comment: 'new',
+      });
+    });
+
     it('accepts deprecated `source` filter for feedback (DuckDB-specific)', async () => {
       await storage.createFeedback({
         feedback: {

--- a/stores/duckdb/src/storage/domains/observability/trace-query.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/trace-query.test.ts
@@ -195,6 +195,54 @@ describe('DuckDB advanced trace query', () => {
     expect(repeatedSpans.sql.match(/current_spans AS/g)).toHaveLength(1);
   });
 
+  it('compiles feedback relations against the existing string value representation', () => {
+    const compiled = compileDuckDBTraceQuery(
+      plan({
+        where: {
+          op: 'and',
+          args: [
+            {
+              feedback: {
+                some: {
+                  op: 'and',
+                  args: [
+                    { op: 'eq', left: { path: 'feedbackType' }, right: { literal: "rating' OR TRUE --" } },
+                    { op: 'lt', left: { path: 'value' }, right: { literal: 0 } },
+                    { op: 'gte', left: { path: 'timestamp' }, right: { literal: '2026-01-01T14:00:00+02:00' } },
+                    { op: 'exists', path: 'value' },
+                  ],
+                },
+              },
+            },
+            { feedback: { none: { op: 'in', value: { path: 'value' }, set: ['bad', 'worse'] } } },
+          ],
+        },
+      }),
+    );
+
+    expect(compiled.sql.match(/current_feedback AS/g)).toHaveLength(1);
+    expect(compiled.sql.match(/FROM current_feedback s/g)).toHaveLength(2);
+    expect(compiled.sql).toContain('s.traceId IS NOT NULL');
+    expect(compiled.sql).toContain('s.traceId = r.traceId');
+    expect(compiled.sql).toContain('TRY_CAST(s.value AS DOUBLE) IS NOT NULL AND TRY_CAST(s.value AS DOUBLE) < ?');
+    expect(compiled.sql).toContain('s.value IS NOT NULL AND s.value IN (?, ?)');
+    expect(compiled.sql).toContain('s.value IS NOT NULL');
+    expect(compiled.sql).not.toContain("rating' OR TRUE --");
+    expect(compiled.values).toContain("rating' OR TRUE --");
+    expect(compiled.values).toContain('2026-01-01T12:00:00.000Z');
+  });
+
+  it('emits feedback scope only when referenced', () => {
+    const traceOnly = compileDuckDBTraceQuery(plan()).sql;
+    const feedbackOnly = compileDuckDBTraceQuery(
+      plan({ where: { feedback: { some: { op: 'exists', path: 'value' } } } }),
+    ).sql;
+
+    expect(traceOnly).not.toContain('current_feedback AS');
+    expect(traceOnly).not.toContain('feedback_events');
+    expect(feedbackOnly.match(/current_feedback AS/g)).toHaveLength(1);
+  });
+
   it('uses total null semantics for negative predicates', () => {
     const compiled = compileDuckDBTraceQuery(
       plan({ where: { op: 'ne', left: { path: 'threadId' }, right: { literal: 'excluded' } } }),

--- a/stores/duckdb/src/storage/domains/observability/trace-query.ts
+++ b/stores/duckdb/src/storage/domains/observability/trace-query.ts
@@ -1,6 +1,7 @@
 import * as coreStorage from '@mastra/core/storage';
 import type {
   TraceQueryCanonicalField,
+  TraceQueryFeedbackField,
   TraceQueryField,
   TraceQueryPredicateField,
   TraceQueryResponse,
@@ -61,6 +62,18 @@ const SCORE_FIELDS = {
   parentEntityVersionId: { sql: 's.parentEntityVersionId', parameterType: 'scalar' },
   rootEntityVersionId: { sql: 's.rootEntityVersionId', parameterType: 'scalar' },
 } satisfies FieldRegistry<TraceQueryScoreField>;
+
+const FEEDBACK_FIELDS = {
+  feedbackType: { sql: 's.feedbackType', parameterType: 'scalar' },
+  feedbackSource: { sql: 's.feedbackSource', parameterType: 'scalar' },
+  feedbackUserId: { sql: 's.feedbackUserId', parameterType: 'scalar' },
+  sourceId: { sql: 's.sourceId', parameterType: 'scalar' },
+  entityVersionId: { sql: 's.entityVersionId', parameterType: 'scalar' },
+  parentEntityVersionId: { sql: 's.parentEntityVersionId', parameterType: 'scalar' },
+  rootEntityVersionId: { sql: 's.rootEntityVersionId', parameterType: 'scalar' },
+  timestamp: { sql: 's.timestamp', parameterType: 'timestamp' },
+  comment: { sql: 's.comment', parameterType: 'scalar' },
+} satisfies FieldRegistry<Exclude<TraceQueryFeedbackField, 'value'>>;
 
 const TRACE_SELECT = `
   r.traceId AS traceId,
@@ -163,11 +176,41 @@ function compileScalarPredicate<TField extends string>(
   };
 }
 
+function compileFeedbackScalarPredicate(predicate: TrustedTraceQueryScalarPredicate): SqlFragment {
+  if (predicate.type === 'boolean') {
+    const values: unknown[] = [];
+    const parts = predicate.args.map(arg => {
+      const compiled = compileFeedbackScalarPredicate(arg);
+      values.push(...compiled.values);
+      return `(${compiled.sql})`;
+    });
+    return { sql: parts.join(predicate.operator === 'and' ? ' AND ' : ' OR '), values };
+  }
+  if (predicate.type === 'not') {
+    const compiled = compileFeedbackScalarPredicate(predicate.arg);
+    return { sql: `NOT (${compiled.sql})`, values: compiled.values };
+  }
+  if (predicate.field !== 'value') return compileScalarPredicate(predicate, FEEDBACK_FIELDS);
+  if (predicate.type === 'presence') {
+    return { sql: `s.value IS ${predicate.operator === 'exists' ? 'NOT ' : ''}NULL`, values: [] };
+  }
+  const sample = predicate.type === 'membership' ? predicate.values[0] : predicate.value;
+  const field = typeof sample === 'number' ? 'TRY_CAST(s.value AS DOUBLE)' : 's.value';
+  return compileScalarPredicate(predicate, { value: { sql: field, parameterType: 'scalar' } });
+}
+
 function compilePredicate(predicate: TrustedTraceQueryPredicate): SqlFragment {
   if (predicate.type === 'relation') {
-    const registry = predicate.collection === 'spans' ? SPAN_FIELDS : SCORE_FIELDS;
-    const compiled = compileScalarPredicate(predicate.predicate, registry);
-    const table = predicate.collection === 'spans' ? 'current_spans' : 'current_scores';
+    const compiled =
+      predicate.collection === 'feedback'
+        ? compileFeedbackScalarPredicate(predicate.predicate)
+        : compileScalarPredicate(predicate.predicate, predicate.collection === 'spans' ? SPAN_FIELDS : SCORE_FIELDS);
+    const table =
+      predicate.collection === 'spans'
+        ? 'current_spans'
+        : predicate.collection === 'scores'
+          ? 'current_scores'
+          : 'current_feedback';
     const existence = `EXISTS (
       SELECT 1 FROM ${table} s
       WHERE s.traceId IS NOT NULL
@@ -200,8 +243,8 @@ function compilePredicate(predicate: TrustedTraceQueryPredicate): SqlFragment {
 
 function collectRelatedCollections(
   predicate: TrustedTraceQueryPredicate | undefined,
-  collections = new Set<'spans' | 'scores'>(),
-): Set<'spans' | 'scores'> {
+  collections = new Set<'spans' | 'scores' | 'feedback'>(),
+): Set<'spans' | 'scores' | 'feedback'> {
   if (!predicate) return collections;
   if (predicate.type === 'relation') {
     collections.add(predicate.collection);
@@ -308,6 +351,15 @@ export function compileDuckDBTraceQuery(plan: TrustedTraceQueryPlan): CompiledDu
       SELECT s.*
       FROM score_events s
       INNER JOIN root_scope roots ON roots.traceId = s.traceId
+    )`);
+  }
+
+  if (relatedCollections.has('feedback')) {
+    ctes.push(`current_feedback AS (
+      SELECT f.*
+      FROM feedback_events f
+      INNER JOIN root_scope roots ON roots.traceId = f.traceId
+      WHERE f.traceId IS NOT NULL
     )`);
   }
 

--- a/stores/duckdb/src/storage/domains/observability/trace-query.ts
+++ b/stores/duckdb/src/storage/domains/observability/trace-query.ts
@@ -359,7 +359,6 @@ export function compileDuckDBTraceQuery(plan: TrustedTraceQueryPlan): CompiledDu
       SELECT f.*
       FROM feedback_events f
       INNER JOIN root_scope roots ON roots.traceId = f.traceId
-      WHERE f.traceId IS NOT NULL
     )`);
   }
 

--- a/stores/pg/src/storage/domains/observability/v-next/feedback.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/feedback.ts
@@ -48,8 +48,16 @@ import {
 } from './olap';
 import { assertDeltaPollingEnabled, deltaPollingFeatureEnabled } from './polling';
 import { parseUpdateFeedbackReviewStatusArgs } from './review-status';
-import { FEEDBACK_TYPED_COLUMNS } from './signal-schema';
+import { FEEDBACK_EVENT_COLUMNS, FEEDBACK_TYPED_COLUMNS } from './signal-schema';
 import { buildInsert, FEEDBACK_SELECT_COLUMNS } from './sql';
+
+const FEEDBACK_CONFLICT_KEYS = new Set(['feedbackId', 'timestamp']);
+const FEEDBACK_UPSERT_CLAUSE = `ON CONFLICT ("feedbackId", "timestamp") DO UPDATE SET ${FEEDBACK_EVENT_COLUMNS.map(
+  column => column.name,
+)
+  .filter(column => !FEEDBACK_CONFLICT_KEYS.has(column))
+  .map(column => `"${column}" = EXCLUDED."${column}"`)
+  .join(', ')}`;
 
 // ---------------------------------------------------------------------------
 // Filter helpers specific to the feedback signal
@@ -99,7 +107,7 @@ function pushFeedbackIdentity(
 
 export async function createFeedback(client: DbClient, schema: string, args: CreateFeedbackArgs): Promise<void> {
   const row = feedbackRecordToRow(args.feedback);
-  const insert = buildInsert(schema, TABLE_FEEDBACK_EVENTS, [row]);
+  const insert = buildInsert(schema, TABLE_FEEDBACK_EVENTS, [row], FEEDBACK_UPSERT_CLAUSE);
   if (insert) await client.query(insert.text, insert.values);
 }
 
@@ -109,8 +117,9 @@ export async function batchCreateFeedback(
   args: BatchCreateFeedbackArgs,
 ): Promise<void> {
   if (args.feedbacks.length === 0) return;
-  const rows = args.feedbacks.map(feedbackRecordToRow);
-  const insert = buildInsert(schema, TABLE_FEEDBACK_EVENTS, rows);
+  const currentFeedback = new Map(args.feedbacks.map(feedback => [feedback.feedbackId, feedback]));
+  const rows = [...currentFeedback.values()].map(feedbackRecordToRow);
+  const insert = buildInsert(schema, TABLE_FEEDBACK_EVENTS, rows, FEEDBACK_UPSERT_CLAUSE);
   if (insert) await client.query(insert.text, insert.values);
 }
 

--- a/stores/pg/src/storage/domains/observability/v-next/trace-query.test.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/trace-query.test.ts
@@ -245,6 +245,8 @@ describe('Postgres advanced trace query', () => {
     expect(compiled.text).toContain('s."valueString" IS NOT NULL AND s."valueString" IN');
     expect(compiled.text).toContain('(s."valueString" IS NOT NULL OR s."valueNumber" IS NOT NULL)');
     expect(compiled.text).toContain('FROM "public"."mastra_feedback_events" s');
+    expect(compiled.text).toContain('newer."feedbackId" = s."feedbackId"');
+    expect(compiled.text).toContain('newer."cursorId" > s."cursorId"');
     expect(compiled.text).not.toContain("rating' OR TRUE --");
     expect(compiled.values).toContain("rating' OR TRUE --");
     expect(compiled.values).toContain('2026-01-01T12:00:00.000Z');

--- a/stores/pg/src/storage/domains/observability/v-next/trace-query.test.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/trace-query.test.ts
@@ -210,6 +210,58 @@ describe('Postgres advanced trace query', () => {
     expect(compiled.text).toContain('r."endedAt" IS NOT NULL');
   });
 
+  it('compiles typed feedback relations with one correlated existence check per clause', () => {
+    const compiled = compilePostgresTraceQuery(
+      'public',
+      plan({
+        where: {
+          op: 'and',
+          args: [
+            {
+              feedback: {
+                some: {
+                  op: 'and',
+                  args: [
+                    { op: 'eq', left: { path: 'feedbackType' }, right: { literal: "rating' OR TRUE --" } },
+                    { op: 'lt', left: { path: 'value' }, right: { literal: 0 } },
+                    { op: 'gte', left: { path: 'timestamp' }, right: { literal: '2026-01-01T14:00:00+02:00' } },
+                    { op: 'exists', path: 'value' },
+                    { op: 'exists', path: 'comment' },
+                  ],
+                },
+              },
+            },
+            { feedback: { none: { op: 'in', value: { path: 'value' }, set: ['bad', 'worse'] } } },
+          ],
+        },
+      }),
+    );
+
+    expect(compiled.text.match(/current_feedback AS/g)).toHaveLength(1);
+    expect(compiled.text.match(/FROM current_feedback s/g)).toHaveLength(2);
+    expect(compiled.text).toContain('s."traceId" IS NOT NULL');
+    expect(compiled.text).toContain('s."traceId" = r."traceId"');
+    expect(compiled.text).toContain('s."valueNumber" IS NOT NULL AND s."valueNumber" <');
+    expect(compiled.text).toContain('s."valueString" IS NOT NULL AND s."valueString" IN');
+    expect(compiled.text).toContain('(s."valueString" IS NOT NULL OR s."valueNumber" IS NOT NULL)');
+    expect(compiled.text).toContain('FROM "public"."mastra_feedback_events" s');
+    expect(compiled.text).not.toContain("rating' OR TRUE --");
+    expect(compiled.values).toContain("rating' OR TRUE --");
+    expect(compiled.values).toContain('2026-01-01T12:00:00.000Z');
+  });
+
+  it('emits feedback scope only when referenced', () => {
+    const traceOnly = compilePostgresTraceQuery('public', plan()).text;
+    const feedbackOnly = compilePostgresTraceQuery(
+      'public',
+      plan({ where: { feedback: { some: { op: 'exists', path: 'value' } } } }),
+    ).text;
+
+    expect(traceOnly).not.toContain('current_feedback AS');
+    expect(traceOnly).not.toContain('mastra_feedback_events');
+    expect(feedbackOnly.match(/current_feedback AS/g)).toHaveLength(1);
+  });
+
   it('uses total null semantics for negative predicates', () => {
     const compiled = compilePostgresTraceQuery(
       'public',

--- a/stores/pg/src/storage/domains/observability/v-next/trace-query.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/trace-query.ts
@@ -1,6 +1,7 @@
 import * as coreStorage from '@mastra/core/storage';
 import type {
   TraceQueryCanonicalField,
+  TraceQueryFeedbackField,
   TraceQueryField,
   TraceQueryPredicateField,
   TraceQueryResponse,
@@ -12,7 +13,7 @@ import type {
 } from '@mastra/core/storage';
 
 import type { DbClient, TxClient } from '../../../client';
-import { qualifiedTable, TABLE_SCORE_EVENTS, TABLE_SPAN_EVENTS } from './ddl';
+import { qualifiedTable, TABLE_FEEDBACK_EVENTS, TABLE_SCORE_EVENTS, TABLE_SPAN_EVENTS } from './ddl';
 
 type SqlFragment = { sql: string; values: unknown[] };
 type FieldRegistry<TField extends string> = Record<TField, string>;
@@ -60,6 +61,18 @@ const SCORE_FIELDS = {
   parentEntityVersionId: 's."parentEntityVersionId"',
   rootEntityVersionId: 's."rootEntityVersionId"',
 } satisfies FieldRegistry<TraceQueryScoreField>;
+
+const FEEDBACK_FIELDS = {
+  feedbackType: 's."feedbackType"',
+  feedbackSource: 's."feedbackSource"',
+  feedbackUserId: 's."feedbackUserId"',
+  sourceId: 's."sourceId"',
+  entityVersionId: 's."entityVersionId"',
+  parentEntityVersionId: 's."parentEntityVersionId"',
+  rootEntityVersionId: 's."rootEntityVersionId"',
+  timestamp: 's."timestamp"',
+  comment: 's."comment"',
+} satisfies FieldRegistry<Exclude<TraceQueryFeedbackField, 'value'>>;
 
 const TRACE_SELECT = `
   r."traceId" AS "traceId",
@@ -156,6 +169,35 @@ function compileScalarPredicate<TField extends string>(
   };
 }
 
+function compileFeedbackScalarPredicate(
+  predicate: TrustedTraceQueryScalarPredicate,
+  parameterOffset: number,
+): SqlFragment {
+  if (predicate.type === 'boolean') {
+    const values: unknown[] = [];
+    const parts = predicate.args.map(arg => {
+      const compiled = compileFeedbackScalarPredicate(arg, parameterOffset + values.length);
+      values.push(...compiled.values);
+      return `(${compiled.sql})`;
+    });
+    return { sql: parts.join(predicate.operator === 'and' ? ' AND ' : ' OR '), values };
+  }
+  if (predicate.type === 'not') {
+    const compiled = compileFeedbackScalarPredicate(predicate.arg, parameterOffset);
+    return { sql: `NOT (${compiled.sql})`, values: compiled.values };
+  }
+  if (predicate.field !== 'value') {
+    return compileScalarPredicate(predicate, FEEDBACK_FIELDS, parameterOffset);
+  }
+  if (predicate.type === 'presence') {
+    const present = `(s."valueString" IS NOT NULL OR s."valueNumber" IS NOT NULL)`;
+    return { sql: predicate.operator === 'exists' ? present : `NOT ${present}`, values: [] };
+  }
+  const sample = predicate.type === 'membership' ? predicate.values[0] : predicate.value;
+  const field = typeof sample === 'number' ? 's."valueNumber"' : 's."valueString"';
+  return compileScalarPredicate(predicate, { value: field }, parameterOffset);
+}
+
 function latestRootPredicate(spanTable: string): string {
   return `NOT EXISTS (
     SELECT 1 FROM ${spanTable} newer
@@ -184,8 +226,8 @@ function latestScorePredicate(scoreTable: string): string {
 
 function collectRelationCollections(
   predicate: TrustedTraceQueryPredicate | undefined,
-  collections = new Set<'spans' | 'scores'>(),
-): Set<'spans' | 'scores'> {
+  collections = new Set<'spans' | 'scores' | 'feedback'>(),
+): Set<'spans' | 'scores' | 'feedback'> {
   if (!predicate) return collections;
   if (predicate.type === 'relation') {
     collections.add(predicate.collection);
@@ -199,12 +241,24 @@ function collectRelationCollections(
 
 function compilePredicate(predicate: TrustedTraceQueryPredicate, parameterOffset: number): SqlFragment {
   if (predicate.type === 'relation') {
-    const registry = predicate.collection === 'spans' ? SPAN_FIELDS : SCORE_FIELDS;
-    const compiled = compileScalarPredicate(predicate.predicate, registry, parameterOffset);
-    const table = predicate.collection === 'spans' ? 'current_spans' : 'current_scores';
+    const compiled =
+      predicate.collection === 'feedback'
+        ? compileFeedbackScalarPredicate(predicate.predicate, parameterOffset)
+        : compileScalarPredicate(
+            predicate.predicate,
+            predicate.collection === 'spans' ? SPAN_FIELDS : SCORE_FIELDS,
+            parameterOffset,
+          );
+    const table =
+      predicate.collection === 'spans'
+        ? 'current_spans'
+        : predicate.collection === 'scores'
+          ? 'current_scores'
+          : 'current_feedback';
     const existence = `EXISTS (
       SELECT 1 FROM ${table} s
-      WHERE s."traceId" = r."traceId"
+      WHERE s."traceId" IS NOT NULL
+        AND s."traceId" = r."traceId"
         AND (${compiled.sql})
     )`;
     return {
@@ -239,6 +293,7 @@ export interface CompiledPostgresTraceQuery {
 export function compilePostgresTraceQuery(schema: string, plan: TrustedTraceQueryPlan): CompiledPostgresTraceQuery {
   const spanTable = qualifiedTable(schema, TABLE_SPAN_EVENTS);
   const scoreTable = qualifiedTable(schema, TABLE_SCORE_EVENTS);
+  const feedbackTable = qualifiedTable(schema, TABLE_FEEDBACK_EVENTS);
   const values: unknown[] = [plan.timeRange.from, plan.timeRange.to];
   const relationCollections = collectRelationCollections(plan.where);
   const rootConditions = [
@@ -302,6 +357,26 @@ export function compilePostgresTraceQuery(schema: string, plan: TrustedTraceQuer
     WHERE s."traceId" IS NOT NULL
       AND s."traceId" IN (SELECT "traceId" FROM root_scope)
       AND ${latestScorePredicate(scoreTable)}
+  )`);
+  }
+  if (relationCollections.has('feedback')) {
+    ctes.push(`current_feedback AS MATERIALIZED (
+    SELECT
+      s."traceId",
+      s."feedbackType",
+      s."feedbackSource",
+      s."feedbackUserId",
+      s."sourceId",
+      s."valueString",
+      s."valueNumber",
+      s."comment",
+      s."timestamp",
+      s."entityVersionId",
+      s."parentEntityVersionId",
+      s."rootEntityVersionId"
+    FROM ${feedbackTable} s
+    WHERE s."traceId" IS NOT NULL
+      AND s."traceId" IN (SELECT "traceId" FROM root_scope)
   )`);
   }
 

--- a/stores/pg/src/storage/domains/observability/v-next/trace-query.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/trace-query.ts
@@ -224,6 +224,14 @@ function latestScorePredicate(scoreTable: string): string {
   )`;
 }
 
+function latestFeedbackPredicate(feedbackTable: string): string {
+  return `NOT EXISTS (
+    SELECT 1 FROM ${feedbackTable} newer
+    WHERE newer."feedbackId" = s."feedbackId"
+      AND newer."cursorId" > s."cursorId"
+  )`;
+}
+
 function collectRelationCollections(
   predicate: TrustedTraceQueryPredicate | undefined,
   collections = new Set<'spans' | 'scores' | 'feedback'>(),
@@ -377,6 +385,7 @@ export function compilePostgresTraceQuery(schema: string, plan: TrustedTraceQuer
     FROM ${feedbackTable} s
     WHERE s."traceId" IS NOT NULL
       AND s."traceId" IN (SELECT "traceId" FROM root_scope)
+      AND ${latestFeedbackPredicate(feedbackTable)}
   )`);
   }
 

--- a/stores/pg/src/storage/index.vnext.test.ts
+++ b/stores/pg/src/storage/index.vnext.test.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto';
-import { createObservabilityVNextTests } from '@internal/storage-test-utils';
+import { createObservabilityVNextTests, normalizeTraceQueryResponse } from '@internal/storage-test-utils';
+import { SpanType } from '@mastra/core/observability';
+import { parseTraceQueryRequest, planTraceQuery } from '@mastra/core/storage';
 import { Pool } from 'pg';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
@@ -209,5 +211,104 @@ describe.skipIf(!integrationEnabled)('PostgresStoreVNext / shared observability 
     cleanup: async storage => {
       await storage.dangerouslyClearAll();
     },
+  });
+
+  it('retains changed-timestamp feedback versions while querying only the latest accepted write', async () => {
+    if (!sharedStorage || !sharedClient || !sharedSchema)
+      throw new Error('shared observability storage was not initialized');
+    await sharedStorage.dangerouslyClearAll();
+    try {
+      await sharedStorage.createSpan({
+        span: {
+          traceId: 'feedback-physical-trace',
+          spanId: 'feedback-physical-root',
+          parentSpanId: null,
+          name: 'feedback-physical-root',
+          spanType: SpanType.AGENT_RUN,
+          isEvent: false,
+          startedAt: new Date('2026-08-10T00:00:00Z'),
+          endedAt: new Date('2026-08-10T00:00:01Z'),
+        },
+      });
+      const feedback = {
+        feedbackId: 'feedback-physical-supersession',
+        timestamp: new Date('2026-08-10T02:00:00Z'),
+        traceId: 'feedback-physical-trace',
+        spanId: null,
+        feedbackSource: 'old-physical-source',
+        feedbackType: 'rating',
+        value: 1,
+        comment: null,
+        experimentId: null,
+        sourceId: null,
+        metadata: null,
+      };
+      await sharedStorage.createFeedback({ feedback });
+      await sharedStorage.createFeedback({
+        feedback: {
+          ...feedback,
+          timestamp: new Date('2026-08-10T01:00:00Z'),
+          feedbackSource: 'current-physical-source',
+        },
+      });
+
+      const rows = await sharedClient.any<{ cursorId: string; feedbackSource: string }>(
+        `SELECT "cursorId", "feedbackSource" FROM "${sharedSchema}"."mastra_feedback_events" WHERE "feedbackId" = $1 ORDER BY "cursorId"`,
+        [feedback.feedbackId],
+      );
+      expect(rows.map(row => row.feedbackSource)).toEqual(['old-physical-source', 'current-physical-source']);
+
+      const queryBySource = async (feedbackSource: string) => {
+        const response = await sharedStorage!.queryTraces(
+          planTraceQuery(
+            parseTraceQueryRequest({
+              timeRange: { from: '2026-08-01T00:00:00Z', to: '2026-09-01T00:00:00Z' },
+              where: {
+                feedback: {
+                  some: { op: 'eq', left: { path: 'feedbackSource' }, right: { literal: feedbackSource } },
+                },
+              },
+            }),
+          ),
+        );
+        return normalizeTraceQueryResponse(response);
+      };
+      await expect(queryBySource('old-physical-source')).resolves.toEqual([]);
+      await expect(queryBySource('current-physical-source')).resolves.toEqual([{ traceId: 'feedback-physical-trace' }]);
+
+      await sharedStorage.createFeedback({
+        feedback: {
+          ...feedback,
+          timestamp: new Date('2026-08-10T01:00:00Z'),
+          feedbackSource: 'same-timestamp-current-source',
+          value: 'updated value',
+          comment: 'updated comment',
+        },
+      });
+      const updatedRows = await sharedClient.any<{
+        comment: string | null;
+        cursorId: string;
+        feedbackSource: string;
+        valueNumber: number | null;
+        valueString: string | null;
+      }>(
+        `SELECT "cursorId", "feedbackSource", "valueString", "valueNumber", "comment" FROM "${sharedSchema}"."mastra_feedback_events" WHERE "feedbackId" = $1 ORDER BY "cursorId"`,
+        [feedback.feedbackId],
+      );
+      expect(updatedRows).toHaveLength(2);
+      expect(updatedRows[1]).toMatchObject({
+        feedbackSource: 'same-timestamp-current-source',
+        valueString: 'updated value',
+        valueNumber: null,
+        comment: 'updated comment',
+      });
+      expect(BigInt(updatedRows[1]!.cursorId)).toBeGreaterThan(BigInt(rows[1]!.cursorId));
+      await expect(queryBySource('current-physical-source')).resolves.toEqual([]);
+      await expect(queryBySource('same-timestamp-current-source')).resolves.toEqual([
+        { traceId: 'feedback-physical-trace' },
+      ]);
+    } finally {
+      await sharedStorage.dangerouslyClearAll();
+    }
   });
 });


### PR DESCRIPTION
Adds `feedback.some` and `feedback.none` predicates to advanced trace queries. Feedback clauses preserve same-record binding, correlate through non-null trace IDs, and support the approved field allowlist. PostgreSQL and ClickHouse preserve strict string-versus-number feedback value semantics.

PostgreSQL, ClickHouse, and DuckDB compile feedback predicates into parameterized existence queries. DuckDB intentionally continues using its existing `value VARCHAR` storage in this PR, so numeric-looking strings remain a known coercion limitation there. The additive typed-value storage migration and strict DuckDB parity are tracked as the fast follow [OBS-306](https://linear.app/kepler-crm/issue/OBS-306/preserve-string-and-numeric-feedback-value-types-in-duckdb).

```typescript
where: {
  feedback: {
    some: {
      op: "and",
      args: [
        { op: "eq", left: { path: "feedbackType" }, right: { literal: "rating" } },
        { op: "lt", left: { path: "value" }, right: { literal: 0 } },
      ],
    },
  },
}
```

Tested with focused Core, shared evaluator, PostgreSQL, ClickHouse, DuckDB, Server, and client builds; Docker-backed PostgreSQL and ClickHouse conformance tests; package checks and lint; and docs formatting, validation, and production build.

Stacked on `obs-15`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Trace queries can now find traces based on related feedback, such as ratings, comments, or feedback sources. The feature works across PostgreSQL, ClickHouse, and DuckDB, with documented type limitations for DuckDB.

## Changes

- Added `feedback.some` and `feedback.none` predicates to advanced trace queries.
- Preserved same-record binding and correlation through non-null trace IDs.
- Added validation for supported fields, operators, timestamps, value types, and membership values.
- Added parameterized feedback existence queries for PostgreSQL, ClickHouse, and DuckDB.
- Preserved strict string-versus-number semantics in PostgreSQL and ClickHouse.
- Documented DuckDB’s known numeric-looking string coercion limitation under OBS-306.
- Added shared planning, evaluation, fixtures, conformance cases, and database-specific tests.
- Added REST validation and OpenAPI support.
- Regenerated client query types and added package changesets.
- Updated trace-query documentation with feedback syntax, fields, operators, limits, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->