### PR TITLE
feat(mastracode): explain the subconscious and its tools in the agent system prompt

### DIFF
--- a/.changeset/subconscious-tool-guidance.md
+++ b/.changeset/subconscious-tool-guidance.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Teach the main agent about its subconscious. When the experimental subconscious is enabled, the system prompt now carries a "Subconscious Memory" section that explains what the background memory system does, how to use `knowledge_search` / `knowledge_read` / `knowledge_browse`, and that `ask_memory` is asynchronous with its answer arriving later as `<remind-answer>` signals. Previously the agent saw only the one-line tool descriptions and effectively never used them.

--- a/.changeset/subconscious-tool-guidance.md
+++ b/.changeset/subconscious-tool-guidance.md
@@ -2,4 +2,4 @@
 '@mastra/code-sdk': patch
 ---
 
-Teach the main agent about its subconscious. When the experimental subconscious is enabled, the system prompt now carries a "Subconscious Memory" section that explains what the background memory system does, how to use `knowledge_search` / `knowledge_read` / `knowledge_browse`, and that `ask_memory` is asynchronous with its answer arriving later as `<remind-answer>` signals. Previously the agent saw only the one-line tool descriptions.
+Improved the agent's guidance for memory tools.

--- a/.changeset/subconscious-tool-guidance.md
+++ b/.changeset/subconscious-tool-guidance.md
@@ -2,4 +2,4 @@
 '@mastra/code-sdk': patch
 ---
 
-Teach the main agent about its subconscious. When the experimental subconscious is enabled, the system prompt now carries a "Subconscious Memory" section that explains what the background memory system does, how to use `knowledge_search` / `knowledge_read` / `knowledge_browse`, and that `ask_memory` is asynchronous with its answer arriving later as `<remind-answer>` signals. Previously the agent saw only the one-line tool descriptions and effectively never used them.
+Teach the main agent about its subconscious. When the experimental subconscious is enabled, the system prompt now carries a "Subconscious Memory" section that explains what the background memory system does, how to use `knowledge_search` / `knowledge_read` / `knowledge_browse`, and that `ask_memory` is asynchronous with its answer arriving later as `<remind-answer>` signals. Previously the agent saw only the one-line tool descriptions.

--- a/mastracode/sdk/src/agents/__tests__/prompt-sections.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/prompt-sections.test.ts
@@ -112,6 +112,36 @@ describe('getDynamicInstructionSections', () => {
     expect(joinPromptSections(sections)).toBe(await getDynamicInstructions({ requestContext }));
   });
 
