### PR TITLE
fix(memory): own the passive reminder thread by the agent resource so ask_memory works under a knowledge resource override

### DIFF
--- a/.changeset/ask-memory-remind-owner.md
+++ b/.changeset/ask-memory-remind-owner.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed a memory tool reliability issue.

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-owner.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-owner.test.ts
@@ -1,0 +1,235 @@
+import type { LanguageModelV2StreamPart } from '@internal/ai-sdk-v5';
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { RequestContext } from '@mastra/core/request-context';
+import { InMemoryStore } from '@mastra/core/storage';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Memory } from '../../..';
+import { applyExtractorHooks } from '../extracted-values';
+import { SubconsciousRemindExtractor } from '../subconscious';
+import {
+  getRemindMessageText,
+  getRemindThreadId,
+  REMIND_PARENT_THREAD_METADATA_KEY,
+} from '../subconscious/remind-protocol';
+import { createAskMemoryTool } from '../subconscious/remind-questions';
+
+const ORG = 'org-1';
+const PROJECT = 'project-1';
+const SESSION = 'session-1';
+const PARENT = 'parent';
+
+function latestUserText(prompt: unknown): string {
+  if (!Array.isArray(prompt)) return '';
+  const users = prompt.filter(message => (message as { role?: unknown }).role === 'user');
+  const last = users[users.length - 1] as { content?: unknown } | undefined;
+  const content = last?.content;
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter((part): part is { type: 'text'; text: string } => {
+      return !!part && typeof part === 'object' && part.type === 'text' && typeof part.text === 'string';
+    })
+    .map(part => part.text)
+    .join('\n');
+}
+
+function toolCallStream(toolName: string, input: Record<string, unknown>, callId: string) {
+  const serialized = JSON.stringify(input);
+  const parts: LanguageModelV2StreamPart[] = [
+    { type: 'stream-start', warnings: [] },
+    { type: 'response-metadata', id: callId, modelId: 'remind-model', timestamp: new Date() },
+    { type: 'tool-input-start', id: callId, toolName },
+    { type: 'tool-input-delta', id: callId, delta: serialized },
+    { type: 'tool-call', toolCallId: callId, toolName, input: serialized },
+    { type: 'finish', finishReason: 'tool-calls', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+  ];
+  return { stream: convertArrayToReadableStream(parts), rawCall: { rawPrompt: null, rawSettings: {} }, warnings: [] };
+}
+
+function textStopStream(text: string) {
+  const parts: LanguageModelV2StreamPart[] = [
+    { type: 'stream-start', warnings: [] },
+    { type: 'response-metadata', id: 'stop', modelId: 'remind-model', timestamp: new Date() },
+    { type: 'text-start', id: 'text-1' },
+    { type: 'text-delta', id: 'text-1', delta: text },
+    { type: 'text-end', id: 'text-1' },
+    { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+  ];
+  return { stream: convertArrayToReadableStream(parts), rawCall: { rawPrompt: null, rawSettings: {} }, warnings: [] };
+}
+
+function createHarness(options: { knowledgeResourceId?: string }) {
+  const storage = new InMemoryStore();
+  const memory = new Memory({ storage });
+  const requestContext = new RequestContext();
+  requestContext.set('organizationId', ORG);
+  if (options.knowledgeResourceId) requestContext.set('knowledgeResourceId', options.knowledgeResourceId);
+
+  const emitted = { reminder: 0, reply: 0 };
+  let sourceRecordId = '';
+  const model = new MockLanguageModelV2({
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop',
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+      warnings: [],
+      content: [{ type: 'text', text: 'ok' }],
+    }),
+    doStream: async streamOptions => {
+      const latest = latestUserText(streamOptions.prompt);
+      const replyId = latest.match(/Memory question (\S+)/)?.[1];
+      if (replyId && emitted.reply === 0) {
+        emitted.reply += 1;
+        return toolCallStream(
+          'reply_to_memory_question',
+          { replyId, answer: 'You decided January 15.', moreComing: false },
+          'reply-call',
+        );
+      }
+      const eventId = latest.match(/Passive reminder check (subconscious:remind:[^\s"\\]+:event)/)?.[1];
+      if (eventId && emitted.reminder === 0) {
+        emitted.reminder += 1;
+        return toolCallStream(
+          'send_reminder',
+          { eventId, reminder: 'Project Atlas launches January 15.', sourceIds: [sourceRecordId] },
+          'reminder-call',
+        );
+      }
+      return textStopStream('Done.');
+    },
+  });
+
+  const signals: Array<{ signal: any; options: any }> = [];
+  const mainAgent = {
+    id: 'main-agent',
+    getModel: vi.fn(async () => model),
+    getMastraInstance: vi.fn(),
+    getPubSub: vi.fn(),
+    sendSignal: vi.fn((signal: unknown, sendOptions: { ifActive: { behavior: string } }) => {
+      signals.push({ signal, options: sendOptions });
+      if (sendOptions.ifActive.behavior === 'persist') {
+        return { signal, accepted: Promise.resolve({ action: 'persist' }), persisted: Promise.resolve() };
+      }
+      return { signal, accepted: Promise.resolve({ action: 'deliver', runId: 'parent-run' }) };
+    }),
+  } as any;
+
+  const errors: unknown[] = [];
+  const writer = {
+    custom: vi.fn(async (event: unknown) => {
+      if ((event as { type?: string }).type === 'data-subconscious-error') errors.push(event);
+    }),
+  } as any;
+
+  return {
+    storage,
+    memory,
+    requestContext,
+    model,
+    emitted,
+    signals,
+    errors,
+    writer,
+    mainAgent,
+    setSourceRecordId(id: string) {
+      sourceRecordId = id;
+    },
+  };
+}
+
+async function runScenario(knowledgeResourceId: string | undefined) {
+  const harness = createHarness({ knowledgeResourceId });
+  const scopeResource = knowledgeResourceId ?? SESSION;
+  const scope = [`org:${ORG}`, `resource:${scopeResource}`];
+
+  const knowledgeStore = await harness.memory.storage.getStore('knowledge');
+  const node = await knowledgeStore.createNode({ name: 'Project Atlas', kind: 'project', scope });
+  const record = await knowledgeStore.appendKnowledge({
+    node,
+    text: 'Project Atlas launches January 15.',
+    scope,
+    sourceThreadId: 'beta',
+    resolutionScope: [...scope, 'thread:beta'],
+    defaultScope: scope,
+  });
+  harness.setSourceRecordId(record.id);
+
+  // Passive path: the reminder sidekick creates subconscious:<parent>:remind.
+  const passiveSendSignal = vi.fn(async () => undefined) as any;
+  const passive = await applyExtractorHooks({
+    source: 'observer',
+    extractors: [new SubconsciousRemindExtractor({ name: 'remind', maxSteps: 3, builtIn: true })],
+    rawObservations: 'The user is scheduling Project Atlas.',
+    threadId: PARENT,
+    resourceId: SESSION,
+    mainAgent: harness.mainAgent,
+    memory: harness.memory,
+    requestContext: harness.requestContext,
+    sendSignal: passiveSendSignal,
+    sendStateSignal: vi.fn(async () => ({ skipped: false })) as any,
+    writer: harness.writer,
+  } as any);
+  expect(passive.failures, JSON.stringify(harness.errors)).toBeUndefined();
+  expect(harness.emitted.reminder).toBe(1);
+
+  const remindThreadId = getRemindThreadId(PARENT);
+  const thread = await harness.memory.getThreadById({ threadId: remindThreadId });
+  expect(thread).not.toBeNull();
+  if (!thread) throw new Error('remind thread missing');
+  const memoryStore = await harness.storage.getStore('memory');
+  const stored = await memoryStore.listMessages({
+    threadId: remindThreadId,
+    resourceId: thread.resourceId,
+    perPage: false,
+  });
+  const passiveChecks = stored.messages.filter(message =>
+    getRemindMessageText(message).startsWith('Passive reminder check'),
+  );
+  expect(passiveChecks.length).toBeGreaterThan(0);
+
+  // Question path: ask_memory from the parent agent under its own resource.
+  const tool = createAskMemoryTool({
+    memory: harness.memory,
+    config: { name: 'remind', builtIn: true, maxSteps: 5 },
+    getParentAgent: () => harness.mainAgent,
+  });
+  const result = (await tool.execute?.({ question: 'What did I decide?' }, {
+    agent: { agentId: 'main-agent', threadId: PARENT, resourceId: SESSION, messages: [] },
+    requestContext: harness.requestContext,
+    writer: harness.writer,
+  } as any)) as any;
+
+  expect(result, `ask_memory result: ${JSON.stringify(result)}`).toMatchObject({ accepted: true, status: 'pending' });
+
+  expect(thread.resourceId).toBe(SESSION);
+  expect(thread.metadata?.[REMIND_PARENT_THREAD_METADATA_KEY]).toBe(PARENT);
+
+  await vi.waitFor(
+    () => {
+      const answer = harness.signals.find(entry => entry.signal?.tagName === 'remind-answer');
+      expect(answer, `no remind-answer signal; errors=${JSON.stringify(harness.errors)}`).toBeDefined();
+    },
+    { timeout: 5000 },
+  );
+  const answers = harness.signals.filter(entry => entry.signal?.tagName === 'remind-answer');
+  expect(answers[0]!.signal.attributes).toMatchObject({
+    replyId: result.replyId,
+    moreComing: 'false',
+    source: 'subconscious',
+    agent: 'remind',
+  });
+  expect(answers.some(entry => entry.options.threadId === PARENT && entry.options.resourceId === SESSION)).toBe(true);
+  expect(harness.emitted).toEqual({ reminder: 1, reply: 1 });
+}
+
+describe('Subconscious remind thread ownership', () => {
+  // Control first: the package vitest config bails after the first failure.
+  it('accepts ask_memory after a passive reminder without override', async () => {
+    await runScenario(undefined);
+  });
+
+  it('accepts ask_memory after a passive reminder with a knowledgeResourceId override', async () => {
+    await runScenario(PROJECT);
+  });
+});

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -109,9 +109,7 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
         let store: KnowledgeStorage | undefined;
         try {
           scope = resolveScope(context);
-          // The knowledgeResourceId override only moves the knowledge-scope rung; the
-          // reminder sidekick thread is owned by the agent's real resource, matching
-          // the ask_memory question path and the curate sidekick.
+          // The knowledgeResourceId override moves only the knowledge scope; the sidekick thread stays owned by the agent resource.
           const resourceId = context.resourceId;
           if (!resourceId) throw new Error('Subconscious remind requires a resourceId.');
           store = await context.memory.storage.getStore('knowledge');

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -109,7 +109,11 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
         let store: KnowledgeStorage | undefined;
         try {
           scope = resolveScope(context);
-          const resourceId = resolveKnowledgeResourceId(context.requestContext, context.resourceId)!;
+          // The knowledgeResourceId override only moves the knowledge-scope rung; the
+          // reminder sidekick thread is owned by the agent's real resource, matching
+          // the ask_memory question path and the curate sidekick.
+          const resourceId = context.resourceId;
+          if (!resourceId) throw new Error('Subconscious remind requires a resourceId.');
           store = await context.memory.storage.getStore('knowledge');
           if (!store) throw new Error('Subconscious remind requires a configured knowledge storage domain.');
           const sources = await dropFreshOwnRecords(


### PR DESCRIPTION
## Summary

When a session runs with a `knowledgeResourceId` request-context override (Factory sets it to the project id), the passive reminder sidekick and the `ask_memory` tool disagreed about who owns the `subconscious:<parent>:remind` thread. The passive path (`remind.ts`) resolved its `resourceId` through the override and created the thread under the project id; `ask_memory` (`remind-questions.ts`) looks for the thread under the agent's real resource. Once a passive reminder had run, subsequent `ask_memory` calls in that session were refused with `Refusing to use reminder thread …: ownership metadata does not match.`

This change makes the passive path own the reminder thread by the agent's real resource, the same split the curate sidekick already uses (`curate.ts`): the override still drives the knowledge *scope* (what the sidekick can search), but thread identity, the reply target, and the sidekick's memory resource follow the agent. The same reminder flow without the override (Mastra Code CLI) is unchanged.

## Changes

- `packages/memory/src/processors/observational-memory/subconscious/remind.ts` — derive `resourceId` from `context.resourceId` instead of `resolveKnowledgeResourceId(...)`; the agent resource is now required for reminder-thread ownership and the knowledge override cannot substitute for it (if absent, throw the existing `Subconscious remind requires a resourceId.` error). `resolveKnowledgeResourceId` remains in use for the scope only.
- `packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-owner.test.ts` — new regression test: one memory, knowledge seeded under the override scope, a passive reminder creates the thread, then `ask_memory` is accepted, the sidekick wakes through the real agent path (no `sendMessage` mock), and its `reply_to_memory_question` call lands as a `remind-answer` signal on the parent (`threadId: parent`, `resourceId: session`). A control case runs the same flow without the override.
- Changeset for `@mastra/memory`.

## Test plan

- New test fails on the base commit (`8c02f9953e`) at the `ask_memory` step with the ownership rejection and passes with the fix.
- `pnpm --filter @mastra/memory test:unit` — 66 files, 1528 passed, 1 todo.
- `pnpm --filter @mastra/memory lint` and `pnpm exec tsc --noEmit -p tsconfig.json` (in `packages/memory`) clean.

## Notes

- Reminder threads created before this change under the project id are refused by the unchanged strict ownership check after upgrade; there is no adoption path. This is pre-release surface; the only known affected deployment is our internal dev instance.
- Existing reminder-sidekick messages persisted under the project resource are left unchanged.
- Builds on the reminder sidekick continuity work by @TylerBarnes in #22783.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Passive reminders now belong to the correct agent, even when a request uses a different knowledge resource. This keeps reminders and `ask_memory` replies connected to the same thread.

## Changes

- Updated `SubconsciousRemindExtractor` to use `context.resourceId` for thread ownership.
- Kept `knowledgeResourceId` overrides for knowledge scope only.
- Added an explicit error when `context.resourceId` is missing.
- Added regression tests for passive reminders with and without a `knowledgeResourceId` override.
- Added a patch changeset for `@mastra/memory`.
- Memory tests, lint, and TypeScript checks pass.

Existing reminder threads are not migrated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->