### PR TITLE
fix(ci): route Studio UI source changes to E2E tests

### DIFF
--- a/.github/scripts/studio-e2e-routing.cjs
+++ b/.github/scripts/studio-e2e-routing.cjs
@@ -1,0 +1,12 @@
+const studioSourcePaths = [
+  'packages/playground/src/',
+  'packages/playground-ui/src/',
+];
+
+function studioE2eChanged(changedFiles) {
+  return changedFiles.some(file => studioSourcePaths.some(prefix => file.startsWith(prefix)));
+}
+
+module.exports = {
+  studioE2eChanged,
+};

--- a/.github/scripts/studio-e2e-routing.cjs
+++ b/.github/scripts/studio-e2e-routing.cjs
@@ -1,7 +1,4 @@
-const studioSourcePaths = [
-  'packages/playground/src/',
-  'packages/playground-ui/src/',
-];
+const studioSourcePaths = ['packages/playground/src/', 'packages/playground-ui/src/'];
 
 function studioE2eChanged(changedFiles) {
   return changedFiles.some(file => studioSourcePaths.some(prefix => file.startsWith(prefix)));

--- a/.github/scripts/studio-e2e-routing.test.ts
+++ b/.github/scripts/studio-e2e-routing.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest';
+import routing from './studio-e2e-routing.cjs';
+
+const { studioE2eChanged } = routing;
+
+const routedPaths = [
+  'packages/playground/src/pages/experiments/review-queue/index.tsx',
+  'packages/playground/src/domains/review/dataset-review.tsx',
+  'packages/playground/src/App.tsx',
+  'packages/playground-ui/src/components/Button/Button.tsx',
+  'packages/playground-ui/src/domains/memory/components/memory-list.tsx',
+];
+
+describe('studio E2E routing', () => {
+  test.each(routedPaths)('routes source change %s', path => {
+    expect(studioE2eChanged([path])).toBe(true);
+  });
+
+  test('routes mixed change lists containing at least one source file', () => {
+    expect(
+      studioE2eChanged([
+        'packages/core/src/index.ts',
+        'packages/playground/src/pages/experiments/review-queue/index.tsx',
+        '.changeset/experiment-review-queue-page.md',
+      ]),
+    ).toBe(true);
+  });
+
+  test.each([
+    'packages/core/src/index.ts',
+    'packages/server/src/index.ts',
+    'docs/guides/playground.mdx',
+    '.changeset/experiment-review-queue-page.md',
+    'packages/playground/package.json',
+    'packages/playground-ui/package.json',
+    'packages/playground/e2e/tests/root.spec.ts',
+    'packages/playground/dist/index.html',
+    'packages/playground-ui/dist/style.css',
+    'packages/playground/playwright.config.ts',
+    'packages/playground/public/favicon.ico',
+  ])('does not route unrelated change %s', path => {
+    expect(studioE2eChanged([path])).toBe(false);
+  });
+
+  test('does not route a changeset-only or docs-only change list', () => {
+    expect(studioE2eChanged(['.changeset/experiment-review-queue-page.md'])).toBe(false);
+    expect(studioE2eChanged(['docs/guides/playground.mdx'])).toBe(false);
+  });
+
+  test('prefix boundary: packages/playground-e2e/src/ does not trigger', () => {
+    expect(studioE2eChanged(['packages/playground-e2e/src/index.ts'])).toBe(false);
+  });
+
+  test('prefix boundary: packages/playgroundui/src/ does not trigger', () => {
+    expect(studioE2eChanged(['packages/playgroundui/src/index.ts'])).toBe(false);
+  });
+
+  test('returns false for an empty change list', () => {
+    expect(studioE2eChanged([])).toBe(false);
+  });
+});

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -220,7 +220,8 @@ jobs:
           const memoryChanged = affectedMemoryTests || changed(file =>
             file.startsWith('packages/memory/') || file === '.github/workflows/prebuild.yml'
           );
-          const e2eChanged = affected(isExternalE2eTest) || (runFull && hasChangedSource) || changed(file =>
+          const { studioE2eChanged } = require('./.github/scripts/studio-e2e-routing.cjs');
+          const e2eChanged = studioE2eChanged(nonMarkdownChangedFiles) || affected(isExternalE2eTest) || (runFull && hasChangedSource) || changed(file =>
             (file.startsWith('e2e-tests/') &&
               !file.startsWith('e2e-tests/experiment-worker/') &&
               !file.startsWith('e2e-tests/_local-registry-setup/')) ||


### PR DESCRIPTION
Playwright E2E specs in `packages/playground/e2e/` are black-box consumers — they navigate to the built Studio via browser URLs rather than importing React source modules. The reverse-dependency graph in `affected-tests.mjs` can't connect changes under `packages/playground/src/` to those Playwright specs, so when fewer than 50% of tests are affected (`run_full=false`) and no E2E file itself changed, the `e2e_changed` gate stayed false and the reusable E2E workflow was skipped.

This caused PR #22981 (Review Queue) to not run any E2E tests despite changing Studio UI source code.

**What changed:**

- Added a deterministic routing function (`.github/scripts/studio-e2e-routing.cjs`) that returns true when any changed file is under `packages/playground/src/` or `packages/playground-ui/src/`
- Added tests (`.github/scripts/studio-e2e-routing.test.ts`) covering positive cases, negative cases (unrelated packages, docs, changesets, dist, configs), prefix boundaries, mixed lists, and empty input
- OR'd the routing result into the existing `e2e_changed` computation in `prebuild.yml`, preserving all existing conditions and the downstream workflow interface

No changeset needed — these are CI-only changes that don't touch any published package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When Studio UI source code changes, CI now runs the Playwright tests that check Studio in a browser. This prevents relevant changes from being missed.

## Changes

- Added `studioE2eChanged` for:
  - `packages/playground/src/`
  - `packages/playground-ui/src/`
- Integrated the routing into `e2e_changed` for non-Markdown files.
- Added Vitest coverage for source, mixed, unrelated, empty, and prefix-boundary paths.
- Preserved the downstream workflow interface.
- Added no changeset because the changes affect CI only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->