+  it('advertises subconscious tools only when the caller says they are registered, not from the env flag', async () => {
+    const requestContext = makeRequestContext({});
+    const previous = process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS;
+    process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS = '1';
+    try {
+      const withoutFlag = await getDynamicInstructions({ requestContext });
+      expect(withoutFlag).not.toContain('# Subconscious Memory');
+
+      const withFlag = await getDynamicInstructions({ requestContext, hasSubconscious: true });
+      expect(withFlag).toContain('# Subconscious Memory');
+      expect(withFlag).toContain('**ask_memory**');
+
+      // A resolver is evaluated against the session state, so Factory sessions
+      // can be refused per request.
+      const seen: unknown[] = [];
+      const resolved = await getDynamicInstructions({
+        requestContext: makeRequestContext({ factoryProjectId: 'proj-1' }),
+        hasSubconscious: s => {
+          seen.push(s?.factoryProjectId);
+          return false;
+        },
+      });
+      expect(seen).toEqual(['proj-1']);
+      expect(resolved).not.toContain('# Subconscious Memory');
+    } finally {
+      if (previous === undefined) delete process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS;
+      else process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS = previous;
+    }
+  });
+
   it('rejoins into exactly getDynamicInstructions output with plugin instructions', async () => {
     const requestContext = makeRequestContext({
       pluginInstructions: ['First plugin guidance.', 'Second plugin guidance.'],

--- a/mastracode/sdk/src/agents/__tests__/subconscious-availability.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/subconscious-availability.test.ts
@@ -1,0 +1,44 @@
+import type { MastraVector } from '@mastra/core/vector';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { MastraCodeState } from '../../schema.js';
+import { hasSubconsciousTools, isSubconsciousEnabled } from '../memory.js';
+
+const vector = {} as MastraVector;
+const state = (partial: Partial<MastraCodeState>) => partial as MastraCodeState;
+
+describe('subconscious tool availability', () => {
+  let previous: string | undefined;
+
+  beforeEach(() => {
+    previous = process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS;
+    process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS = '1';
+  });
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS;
+    else process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS = previous;
+  });
+
+  it('requires both the opt-in flag and a vector store', () => {
+    expect(isSubconsciousEnabled(vector)).toBe(true);
+    expect(isSubconsciousEnabled(undefined)).toBe(false);
+    delete process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS;
+    expect(isSubconsciousEnabled(vector)).toBe(false);
+  });
+
+  it('is available for local sessions and org-resolved Factory sessions', () => {
+    expect(hasSubconsciousTools(vector, undefined)).toBe(true);
+    expect(hasSubconsciousTools(vector, state({ projectPath: '/repo' }))).toBe(true);
+    expect(hasSubconsciousTools(vector, state({ factoryProjectId: 'proj-1', factoryOrgId: 'org-1' }))).toBe(true);
+  });
+
+  it('is refused for Factory sessions whose org could not be resolved, matching the memory wiring', () => {
+    expect(hasSubconsciousTools(vector, state({ factoryProjectId: 'proj-1' }))).toBe(false);
+    expect(hasSubconsciousTools(vector, state({ factoryOrgUnresolved: true }))).toBe(false);
+  });
+
+  it('is never available without a vector store', () => {
+    expect(hasSubconsciousTools(undefined, state({ factoryProjectId: 'proj-1', factoryOrgId: 'org-1' }))).toBe(false);
+  });
+});

--- a/mastracode/sdk/src/agents/instructions.ts
+++ b/mastracode/sdk/src/agents/instructions.ts
@@ -1,5 +1,5 @@
 import type { AgentControllerRequestContext } from '@mastra/core/agent-controller';
-import type { MastraCodeComposedState } from '../schema.js';
+import type { MastraCodeComposedState, MastraCodeState } from '../schema.js';
 import { detectCommonBinariesAsync } from '../utils/binaries.js';
 import { getCurrentGitBranchAsync } from '../utils/project.js';
 import type { PromptContext, PromptSection } from './prompts/index.js';
@@ -8,11 +8,13 @@ import { buildFullPromptSections, joinPromptSections } from './prompts/index.js'
 export async function getDynamicInstructions({
   requestContext,
   hostInstructions,
+  hasSubconscious,
 }: {
   requestContext: { get(key: string): unknown };
   hostInstructions?: string;
+  hasSubconscious?: boolean | ((state: MastraCodeState | undefined) => boolean);
 }): Promise<string> {
-  return joinPromptSections(await getDynamicInstructionSections({ requestContext, hostInstructions }));
+  return joinPromptSections(await getDynamicInstructionSections({ requestContext, hostInstructions, hasSubconscious }));
 }
 
 /**
@@ -23,9 +25,16 @@ export async function getDynamicInstructions({
 export async function getDynamicInstructionSections({
   requestContext,
   hostInstructions,
+  hasSubconscious,
 }: {
   requestContext: { get(key: string): unknown };
   hostInstructions?: string;
+  /**
+   * The subconscious knowledge tools are registered on the agent. A function
+   * is resolved against the session state, since Factory sessions can refuse
+   * the subconscious per request.
+   */
+  hasSubconscious?: boolean | ((state: MastraCodeState | undefined) => boolean);
 }): Promise<PromptSection[]> {
   const agentControllerContext = requestContext.get('controller') as
     | AgentControllerRequestContext<MastraCodeComposedState>
@@ -52,6 +61,7 @@ export async function getDynamicInstructionSections({
     workingDir: projectPath,
     state,
     hostInstructions,
+    hasSubconscious: typeof hasSubconscious === 'function' ? hasSubconscious(state) : hasSubconscious,
   };
 
   const promptSections = buildFullPromptSections(promptCtx);

--- a/mastracode/sdk/src/agents/memory.ts
+++ b/mastracode/sdk/src/agents/memory.ts
@@ -101,6 +101,26 @@ function reportOrgUnresolved(
 }
 
 /**
+ * Whether the experimental subconscious (knowledge graph + reminder sidekick)
+ * is switched on for this process: it needs a vector store and the opt-in flag.
+ */
+export function isSubconsciousEnabled(vector: MastraVector | undefined): boolean {
+  return Boolean(vector) && process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS === '1';
+}
+
+/**
+ * Whether the subconscious tools (`knowledge_*`, `ask_memory`) are registered
+ * for a given session. Beyond the process-level switch, a Factory-owned
+ * session that cannot resolve its org refuses the subconscious entirely (see
+ * `getDynamicMemory`, which applies the same two checks inline because it also
+ * needs the resolved identity). The system prompt's tool guidance calls here so
+ * it never advertises tools that `getDynamicMemory` did not register.
+ */
+export function hasSubconsciousTools(vector: MastraVector | undefined, state: MastraCodeState | undefined): boolean {
+  return isSubconsciousEnabled(vector) && resolveKnowledgeScopeIdentity(state).resolved;
+}
+
+/**
  * Dynamic memory factory function.
  * Reads OM thresholds from controller state via requestContext.
  * Model functions also read from requestContext (no mutable bridge needed).
@@ -114,7 +134,7 @@ export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraV
   return ({ requestContext }: { requestContext: RequestContext }) => {
     const controller = requestContext.get('controller') as AgentControllerRequestContext<MastraCodeState> | undefined;
     const state = controller?.getState() as MastraCodeState | undefined;
-    const subconsciousEnabled = Boolean(vector) && process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS === '1';
+    const subconsciousEnabled = isSubconsciousEnabled(vector);
     const factoryProjectId = state?.factoryProjectId;
     const isFactory = typeof factoryProjectId === 'string' && factoryProjectId.trim().length > 0;
 

--- a/mastracode/sdk/src/agents/prompts/index.ts
+++ b/mastracode/sdk/src/agents/prompts/index.ts
@@ -28,6 +28,8 @@ import { buildToolGuidance } from './tool-guidance.js';
 export interface PromptContext extends Omit<BasePromptContext, 'toolGuidance'> {
   modeId: string;
   state?: any;
+  /** The subconscious knowledge tools are registered on the agent. */
+  hasSubconscious?: boolean;
   hostInstructions?: string;
   currentDate: string;
   workingDir: string;
@@ -106,6 +108,7 @@ export function buildFullPromptSections(ctx: PromptContext): PromptSection[] {
   const factoryProjectId = typeof ctx.state?.factoryProjectId === 'string' ? ctx.state.factoryProjectId : undefined;
   const toolGuidance = buildToolGuidance(ctx.modeId, {
     hasWebSearch,
+    hasSubconscious: ctx.hasSubconscious === true,
     deniedTools,
     plansDir: getLocalPlansRelativeDir({ factoryProjectId }),
   });

--- a/mastracode/sdk/src/agents/prompts/tool-guidance.test.ts
+++ b/mastracode/sdk/src/agents/prompts/tool-guidance.test.ts
@@ -38,3 +38,56 @@ describe('buildToolGuidance task tools', () => {
     expect(guidance).not.toContain('.artifacts/plans/');
   });
 });
+
+describe('buildToolGuidance subconscious tools', () => {
+  it('omits subconscious guidance when the subconscious is off', () => {
+    const guidance = buildToolGuidance('build');
+
+    expect(guidance).not.toContain('Subconscious Memory');
+    expect(guidance).not.toContain('ask_memory');
+    expect(guidance).not.toContain('knowledge_search');
+  });
+
+  it('explains the subconscious, the knowledge tools, and async ask_memory when enabled', () => {
+    const guidance = buildToolGuidance('build', { hasSubconscious: true });
+
+    expect(guidance).toContain('# Subconscious Memory');
+    expect(guidance).toContain('**knowledge_search** / **knowledge_read** / **knowledge_browse**');
+    expect(guidance).toContain('**ask_memory**');
+    expect(guidance).toContain('ASYNCHRONOUS');
+    expect(guidance).toContain('<remind-answer source="subconscious" agent="remind"');
+    expect(guidance).toContain('moreComing="false"');
+    expect(guidance).toContain('Prefer these over `recall`');
+  });
+
+  it('drops denied subconscious tools individually', () => {
+    const guidance = buildToolGuidance('build', {
+      hasSubconscious: true,
+      deniedTools: new Set(['ask_memory', 'knowledge_browse']),
+    });
+
+    expect(guidance).toContain('# Subconscious Memory');
+    expect(guidance).toContain('**knowledge_search** / **knowledge_read**');
+    expect(guidance).not.toContain('knowledge_browse');
+    expect(guidance).not.toContain('ask_memory');
+  });
+
+  it('does not recommend a denied recall tool from the knowledge guidance', () => {
+    const guidance = buildToolGuidance('build', {
+      hasSubconscious: true,
+      deniedTools: new Set(['recall']),
+    });
+
+    expect(guidance).toContain('# Subconscious Memory');
+    expect(guidance).not.toContain('recall');
+  });
+
+  it('omits the whole section when every subconscious tool is denied', () => {
+    const guidance = buildToolGuidance('build', {
+      hasSubconscious: true,
+      deniedTools: new Set(['ask_memory', 'knowledge_search', 'knowledge_read', 'knowledge_browse']),
+    });
+
+    expect(guidance).not.toContain('Subconscious Memory');
+  });
+});

--- a/mastracode/sdk/src/agents/prompts/tool-guidance.ts
+++ b/mastracode/sdk/src/agents/prompts/tool-guidance.ts
@@ -8,6 +8,8 @@ import { MC_TOOLS } from '../../tool-names.js';
 
 interface ToolGuidanceOptions {
   hasWebSearch?: boolean;
+  /** Subconscious knowledge tools are registered (experimental subconscious enabled). */
+  hasSubconscious?: boolean;
   /** Tool names that have been denied — omit their guidance sections. */
   deniedTools?: Set<string>;
   /** Workspace-relative directory where plan mode can write plans. */
@@ -134,6 +136,53 @@ You have access to the following tools. Use the RIGHT tool for the job:`);
       sections.push(`
 ${webTools.join(' / ')} — Search the web / extract page content
 - Use for looking up documentation, error messages, package APIs.`);
+    }
+  }
+
+  // --- Subconscious knowledge tools (all modes, conditionally available) ---
+
+  if (options.hasSubconscious) {
+    const knowledgeTools = ['knowledge_search', 'knowledge_read', 'knowledge_browse'].filter(name => !denied.has(name));
+    const hasAskMemory = !denied.has('ask_memory');
+    if (knowledgeTools.length > 0 || hasAskMemory) {
+      const lines = [
+        `
+# Subconscious Memory
+
+A background memory system (the "subconscious") runs alongside you. After conversations, it extracts durable knowledge — decisions, preferences, people, files, repos, work items — into a knowledge graph scoped to this project, visible across your sessions here. It also delivers reminders (\`<remembered>\`) and pinned knowledge into your context on its own; you do not manage those directly.`,
+      ];
+      if (knowledgeTools.length > 0) {
+        const bullets: string[] = [];
+        if (knowledgeTools.includes('knowledge_search')) {
+          bullets.push(
+            "- Use `knowledge_search` for a quick lexical + semantic lookup when you need a specific fact (a past decision, a person's role, what a file is for). Cheaper than re-deriving it from the codebase or asking the user.",
+          );
+        }
+        if (knowledgeTools.includes('knowledge_read')) {
+          bullets.push('- Use `knowledge_read` to open a node by name or ID and see the records about it.');
+        }
+        if (knowledgeTools.includes('knowledge_browse')) {
+          bullets.push(
+            "- Use `knowledge_browse` to list nodes by kind or name prefix, or to walk a node's mentions and backlinks.",
+          );
+        }
+        if (!denied.has('recall')) {
+          bullets.push(
+            '- Prefer these over `recall` when the question is about durable facts rather than what was said in a specific past conversation.',
+          );
+        }
+        lines.push(`
+${knowledgeTools.map(name => `**${name}**`).join(' / ')} — Query the knowledge graph directly
+${bullets.join('\n')}`);
+      }
+      if (hasAskMemory) {
+        lines.push(`
+**ask_memory** — Ask the reminder sidekick a question about existing memory
+- Use only when the answer is not already in your context and a direct search is not enough: open-ended questions ("what did we decide about X and why?") or questions that need synthesis across several memories. It answers from what is already remembered; it does not store anything.
+- It is ASYNCHRONOUS. The tool returns as soon as the question is accepted; the answer arrives later as one or more \`<remind-answer source="subconscious" agent="remind" replyId="…" moreComing="true|false">\` messages in your context. Keep working — do not poll or wait, and do not re-ask the same question.
+- Treat a message with \`moreComing="true"\` as partial; the reply is complete only when \`moreComing="false"\` arrives. Fold the answer into your work and cite it as remembered context rather than as something you verified yourself.`);
+      }
+      sections.push(lines.join('\n'));
     }
   }
 

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -48,7 +48,7 @@ import { PostgresStore } from '@mastra/pg';
 
 import { hasCredentialStoreProvider } from './agents/credential-resolver.js';
 import { getDynamicInstructions } from './agents/instructions.js';
