### PR TITLE
feat(core): type processor span input/output payloads by phase

### DIFF
--- a/.changeset/gold-spiders-repeat.md
+++ b/.changeset/gold-spiders-repeat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added typed processor span payloads to `@mastra/core/processors`. Use `isProcessorSpan(span, phase)` and `getProcessorSpanPhase(span)` to narrow a stored `SpanRecord`'s `input`/`output` to the shape recorded for each processor phase (`input`, `inputStep`, `output`, `outputStep`, `toolResult`). These types are derived from the processor argument types, so adding a field to processor args now requires deciding whether it is recorded in traces.

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -261,6 +261,33 @@ async processInputStep({ messageList, tracingContext }: ProcessInputStepArgs) {
 }
 ```
 
+### Reading processor spans
+
+A stored processor span's `input` and `output` are typed `unknown`, because their shape depends on the phase the processor ran in. The span's `entityType` identifies that phase, and `isProcessorSpan` narrows `input` and `output` to the payload recorded for it:
+
+| `entityType` | Phase | `input` / `output` types |
+| - | - | - |
+| `INPUT_PROCESSOR` | `input` | `ProcessorInputSpanInput` / `ProcessorInputSpanOutput` |
+| `INPUT_STEP_PROCESSOR` | `inputStep` | `ProcessorInputStepSpanInput` / `ProcessorInputStepSpanOutput` |
+| `OUTPUT_PROCESSOR` | `output` | `ProcessorOutputSpanInput` / `ProcessorOutputSpanOutput` |
+| `OUTPUT_STEP_PROCESSOR` | `outputStep` | `ProcessorOutputStepSpanInput` / `ProcessorOutputStepSpanOutput` |
+| `TOOL_RESULT_PROCESSOR` | `toolResult` | `ProcessorToolResultSpanInput` / `ProcessorToolResultSpanOutput` |
+
+```typescript
+import { isProcessorSpan, getProcessorSpanPhase } from '@mastra/core/processors'
+import type { SpanRecord } from '@mastra/core/storage'
+
+function describe(span: SpanRecord) {
+  if (isProcessorSpan(span, 'inputStep')) {
+    // span.input is ProcessorInputStepSpanInput | null | undefined
+    return `step ${span.input?.stepNumber} with ${span.input?.messages.length} messages`
+  }
+  return getProcessorSpanPhase(span) ?? 'not a processor span'
+}
+```
+
+Output payloads only contain the fields the processor changed, so every field on an output type is optional. The `output` phase covers both the result and stream forms of output processing, so `ProcessorOutputSpanInput` is a union.
+
 ## Message arguments
 
 Most processor methods receive both `messages` and `messageList`. They point to the same underlying conversation but expose it differently.

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -970,6 +970,14 @@ export {
 export type { CompatRule } from './provider-history-compat';
 export { ProcessorState, ProcessorRunner } from './runner';
 export { createProcessorSendSignal } from './send-signal';
+export * from './span-io';
+export type {
+  ProcessorModelSummary,
+  ProcessorToolSummary,
+  ActiveToolSummary,
+  ProcessorToolChoiceSummary,
+  ProcessorResultSummary,
+} from './span-payload';
 export * from './memory';
 export type { TripWireOptions } from '../agent/trip-wire';
 export {

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -1,4 +1,5 @@
 import type { LanguageModelV2Prompt, LanguageModelV2CallWarning } from '@ai-sdk/provider-v5';
+import type { CoreMessage as CoreMessageV4 } from '@internal/ai-sdk-v4';
 import type { StepResult } from '@internal/ai-sdk-v5';
 import type { Agent } from '../agent';
 import type { MastraDBMessage, MessageInput } from '../agent/message-list';
@@ -30,6 +31,20 @@ import { isProcessorWorkflow } from './is-processor-workflow';
 import { isMaybeAnthropicWithoutAssistantPrefill } from './provider-history-compat';
 import { createProcessorSendSignal } from './send-signal';
 import { resolveProcessorSpanAttributes, resolveProcessorSpanName } from './span-declaration';
+import type {
+  ProcessorInputSpanInput,
+  ProcessorInputSpanOutput,
+  ProcessorInputStepSpanInput,
+  ProcessorInputStepSpanOutput,
+  ProcessorOutputResultSpanInput,
+  ProcessorOutputSpanOutput,
+  ProcessorOutputStepSpanInput,
+  ProcessorOutputStepSpanOutput,
+  ProcessorOutputStreamSpanInput,
+  ProcessorOutputStreamSpanOutput,
+  ProcessorToolResultSpanInput,
+  ProcessorToolResultSpanOutput,
+} from './span-io';
 import {
   summarizeActiveToolsForSpan,
   summarizeProcessorModelForSpan,
@@ -152,7 +167,7 @@ export class ProcessorState<OUTPUT = undefined> {
       },
       input: {
         totalChunks: 0,
-      },
+      } satisfies ProcessorOutputStreamSpanInput,
     });
   }
 
@@ -168,7 +183,7 @@ export class ProcessorState<OUTPUT = undefined> {
       this.span.input = {
         totalChunks: this.streamParts.length,
         accumulatedText: this.inputAccumulatedText,
-      };
+      } satisfies ProcessorOutputStreamSpanInput;
     }
   }
 
@@ -183,7 +198,7 @@ export class ProcessorState<OUTPUT = undefined> {
   }
 
   /** Get final output for span */
-  getFinalOutput(): { totalChunks: number; accumulatedText: string } {
+  getFinalOutput(): ProcessorOutputStreamSpanOutput {
     return {
       totalChunks: this.outputChunkCount,
       accumulatedText: this.outputAccumulatedText,
@@ -213,7 +228,7 @@ function areProcessorMessageArraysEqual(before: unknown[] | undefined, after: un
 
 function buildProcessInputStepSpanInput(args: {
   messages: MastraDBMessage[];
-  systemMessages: unknown[];
+  systemMessages: CoreMessageV4[];
   stepNumber: number;
   messageId?: string;
   retryCount: number;
@@ -221,7 +236,7 @@ function buildProcessInputStepSpanInput(args: {
   tools?: unknown;
   toolChoice?: unknown;
   activeTools?: unknown;
-}) {
+}): ProcessorInputStepSpanInput {
   const summarizedModel = summarizeProcessorModelForSpan(args.model);
   const summarizedTools = summarizeProcessorToolsForSpan(args.tools);
   const summarizedToolChoice = summarizeToolChoiceForSpan(args.toolChoice, args.tools);
@@ -245,11 +260,11 @@ function buildProcessInputStepSpanOutput(args: {
   beforeStepInput: Pick<RunProcessInputStepResult, 'messageId' | 'model' | 'tools' | 'toolChoice' | 'activeTools'>;
   afterStepInput: RunProcessInputStepResult;
   beforeMessages: MastraDBMessage[];
-  beforeSystemMessages: unknown[];
+  beforeSystemMessages: CoreMessageV4[];
   messages: MastraDBMessage[];
-  systemMessages: unknown[];
-}) {
-  const output: Record<string, unknown> = {};
+  systemMessages: CoreMessageV4[];
+}): ProcessorInputStepSpanOutput {
+  const output: ProcessorInputStepSpanOutput = {};
 
   if (!areProcessorMessageArraysEqual(args.beforeMessages, args.messages)) {
     output.messages = args.messages;
@@ -747,7 +762,7 @@ export class ProcessorRunner {
           messages: processableMessages,
           ...(summarizedResult ? { result: summarizedResult } : {}),
           retryCount,
-        },
+        } satisfies ProcessorOutputResultSpanInput,
       });
 
       // Start recording MessageList mutations for this processor
@@ -811,7 +826,7 @@ export class ProcessorRunner {
             ...(!areProcessorMessageArraysEqual(outputSystemMessagesBefore, messageList.getAllSystemMessages())
               ? { systemMessages: messageList.getAllSystemMessages() }
               : {}),
-          },
+          } satisfies ProcessorOutputSpanOutput,
           attributes: mutations.length > 0 ? { messageListMutations: mutations } : undefined,
         });
       } catch (error) {
@@ -1267,7 +1282,7 @@ export class ProcessorRunner {
         input: {
           messages: processableMessages,
           systemMessages: currentSystemMessages,
-        },
+        } satisfies ProcessorInputSpanInput,
       });
 
       // Start recording MessageList mutations for this processor
@@ -1399,7 +1414,7 @@ export class ProcessorRunner {
             ...(!areProcessorMessageArraysEqual(inputSystemMessagesBefore, messageList.getSystemMessages())
               ? { systemMessages: messageList.getSystemMessages() }
               : {}),
-          },
+          } satisfies ProcessorInputSpanOutput,
           attributes: mutations.length > 0 ? { messageListMutations: mutations } : undefined,
         });
       } catch (error) {
@@ -2103,7 +2118,7 @@ export class ProcessorRunner {
           ...(finishReason !== undefined ? { finishReason } : {}),
           ...(toolCalls !== undefined ? { toolCalls } : {}),
           ...(text !== undefined ? { text } : {}),
-        },
+        } satisfies ProcessorOutputStepSpanInput,
       });
 
       // Start recording MessageList mutations for this processor
@@ -2180,7 +2195,7 @@ export class ProcessorRunner {
             ...(!areProcessorMessageArraysEqual(currentSystemMessages, messageList.getSystemMessages())
               ? { systemMessages: messageList.getSystemMessages() }
               : {}),
-          },
+          } satisfies ProcessorOutputStepSpanOutput,
           attributes: mutations.length > 0 ? { messageListMutations: mutations } : undefined,
         });
       } catch (error) {
@@ -2320,7 +2335,7 @@ export class ProcessorRunner {
           toolCallId,
           stepNumber,
           ...(providerExecuted !== undefined ? { providerExecuted } : {}),
-        },
+        } satisfies ProcessorToolResultSpanInput,
       });
 
       // Start recording MessageList mutations for this processor
@@ -2383,7 +2398,7 @@ export class ProcessorRunner {
             ...(!areProcessorMessageArraysEqual(currentSystemMessages, messageList.getAllSystemMessages())
               ? { systemMessages: messageList.getAllSystemMessages() }
               : {}),
-          },
+          } satisfies ProcessorToolResultSpanOutput,
           attributes: mutations.length > 0 ? { messageListMutations: mutations } : undefined,
         });
       } catch (error) {

--- a/packages/core/src/processors/span-io.test-d.ts
+++ b/packages/core/src/processors/span-io.test-d.ts
@@ -1,0 +1,63 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { SpanRecord } from '../storage/domains/observability/tracing';
+import type {
+  ProcessorInputStepSpanInput,
+  ProcessorInputStepSpanOutput,
+  ProcessorSpanIOPhase,
+  ProjectedSpanPayload,
+  SpanProjection,
+} from './span-io';
+import { isProcessorSpan } from './span-io';
+import type { ProcessInputStepArgs } from './index';
+
+describe('span-io types', () => {
+  it('isProcessorSpan narrows input/output to the phase payload types', () => {
+    const span = {} as SpanRecord;
+    if (isProcessorSpan(span, 'inputStep')) {
+      expectTypeOf(span.input).toEqualTypeOf<ProcessorInputStepSpanInput | null | undefined>();
+      expectTypeOf(span.output).toEqualTypeOf<ProcessorInputStepSpanOutput | null | undefined>();
+    }
+  });
+
+  type Source = { a: string; b?: number; c: () => void; d: Date };
+
+  it('ProjectedSpanPayload drops omit, keeps keep, makes optional optional, substitutes summary', () => {
+    const spec = {
+      a: 'keep',
+      b: 'optional',
+      c: 'omit',
+      d: { summary: undefined as unknown as string },
+    } as const satisfies SpanProjection<Source>;
+
+    type Projected = ProjectedSpanPayload<Source, typeof spec>;
+    expectTypeOf<Projected>().toEqualTypeOf<{ a: string; b?: number; d?: string }>();
+  });
+
+  it('rejects a spec that misses a source key (the drift lock)', () => {
+    // @ts-expect-error — `d` is not classified
+    const _missing = { a: 'keep', b: 'omit', c: 'omit' } as const satisfies SpanProjection<Source>;
+    void _missing;
+  });
+
+  it('rejects a spec with a key that no longer exists on the source', () => {
+    const _extra = {
+      a: 'keep',
+      b: 'omit',
+      c: 'omit',
+      d: 'omit',
+      // @ts-expect-error — `zzz` is not a key of Source
+      zzz: 'keep',
+    } as const satisfies SpanProjection<Source>;
+    void _extra;
+  });
+
+  it('SpanProjection requires every ProcessInputStepArgs key', () => {
+    expectTypeOf<keyof SpanProjection<ProcessInputStepArgs>>().toEqualTypeOf<keyof ProcessInputStepArgs>();
+  });
+
+  it('phase union is closed', () => {
+    expectTypeOf<ProcessorSpanIOPhase>().toEqualTypeOf<
+      'input' | 'inputStep' | 'output' | 'outputStep' | 'toolResult'
+    >();
+  });
+});

--- a/packages/core/src/processors/span-io.test.ts
+++ b/packages/core/src/processors/span-io.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { EntityType, SpanType } from '../observability';
+import type { SpanRecord } from '../storage/domains/observability/tracing';
+import { PROCESSOR_ENTITY_TYPE_TO_PHASE, getProcessorSpanPhase, isProcessorSpan } from './span-io';
+
+function makeSpan(entityType: EntityType | null): SpanRecord {
+  return {
+    traceId: 't',
+    spanId: 's',
+    name: 'processor',
+    spanType: SpanType.PROCESSOR_RUN,
+    isEvent: false,
+    startedAt: new Date(),
+    entityType,
+    input: null,
+    output: null,
+  } as SpanRecord;
+}
+
+describe('span-io', () => {
+  describe('getProcessorSpanPhase', () => {
+    it.each([
+      [EntityType.INPUT_PROCESSOR, 'input'],
+      [EntityType.INPUT_STEP_PROCESSOR, 'inputStep'],
+      [EntityType.OUTPUT_PROCESSOR, 'output'],
+      [EntityType.OUTPUT_STEP_PROCESSOR, 'outputStep'],
+      [EntityType.TOOL_RESULT_PROCESSOR, 'toolResult'],
+    ] as const)('maps %s to %s', (entityType, phase) => {
+      expect(getProcessorSpanPhase(makeSpan(entityType))).toBe(phase);
+      expect(PROCESSOR_ENTITY_TYPE_TO_PHASE[entityType]).toBe(phase);
+    });
+
+    it('returns undefined for non-processor entity types', () => {
+      expect(getProcessorSpanPhase(makeSpan(EntityType.AGENT))).toBeUndefined();
+      expect(getProcessorSpanPhase(makeSpan(null))).toBeUndefined();
+    });
+  });
+
+  describe('isProcessorSpan', () => {
+    it('matches only the requested phase', () => {
+      const span = makeSpan(EntityType.INPUT_STEP_PROCESSOR);
+      expect(isProcessorSpan(span, 'inputStep')).toBe(true);
+      expect(isProcessorSpan(span, 'input')).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/processors/span-io.ts
+++ b/packages/core/src/processors/span-io.ts
@@ -1,0 +1,317 @@
+/**
+ * Typed `input` / `output` payloads for processor spans.
+ *
+ * The payload types are NOT hand-written. They are projected from the processor
+ * args/result types (`ProcessInputStepArgs`, `ProcessOutputStepArgs`, ...) via an
+ * exhaustive spec: every key of the source type must be classified as `keep`,
+ * `optional`, `omit`, or `{ summary }`. Adding a field to a processor args type
+ * without deciding whether it belongs in the trace is a compile error on the spec,
+ * and the span builders (`runner.ts`, `workflows/workflow.ts`,
+ * `workflows/evented/workflow.ts`) are annotated against the projected types so a
+ * `keep` decision that is not honoured by a builder is a compile error too.
+ *
+ * Nothing here runs at request time beyond `getProcessorSpanPhase` /
+ * `isProcessorSpan`; the specs exist to carry `satisfies` checks.
+ */
+import { EntityType } from '../observability';
+import type { SpanRecord } from '../storage/domains/observability/tracing';
+import type {
+  ActiveToolSummary,
+  ProcessorModelSummary,
+  ProcessorResultSummary,
+  ProcessorToolChoiceSummary,
+  ProcessorToolSummary,
+} from './span-payload';
+import type {
+  ProcessInputArgs,
+  ProcessInputResultWithSystemMessages,
+  ProcessInputStepArgs,
+  ProcessInputStepResult,
+  ProcessOutputResultArgs,
+  ProcessOutputStepArgs,
+  ProcessToolResultArgs,
+} from './index';
+
+// ============================================================================
+// Projection mechanism
+// ============================================================================
+
+/**
+ * Per-field decision when projecting processor args onto a span payload.
+ * - `keep`: copied as-is, key stays required/optional as in the source.
+ * - `optional`: copied as-is but always optional (used when the two executors
+ *   diverge — one always emits the key, the other only conditionally).
+ * - `omit`: not recorded (runtime handles, non-serializable, or too large).
+ * - `{ summary: S }`: replaced by a serializable summary of type `S`; always optional
+ *   because summaries return `undefined` when nothing meaningful can be extracted.
+ */
+export type SpanFieldRule = 'keep' | 'optional' | 'omit' | { summary: unknown };
+
+/** `-?` makes every source key mandatory in the spec, which is what forces exhaustiveness. */
+export type SpanProjection<TSource> = { [K in keyof TSource]-?: SpanFieldRule };
+
+type Simplify<T> = { [K in keyof T]: T[K] } & {};
+
+/** Applies a projection spec to a source type. */
+export type ProjectedSpanPayload<TSource, TSpec extends SpanProjection<TSource>> = Simplify<
+  { [K in keyof TSource as TSpec[K] extends 'keep' ? K : never]: TSource[K] } & {
+    [K in keyof TSource as TSpec[K] extends 'optional' ? K : never]?: TSource[K];
+  } & {
+    [K in keyof TSource as TSpec[K] extends { summary: unknown } ? K : never]?: TSpec[K] extends {
+      summary: infer S;
+    }
+      ? S
+      : never;
+  }
+>;
+
+/** Helper to declare a `{ summary }` rule without a runtime value. */
+const summary = <S>() => ({ summary: undefined as unknown as S });
+
+// ============================================================================
+// Executor divergences surfaced as wider types
+// ============================================================================
+
+/**
+ * System messages as they appear in span payloads. The legacy runner records
+ * `CoreMessageV4[]`; the workflow executor records the looser
+ * `{ role, content? }[]` shape of `ProcessorStepInput.systemMessages`.
+ * A stored span may come from either, so the payload type is the union-compatible shape.
+ */
+export type ProcessorSpanSystemMessage = { role: 'system' | 'user' | 'assistant' | 'tool'; content?: unknown };
+
+/** Tool calls as recorded by both executors (`args` is optional in the workflow step schema). */
+export type ProcessorSpanToolCall = { toolName: string; toolCallId: string; args?: unknown };
+
+/**
+ * Fields inherited from `ProcessorContext` / `ObservabilityContext` that are never recorded:
+ * runtime handles, callbacks, and per-request context.
+ */
+const contextOmissions = {
+  abort: 'omit',
+  requestContext: 'omit',
+  agent: 'omit',
+  sendSignal: 'omit',
+  sendStateSignal: 'omit',
+  writer: 'omit',
+  abortSignal: 'omit',
+  tracing: 'omit',
+  loggerVNext: 'omit',
+  metrics: 'omit',
+  tracingContext: 'omit',
+  messageList: 'omit',
+} as const;
+
+// ============================================================================
+// Phase: input  (entityType INPUT_PROCESSOR)
+// ============================================================================
+
+export const processorInputSpanInputSpec = {
+  ...contextOmissions,
+  messages: 'keep',
+  systemMessages: summary<ProcessorSpanSystemMessage[]>(),
+  state: 'omit',
+  /** Legacy runner never records it, workflow executor records it when present. */
+  retryCount: 'optional',
+} as const satisfies SpanProjection<ProcessInputArgs>;
+
+export type ProcessorInputSpanInput = ProjectedSpanPayload<ProcessInputArgs, typeof processorInputSpanInputSpec>;
+
+/**
+ * Diff of what a message-based processor changed. Only modified fields are emitted.
+ * Shared by the `input`, `output`, `outputStep` and `toolResult` phases.
+ */
+export const processorMessagesDiffSpanOutputSpec = {
+  messages: 'optional',
+  systemMessages: summary<ProcessorSpanSystemMessage[]>(),
+} as const satisfies SpanProjection<ProcessInputResultWithSystemMessages>;
+
+export type ProcessorMessagesDiffSpanOutput = ProjectedSpanPayload<
+  ProcessInputResultWithSystemMessages,
+  typeof processorMessagesDiffSpanOutputSpec
+>;
+
+export type ProcessorInputSpanOutput = ProcessorMessagesDiffSpanOutput;
+
+// ============================================================================
+// Phase: inputStep  (entityType INPUT_STEP_PROCESSOR)
+// ============================================================================
+
+export const processorInputStepSpanInputSpec = {
+  ...contextOmissions,
+  messages: 'keep',
+  systemMessages: summary<ProcessorSpanSystemMessage[]>(),
+  /** Always recorded by the legacy runner, conditionally by the workflow executor. */
+  stepNumber: 'optional',
+  messageId: 'keep',
+  retryCount: 'optional',
+  model: summary<ProcessorModelSummary>(),
+  tools: summary<ProcessorToolSummary[]>(),
+  toolChoice: summary<ProcessorToolChoiceSummary>(),
+  activeTools: summary<ActiveToolSummary[]>(),
+  steps: 'omit',
+  state: 'omit',
+  rotateResponseMessageId: 'omit',
+  providerOptions: 'omit',
+  modelSettings: 'omit',
+  structuredOutput: 'omit',
+} as const satisfies SpanProjection<ProcessInputStepArgs>;
+
+export type ProcessorInputStepSpanInput = ProjectedSpanPayload<
+  ProcessInputStepArgs,
+  typeof processorInputStepSpanInputSpec
+>;
+
+export const processorInputStepSpanOutputSpec = {
+  messages: 'optional',
+  systemMessages: summary<ProcessorSpanSystemMessage[]>(),
+  messageId: 'optional',
+  model: summary<ProcessorModelSummary>(),
+  tools: summary<ProcessorToolSummary[]>(),
+  toolChoice: summary<ProcessorToolChoiceSummary>(),
+  activeTools: summary<ActiveToolSummary[]>(),
+  retryCount: 'optional',
+  messageList: 'omit',
+  providerOptions: 'omit',
+  modelSettings: 'omit',
+  structuredOutput: 'omit',
+} as const satisfies SpanProjection<ProcessInputStepResult>;
+
+export type ProcessorInputStepSpanOutput = ProjectedSpanPayload<
+  ProcessInputStepResult,
+  typeof processorInputStepSpanOutputSpec
+>;
+
+// ============================================================================
+// Phase: output  (entityType OUTPUT_PROCESSOR) — result and stream variants
+// ============================================================================
+
+export const processorOutputResultSpanInputSpec = {
+  ...contextOmissions,
+  messages: 'keep',
+  result: summary<ProcessorResultSummary>(),
+  retryCount: 'optional',
+  state: 'omit',
+} as const satisfies SpanProjection<ProcessOutputResultArgs>;
+
+export type ProcessorOutputResultSpanInput = ProjectedSpanPayload<
+  ProcessOutputResultArgs,
+  typeof processorOutputResultSpanInputSpec
+>;
+
+/**
+ * Streaming output processors aggregate over chunks rather than receiving a single
+ * args object, so their payload is not a projection. The legacy runner records
+ * `accumulatedText`; the workflow executor only records `totalChunks`.
+ */
+export interface ProcessorOutputStreamSpanInput {
+  totalChunks: number;
+  accumulatedText?: string;
+}
+export type ProcessorOutputStreamSpanOutput = ProcessorOutputStreamSpanInput;
+
+/** Both variants share `entityType: OUTPUT_PROCESSOR`, so the stored payload is the union. */
+export type ProcessorOutputSpanInput = ProcessorOutputResultSpanInput | ProcessorOutputStreamSpanInput;
+export type ProcessorOutputSpanOutput = ProcessorMessagesDiffSpanOutput | ProcessorOutputStreamSpanOutput;
+
+// ============================================================================
+// Phase: outputStep  (entityType OUTPUT_STEP_PROCESSOR)
+// ============================================================================
+
+export const processorOutputStepSpanInputSpec = {
+  ...contextOmissions,
+  messages: 'keep',
+  systemMessages: summary<ProcessorSpanSystemMessage[]>(),
+  stepNumber: 'optional',
+  finishReason: 'keep',
+  toolCalls: summary<ProcessorSpanToolCall[]>(),
+  text: 'keep',
+  retryCount: 'optional',
+  providerMetadata: 'omit',
+  usage: 'omit',
+  steps: 'omit',
+  state: 'omit',
+} as const satisfies SpanProjection<ProcessOutputStepArgs>;
+
+export type ProcessorOutputStepSpanInput = ProjectedSpanPayload<
+  ProcessOutputStepArgs,
+  typeof processorOutputStepSpanInputSpec
+>;
+export type ProcessorOutputStepSpanOutput = ProcessorMessagesDiffSpanOutput;
+
+// ============================================================================
+// Phase: toolResult  (entityType TOOL_RESULT_PROCESSOR)
+// ============================================================================
+
+export const processorToolResultSpanInputSpec = {
+  ...contextOmissions,
+  stepNumber: 'optional',
+  toolName: 'optional',
+  toolCallId: 'optional',
+  providerExecuted: 'keep',
+  retryCount: 'optional',
+  messages: 'omit',
+  systemMessages: 'omit',
+  args: 'omit',
+  result: 'omit',
+  steps: 'omit',
+  state: 'omit',
+} as const satisfies SpanProjection<ProcessToolResultArgs>;
+
+export type ProcessorToolResultSpanInput = ProjectedSpanPayload<
+  ProcessToolResultArgs,
+  typeof processorToolResultSpanInputSpec
+>;
+export type ProcessorToolResultSpanOutput = ProcessorMessagesDiffSpanOutput;
+
+// ============================================================================
+// Phase map, discriminant and guards
+// ============================================================================
+
+export interface ProcessorSpanIOMap {
+  input: { input: ProcessorInputSpanInput; output: ProcessorInputSpanOutput };
+  inputStep: { input: ProcessorInputStepSpanInput; output: ProcessorInputStepSpanOutput };
+  output: { input: ProcessorOutputSpanInput; output: ProcessorOutputSpanOutput };
+  outputStep: { input: ProcessorOutputStepSpanInput; output: ProcessorOutputStepSpanOutput };
+  toolResult: { input: ProcessorToolResultSpanInput; output: ProcessorToolResultSpanOutput };
+}
+
+export type ProcessorSpanIOPhase = keyof ProcessorSpanIOMap;
+
+/**
+ * Stored `entityType` → payload phase. This is the only discriminant available on a
+ * persisted span: `spanType` is `PROCESSOR_RUN` (or a processor-declared override)
+ * for every phase, and `name` is cosmetic.
+ *
+ * Known over-approximation: the legacy-only `llmRequest` / `llmResponse` phases are
+ * recorded with `INPUT_PROCESSOR`, and `requestError` with `OUTPUT_STEP_PROCESSOR`.
+ * Their payloads (`{ prompt, stepNumber, retryCount }`, `{ stepNumber, retryCount,
+ * fromCache, chunkCount }`, `{ messages, error, stepNumber, messageId?, retryCount }`)
+ * do not match the phase types below, so `isProcessorSpan` narrows them incorrectly.
+ * Disambiguating them requires persisting a phase attribute, which is out of scope here.
+ */
+export const PROCESSOR_ENTITY_TYPE_TO_PHASE = {
+  [EntityType.INPUT_PROCESSOR]: 'input',
+  [EntityType.INPUT_STEP_PROCESSOR]: 'inputStep',
+  [EntityType.OUTPUT_PROCESSOR]: 'output',
+  [EntityType.OUTPUT_STEP_PROCESSOR]: 'outputStep',
+  [EntityType.TOOL_RESULT_PROCESSOR]: 'toolResult',
+} as const satisfies Partial<Record<EntityType, ProcessorSpanIOPhase>>;
+
+export type ProcessorSpanRecord<P extends ProcessorSpanIOPhase> = Omit<SpanRecord, 'input' | 'output'> & {
+  input?: ProcessorSpanIOMap[P]['input'] | null;
+  output?: ProcessorSpanIOMap[P]['output'] | null;
+};
+
+export function getProcessorSpanPhase(span: Pick<SpanRecord, 'entityType'>): ProcessorSpanIOPhase | undefined {
+  if (!span.entityType) return undefined;
+  return (PROCESSOR_ENTITY_TYPE_TO_PHASE as Partial<Record<EntityType, ProcessorSpanIOPhase>>)[span.entityType];
+}
+
+/** Narrows a stored span to the payload types of `phase`, based on `entityType` only. */
+export function isProcessorSpan<P extends ProcessorSpanIOPhase>(
+  span: SpanRecord,
+  phase: P,
+): span is ProcessorSpanRecord<P> {
+  return getProcessorSpanPhase(span) === phase;
+}

--- a/packages/core/src/processors/span-payload.ts
+++ b/packages/core/src/processors/span-payload.ts
@@ -11,15 +11,44 @@ function readString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
 }
 
-type ProcessorToolSummary = {
+export type ProcessorToolSummary = {
   id: string;
   name: string;
   description?: string;
 };
 
-type ActiveToolSummary = {
+export type ActiveToolSummary = {
   id: string;
   name: string;
+};
+
+export type ProcessorModelSummary = {
+  modelId?: string;
+  provider?: string;
+  specificationVersion?: string;
+};
+
+export type ProcessorToolChoiceSummary = {
+  type: string;
+  tool?: ActiveToolSummary;
+};
+
+const PROCESSOR_RESULT_SUMMARY_KEYS = [
+  'text',
+  'object',
+  'finishReason',
+  'toolCalls',
+  'toolResults',
+  'warnings',
+  'files',
+  'sources',
+  'reasoning',
+  'reasoningText',
+  'tripwire',
+] as const;
+
+export type ProcessorResultSummary = Partial<Record<(typeof PROCESSOR_RESULT_SUMMARY_KEYS)[number], unknown>> & {
+  stepCount?: number;
 };
 
 function summarizeProcessorToolEntry(key: string, value: unknown): ProcessorToolSummary {
@@ -41,13 +70,7 @@ function summarizeProcessorToolEntry(key: string, value: unknown): ProcessorTool
   };
 }
 
-export function summarizeProcessorModelForSpan(value: unknown):
-  | {
-      modelId?: string;
-      provider?: string;
-      specificationVersion?: string;
-    }
-  | undefined {
+export function summarizeProcessorModelForSpan(value: unknown): ProcessorModelSummary | undefined {
   if (!isPlainObject(value)) {
     return undefined;
   }
@@ -130,12 +153,7 @@ export function summarizeActiveToolsForSpan(activeTools: unknown, tools?: unknow
 export function summarizeToolChoiceForSpan(
   toolChoice: unknown,
   tools?: unknown,
-):
-  | {
-      type: string;
-      tool?: ActiveToolSummary;
-    }
-  | undefined {
+): ProcessorToolChoiceSummary | undefined {
   if (typeof toolChoice === 'string') {
     return { type: toolChoice };
   }
@@ -177,25 +195,13 @@ export function summarizeToolChoiceForSpan(
   };
 }
 
-export function summarizeProcessorResultForSpan(value: unknown): Record<string, unknown> | undefined {
+export function summarizeProcessorResultForSpan(value: unknown): ProcessorResultSummary | undefined {
   if (!isPlainObject(value)) {
     return undefined;
   }
 
-  const projected: Record<string, unknown> = {};
-  for (const key of [
-    'text',
-    'object',
-    'finishReason',
-    'toolCalls',
-    'toolResults',
-    'warnings',
-    'files',
-    'sources',
-    'reasoning',
-    'reasoningText',
-    'tripwire',
-  ] as const) {
+  const projected: ProcessorResultSummary = {};
+  for (const key of PROCESSOR_RESULT_SUMMARY_KEYS) {
     if (value[key] !== undefined) {
       projected[key] = value[key];
     }

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -28,7 +28,7 @@ import {
 } from '../../observability';
 import type { ObservabilityContext, TracingContext, TracingPolicy } from '../../observability';
 import { executeWithContext } from '../../observability/utils';
-import type { OutputResult, Processor, ProcessorStreamWriter } from '../../processors';
+import type { OutputResult, ProcessInputStepResult, Processor, ProcessorStreamWriter } from '../../processors';
 import {
   ProcessorRunner,
   ProcessorState,
@@ -41,6 +41,16 @@ import {
   resolveProcessorSpanName,
   toProcessorSpanPhase,
 } from '../../processors/span-declaration';
+import type {
+  ProcessorInputSpanInput,
+  ProcessorInputStepSpanInput,
+  ProcessorInputStepSpanOutput,
+  ProcessorMessagesDiffSpanOutput,
+  ProcessorOutputResultSpanInput,
+  ProcessorOutputStepSpanInput,
+  ProcessorOutputStreamSpanOutput,
+  ProcessorToolResultSpanInput,
+} from '../../processors/span-io';
 import {
   summarizeActiveToolsForSpan,
   summarizeProcessorModelForSpan,
@@ -874,7 +884,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               messages: (messages as MastraDBMessage[]) ?? [],
               ...(systemMessages ? { systemMessages } : {}),
               ...(retryCount !== undefined ? { retryCount } : {}),
-            };
+            } satisfies ProcessorInputSpanInput;
           case 'inputStep': {
             const summarizedModel = summarizeProcessorModelForSpan(model);
             const summarizedTools = summarizeProcessorToolsForSpan(tools);
@@ -891,7 +901,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               ...(summarizedTools ? { tools: summarizedTools } : {}),
               ...(summarizedToolChoice ? { toolChoice: summarizedToolChoice } : {}),
               ...(summarizedActiveTools ? { activeTools: summarizedActiveTools } : {}),
-            };
+            } satisfies ProcessorInputStepSpanInput;
           }
           case 'outputResult': {
             const summarizedResult = summarizeProcessorResultForSpan(outputResult ?? defaultOutputResult);
@@ -900,7 +910,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               messages: (messages as MastraDBMessage[]) ?? [],
               ...(summarizedResult ? { result: summarizedResult } : {}),
               ...(retryCount !== undefined ? { retryCount } : {}),
-            };
+            } satisfies ProcessorOutputResultSpanInput;
           }
           case 'outputStep':
             return {
@@ -911,7 +921,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               ...(text !== undefined ? { text } : {}),
               ...(toolCalls !== undefined ? { toolCalls } : {}),
               ...(retryCount !== undefined ? { retryCount } : {}),
-            };
+            } satisfies ProcessorOutputStepSpanInput;
           case 'toolResult':
             return {
               ...(stepNumber !== undefined ? { stepNumber } : {}),
@@ -919,7 +929,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               ...(toolCallId !== undefined ? { toolCallId } : {}),
               ...(providerExecuted !== undefined ? { providerExecuted } : {}),
               ...(retryCount !== undefined ? { retryCount } : {}),
-            };
+            } satisfies ProcessorToolResultSpanInput;
           default:
             return undefined;
         }
@@ -942,58 +952,63 @@ function createStepFromProcessor<TProcessorId extends string>(
               !areProcessorMessageArraysEqual(systemMessages as unknown[] | undefined, payload.systemMessages)
                 ? { systemMessages: payload.systemMessages }
                 : {}),
-            };
+            } satisfies ProcessorMessagesDiffSpanOutput;
           case 'inputStep': {
-            const output: Record<string, unknown> = {};
+            const output: ProcessorInputStepSpanOutput = {};
+            // Same object as `payload`; typed against the processor result so the diff below is checked.
+            const stepResult = payload as Partial<ProcessInputStepResult>;
 
             if (
-              Array.isArray(payload.messages) &&
-              !areProcessorMessageArraysEqual(messages as unknown[] | undefined, payload.messages)
+              Array.isArray(stepResult.messages) &&
+              !areProcessorMessageArraysEqual(messages as unknown[] | undefined, stepResult.messages)
             ) {
-              output.messages = payload.messages;
+              output.messages = stepResult.messages;
             }
 
             if (
-              Array.isArray(payload.systemMessages) &&
-              !areProcessorMessageArraysEqual(systemMessages as unknown[] | undefined, payload.systemMessages)
+              Array.isArray(stepResult.systemMessages) &&
+              !areProcessorMessageArraysEqual(systemMessages as unknown[] | undefined, stepResult.systemMessages)
             ) {
-              output.systemMessages = payload.systemMessages;
+              output.systemMessages = stepResult.systemMessages;
             }
 
-            if (payload.messageId !== undefined && payload.messageId !== initialMessageId) {
-              output.messageId = payload.messageId;
+            if (stepResult.messageId !== undefined && stepResult.messageId !== initialMessageId) {
+              output.messageId = stepResult.messageId;
             }
 
-            if (payload.model !== undefined && payload.model !== model) {
-              const summarizedModel = summarizeProcessorModelForSpan(payload.model);
+            if (stepResult.model !== undefined && stepResult.model !== model) {
+              const summarizedModel = summarizeProcessorModelForSpan(stepResult.model);
               if (summarizedModel) {
                 output.model = summarizedModel;
               }
             }
 
-            if (payload.tools !== undefined && payload.tools !== tools) {
-              const summarizedTools = summarizeProcessorToolsForSpan(payload.tools);
+            if (stepResult.tools !== undefined && stepResult.tools !== tools) {
+              const summarizedTools = summarizeProcessorToolsForSpan(stepResult.tools);
               if (summarizedTools) {
                 output.tools = summarizedTools;
               }
             }
 
-            if (payload.toolChoice !== undefined && payload.toolChoice !== toolChoice) {
-              const summarizedToolChoice = summarizeToolChoiceForSpan(payload.toolChoice, payload.tools ?? tools);
+            if (stepResult.toolChoice !== undefined && stepResult.toolChoice !== toolChoice) {
+              const summarizedToolChoice = summarizeToolChoiceForSpan(stepResult.toolChoice, stepResult.tools ?? tools);
               if (summarizedToolChoice) {
                 output.toolChoice = summarizedToolChoice;
               }
             }
 
-            if (payload.activeTools !== undefined && payload.activeTools !== activeTools) {
-              const summarizedActiveTools = summarizeActiveToolsForSpan(payload.activeTools, payload.tools ?? tools);
+            if (stepResult.activeTools !== undefined && stepResult.activeTools !== activeTools) {
+              const summarizedActiveTools = summarizeActiveToolsForSpan(
+                stepResult.activeTools,
+                stepResult.tools ?? tools,
+              );
               if (summarizedActiveTools) {
                 output.activeTools = summarizedActiveTools;
               }
             }
 
-            if (payload.retryCount !== undefined && payload.retryCount !== retryCount) {
-              output.retryCount = payload.retryCount;
+            if (stepResult.retryCount !== undefined && stepResult.retryCount !== retryCount) {
+              output.retryCount = stepResult.retryCount;
             }
 
             return output;
@@ -1010,7 +1025,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               !areProcessorMessageArraysEqual(systemMessages as unknown[] | undefined, payload.systemMessages)
                 ? { systemMessages: payload.systemMessages }
                 : {}),
-            };
+            } satisfies ProcessorMessagesDiffSpanOutput;
           default:
             return undefined;
         }
@@ -1373,7 +1388,9 @@ function createStepFromProcessor<TProcessorId extends string>(
 
                 // End span on finish chunk
                 if (part && (part as ChunkType).type === 'finish') {
-                  processorSpan?.end({ output: { totalChunks: (streamParts ?? []).length } });
+                  processorSpan?.end({
+                    output: { totalChunks: (streamParts ?? []).length } satisfies ProcessorOutputStreamSpanOutput,
+                  });
                   delete mutableState[spanKey];
                 }
               } catch (error) {

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -31,7 +31,13 @@ import {
   resolveObservabilityContext,
 } from '../observability';
 import { executeWithContext } from '../observability/utils';
-import type { OutputResult, Processor, ProcessorStreamWriter, ProcessorStreamWriterOptions } from '../processors';
+import type {
+  OutputResult,
+  ProcessInputStepResult,
+  Processor,
+  ProcessorStreamWriter,
+  ProcessorStreamWriterOptions,
+} from '../processors';
 import { ProcessorRunner, ProcessorState } from '../processors/runner';
 import { createProcessorSendSignal } from '../processors/send-signal';
 import {
@@ -39,6 +45,16 @@ import {
   resolveProcessorSpanName,
   toProcessorSpanPhase,
 } from '../processors/span-declaration';
+import type {
+  ProcessorInputSpanInput,
+  ProcessorInputStepSpanInput,
+  ProcessorInputStepSpanOutput,
+  ProcessorMessagesDiffSpanOutput,
+  ProcessorOutputResultSpanInput,
+  ProcessorOutputStepSpanInput,
+  ProcessorOutputStreamSpanOutput,
+  ProcessorToolResultSpanInput,
+} from '../processors/span-io';
 import {
   summarizeActiveToolsForSpan,
   summarizeProcessorModelForSpan,
@@ -788,7 +804,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               messages: (messages as MastraDBMessage[]) ?? [],
               ...(systemMessages ? { systemMessages } : {}),
               ...(retryCount !== undefined ? { retryCount } : {}),
-            };
+            } satisfies ProcessorInputSpanInput;
           case 'inputStep': {
             const summarizedModel = summarizeProcessorModelForSpan(model);
             const summarizedTools = summarizeProcessorToolsForSpan(tools);
@@ -805,7 +821,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               ...(summarizedTools ? { tools: summarizedTools } : {}),
               ...(summarizedToolChoice ? { toolChoice: summarizedToolChoice } : {}),
               ...(summarizedActiveTools ? { activeTools: summarizedActiveTools } : {}),
-            };
+            } satisfies ProcessorInputStepSpanInput;
           }
           case 'outputResult': {
             const summarizedResult = summarizeProcessorResultForSpan(outputResult ?? defaultOutputResult);
@@ -814,7 +830,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               messages: (messages as MastraDBMessage[]) ?? [],
               ...(summarizedResult ? { result: summarizedResult } : {}),
               ...(retryCount !== undefined ? { retryCount } : {}),
-            };
+            } satisfies ProcessorOutputResultSpanInput;
           }
           case 'outputStep':
             return {
@@ -825,7 +841,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               ...(text !== undefined ? { text } : {}),
               ...(toolCalls !== undefined ? { toolCalls } : {}),
               ...(retryCount !== undefined ? { retryCount } : {}),
-            };
+            } satisfies ProcessorOutputStepSpanInput;
           case 'toolResult':
             return {
               ...(stepNumber !== undefined ? { stepNumber } : {}),
@@ -833,7 +849,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               ...(toolCallId !== undefined ? { toolCallId } : {}),
               ...(providerExecuted !== undefined ? { providerExecuted } : {}),
               ...(retryCount !== undefined ? { retryCount } : {}),
-            };
+            } satisfies ProcessorToolResultSpanInput;
           default:
             return undefined;
         }
@@ -856,58 +872,63 @@ function createStepFromProcessor<TProcessorId extends string>(
               !areProcessorMessageArraysEqual(systemMessages as unknown[] | undefined, payload.systemMessages)
                 ? { systemMessages: payload.systemMessages }
                 : {}),
-            };
+            } satisfies ProcessorMessagesDiffSpanOutput;
           case 'inputStep': {
-            const output: Record<string, unknown> = {};
+            const output: ProcessorInputStepSpanOutput = {};
+            // Same object as `payload`; typed against the processor result so the diff below is checked.
+            const stepResult = payload as Partial<ProcessInputStepResult>;
 
             if (
-              Array.isArray(payload.messages) &&
-              !areProcessorMessageArraysEqual(messages as unknown[] | undefined, payload.messages)
+              Array.isArray(stepResult.messages) &&
+              !areProcessorMessageArraysEqual(messages as unknown[] | undefined, stepResult.messages)
             ) {
-              output.messages = payload.messages;
+              output.messages = stepResult.messages;
             }
 
             if (
-              Array.isArray(payload.systemMessages) &&
-              !areProcessorMessageArraysEqual(systemMessages as unknown[] | undefined, payload.systemMessages)
+              Array.isArray(stepResult.systemMessages) &&
+              !areProcessorMessageArraysEqual(systemMessages as unknown[] | undefined, stepResult.systemMessages)
             ) {
-              output.systemMessages = payload.systemMessages;
+              output.systemMessages = stepResult.systemMessages;
             }
 
-            if (payload.messageId !== undefined && payload.messageId !== initialMessageId) {
-              output.messageId = payload.messageId;
+            if (stepResult.messageId !== undefined && stepResult.messageId !== initialMessageId) {
+              output.messageId = stepResult.messageId;
             }
 
-            if (payload.model !== undefined && payload.model !== model) {
-              const summarizedModel = summarizeProcessorModelForSpan(payload.model);
+            if (stepResult.model !== undefined && stepResult.model !== model) {
+              const summarizedModel = summarizeProcessorModelForSpan(stepResult.model);
               if (summarizedModel) {
                 output.model = summarizedModel;
               }
             }
 
-            if (payload.tools !== undefined && payload.tools !== tools) {
-              const summarizedTools = summarizeProcessorToolsForSpan(payload.tools);
+            if (stepResult.tools !== undefined && stepResult.tools !== tools) {
+              const summarizedTools = summarizeProcessorToolsForSpan(stepResult.tools);
               if (summarizedTools) {
                 output.tools = summarizedTools;
               }
             }
 
-            if (payload.toolChoice !== undefined && payload.toolChoice !== toolChoice) {
-              const summarizedToolChoice = summarizeToolChoiceForSpan(payload.toolChoice, payload.tools ?? tools);
+            if (stepResult.toolChoice !== undefined && stepResult.toolChoice !== toolChoice) {
+              const summarizedToolChoice = summarizeToolChoiceForSpan(stepResult.toolChoice, stepResult.tools ?? tools);
               if (summarizedToolChoice) {
                 output.toolChoice = summarizedToolChoice;
               }
             }
 
-            if (payload.activeTools !== undefined && payload.activeTools !== activeTools) {
-              const summarizedActiveTools = summarizeActiveToolsForSpan(payload.activeTools, payload.tools ?? tools);
+            if (stepResult.activeTools !== undefined && stepResult.activeTools !== activeTools) {
+              const summarizedActiveTools = summarizeActiveToolsForSpan(
+                stepResult.activeTools,
+                stepResult.tools ?? tools,
+              );
               if (summarizedActiveTools) {
                 output.activeTools = summarizedActiveTools;
               }
             }
 
-            if (payload.retryCount !== undefined && payload.retryCount !== retryCount) {
-              output.retryCount = payload.retryCount;
+            if (stepResult.retryCount !== undefined && stepResult.retryCount !== retryCount) {
+              output.retryCount = stepResult.retryCount;
             }
 
             return output;
@@ -924,7 +945,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               !areProcessorMessageArraysEqual(systemMessages as unknown[] | undefined, payload.systemMessages)
                 ? { systemMessages: payload.systemMessages }
                 : {}),
-            };
+            } satisfies ProcessorMessagesDiffSpanOutput;
           default:
             return undefined;
         }
@@ -1304,7 +1325,9 @@ function createStepFromProcessor<TProcessorId extends string>(
                 // End span on finish chunk
                 if (part && (part as ChunkType).type === 'finish') {
                   // Output just totalChunks (workflow processors don't track accumulated text yet)
-                  processorSpan?.end({ output: { totalChunks: (streamParts ?? []).length } });
+                  processorSpan?.end({
+                    output: { totalChunks: (streamParts ?? []).length } satisfies ProcessorOutputStreamSpanOutput,
+                  });
                   // Keep the ended span reference in mutableState so that
                   // post-finish chunks (e.g. step-finish) don't trigger a
                   // new span creation at the guard above.


### PR DESCRIPTION
Processor spans store `input`/`output` as `unknown`, so anything reading a trace (the playground, for instance) has no idea which shape a given span carries. It's also easy to add a field to a processor's args and forget to record it in the span, and nothing tells you.

This derives the span payload types from the processor args/result types instead of hand-writing them. Each phase has a spec where every key of the source type must be classified as `keep`, `optional`, `omit` or `{ summary }`, and the runner plus both workflow executors are annotated with `satisfies` against the resulting types. Adding a field to `ProcessInputStepArgs` now fails the build until you decide whether it goes in the trace, and deciding `keep` without emitting it in a builder fails too. Span construction itself is untouched.

Consumers can narrow a stored span by its `entityType`, which is the only phase discriminant persisted on a span:

```ts
import { isProcessorSpan } from '@mastra/core/processors'

if (isProcessorSpan(span, 'inputStep')) {
  span.input?.stepNumber // number | undefined
  span.output?.model     // ProcessorModelSummary | undefined
}
```

The legacy-only `llmRequest`/`llmResponse`/`requestError` spans reuse the entityType of other phases, so `isProcessorSpan` over-approximates for them. That's documented in `span-io.ts`; disambiguating properly would mean persisting a phase attribute, which I left out of this PR on purpose. Happy to do it as a follow-up if you'd rather have it.

Type tests live in `span-io.test-d.ts` and prove the drift lock: dropping a key from a spec, or adding an unknown one, is a type error.
