### PR TITLE
fix(observability): redact sensitive fields in span requestContext

### DIFF
--- a/.changeset/funky-games-go.md
+++ b/.changeset/funky-games-go.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed `SensitiveDataFilter` so it also redacts sensitive fields inside a span's `requestContext`. Secrets stored in `RequestContext` (for example a per-request API token that tools use) were exported to every tracing exporter in plain text, even when the key was listed in `sensitiveFields`. The filter now applies the same redaction to `requestContext` as it does to `attributes`, `metadata`, `input`, `output`, and `errorInfo`. Fixes https://github.com/mastra-ai/mastra/issues/23046

--- a/docs/src/content/en/reference/observability/tracing/processors/sensitive-data-filter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/processors/sensitive-data-filter.mdx
@@ -216,7 +216,7 @@ export function redactSpan(span: AnySpan): AnySpan {
   {
     name: 'span',
     type: 'AnySpan',
-    description: 'Span whose attributes, metadata, input, output, and error information are filtered.',
+    description: 'Span whose attributes, metadata, input, output, error information, and request context are filtered.',
   },
 ]}
 />

--- a/docs/src/content/en/reference/observability/tracing/processors/sensitive-data-filter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/processors/sensitive-data-filter.mdx
@@ -172,6 +172,7 @@ When a matched field contains an object or array, the filter traverses that valu
 - `input`
 - `output`
 - `errorInfo`
+- `requestContext`
 
 Within each field, the processor:
 