-import { getDynamicMemory } from './agents/memory.js';
+import { getDynamicMemory, hasSubconsciousTools } from './agents/memory.js';
 import { createMastraCodeGateway, getDynamicModel, getGoalJudgeModel, resolveModel } from './agents/model.js';
 import { buildMode } from './agents/modes/build.js';
 import { fastMode } from './agents/modes/explore.js';
@@ -639,6 +639,10 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
   });
 
   const memory = config?.memory === false ? undefined : (config?.memory ?? getDynamicMemory(storage, vector));
+  // Only the default memory wiring registers the subconscious tools; a
+  // caller-supplied memory is opaque here, so its prompt must not advertise them.
+  const hasSubconscious =
+    config?.memory === undefined ? (state: MastraCodeState | undefined) => hasSubconsciousTools(vector, state) : false;
 
   // MCP
   const mcpManager = config?.disableMcp
@@ -843,7 +847,7 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
     instructions: async ({ requestContext }) => {
       const configured = config?.hostInstructions;
       const hostInstructions = typeof configured === 'function' ? await configured({ requestContext }) : configured;
-      return getDynamicInstructions({ requestContext, hostInstructions });
+      return getDynamicInstructions({ requestContext, hostInstructions, hasSubconscious });
     },
     // `settingsPath` matches the source `createMastraCode()` reads from so the
     // per-mode thinking defaults resolve against the same config file.


