### PR TITLE
fix(observability): keep indexed redaction tokens stable across span events

### DIFF
--- a/.changeset/wide-pants-sink.md
+++ b/.changeset/wide-pants-sink.md
@@ -2,4 +2,4 @@
 '@mastra/observability': patch
 ---
 
-Fixed the `indexed` redaction style of `SensitiveDataFilter` giving the same value a new token every time a span was exported. A span is processed again for each `span_started`, `span_updated`, and `span_ended` event, and the filter treated its own `[APIKEY_1]` token as a new secret and replaced it with `[APIKEY_2]`. Already redacted values now keep their token, so the same secret maps to one token across every span and event of a trace. Fixes #23056
+Fixed the `indexed` redaction style of `SensitiveDataFilter` giving the same value a new token every time a span was exported. A span is processed again for each `span_started`, `span_updated`, and `span_ended` event, and the filter treated its own `[APIKEY_1]` token as a new secret and replaced it with `[APIKEY_2]`. Already redacted values now keep their token, so the same secret maps to one token across every span and event of a trace while the trace's mapping is retained (state is kept for the 1000 most recently seen traces). Fixes #23056

--- a/.changeset/wide-pants-sink.md
+++ b/.changeset/wide-pants-sink.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed the `indexed` redaction style of `SensitiveDataFilter` giving the same value a new token every time a span was exported. A span is processed again for each `span_started`, `span_updated`, and `span_ended` event, and the filter treated its own `[APIKEY_1]` token as a new secret and replaced it with `[APIKEY_2]`. Already redacted values now keep their token, so the same secret maps to one token across every span and event of a trace. Fixes #23056