--- a/observability/mastra/src/span_processors/sensitive-data-filter.ts
+++ b/observability/mastra/src/span_processors/sensitive-data-filter.ts
@@ -111,7 +111,7 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
 
   /**
    * Process a span by filtering sensitive data across its key fields.
-   * Fields processed: attributes, metadata, input, output, errorInfo.
+   * Fields processed: attributes, metadata, input, output, errorInfo, requestContext.
    *
    * @param span - The input span to filter
    * @returns A new span with sensitive values redacted
@@ -123,6 +123,7 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
     span.input = this.tryFilter(span.input, indexedState);
     span.output = this.tryFilter(span.output, indexedState);
     span.errorInfo = this.tryFilter(span.errorInfo, indexedState);
+    span.requestContext = this.tryFilter(span.requestContext, indexedState);
     return span;
   }
 

--- a/observability/mastra/src/span_processors/senstive-data-filter.test.ts
+++ b/observability/mastra/src/span_processors/senstive-data-filter.test.ts
@@ -1,5 +1,6 @@
 import type { TracingEvent, ObservabilityExporter } from '@mastra/core/observability';
 import { SpanType, SamplingStrategyType } from '@mastra/core/observability';
+import { RequestContext } from '@mastra/core/request-context';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DefaultObservabilityInstance } from '../instances';
 import { SensitiveDataFilter } from './sensitive-data-filter';
@@ -444,6 +445,39 @@ describe('Tracing', () => {
         expect(attributes?.['sensitiveData']).toBeUndefined();
         expect(attributes?.['problematicObject']).toBeUndefined();
       });
+
+      it('should redact sensitive fields in requestContext', () => {
+        const processor = new SensitiveDataFilter({ sensitiveFields: ['apiToken'] });
+
+        const mockSpan = {
+          id: 'test-span-request-context',
+          name: 'test-span',
+          type: SpanType.AGENT_RUN,
+          startTime: new Date(),
+          traceId: 'trace-123',
+          trace: { traceId: 'trace-123' } as any,
+          attributes: { agentId: 'agent-123' },
+          requestContext: {
+            apiToken: 'live-token', // Should be redacted
+            tenantId: 'tenant-1', // Should NOT be redacted
+            user: { id: 'user-1', apiToken: 'live-token' }, // Nested key should be redacted
+          },
+          observabilityInstance: {} as any,
+          end: () => {},
+          error: () => {},
+          update: () => {},
+          createChildSpan: () => ({}) as any,
+        } as any;
+
+        const filtered = processor.process(mockSpan);
+        expect(filtered).not.toBeNull();
+
+        const requestContext = filtered!.requestContext as any;
+        expect(requestContext?.['apiToken']).toBe('[REDACTED]');
+        expect(requestContext?.['tenantId']).toBe('tenant-1');
+        expect(requestContext?.['user']?.['id']).toBe('user-1');
+        expect(requestContext?.['user']?.['apiToken']).toBe('[REDACTED]');
+      });
     });
 
     describe('indexed redaction style', () => {
@@ -611,6 +645,20 @@ describe('Tracing', () => {
         }
       });
 
+      it('should share tokens between requestContext and the other span fields', () => {
+        const processor = new SensitiveDataFilter({ redactionStyle: 'indexed' });
+
+        const span = makeSpan('trace-1', { attributes: { apiKey: 'sk-first' } });
+        span.requestContext = { apiKey: 'sk-first', user: { apiKey: 'sk-second' } };
+
+        const filtered = processor.process(span)!;
+
+        // The same value maps to the same token no matter which field carries it
+        expect((filtered.attributes as any).apiKey).toBe('[APIKEY_1]');
+        expect((filtered.requestContext as any).apiKey).toBe('[APIKEY_1]');
+        expect((filtered.requestContext as any).user.apiKey).toBe('[APIKEY_2]');
+      });
+
       it('should fall back to the full redaction token once the per-trace value cap is reached', () => {
         const processor = new SensitiveDataFilter({ redactionStyle: 'indexed' });
 
@@ -663,6 +711,39 @@ describe('Tracing', () => {
         // Check the updated span for the filtered field
         const updatedSpan = testExporter.events[1].exportedSpan; // span_updated event
         expect((updatedSpan.attributes as any)?.['apiKey']).toBe('[REDACTED]');
+      });
+
+      it('should redact the request context snapshot captured on exported spans', () => {
+        const tracing = new DefaultObservabilityInstance({
+          serviceName: 'test-tracing',
+          name: 'test-instance',
+          sampling: { type: SamplingStrategyType.ALWAYS },
+          exporters: [testExporter],
+          spanOutputProcessors: [new SensitiveDataFilter()],
+        });
+
+        const requestContext = new RequestContext();
+        requestContext.set('token', 'live-token');
+        requestContext.set('tenantId', 'tenant-1');
+        requestContext.set('user', { id: 'user-1', password: 'hunter2' });
+
+        const span = tracing.startSpan({
+          type: SpanType.AGENT_RUN,
+          name: 'test-agent',
+          attributes: { agentId: 'agent-123' },
+          requestContext,
+        });
+        span.end();
+
+        // The raw values never reach the exporter, on the start or the end event
+        for (const event of testExporter.events) {
+          const exported = event.exportedSpan.requestContext as any;
+          expect(exported?.['token']).toBe('[REDACTED]');
+          expect(exported?.['tenantId']).toBe('tenant-1');
+          expect(exported?.['user']?.['id']).toBe('user-1');
+          expect(exported?.['user']?.['password']).toBe('[REDACTED]');
+        }
+        expect(testExporter.events.length).toBeGreaterThan(0);
       });
     });
   });


### PR DESCRIPTION
## Description

`SensitiveDataFilter` redacted `attributes`, `metadata`, `input`, `output`, and `errorInfo`, but never `span.requestContext`. Any secret an application stores in `RequestContext` (for example a per-request API token that tools use) was exported to every tracing exporter in plain text, even when the key was listed in `sensitiveFields`. Only the framework's own `mastra__authToken` was protected, by `RequestContext.serializeForSpan()`.

- Filter `span.requestContext` in `SensitiveDataFilter.process()` with the same `tryFilter` traversal as the other fields, so top-level and nested keys are redacted and indexed tokens stay consistent across fields
- Add unit tests for top-level and nested keys, for indexed-token sharing between `requestContext` and `attributes`, and an end-to-end test through `DefaultObservabilityInstance` with a real `RequestContext`
- List `requestContext` in the "Processing behavior" section of the reference docs

Verified with real credentials on `@mastra/core` 1.64.0 / `@mastra/observability` 1.17.5 (leaks on 3 of 10 spans) versus this branch (0 leaks), using an agent whose tool reads the token from `RequestContext`.

## Related Issue(s)

Fixes #23046

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

`SensitiveDataFilter` now also protects secrets stored in `requestContext`. This prevents configured sensitive values, such as API tokens, from appearing in exported traces.

## Changes

- Redacts sensitive fields at the top level and in nested `requestContext` objects.
- Preserves consistent indexed-token redaction across `requestContext` and other span fields.
- Adds unit and end-to-end tests with `RequestContext`.
- Updates the reference documentation and adds a release changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->