### PR DESCRIPTION
## Summary

When the experimental subconscious is enabled, the main Mastra Code agent gets `knowledge_search`, `knowledge_read`, `knowledge_browse`, and `ask_memory` — but the system prompt said nothing about them beyond each tool's one-line description. The `ask_memory` description does say it is asynchronous, but nothing told the agent what the reply looks like, that it may arrive in parts, or that it should keep working rather than poll or re-ask.

This PR adds a **"Subconscious Memory"** section to the mode-aware tool guidance (`buildToolGuidance`) that:

- explains what the background memory system is (a knowledge graph scoped to the project, plus reminders and pinned knowledge that arrive on their own);
- describes when to use `knowledge_search` / `knowledge_read` / `knowledge_browse`, and to prefer them over `recall` for durable facts;
- documents `ask_memory` correctly: it answers from existing memory (does not store), it is asynchronous, and its reply lands as one or more `<remind-answer source="subconscious" agent="remind" replyId="…" moreComing="true|false" outcome="…">` messages — partial while `moreComing="true"`, complete on `"false"`; keep working, don't poll, don't re-ask.

The section is gated so the prompt never advertises tools that aren't actually registered:

- `isSubconsciousEnabled(vector)` (new export from `agents/memory.ts`) is the process-level switch — vector store present **and** `MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS=1` — and is now what `getDynamicMemory` uses too.
- `hasSubconsciousTools(vector, state)` adds the per-session check: a Factory-owned session whose org cannot be resolved refuses the subconscious, so its prompt omits the section.
- Each tool bullet is individually suppressed when that tool is denied by permission rules, matching how the rest of the guidance handles denied tools.