--- a/observability/mastra/src/span_processors/sensitive-data-filter.ts
+++ b/observability/mastra/src/span_processors/sensitive-data-filter.ts
@@ -5,13 +5,15 @@ export type RedactionStyle = 'full' | 'partial' | 'indexed';
 
 /**
  * Per-trace state for indexed redaction: maps SHA-256 digests of values to
- * their assigned tokens and tracks the next index per token label.
+ * their assigned tokens, tracks the next index per token label, and remembers
+ * every issued token so re-processing an already redacted span is a no-op.
  * Keying on fixed-length digests keeps state size bounded and avoids
  * retaining raw sensitive values in memory.
  */
 interface IndexedRedactionState {
   tokensByValue: Map<string, string>;
   counters: Map<string, number>;
+  issuedTokens: Set<string>;
 }
 
 /**
@@ -136,7 +138,7 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
     if (state) {
       this.traceStates.delete(traceId);
     } else {
-      state = { tokensByValue: new Map(), counters: new Map() };
+      state = { tokensByValue: new Map(), counters: new Map(), issuedTokens: new Set() };
     }
     this.traceStates.set(traceId, state);
     while (this.traceStates.size > MAX_TRACKED_TRACES) {
@@ -274,6 +276,9 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
     }
 
     if (this.redactionStyle === 'indexed' && indexedState) {
+      if (typeof value === 'string' && indexedState.issuedTokens.has(value)) {
+        return value;
+      }
       const valueKey = createHash('sha256').update(String(value)).digest('hex');
       const existing = indexedState.tokensByValue.get(valueKey);
       if (existing) {
@@ -287,6 +292,7 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
       indexedState.counters.set(label, count);
       const token = `[${label}_${count}]`;
       indexedState.tokensByValue.set(valueKey, token);
+      indexedState.issuedTokens.add(token);
       return token;
     }
 

--- a/observability/mastra/src/span_processors/senstive-data-filter.test.ts
+++ b/observability/mastra/src/span_processors/senstive-data-filter.test.ts
@@ -518,6 +518,25 @@ describe('Tracing', () => {
         expect((second.attributes as any).secret).toBe('[SECRET_1]');
       });
 
+      it('should keep the same token when a span is processed again', () => {
+        const processor = new SensitiveDataFilter({ redactionStyle: 'indexed' });
+
+        const span = makeSpan('trace-1', {
+          attributes: { apiKey: 'sk-live', nested: { password: 'hunter2' } },
+          input: JSON.stringify({ token: 'sk-live' }),
+        });
+
+        processor.process(span);
+        const again = processor.process(span)!;
+
+        expect((again.attributes as any).apiKey).toBe('[APIKEY_1]');
+        expect((again.attributes as any).nested.password).toBe('[PASSWORD_1]');
+        expect(JSON.parse(again.input as string).token).toBe('[APIKEY_1]');
+
+        const sibling = processor.process(makeSpan('trace-1', { attributes: { apiKey: 'sk-live' } }))!;
+        expect((sibling.attributes as any).apiKey).toBe('[APIKEY_1]');
+      });
+
       it('should number tokens independently per trace', () => {
         const processor = new SensitiveDataFilter({ redactionStyle: 'indexed' });
 
@@ -629,6 +648,35 @@ describe('Tracing', () => {
     });
 
     describe('as part of the default config', () => {
+      it('should keep indexed tokens stable across span events', () => {
+        const tracing = new DefaultObservabilityInstance({
+          serviceName: 'test-tracing',
+          name: 'test-instance',
+          sampling: { type: SamplingStrategyType.ALWAYS },
+          exporters: [testExporter],
+          spanOutputProcessors: [new SensitiveDataFilter({ redactionStyle: 'indexed' })],
+        });
+
+        const span = tracing.startSpan({
+          type: SpanType.AGENT_RUN,
+          name: 'test-agent',
+          attributes: { apiKey: 'sk-live' } as any,
+        });
+        span.update({ metadata: { step: 1 } });
+        const child = span.createChildSpan({
+          type: SpanType.TOOL_CALL,
+          name: 'test-tool',
+          attributes: { apiKey: 'sk-live' } as any,
+        });
+        child.end();
+        span.end();
+
+        expect(testExporter.events).toHaveLength(5);
+        for (const event of testExporter.events) {
+          expect((event.exportedSpan.attributes as any)?.['apiKey']).toBe('[APIKEY_1]');
+        }
+      });
+
       it('should automatically filter sensitive data in default tracing', () => {
         const tracing = new DefaultObservabilityInstance({
           serviceName: 'test-tracing',


### PR DESCRIPTION
## Description

`SensitiveDataFilter` with `redactionStyle: 'indexed'` gave the same secret a new token on every span event. `process()` writes the redacted fields back onto the live span, and the tracing instance runs the processors again for `span_started`, each `span_updated`, and `span_ended`. On the second run the filter hashed its own `[APIKEY_1]` token as a fresh value and issued `[APIKEY_2]`, so the cross-span correlation the indexed style exists for was lost.

- Track every token issued for a trace in the per-trace state and return a value unchanged when it is one of them, which makes indexed redaction idempotent across repeated processing
- Add a unit test that processes the same span twice (attributes, nested objects, and JSON-string content) and a `DefaultObservabilityInstance` test that checks the token across start, update, child, and end events
- `full` and `partial` styles are unchanged; they were already idempotent
- Verified with a real OpenAI agent run whose tool receives the secret as input: before, the tool span exported `[APIKEY_1]` on start and `[APIKEY_2]` on end; after, every event of the trace shows `[APIKEY_1]`

## Related Issue(s)

Fixes #23056

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The filter now gives the same secret the same label throughout a trace, even when the trace is processed many times. This keeps related events connected and avoids using extra labels.

## Changes

- Preserve indexed `SensitiveDataFilter` tokens across span events.
- Keep already redacted values unchanged.
- Retain mappings for the 1,000 most recently seen traces.
- Keep full and partial redaction behavior unchanged.
- Add tests for repeated spans, nested objects, JSON strings, sibling spans, and span lifecycle events.
- Add a patch changeset for `@mastra/observability`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->