### PR TITLE
fix(core): preserve reasoning providerMetadata and avoid empty turns on replay

### DIFF
--- a/.changeset/preserve-thinking-signatures.md
+++ b/.changeset/preserve-thinking-signatures.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fix API replay errors with reasoning models (such as Anthropic extended thinking) by preserving provider signatures and reasoning metadata during stream processing, and preventing empty assistant turns from being sent back to model providers on multi-turn conversations.
+Fixed replay errors for reasoning responses. Reasoning signatures are retained, and empty assistant messages are removed before requests are sent.

--- a/.changeset/preserve-thinking-signatures.md
+++ b/.changeset/preserve-thinking-signatures.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Preserve reasoning block providerMetadata and cryptographic signatures in session run engine thread history, and omit assistant messages that become empty after stripping reasoning to prevent API replay errors.
+Fix API replay errors with reasoning models (such as Anthropic extended thinking) by preserving provider signatures and reasoning metadata during stream processing, and preventing empty assistant turns from being sent back to model providers on multi-turn conversations.

--- a/.changeset/preserve-thinking-signatures.md
+++ b/.changeset/preserve-thinking-signatures.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Preserve reasoning block providerMetadata and cryptographic signatures in session run engine thread history, and omit assistant messages that become empty after stripping reasoning to prevent API replay errors.

--- a/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
+++ b/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
@@ -114,6 +114,64 @@ describe('SessionRunEngine — MastraDBMessage contract', () => {
     expect(reasoningPart).toMatchObject({ type: 'reasoning', reasoning: 'thinking…' });
   });
 
+  it('Given a reasoning stream with reasoning-end providerMetadata, Then providerMetadata is preserved on the reasoning part', async () => {
+    const { engine, events } = createHarness();
+    const state = engine.createStreamState();
+    const ctx = requestContext();
+
+    await engine.processStreamChunk(state, chunk({ type: 'reasoning-start', payload: { id: 'r1' } }), ctx);
+    await engine.processStreamChunk(
+      state,
+      chunk({ type: 'reasoning-delta', payload: { id: 'r1', text: 'thinking…' } }),
+      ctx,
+    );
+    await engine.processStreamChunk(
+      state,
+      chunk({
+        type: 'reasoning-end',
+        payload: { id: 'r1', providerMetadata: { anthropic: { signature: 'sig_test_123' } } },
+      }),
+      ctx,
+    );
+
+    const message = lastMessageEvent(events);
+    const reasoningPart = message.content.parts.find(part => part.type === 'reasoning');
+    expect(reasoningPart).toMatchObject({
+      type: 'reasoning',
+      reasoning: 'thinking…',
+      providerMetadata: { anthropic: { signature: 'sig_test_123' } },
+    });
+  });
+
+  it('Given a reasoning stream with reasoning-signature chunk, Then signature is attached to providerMetadata', async () => {
+    const { engine, events } = createHarness();
+    const state = engine.createStreamState();
+    const ctx = requestContext();
+
+    await engine.processStreamChunk(state, chunk({ type: 'reasoning-start', payload: { id: 'r1' } }), ctx);
+    await engine.processStreamChunk(
+      state,
+      chunk({ type: 'reasoning-delta', payload: { id: 'r1', text: 'thinking…' } }),
+      ctx,
+    );
+    await engine.processStreamChunk(
+      state,
+      chunk({
+        type: 'reasoning-signature',
+        payload: { id: 'r1', signature: 'sig_chunk_456' },
+      }),
+      ctx,
+    );
+
+    const message = lastMessageEvent(events);
+    const reasoningPart = message.content.parts.find(part => part.type === 'reasoning');
+    expect(reasoningPart).toMatchObject({
+      type: 'reasoning',
+      reasoning: 'thinking…',
+      providerMetadata: { anthropic: { signature: 'sig_chunk_456' } },
+    });
+  });
+
   it('Given a tool call + result, When chunks arrive, Then it emits a tool-invocation part', async () => {
     const { engine, events } = createHarness();
     const state = engine.createStreamState();

--- a/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
+++ b/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
@@ -173,6 +173,36 @@ describe('SessionRunEngine — MastraDBMessage contract', () => {
     });
   });
 