Wiring: `createMastraCode` passes a `hasSubconscious` resolver through `getDynamicInstructionSections` → `PromptContext` → `buildToolGuidance`.

## Test plan

- `mastracode/sdk/src/agents/prompts/tool-guidance.test.ts`: section renders only when `hasSubconscious` is set; per-tool bullets drop out when denied; the `recall` comparison line disappears when `recall` is denied; `ask_memory` paragraph names the `<remind-answer>` signal and `moreComing` semantics.
- `mastracode/sdk/src/agents/__tests__/prompt-sections.test.ts`: full prompt assembly includes/excludes the section by flag.
- `mastracode/sdk/src/agents/__tests__/subconscious-availability.test.ts`: `isSubconsciousEnabled` requires both the env flag and a vector store; `hasSubconsciousTools` is available for local and org-resolved Factory sessions, refused for Factory sessions whose org could not be resolved (matching the memory wiring), and never available without a vector store.
- Red run captured: the new tests fail on `main` (no section, no exports) and pass on this branch.
- `pnpm vitest run src/agents` in `mastracode/sdk`: 363 pass (1 pre-existing, unrelated `spawn E2BIG` sandbox-filesystem conformance failure also present on `main`). `tsc --noEmit`, eslint, prettier clean.
- One observation from a Factory deployment running this branch's snapshot (not a controlled measurement): a work-item session, asked to consult memory, called `ask_memory` and then fell back to `knowledge_search` when the sidekick refused — the refusal is a separate `@mastra/memory` bug (reminder thread created under the knowledge-scope resource, question path checks against the raw agent resource) and will be a separate PR.

## Notes for reviewers

- Only the main agent's prompt changes. Curator / observer / reminder agent prompts are untouched.
- The signal name and `moreComing` semantics were verified against `packages/memory/src/processors/observational-memory/subconscious/remind-questions.ts` (`<remind-answer>`), not the unsolicited-reminder tag (`<remembered>`), which is a different path.
- `getDynamicMemory` still evaluates the org-resolution condition inline because it needs the resolved identity for scope; `hasSubconsciousTools` reconstructs the same two checks. That duplication is deliberate and noted in the doc comment — the alternative (threading the resolved identity out of memory wiring into prompt assembly) was more plumbing than this warrants.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR teaches the Mastra Code agent how to use subconscious memory. The agent shows this guidance only when the required memory tools are available.

## Changes

- Added gated **Subconscious Memory** prompt guidance.
- Documented `knowledge_search`, `knowledge_read`, `knowledge_browse`, and asynchronous `ask_memory` behavior.
- Added support for `<remind-answer>` responses, partial replies, and continuation behavior.
- Filtered guidance by tool permissions.
- Centralized availability checks with `isSubconsciousEnabled` and `hasSubconsciousTools`.
- Passed subconscious availability through prompt construction.
- Added tests for prompt rendering, permission filtering, availability checks, and full prompt assembly.
- Added a patch changeset for `@mastra/code-sdk`.

## Testing

The agent test suite passes except for one pre-existing unrelated failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->