+  it('Given a reasoning stream with an id-less reasoning-signature chunk, Then signature is attached to active reasoning part without creating an extra empty part', async () => {
+    const { engine, events } = createHarness();
+    const state = engine.createStreamState();
+    const ctx = requestContext();
+
+    await engine.processStreamChunk(state, chunk({ type: 'reasoning-start', payload: { id: 'r1' } }), ctx);
+    await engine.processStreamChunk(
+      state,
+      chunk({ type: 'reasoning-delta', payload: { id: 'r1', text: 'thinking…' } }),
+      ctx,
+    );
+    await engine.processStreamChunk(
+      state,
+      chunk({
+        type: 'reasoning-signature',
+        signature: 'top_level_sig_789',
+      }),
+      ctx,
+    );
+
+    const message = lastMessageEvent(events);
+    const reasoningParts = message.content.parts.filter(part => part.type === 'reasoning');
+    expect(reasoningParts).toHaveLength(1);
+    expect(reasoningParts[0]).toMatchObject({
+      type: 'reasoning',
+      reasoning: 'thinking…',
+      providerMetadata: { anthropic: { signature: 'top_level_sig_789' } },
+    });
+  });
+
   it('Given a tool call + result, When chunks arrive, Then it emits a tool-invocation part', async () => {
     const { engine, events } = createHarness();
     const state = engine.createStreamState();

--- a/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
+++ b/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
@@ -39,6 +39,7 @@ function createHarness() {
 
   const machinery: SessionMachinery = {
     getAgent: () => ({ id: 'agent-stub' }) as unknown as ReturnType<SessionMachinery['getAgent']>,
+    getRunScope: () => undefined,
     subscribeToThread: async () => {
       throw new Error('subscribeToThread is not used by these stream-folding tests');
     },

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -71,7 +71,7 @@ type StreamChunk =
   | StreamPayloadChunk<'reasoning-start'>
   | StreamPayloadChunk<'reasoning-delta'>
   | StreamPayloadChunk<'reasoning-end'>
-  | StreamPayloadChunk<'reasoning-signature'>
+  | (StreamPayloadChunk<'reasoning-signature'> & { signature?: unknown })
   | StreamPayloadChunk<'tool-call-input-streaming-start'>
   | StreamPayloadChunk<'tool-call-delta'>
   | StreamPayloadChunk<'tool-call-input-streaming-end'>
@@ -614,7 +614,7 @@ export class SessionRunEngine {
           getString(payload.signature) ??
           (isRecord(chunk) && 'signature' in chunk ? getString(chunk.signature) : undefined);
 
-        let thinkingContent: (MessageContentPart & { type: 'reasoning' }) | undefined;
+        let thinkingContent: (MastraMessagePart & { type: 'reasoning' }) | undefined;
 
         if (id && state.thinkingContentById.has(id)) {
           const thinkingState = state.thinkingContentById.get(id);
@@ -627,18 +627,20 @@ export class SessionRunEngine {
         if (!thinkingContent) {
           const lastReasoningPart = [...state.currentMessage.content.parts]
             .reverse()
-            .find((p): p is MessageContentPart & { type: 'reasoning' } => p.type === 'reasoning');
+            .find((p): p is MastraMessagePart & { type: 'reasoning' } => p.type === 'reasoning');
           if (lastReasoningPart) {
             thinkingContent = lastReasoningPart;
           } else {
             const thinkingIndex = state.currentMessage.content.parts.length;
-            const newPart: MessageContentPart & { type: 'reasoning' } = {
+            const newPart: MastraMessagePart & { type: 'reasoning' } = {
               type: 'reasoning',
               reasoning: '',
               details: [],
             };
             state.currentMessage.content.parts.push(newPart);
-            state.thinkingContentById.set(id, { index: thinkingIndex, text: '' });
+            if (id) {
+              state.thinkingContentById.set(id, { index: thinkingIndex, text: '' });
+            }
             thinkingContent = newPart;
           }
         }

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -41,8 +41,6 @@ type StreamIgnoredChunk =
   | StreamPayloadChunk<'abort'>
   | StreamPayloadChunk<'response-metadata'>
   | StreamPayloadChunk<'text-end'>
-  | StreamPayloadChunk<'reasoning-end'>
-  | StreamPayloadChunk<'reasoning-signature'>
   | StreamPayloadChunk<'redacted-reasoning'>
   | StreamPayloadChunk<'source'>
   | StreamPayloadChunk<'file'>
@@ -72,6 +70,8 @@ type StreamChunk =
   | StreamPayloadChunk<'text-delta'>
   | StreamPayloadChunk<'reasoning-start'>
   | StreamPayloadChunk<'reasoning-delta'>
+  | StreamPayloadChunk<'reasoning-end'>
+  | StreamPayloadChunk<'reasoning-signature'>
   | StreamPayloadChunk<'tool-call-input-streaming-start'>
   | StreamPayloadChunk<'tool-call-delta'>
   | StreamPayloadChunk<'tool-call-input-streaming-end'>
@@ -545,11 +545,19 @@ export class SessionRunEngine {
       }
 
       case 'reasoning-start': {
+        const payload = getPayload(chunk);
+        const id = getString(payload.id) ?? '';
         // Mirror text-start: a late start for an already-seeded id is a no-op.
-        if (state.thinkingContentById.has(getString(getPayload(chunk).id) ?? '')) break;
+        if (state.thinkingContentById.has(id)) break;
         const thinkingIndex = state.currentMessage.content.parts.length;
-        state.currentMessage.content.parts.push({ type: 'reasoning', reasoning: '', details: [] });
-        state.thinkingContentById.set(getString(getPayload(chunk).id) ?? '', { index: thinkingIndex, text: '' });
+        const providerMetadata = isProviderMetadata(payload.providerMetadata) ? payload.providerMetadata : undefined;
+        state.currentMessage.content.parts.push({
+          type: 'reasoning',
+          reasoning: '',
+          details: [],
+          ...(providerMetadata ? { providerMetadata } : {}),
+        });
+        state.thinkingContentById.set(id, { index: thinkingIndex, text: '' });
         this.#session.emit({ type: 'message_update', message: state.currentMessage });
         break;
       }
@@ -570,6 +578,62 @@ export class SessionRunEngine {
         if (thinkingContent && thinkingContent.type === 'reasoning') {
           thinkingContent.reasoning = thinkingState.text;
           thinkingContent.details = [{ type: 'text', text: thinkingState.text }];
+        }
+        this.#session.emit({ type: 'message_update', message: state.currentMessage });
+        break;
+      }
+
+      case 'reasoning-end': {
+        const payload = getPayload(chunk);
+        const id = getString(payload.id) ?? '';
+        let thinkingState = state.thinkingContentById.get(id);
+        if (!thinkingState) {
+          const thinkingIndex = state.currentMessage.content.parts.length;
+          state.currentMessage.content.parts.push({ type: 'reasoning', reasoning: '', details: [] });
+          thinkingState = { index: thinkingIndex, text: '' };
+          state.thinkingContentById.set(id, thinkingState);
+        }
+        const thinkingContent = state.currentMessage.content.parts[thinkingState.index];
+        if (thinkingContent && thinkingContent.type === 'reasoning') {
+          const providerMetadata = isProviderMetadata(payload.providerMetadata) ? payload.providerMetadata : undefined;
+          if (providerMetadata) {
+            thinkingContent.providerMetadata = {
+              ...(thinkingContent.providerMetadata || {}),
+              ...providerMetadata,
+            };
+          }
+        }
+        this.#session.emit({ type: 'message_update', message: state.currentMessage });
+        break;
+      }
+
+      case 'reasoning-signature': {
+        const payload = getPayload(chunk);
+        const id = getString(payload.id) ?? '';
+        const signature =
+          getString(payload.signature) ??
+          (isRecord(chunk) && 'signature' in chunk ? getString(chunk.signature) : undefined);
+        let thinkingState = state.thinkingContentById.get(id);
+        if (!thinkingState) {
+          const thinkingIndex = state.currentMessage.content.parts.length;
+          state.currentMessage.content.parts.push({ type: 'reasoning', reasoning: '', details: [] });
+          thinkingState = { index: thinkingIndex, text: '' };
+          state.thinkingContentById.set(id, thinkingState);
+        }
+        if (signature) {
+          const thinkingContent = state.currentMessage.content.parts[thinkingState.index];
+          if (thinkingContent && thinkingContent.type === 'reasoning') {
+            const existingAnthropic = isRecord(thinkingContent.providerMetadata?.anthropic)
+              ? (thinkingContent.providerMetadata!.anthropic as Record<string, unknown>)
+              : {};
+            thinkingContent.providerMetadata = {
+              ...(thinkingContent.providerMetadata || {}),
+              anthropic: {
+                ...existingAnthropic,
+                signature,
+              },
+            };
+          }
         }
         this.#session.emit({ type: 'message_update', message: state.currentMessage });
         break;

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -613,27 +613,47 @@ export class SessionRunEngine {
         const signature =
           getString(payload.signature) ??
           (isRecord(chunk) && 'signature' in chunk ? getString(chunk.signature) : undefined);
-        let thinkingState = state.thinkingContentById.get(id);
-        if (!thinkingState) {
-          const thinkingIndex = state.currentMessage.content.parts.length;
-          state.currentMessage.content.parts.push({ type: 'reasoning', reasoning: '', details: [] });
-          thinkingState = { index: thinkingIndex, text: '' };
-          state.thinkingContentById.set(id, thinkingState);
-        }
-        if (signature) {
-          const thinkingContent = state.currentMessage.content.parts[thinkingState.index];
-          if (thinkingContent && thinkingContent.type === 'reasoning') {
-            const existingAnthropic = isRecord(thinkingContent.providerMetadata?.anthropic)
-              ? (thinkingContent.providerMetadata!.anthropic as Record<string, unknown>)
-              : {};
-            thinkingContent.providerMetadata = {
-              ...(thinkingContent.providerMetadata || {}),
-              anthropic: {
-                ...existingAnthropic,
-                signature,
-              },
-            };
+
+        let thinkingContent: (MessageContentPart & { type: 'reasoning' }) | undefined;
+
+        if (id && state.thinkingContentById.has(id)) {
+          const thinkingState = state.thinkingContentById.get(id);
+          const part = thinkingState ? state.currentMessage.content.parts[thinkingState.index] : undefined;
+          if (part && part.type === 'reasoning') {
+            thinkingContent = part;
           }
+        }
+
+        if (!thinkingContent) {
+          const lastReasoningPart = [...state.currentMessage.content.parts]
+            .reverse()
+            .find((p): p is MessageContentPart & { type: 'reasoning' } => p.type === 'reasoning');
+          if (lastReasoningPart) {
+            thinkingContent = lastReasoningPart;
+          } else {
+            const thinkingIndex = state.currentMessage.content.parts.length;
+            const newPart: MessageContentPart & { type: 'reasoning' } = {
+              type: 'reasoning',
+              reasoning: '',
+              details: [],
+            };
+            state.currentMessage.content.parts.push(newPart);
+            state.thinkingContentById.set(id, { index: thinkingIndex, text: '' });
+            thinkingContent = newPart;
+          }
+        }
+
+        if (signature && thinkingContent) {
+          const existingAnthropic = isRecord(thinkingContent.providerMetadata?.anthropic)
+            ? (thinkingContent.providerMetadata!.anthropic as Record<string, unknown>)
+            : {};
+          thinkingContent.providerMetadata = {
+            ...(thinkingContent.providerMetadata || {}),
+            anthropic: {
+              ...existingAnthropic,
+              signature,
+            },
+          };
         }
         this.#session.emit({ type: 'message_update', message: state.currentMessage });
         break;

--- a/packages/core/src/processors/provider-history-compat.test.ts
+++ b/packages/core/src/processors/provider-history-compat.test.ts
@@ -725,6 +725,33 @@ describe('trailing assistant message protection', () => {
     expect(result).toBeDefined();
     expect((result![3].content as any[]).map(p => p.type)).toEqual(['reasoning', 'tool-call']);
   });
+
+  it('omits assistant messages that become empty after stripping foreign reasoning', () => {
+    const prompt: LanguageModelV2Prompt = [
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'foreign thinking only',
+            providerOptions: { openai: { itemId: 'rs_123' } },
+          },
+        ],
+      },
+      { role: 'user', content: [{ type: 'text', text: 'what is 2+2?' }] },
+    ];
+
+    const result = anthropicStripForeignReasoningContent.applyToPrompt!({
+      prompt,
+      model: anthropicModel,
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.length).toBe(2);
+    expect(result![0].role).toBe('user');
+    expect(result![1].role).toBe('user');
+  });
 });
 
 describe('azureSystemReminderTransform', () => {

--- a/packages/core/src/processors/provider-history-compat.ts
+++ b/packages/core/src/processors/provider-history-compat.ts
@@ -388,16 +388,32 @@ function stripReasoningFromPrompt(
   skipIndex = -1,
 ): LanguageModelV2Prompt | undefined {
   let mutated = false;
-  const next: LanguageModelV2Prompt = prompt.map((message, index) => {
-    if (index === skipIndex) return message;
-    if (message.role !== 'assistant') return message;
-    if (typeof message.content === 'string') return message;
-    if (!Array.isArray(message.content)) return message;
+  const next: LanguageModelV2Prompt = [];
+  for (let index = 0; index < prompt.length; index++) {
+    const message = prompt[index]!;
+    if (
+      index === skipIndex ||
+      message.role !== 'assistant' ||
+      typeof message.content === 'string' ||
+      !Array.isArray(message.content)
+    ) {
+      next.push(message);
+      continue;
+    }
     const filtered = message.content.filter(part => part.type !== 'reasoning' || !shouldStrip(part as any));
-    if (filtered.length === message.content.length) return message;
+    if (filtered.length === message.content.length) {
+      next.push(message);
+      continue;
+    }
     mutated = true;
-    return { ...message, content: filtered };
-  });
+    if (filtered.length === 0) {
+      // Stripping all reasoning parts left this assistant message with no content.
+      // Emitting an empty content array causes provider API errors on replay (e.g. Anthropic
+      // "messages: text content blocks must be non-empty").
+      continue;
+    }
+    next.push({ ...message, content: filtered });
+  }
   return mutated ? next : undefined;
 }
 

--- a/packages/core/src/processors/step-schema.ts
+++ b/packages/core/src/processors/step-schema.ts
@@ -34,6 +34,7 @@ export type ReasoningPartType = {
   type: 'reasoning';
   reasoning: string;
   details: Array<{ type: 'text' | 'redacted'; text?: string; data?: string }>;
+  providerMetadata?: Record<string, unknown>;
 };
 
 export type SourcePartType = {


### PR DESCRIPTION
### Problem
When using reasoning models (such as Claude with extended thinking), two related defects cause API failures during session continuation and replay:
1. In `SessionRunEngine`, `reasoning-end` and `reasoning-signature` stream chunks were categorized as `StreamIgnoredChunk`. Consequently, provider metadata emitted at reasoning completion (such as Anthropic thinking block cryptographic signatures) was discarded, causing persisted DB messages in thread history to lose provider signatures. Replaying messages with unsigned thinking blocks triggers API errors from providers requiring cryptographic signatures.
2. In `provider-history-compat.ts` (`stripReasoningFromPrompt`), when foreign reasoning blocks are stripped from previous turns, an assistant message containing solely reasoning parts was reduced to `content: []`. Emitting an assistant message with an empty content array causes provider rejection (e.g. Anthropic returns `Invalid request: messages: text content blocks must be non-empty`).

Fixes #14559.

### Invariant
1. Provider metadata and cryptographic signatures emitted during stream reasoning transitions (`reasoning-start`, `reasoning-end`, `reasoning-signature`) must be preserved on the corresponding `reasoning` part in thread message history.
2. Prompt history sanitizers that strip foreign reasoning parts must omit assistant messages whose content becomes completely empty rather than producing empty content arrays.

### Root cause
1. `session-run-engine.ts` dropped `reasoning-end` and `reasoning-signature` by listing them under `StreamIgnoredChunk`, leaving reasoning parts in `state.currentMessage.content.parts` without the `providerMetadata` populated by provider adapters upon completion.
2. `stripReasoningFromPrompt` used `prompt.map(...)` and preserved assistant messages whose content was filtered down to zero elements, producing empty assistant turns.

### Design
- Updated `session-run-engine.ts` to handle `reasoning-start`, `reasoning-end`, and `reasoning-signature` chunks. If `reasoning-end` contains `providerMetadata`, it is merged into the active reasoning part's `providerMetadata`. If `reasoning-signature` contains a signature string, it is attached to `providerMetadata.anthropic.signature`.
- Updated `stripReasoningFromPrompt` in `provider-history-compat.ts` to omit assistant messages from the filtered prompt array when `filtered.length === 0`.
- Extended `ReasoningPartType` in `step-schema.ts` to include optional `providerMetadata?: Record<string, unknown>`.

### Implementation
- `packages/core/src/agent-controller/session-run-engine.ts`: Moved `reasoning-end` and `reasoning-signature` from `StreamIgnoredChunk` to `StreamChunk`, and added explicit state-tracking handlers in `processStreamChunk`.
- `packages/core/src/processors/provider-history-compat.ts`: Updated `stripReasoningFromPrompt` loop to drop turns where all reasoning content has been stripped.
- `packages/core/src/processors/step-schema.ts`: Added `providerMetadata?: Record<string, unknown>` to `ReasoningPartType`.
- `packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts`: Added regression tests for `reasoning-end` providerMetadata preservation and `reasoning-signature` attachment.
- `packages/core/src/processors/provider-history-compat.test.ts`: Added unit test verifying that assistant messages left empty after stripping reasoning are omitted from the prompt.
- `.changeset/preserve-thinking-signatures.md`: Added patch changeset.

### Tests
- `run-engine-db-message.test.ts`:
  - Verified `reasoning-end` chunk with `providerMetadata: { anthropic: { signature: ... } }` is attached to reasoning part.
  - Verified `reasoning-signature` chunk updates `providerMetadata.anthropic.signature`.
- `provider-history-compat.test.ts`:
  - Verified `anthropicStripForeignReasoningContent` omits assistant turns that contain only stripped reasoning.
  - All 54 tests in `provider-history-compat.test.ts` passed.
  - All 21 tests in `run-engine-db-message.test.ts` passed.

### Verification
- `pnpm --filter @mastra/core test src/processors/provider-history-compat.test.ts` (passed, 54/54 tests)
- `pnpm --filter @mastra/core test src/agent-controller/__tests__/run-engine-db-message.test.ts` (passed, 18 passed / 3 skipped)
- `pnpm --filter @mastra/core run typecheck` (`tsc --noEmit -p tsconfig.build.json` completed with 0 errors)

### Scope
Focused strictly on reasoning stream chunk handling in `SessionRunEngine` and prompt history sanitization in `provider-history-compat`. No changes to external tool calling or model routing protocols.

### Compatibility
Fully backwards compatible. Unmodified reasoning parts without metadata continue to behave identically. Messages with preserved signatures avoid downstream API rejection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR keeps the information needed to replay reasoning messages correctly. It also removes empty assistant messages that can cause provider errors.

## Changes

- Preserve reasoning metadata and Anthropic signatures in `SessionRunEngine`.
- Handle `reasoning-start`, `reasoning-end`, and `reasoning-signature` stream events.
- Attach signatures to the active reasoning part, including id-less signature chunks.
- Add optional `providerMetadata` to `ReasoningPartType`.
- Remove assistant messages when stripping reasoning leaves no content.
- Add regression tests for metadata preservation and empty-message removal.
- Add a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->