### PR TITLE
docs: add agent lifecycle guide

### DIFF
--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -988,6 +988,7 @@ Mastra includes a built-in [`PrefillErrorHandler`](/reference/processors/prefill
 
 ## Related documentation
 
+- [Agent lifecycle](/docs/guides/agent-lifecycle): Full-run ordering and `RequestContext` visibility
 - [Guardrails](/docs/agents/guardrails): Security and validation processors
 - [Memory Processors](/docs/memory/memory-processors): Memory-specific processors and automatic integration
 - [Processor Interface](/reference/processors/processor-interface): Full API reference for processors

--- a/docs/src/content/en/docs/guides/agent-lifecycle.mdx
+++ b/docs/src/content/en/docs/guides/agent-lifecycle.mdx
@@ -7,7 +7,7 @@ packages:
 
 # Agent lifecycle
 
-When you call `generate()` or `stream()`, Mastra starts an agent run. It prepares the agent and its input before calling the model. If the model requests a tool, Mastra runs it and may call the model again. When the work is complete, Mastra finalizes and returns the result.
+When you call [`generate()`](/reference/agents/generate) or [`stream()`](/reference/streaming/agents/stream), Mastra starts an agent run. It prepares the agent and its input before calling the model. If the model requests a tool, Mastra runs it and may call the model again. When the work is complete, Mastra finalizes and returns the result.
 
 This guide breaks that work into preparation, loop execution, and finalization. It explains where [processors](/docs/agents/processors) run, what can cause another model call, and how regular and durable runs differ.
 
@@ -52,15 +52,15 @@ By the end of preparation, the run has the messages, tools, and processor config
 
 | Preparation work | Timing | What this means for `RequestContext` |
 | - | - | - |
-| Validation, workspace, model, and instructions | Before `processInput` | Required values must already exist when the run starts. |
+| Validation, workspace, model, and instructions | Before [`processInput`](/reference/processors/processor-interface#processinput) | Required values must already exist when the run starts. |
 | Memory-, workspace-, and skills-derived processor instances used for `processInput` | Resolved before `processInput` | A context change inside `processInput` can't change how these instances were selected. |
 | Dynamic skill resolution | Before `processInput` | Skill selection can't depend on a value first added by `processInput`. |
-| Tool conversion in a regular run | In parallel with memory and input preparation | A dynamic `tools` callback has no guaranteed ordering relative to `processInput`. |
+| Tool conversion in a regular run | In parallel with memory and input preparation | A dynamic [`tools` callback](/reference/agents/agent) has no guaranteed ordering relative to `processInput`. |
 | `processInput` | Once during initial input preparation | It can transform messages and establish state for later loop callbacks and tool execution. |
 | Effective input, LLM-request, and error processor factories used by the loop | After the regular preparation branches join | These factories can observe earlier context changes, but `processInput` isn't a safe setup point for every resolver. |
 | Durable preparation | Before durable loop execution | Its placement differs from the regular path, and resumed work may skip initial input processing. |
 
-`generate()` and `stream()` validate `RequestContext` before resolving dynamic default options. A default-options callback therefore can't add a missing required value in time for validation.
+`generate()` and `stream()` validate `RequestContext` before calling [`getDefaultOptions()`](/reference/agents/getDefaultOptions). A function-based default option therefore can't add a missing required value in time for validation.
 
 In a regular run, Mastra reuses the caller's `RequestContext` instance throughout execution. Dynamic configuration, processors, and tool execution receive that live instance rather than separate copies. Whether a change is visible depends on whether the consumer has already resolved.
 
@@ -102,13 +102,13 @@ The loop works with the messages accumulated so far. Each iteration gives those 
 
 Processor callbacks run in this public sequence:
 
-1. `processInputStep` receives the accumulated message list before the next model call.
-1. `processLLMRequest` receives the provider-facing prompt after message conversion.
-1. The provider streams its response, and `processOutputStream` can inspect or transform each chunk.
-1. `processLLMResponse` runs after the provider stream for that step completes.
-1. `processOutputStep` runs after the model step, before locally executed tools.
+1. [`processInputStep`](/reference/processors/processor-interface#processinputstep) receives the accumulated message list before the next model call.
+1. [`processLLMRequest`](/reference/processors/processor-interface#processllmrequest) receives the provider-facing prompt after message conversion.
+1. The provider streams its response, and [`processOutputStream`](/reference/processors/processor-interface#processoutputstream) can inspect or transform each chunk.
+1. [`processLLMResponse`](/reference/processors/processor-interface#processllmresponse) runs after the provider stream for that step completes.
+1. [`processOutputStep`](/reference/processors/processor-interface#processoutputstep) runs after the model step, before locally executed tools.
 1. If the model requested local or client tools, Mastra processes their input and handles any configured approval. It then executes the tool or waits for its result.
-1. `processToolResult` receives each local or client tool result before the raw result enters the message list.
+1. [`processToolResult`](/reference/processors/processor-interface#processtoolresult) receives each local or client tool result before the raw result enters the message list.
 
 Provider-executed tools can return results differently. If a deferred provider result arrives during a later model stream, `processToolResult` runs when that result arrives. It doesn't have one universal position after every model step.
 
@@ -124,15 +124,15 @@ The [Processor interface](/reference/processors/processor-interface) documents c
 | `processOutputStream` | Per streamed chunk | Runs while model output arrives. Data chunks are included when the processor opts in. |
 | `processLLMResponse` | Once per completed provider stream | Receives the completed response for the current model step. |
 | `processOutputStep` | Once per model step | Runs after the model response and before locally executed tools. |
-| Tool `onInputStart` | When streamed tool input begins | Runs before complete tool arguments are available. |
-| Tool `onInputDelta` | Per streamed tool-input chunk | Observes incremental tool arguments. |
-| Tool `onInputAvailable` | Once when tool input is complete | Runs after arguments are parsed and validated, before execution. |
+| Tool [`onInputStart`](/reference/tools/create-tool#oninputstart) | When streamed tool input begins | Runs before complete tool arguments are available. |
+| Tool [`onInputDelta`](/reference/tools/create-tool#oninputdelta) | Per streamed tool-input chunk | Observes incremental tool arguments. |
+| Tool [`onInputAvailable`](/reference/tools/create-tool#oninputavailable) | Once when tool input is complete | Runs after arguments are parsed and validated, before execution. |
 | Tool execution | Once per local tool call | Receives the live `RequestContext`. Approval or suspension can delay execution. |
-| Tool `onOutput` | Once after successful local execution | Receives the tool output. |
+| Tool [`onOutput`](/reference/tools/create-tool#onoutput) | Once after successful local execution | Receives the tool output. |
 | `processToolResult` | Per local/client result, or when a deferred provider result arrives | Can inspect, redact, or abort before a raw tool result enters the message list. |
-| `processAPIError` | On eligible provider API errors | Can update request state and request another provider attempt. |
-| `onIterationComplete` | Once after each completed loop iteration | Observes the iteration result and can influence whether execution continues. |
-| `processOutputResult` | Once at finalization | Post-processes the completed agent result before it's returned. |
+| [`processAPIError`](/reference/processors/processor-interface#processapierror) | On eligible provider API errors | Can update request state and request another provider attempt. |
+| [`onIterationComplete`](/reference/agents/generate#parameters) | Once after each completed loop iteration | Observes the iteration result and can influence whether execution continues. |
+| [`processOutputResult`](/reference/processors/processor-interface#processoutputresult) | Once at finalization | Post-processes the completed agent result before it's returned. |
 
 ### What changes persist
 
@@ -151,8 +151,8 @@ After the model step and any requested tool work, Mastra decides whether the run
 The loop stops when a configured or terminal condition is reached. These conditions can include:
 
 - A final model response that doesn't request another tool.
-- A custom `stopWhen` condition evaluated against accumulated steps.
-- The `maxSteps` limit.
+- A custom [`stopWhen`](/reference/agents/generate#parameters) condition evaluated against accumulated steps.
+- The [`maxSteps`](/reference/agents/generate#using-maxsteps) limit.
 - Task-completion, goal, or [subagent](/docs/subagents) delegation outcomes.
 - A terminal provider finish reason, error, processor tripwire, or abort.
 
@@ -166,9 +166,9 @@ Finalization is separate from a model step. It operates on the result of the who
 
 ## Errors, retries, and aborts
 
-A provider API rejection can reach `processAPIError`. An error processor may change the request or messages and request another provider attempt. `processAPIError` retries and tripwire retries share the same `maxProcessorRetries` bound on the request. When error processors are configured and `maxProcessorRetries` is omitted, Mastra applies a default error-retry budget. Set `maxProcessorRetries` explicitly when you need a specific limit.
+A provider API rejection can reach `processAPIError`. An error processor may change the request or messages and request another provider attempt. `processAPIError` retries and tripwire retries share the same [`maxProcessorRetries`](/reference/agents/generate#parameters) bound on the request. When error processors are configured and `maxProcessorRetries` is omitted, Mastra applies a default error-retry budget. Set `maxProcessorRetries` explicitly when you need a specific limit.
 
-Calling `abort()` from an input or output processor raises a tripwire. Set `retry: true` to let an eligible input-step or output-step check replay the model step with feedback. `maxProcessorRetries` bounds replay attempts. A tripwire without a retry stops normal execution and is included in the result or stream.
+Calling [`abort()`](/reference/processors/processor-interface#aborting-and-tripwire-chunks) from an input or output processor raises a tripwire. Set `retry: true` to let an eligible input-step or output-step check replay the model step with feedback. `maxProcessorRetries` bounds replay attempts. A tripwire without a retry stops normal execution and is included in the result or stream.
 
 An external abort signal passes through provider calls and tool lifecycle work. When triggered, it stops further loop execution and terminates the stream while preserving the partial result where supported. Errors that no processor recovers propagate to the caller.
 
@@ -176,7 +176,7 @@ See [Processors](/docs/agents/processors#retry-mechanism) for retry configuratio
 
 ## Regular and durable runs
 
-A regular `Agent` run keeps the loop in the current process. If that process ends, the in-memory execution ends with it.
+A regular [`Agent`](/reference/agents/agent) run keeps the loop in the current process. If that process ends, the in-memory execution ends with it.
 
 A [durable agent](/docs/harness/durable-agents) wraps the same agent loop in a workflow. It persists run state and publishes events through PubSub so supported runtimes can recover work and clients can reconnect. Persistent production backends are required when that state and event history must survive process restarts.
 

--- a/docs/src/content/en/docs/guides/agent-lifecycle.mdx
+++ b/docs/src/content/en/docs/guides/agent-lifecycle.mdx
@@ -160,13 +160,13 @@ These checks work together rather than forming a public, exhaustive internal ord
 
 ## Finalization
 
-A stop moves the run into finalization. `processOutputResult` runs once per request on the final assistant message, whether the run completes normally or the provider throws. Configured output processors run first, then auto-attached memory output processors run after them so message history can persist the final form. Observational Memory manages its own persistence during its `processOutputStep` instead. When finalization completes, `generate()` resolves or the stream closes.
+A stop moves the run into finalization. `processOutputResult` runs once per request on the final assistant message, whether the run completes normally or the provider throws. Configured output processors run first, then auto-attached memory output processors run after them so message history can persist the final form. Observational Memory persists on its own hooks instead of relying on that auto-attached memory output processor. When finalization completes, `generate()` resolves or the stream closes.
 
 Finalization is separate from a model step. It operates on the result of the whole run rather than the response from one provider call.
 
 ## Errors, retries, and aborts
 
-A provider API rejection can reach `processAPIError`. An error processor may change the request or messages and request another provider attempt. `processAPIError` retries and tripwire retries share the same `maxProcessorRetries` bound on the request. When error processors are configured and `maxProcessorRetries` is omitted, Mastra applies a default budget. Set `maxProcessorRetries` explicitly when you need a specific limit.
+A provider API rejection can reach `processAPIError`. An error processor may change the request or messages and request another provider attempt. `processAPIError` retries and tripwire retries share the same `maxProcessorRetries` bound on the request. When error processors are configured and `maxProcessorRetries` is omitted, Mastra applies a default error-retry budget. Set `maxProcessorRetries` explicitly when you need a specific limit.
 
 Calling `abort()` from an input or output processor raises a tripwire. Set `retry: true` to let an eligible input-step or output-step check replay the model step with feedback. `maxProcessorRetries` bounds replay attempts. A tripwire without a retry stops normal execution and is included in the result or stream.
 
@@ -184,7 +184,7 @@ Durable execution also lets a run suspend, such as while a tool waits for approv
 
 Mastra snapshots serializable `RequestContext` entries for durable work. Functions, class instances, open connections, and similar non-serializable values shouldn't be expected to survive either suspension or transport into another process. Reconstruct them from stable identifiers at a trusted request or resume boundary.
 
-Resuming from a stored snapshot can skip initial `processInput` processing, while signal and schedule wakes run it again.
+Initial `processInput` processing is skipped when a durable run resumes from a stored snapshot. Wakes that start a fresh segment, including signal and schedule wakes, run it again.
 
 - Repeat the authoritative enrichment step whenever an external request resumes a run.
 - Store only the serializable scope you need downstream.

--- a/docs/src/content/en/docs/guides/agent-lifecycle.mdx
+++ b/docs/src/content/en/docs/guides/agent-lifecycle.mdx
@@ -1,15 +1,17 @@
 ---
 title: "Agent lifecycle"
-description: "Understand agent execution order, processor callback timing, and when RequestContext changes become visible to dynamic configuration, tools, and the agent loop."
+description: "Follow an agent run from initial preparation to final response, including processor timing and how RequestContext values flow through each phase."
 packages:
   - "@mastra/core"
 ---
 
 # Agent lifecycle
 
-An agent run starts before the first model call. Initial setup covers request context validation and dynamic configuration. Mastra prepares the input and tools before entering the model loop. Finalization begins after the loop stops.
+The agent lifecycle describes what happens during an agent run. A run begins when you call `generate()` or `stream()` and ends after Mastra produces the final result. Mastra prepares the agent before calling the model. If the model requests a tool, Mastra runs it and may call the model again. This repeats until the run is complete.
 
-If validation, dynamic models, instructions, tools, skills, processor factories, or workspace configuration need a value, establish it in server middleware or immediately before calling `agent.generate()` or `agent.stream()`. Don't rely on `processInput` as universal setup middleware: some preparation has already completed, while regular tool preparation can run in parallel with it.
+Preparation, the model loop, and finalization form the three main phases described here. [Processor callbacks](/docs/agents/processors) can inspect or change the run within each phase. The timing also determines which parts of the run can use values from [`RequestContext`](/docs/server/request-context).
+
+Use this lifecycle as a mental model when you customize or debug an agent. The overview below shows the complete run before the following sections examine each phase in detail.
 
 ## Lifecycle overview
 
@@ -27,7 +29,7 @@ flowchart LR
   tools --> model
 ```
 
-The diagram shows stable conceptual phases rather than internal workflow steps. Some preparation is concurrent, and durable execution places work across persistence boundaries differently from a regular in-process run.
+The diagram shows the main phases, not internal workflow steps. Mastra may prepare tools while it prepares the input and memory. Durable runs can save and restore their state. Regular runs continue in the current process.
 
 ## Before the loop
 

--- a/docs/src/content/en/docs/guides/agent-lifecycle.mdx
+++ b/docs/src/content/en/docs/guides/agent-lifecycle.mdx
@@ -138,7 +138,7 @@ Processor methods don't all modify the same representation:
 - `processLLMRequest` changes only the prompt sent for that provider call. Use it for temporary provider-facing changes that shouldn't alter stored conversation history.
 - `processOutputStream` changes streamed chunks. Processor state can carry data across chunks and later output callbacks for the same request.
 - `processToolResult` runs before a raw tool result enters the message list, allowing validation or redaction before later model steps or persistence.
-- `processOutputResult` can change the final returned messages or metadata during finalization.
+- [`processOutputResult`](/reference/processors/processor-interface#processoutputresult) can change returned messages or metadata during finalization.
 
 ## How the loop decides to continue
 
@@ -156,7 +156,9 @@ These checks work together rather than forming a public, exhaustive internal ord
 
 ## Finalization
 
-A stop moves the run into finalization. `processOutputResult` runs once per request on the final assistant message, whether the run completes normally or the provider throws. Configured output processors run first, then auto-attached memory output processors run after them so message history can persist the final form. Observational Memory persists on its own hooks instead of relying on that auto-attached memory output processor. When finalization completes, `generate()` resolves or the stream closes.
+A stop moves the run into finalization. `processOutputResult` runs once per request on the completed result and messages, whether the run completes normally or the provider throws. Those messages may not include a final assistant response, such as when `maxSteps` ends on a tool call.
+
+Configured output processors run first, then auto-attached memory output processors run after them so message history can persist the final form. Observational Memory persists on its own hooks instead of relying on that auto-attached memory output processor. When finalization completes, `generate()` resolves or the stream closes.
 
 Finalization is separate from a model step. It operates on the result of the whole run rather than the response from one provider call.
 

--- a/docs/src/content/en/docs/guides/agent-lifecycle.mdx
+++ b/docs/src/content/en/docs/guides/agent-lifecycle.mdx
@@ -19,7 +19,7 @@ Work happens at three levels:
 - **Loop iteration**: One pass through the agent loop. It starts with a model step. Requested tool work follows before Mastra decides whether to continue.
 - **Model step**: One request to the model provider and the response it produces. Input and output processors run around this request.
 
-A run contains one or more loop iterations. If the model returns a final answer, the run can stop after the current iteration. If the model requests a tool, Mastra processes the tool result and can begin another iteration so the model can use it.
+A run contains one or more loop iterations. It stops after the current iteration when the model returns a final answer, or processes the requested tool result and begins another iteration when the model requests a tool. An iteration commonly coincides with one model step, but treat that pairing as implementation behavior rather than a stable contract.
 
 ## Lifecycle overview
 
@@ -118,7 +118,7 @@ The [Processor interface](/reference/processors/processor-interface) documents c
 
 | Callback or operation | Frequency | Position and visibility |
 | - | - | - |
-| `processInput` | Once per initial request | During input preparation before the loop. Durable resume may skip it. |
+| `processInput` | Once per initial request | During input preparation before the loop. Resuming from a durable snapshot may skip it. |
 | `processInputStep` | Once per model step | Before the provider request. It sees messages and tool results accumulated so far. |
 | `processLLMRequest` | Once per provider call | Last processor stage for rewriting the provider-facing prompt. Its prompt changes aren't written back to the message list. |
 | `processOutputStream` | Per streamed chunk | Runs while model output arrives. Data chunks are included when the processor opts in. |
@@ -160,13 +160,13 @@ These checks work together rather than forming a public, exhaustive internal ord
 
 ## Finalization
 
-A normal stop moves the run into finalization. `processOutputResult` runs once on the completed result. During the same finalization pass, memory output processors run last so they can persist the final form. When finalization completes, `generate()` resolves or the stream closes.
+A stop moves the run into finalization. `processOutputResult` runs once per request on the final assistant message, whether the run completes normally or the provider throws. Configured output processors run first, then auto-attached memory output processors run after them so message history can persist the final form. Observational Memory manages its own persistence during its `processOutputStep` instead. When finalization completes, `generate()` resolves or the stream closes.
 
 Finalization is separate from a model step. It operates on the result of the whole run rather than the response from one provider call.
 
 ## Errors, retries, and aborts
 
-A provider API rejection can reach `processAPIError`. An error processor may change the request or messages and request another provider attempt. Error-processor retries have their own default budget. Set `maxProcessorRetries` explicitly when you need a specific limit.
+A provider API rejection can reach `processAPIError`. An error processor may change the request or messages and request another provider attempt. `processAPIError` retries and tripwire retries share the same `maxProcessorRetries` bound on the request. When error processors are configured and `maxProcessorRetries` is omitted, Mastra applies a default budget. Set `maxProcessorRetries` explicitly when you need a specific limit.
 
 Calling `abort()` from an input or output processor raises a tripwire. Set `retry: true` to let an eligible input-step or output-step check replay the model step with feedback. `maxProcessorRetries` bounds replay attempts. A tripwire without a retry stops normal execution and is included in the result or stream.
 
@@ -184,7 +184,11 @@ Durable execution also lets a run suspend, such as while a tool waits for approv
 
 Mastra snapshots serializable `RequestContext` entries for durable work. Functions, class instances, open connections, and similar non-serializable values shouldn't be expected to survive either suspension or transport into another process. Reconstruct them from stable identifiers at a trusted request or resume boundary.
 
-Initial `processInput` processing may be skipped when a durable run resumes because the conversation state already exists in the durable snapshot. Don't depend on a one-time `processInput` side effect running again. For authorization and tool scoping, repeat the authoritative enrichment step whenever an external request resumes a run and store only the serializable scope needed downstream.
+Resuming from a stored snapshot can skip initial `processInput` processing, while signal and schedule wakes run it again.
+
+- Repeat the authoritative enrichment step whenever an external request resumes a run.
+- Store only the serializable scope you need downstream.
+- Don't rely on a one-time `processInput` side effect.
 
 ## What to read next
 

--- a/docs/src/content/en/docs/guides/agent-lifecycle.mdx
+++ b/docs/src/content/en/docs/guides/agent-lifecycle.mdx
@@ -1,0 +1,205 @@
+---
+title: "Agent lifecycle"
+description: "Understand agent execution order, processor callback timing, and when RequestContext changes become visible to dynamic configuration, tools, and the agent loop."
+packages:
+  - "@mastra/core"
+---
+
+# Agent lifecycle
+
+An agent run starts before the first model call. Initial setup covers request context validation and dynamic configuration. Mastra prepares the input and tools before entering the model loop. Finalization begins after the loop stops.
+
+If validation, dynamic models, instructions, tools, skills, processor factories, or workspace configuration need a value, establish it in server middleware or immediately before calling `agent.generate()` or `agent.stream()`. Don't rely on `processInput` as universal setup middleware: some preparation has already completed, while regular tool preparation can run in parallel with it.
+
+## Lifecycle overview
+
+```mermaid
+flowchart LR
+  accTitle: Lifecycle of a Mastra agent run
+  accDescr: A caller supplies request context, Mastra validates and prepares the run, then repeats model and tool work until a stop condition is reached before finalizing the response.
+  caller((agent call)) --> setup([validate and resolve<br/>dynamic setup])
+  setup --> prepare([prepare tools,<br/>memory, and input])
+  prepare --> model([run model step])
+  model --> decision{continue?}
+  decision -->|tool call| tools([run tools and<br/>process results])
+  tools --> model
+  decision -->|stop| final([final processors<br/>and persistence])
+  final --> response((response))
+```
+
+The diagram shows stable conceptual phases rather than internal workflow steps. Some preparation is concurrent, and durable execution places work across persistence boundaries differently from a regular in-process run.
+
+## Before the loop
+
+`generate()` and `stream()` first validate the supplied `RequestContext` against the agent's `requestContextSchema`. Validation happens before dynamic default options, so a default-options callback can't add a missing required value in time.
+
+Mastra then reuses the caller's `RequestContext` instance throughout the run. Dynamic configuration, processors, and tool execution receive that live instance rather than independent per-callback copies. A mutation can therefore be visible later in the same run, subject to when each consumer resolves.
+
+Preparation doesn't have one strictly linear order:
+
+| Work | Timing | What this means for `RequestContext` |
+| - | - | - |
+| Validation, workspace, model, and instructions | Before `processInput` | Required values must already exist at the call boundary. |
+| Memory-, workspace-, and skills-derived processor instances used for `processInput` | Resolved before `processInput` | Mutating context inside `processInput` can't change how these instances were selected. |
+| Dynamic skill resolution | Before `processInput` | Skill selection can't depend on a value first added by `processInput`. |
+| Tool conversion in a regular run | In parallel with memory and input preparation | A dynamic `tools` callback has no guaranteed ordering relative to `processInput`. |
+| `processInput` | Once during initial input preparation | It can transform messages and establish state for later loop callbacks and tool execution. |
+| Effective input, LLM-request, and error processor factories used by the loop | After the regular preparation branches join | These factories can observe earlier context mutations, but this doesn't make `processInput` a safe setup point for every resolver. |
+| Durable preparation | Before durable loop execution | The placement differs from the regular path, and resumed work may skip initial input processing. |
+
+This ordering is why caller-side or middleware enrichment is the reliable choice for authorization, tenant scope, feature flags, and other values that must be visible everywhere.
+
+## Populate RequestContext at the correct boundary
+
+Perform authoritative backend checks before the agent call, then put the resulting scope in a new `RequestContext` for that request. Both the dynamic tool resolver and the selected tool can read it:
+
+```typescript title="src/mastra/run-support-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { RequestContext } from '@mastra/core/request-context'
+import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+import { accounts, authorization } from './services'
+
+const toolScopeSchema = z.object({
+  tenantId: z.string(),
+  accountIds: z.array(z.string()),
+})
+
+const requestContextSchema = z.object({
+  toolScope: toolScopeSchema,
+})
+
+type SupportRequestContext = z.infer<typeof requestContextSchema>
+
+const listAccounts = createTool({
+  id: 'list-accounts',
+  description: 'List accounts available to the current user',
+  inputSchema: z.object({}),
+  outputSchema: z.array(z.object({ id: z.string(), name: z.string() })),
+  requestContextSchema,
+  execute: async (_, { requestContext }) => {
+    const scope = requestContext?.get('toolScope')
+
+    if (!scope) throw new Error('Tool scope is missing')
+
+    return accounts.list({
+      tenantId: scope.tenantId,
+      accountIds: scope.accountIds,
+    })
+  },
+})
+
+const supportAgent = new Agent({
+  id: 'support-agent',
+  name: 'Support Agent',
+  instructions: 'Help users with the accounts available to them.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  requestContextSchema,
+  tools: ({ requestContext }) => {
+    const scope = requestContext.get('toolScope')
+    return scope.accountIds.length > 0 ? { listAccounts } : {}
+  },
+})
+
+export async function runSupportAgent(userId: string, question: string) {
+  const toolScope = await authorization.getToolScope(userId)
+  const requestContext = new RequestContext<SupportRequestContext>()
+  requestContext.set('toolScope', toolScope)
+
+  return supportAgent.stream(question, { requestContext })
+}
+```
+
+Create one context per independent request unless you intentionally want to share its values. See [Request context](/docs/server/request-context) for server middleware, schemas, and reserved identity values.
+
+`processInput` may still mutate the same live context for later processor hooks or tool execution. Use that for loop-downstream state, not for values required by initial validation, skills, already-resolved processor instances, or dynamic tools whose regular preparation may be running concurrently.
+
+`RequestContext` is runtime data. The model doesn't see its values unless instructions, messages, a processor, or a tool explicitly puts them into model-visible content.
+
+## Inside each model step
+
+Each model step follows this public callback sequence:
+
+1. `processInputStep` receives the accumulated message list before the next model call.
+1. `processLLMRequest` receives the provider-facing prompt after message conversion.
+1. The provider streams its response, and `processOutputStream` can inspect or transform each chunk.
+1. `processLLMResponse` runs after the provider stream for that step completes.
+1. `processOutputStep` runs after the model step, before locally executed tools.
+1. If the model requested local or client tools, Mastra processes their input and handles any configured approval. It then executes the tool or waits for its result.
+1. `processToolResult` receives each local or client tool result before the raw result is persisted to the message list.
+
+A provider-executed tool can return its result differently. If a deferred provider result arrives during a later model stream, `processToolResult` runs inline when that result arrives rather than at one universal post-step position.
+
+See the [Processor interface](/reference/processors/processor-interface) for callback arguments and return types.
+
+### Callback timing
+
+| Callback or operation | Frequency | Position and visibility |
+| - | - | - |
+| `processInput` | Once per initial request | During input preparation before the loop. Durable resume may skip it. |
+| `processInputStep` | Once per model step | Before the provider request. It sees messages and tool results accumulated so far. |
+| `processLLMRequest` | Once per provider call | Last processor stage for rewriting the provider-facing prompt. Its prompt changes aren't written back to the message list. |
+| `processOutputStream` | Per streamed chunk | Runs while model output arrives. Data chunks are included when the processor opts in. |
+| `processLLMResponse` | Once per completed provider stream | Receives the completed response for the current model step. |
+| `processOutputStep` | Once per model step | Runs after the model response and before locally executed tools. |
+| Tool `onInputStart` | When streamed tool input begins | Runs before complete tool arguments are available. |
+| Tool `onInputDelta` | Per streamed tool-input chunk | Observes incremental tool arguments. |
+| Tool `onInputAvailable` | Once when tool input is complete | Runs after arguments are parsed and validated, before execution. |
+| Tool execution | Once per local tool call | Receives the live `RequestContext`. Approval or suspension can delay execution. |
+| Tool `onOutput` | Once after successful local execution | Receives the tool output. |
+| `processToolResult` | Per local/client result, or when a deferred provider result arrives | Can inspect, redact, or abort before a raw tool result is persisted. |
+| `processAPIError` | On eligible provider API errors | Can update request state and request another provider attempt. |
+| `onIterationComplete` | Once after each completed loop iteration | Observes the iteration result and can influence whether execution continues. |
+| `processOutputResult` | Once at finalization | Post-processes the completed agent result before it's returned. |
+
+### Understand what persists
+
+Processor methods don't all modify the same representation:
+
+- `processInput` and `processInputStep` work with the live message list. Their changes can affect later model steps and may be saved by memory processors.
+- `processLLMRequest` changes only the prompt sent for that provider call. Use it for transient provider-facing changes that shouldn't alter stored conversation history.
+- `processOutputStream` changes streamed chunks. Processor state can carry data across chunks and later output callbacks for the same request.
+- `processToolResult` runs before a raw tool result enters the message list, allowing validation or redaction before later model steps or persistence.
+- `processOutputResult` can change the final returned messages or metadata during finalization.
+
+## Continue or stop
+
+After a model step and any requested tool work, Mastra decides whether another model step is needed. The loop can continue when tool results need to be sent back to the model or when an iteration hook explicitly requests more work.
+
+Execution stops when a configured condition is met. These conditions can include:
+
+- A final model response that doesn't request another tool.
+- A custom `stopWhen` condition evaluated against accumulated steps.
+- The `maxSteps` limit.
+- Task-completion, goal, or delegation outcomes.
+- A terminal provider finish reason, error, processor tripwire, or abort.
+
+These checks cooperate rather than forming a public, exhaustive internal order. Treat `maxSteps` as a bound on model steps and use `stopWhen` for application-specific completion rules.
+
+When the loop stops normally, final output processing runs once, memory and other completion side effects run as configured, and `generate()` resolves or the stream closes with the final result.
+
+## Errors, retries, and aborts
+
+Provider API rejections can reach `processAPIError`. An error processor may adjust the request or messages and request a retry. Error-processor retries have their own default budget. Set `maxProcessorRetries` explicitly when you need a specific limit.
+
+Calling `abort()` from an input or output processor raises a tripwire. Set `retry: true` to let an eligible input-step or output-step check replay the model step with feedback. `maxProcessorRetries` bounds replay attempts. A tripwire without a retry stops normal execution and is exposed in the result or stream.
+
+An external abort signal is passed through provider calls and tool lifecycle work. Aborting stops further loop execution and emits the appropriate stream termination. Mastra preserves the partial result where supported. Errors that aren't recovered by a processor propagate to the caller.
+
+See [Processors](/docs/agents/processors#retry-mechanism) for retry configuration, tripwires, and API error handling.
+
+## Durable suspend and resume
+
+Durable execution crosses serialization boundaries. Mastra snapshots serializable `RequestContext` entries for durable work, so functions, class instances, open connections, and other non-serializable values shouldn't be expected to survive a suspension, process restart, or cross-process transport.
+
+Reconstruct those values from stable identifiers at a trusted request or resume boundary. Initial `processInput` processing may be skipped when a durable run resumes because the conversation state already lives in the durable snapshot. Don't depend on a one-time `processInput` side effect being replayed.
+
+For authorization and tool scoping, repeat the authoritative enrichment step whenever an external request resumes a run, and store only the serializable scope needed by downstream components. See [Durable agents](/docs/harness/durable-agents) for persistence and recovery behavior.
+
+## Related documentation
+
+- [Request context](/docs/server/request-context): Define, validate, and populate runtime context.
+- [Processors](/docs/agents/processors): Configure processors, retries, and tripwires.
+- [Processor interface](/reference/processors/processor-interface): Review callback arguments and return values.
+- [Tools](/docs/agents/tools): Configure tool execution, approval, and lifecycle hooks.
+- [Durable agents](/docs/harness/durable-agents): Persist and resume long-running agent execution.

--- a/docs/src/content/en/docs/guides/agent-lifecycle.mdx
+++ b/docs/src/content/en/docs/guides/agent-lifecycle.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent lifecycle"
-description: "Follow an agent run from preparation through the model loop and finalization, including processor timing and durable resume behavior."
+description: "Follow an agent run from input preparation through repeated model and tool calls to the final result, for both regular and durable execution."
 packages:
   - "@mastra/core"
 ---

--- a/docs/src/content/en/docs/guides/agent-lifecycle.mdx
+++ b/docs/src/content/en/docs/guides/agent-lifecycle.mdx
@@ -15,9 +15,14 @@ This guide breaks that work into preparation, loop execution, and finalization. 
 
 Work happens at three levels:
 
-- **Run**: One call to `generate()` or `stream()` and the work it starts. A run ends with a result or error, or it can suspend and resume when durable execution waits for external input.
-- **Loop iteration**: One pass through the agent loop. It starts with a model step. Requested tool work follows before Mastra decides whether to continue.
-- **Model step**: One request to the model provider and the response it produces. Input and output processors run around this request.
+- **Run**: All work started by one call to `generate()` or `stream()` through the final result or error, including any pause and resume while durable execution waits for external input.
+- **Loop iteration**: One pass through the agent loop, beginning with a model step and including any requested tool work before Mastra decides whether to continue.
+- **Model step**: One request to the model provider and its response, together with the input and output processors that run around that request.
+
+Preparation depends on runtime context and initial input processing:
+
+- [`RequestContext`](/docs/server/request-context) carries trusted runtime data, such as identity or tenant information, to dynamic configuration, processors, and tools, but its values aren't automatically included in the model prompt.
+- [`processInput`](/reference/processors/processor-interface#processinput) handles the initial messages before the loop begins, where it can transform those messages and establish state that later processor hooks and tools use.
 
 A run contains one or more loop iterations. It stops after the current iteration when the model returns a final answer, or processes the requested tool result and begins another iteration when the model requests a tool. An iteration commonly coincides with one model step, but treat that pairing as implementation behavior rather than a stable contract.
 
@@ -26,18 +31,14 @@ A run contains one or more loop iterations. It stops after the current iteration
 ```mermaid
 flowchart LR
   accTitle: Lifecycle of a Mastra agent run
-  accDescr: Mastra prepares an agent run, repeats model and tool work while needed, then finalizes and returns the result.
-  caller((agent call)) --> setup([validate context<br/>resolve setup])
-  setup --> prepare([prepare tools,<br/>memory and input])
-  prepare --> model([run model step])
-  model --> decision{continue?}
-  decision -->|stop| final([final processors<br/>and persistence])
-  final --> response((response))
-  decision -->|tool call| tools([run tools and<br/>process results])
-  tools --> model
+  accDescr: An agent run moves from preparation into a model and tool loop, then finalizes and returns the result.
+  caller((agent call)) --> prepare([prepare agent<br/>and input])
+  prepare --> loop([run model<br/>and tools])
+  loop --> final([finalize result])
+  final --> response((result))
 ```
 
-The diagram shows the public mental model, not internal workflow steps. Validation and dynamic setup are part of preparation, and tool preparation can overlap input and memory preparation. A regular run keeps working in the current process. A durable run can save its state and restore it later.
+The diagram shows the three main phases rather than internal workflow steps. Preparation creates the first model interaction. The loop may repeat model and tool work several times before finalization produces the result. A regular run keeps working in the current process, while a durable run can save its state and restore it later.
 
 ## Preparation
 

--- a/docs/src/content/en/docs/guides/agent-lifecycle.mdx
+++ b/docs/src/content/en/docs/guides/agent-lifecycle.mdx
@@ -24,7 +24,7 @@ Preparation depends on runtime context and initial input processing:
 - [`RequestContext`](/docs/server/request-context) carries trusted runtime data, such as identity or tenant information, to dynamic configuration, processors, and tools, but its values aren't automatically included in the model prompt.
 - [`processInput`](/reference/processors/processor-interface#processinput) handles the initial messages before the loop begins, where it can transform those messages and establish state that later processor hooks and tools use.
 
-A run contains one or more loop iterations. It stops after the current iteration when the model returns a final answer, or processes the requested tool result and begins another iteration when the model requests a tool. An iteration commonly coincides with one model step, but treat that pairing as implementation behavior rather than a stable contract.
+A run contains one or more loop iterations. It stops after the current iteration when the model returns a final answer. When the model requests a tool, Mastra processes the result and may begin another iteration unless a configured [`stopWhen`](/reference/agents/generate#parameters) or terminal condition ends the run after tool work. An iteration commonly coincides with one model step, but treat that pairing as implementation behavior rather than a stable contract.
 
 ## Lifecycle overview
 

--- a/docs/src/content/en/docs/guides/agent-lifecycle.mdx
+++ b/docs/src/content/en/docs/guides/agent-lifecycle.mdx
@@ -113,27 +113,7 @@ Processor callbacks run in this public sequence:
 
 Provider-executed tools can return results differently. If a deferred provider result arrives during a later model stream, `processToolResult` runs when that result arrives. It doesn't have one universal position after every model step.
 
-The [Processor interface](/reference/processors/processor-interface) documents callback arguments and return types.
-
-### Callback timing
-
-| Callback or operation | Frequency | Position and visibility |
-| - | - | - |
-| `processInput` | Once per initial request | During input preparation before the loop. Resuming from a durable snapshot may skip it. |
-| `processInputStep` | Once per model step | Before the provider request. It sees messages and tool results accumulated so far. |
-| `processLLMRequest` | Once per provider call | Last processor stage for rewriting the provider-facing prompt. Its prompt changes aren't written back to the message list. |
-| `processOutputStream` | Per streamed chunk | Runs while model output arrives. Data chunks are included when the processor opts in. |
-| `processLLMResponse` | Once per completed provider stream | Receives the completed response for the current model step. |
-| `processOutputStep` | Once per model step | Runs after the model response and before locally executed tools. |
-| Tool [`onInputStart`](/reference/tools/create-tool#oninputstart) | When streamed tool input begins | Runs before complete tool arguments are available. |
-| Tool [`onInputDelta`](/reference/tools/create-tool#oninputdelta) | Per streamed tool-input chunk | Observes incremental tool arguments. |
-| Tool [`onInputAvailable`](/reference/tools/create-tool#oninputavailable) | Once when tool input is complete | Runs after arguments are parsed and validated, before execution. |
-| Tool execution | Once per local tool call | Receives the live `RequestContext`. Approval or suspension can delay execution. |
-| Tool [`onOutput`](/reference/tools/create-tool#onoutput) | Once after successful local execution | Receives the tool output. |
-| `processToolResult` | Per local/client result, or when a deferred provider result arrives | Can inspect, redact, or abort before a raw tool result enters the message list. |
-| [`processAPIError`](/reference/processors/processor-interface#processapierror) | On eligible provider API errors | Can update request state and request another provider attempt. |
-| [`onIterationComplete`](/reference/agents/generate#parameters) | Once after each completed loop iteration | Observes the iteration result and can influence whether execution continues. |
-| [`processOutputResult`](/reference/processors/processor-interface#processoutputresult) | Once at finalization | Post-processes the completed agent result before it's returned. |
+For exact frequencies, visibility guarantees, arguments, and return types, see [callback timing in the Processor interface](/reference/processors/processor-interface#callback-timing).
 
 ### What changes persist
 

--- a/docs/src/content/en/docs/guides/agent-lifecycle.mdx
+++ b/docs/src/content/en/docs/guides/agent-lifecycle.mdx
@@ -17,14 +17,14 @@ If validation, dynamic models, instructions, tools, skills, processor factories,
 flowchart LR
   accTitle: Lifecycle of a Mastra agent run
   accDescr: A caller supplies request context, Mastra validates and prepares the run, then repeats model and tool work until a stop condition is reached before finalizing the response.
-  caller((agent call)) --> setup([validate and resolve<br/>dynamic setup])
-  setup --> prepare([prepare tools,<br/>memory, and input])
+  caller((agent call)) --> setup([validate context<br/>resolve setup])
+  setup --> prepare([prepare tools,<br/>memory and input])
   prepare --> model([run model step])
   model --> decision{continue?}
-  decision -->|tool call| tools([run tools and<br/>process results])
-  tools --> model
   decision -->|stop| final([final processors<br/>and persistence])
   final --> response((response))
+  decision -->|tool call| tools([run tools and<br/>process results])
+  tools --> model
 ```
 
 The diagram shows stable conceptual phases rather than internal workflow steps. Some preparation is concurrent, and durable execution places work across persistence boundaries differently from a regular in-process run.
@@ -78,7 +78,7 @@ const listAccounts = createTool({
   outputSchema: z.array(z.object({ id: z.string(), name: z.string() })),
   requestContextSchema,
   execute: async (_, { requestContext }) => {
-    const scope = requestContext?.get('toolScope')
+    const scope = requestContext.get('toolScope')
 
     if (!scope) throw new Error('Tool scope is missing')
 

--- a/docs/src/content/en/docs/guides/agent-lifecycle.mdx
+++ b/docs/src/content/en/docs/guides/agent-lifecycle.mdx
@@ -49,72 +49,35 @@ Preparation doesn't have one strictly linear order:
 
 This ordering is why caller-side or middleware enrichment is the reliable choice for authorization, tenant scope, feature flags, and other values that must be visible everywhere.
 
-## Populate RequestContext at the correct boundary
+## Choose the `RequestContext` boundary
 
-Perform authoritative backend checks before the agent call, then put the resulting scope in a new `RequestContext` for that request. Both the dynamic tool resolver and the selected tool can read it:
+A context value can only affect work that hasn't happened yet. Set each value at the earliest trusted boundary that needs it.
 
-```typescript title="src/mastra/run-support-agent.ts"
-import { Agent } from '@mastra/core/agent'
-import { RequestContext } from '@mastra/core/request-context'
-import { createTool } from '@mastra/core/tools'
-import { z } from 'zod'
-import { accounts, authorization } from './services'
+For example, an application may check a user's access and derive a tenant or account scope. Perform that check outside the agent, store the result in a new `RequestContext`, then pass the context to `generate()` or `stream()`. Dynamic configuration and tools can read the same trusted scope without performing the check again.
 
-const toolScopeSchema = z.object({
-  tenantId: z.string(),
-  accountIds: z.array(z.string()),
-})
-
-const requestContextSchema = z.object({
-  toolScope: toolScopeSchema,
-})
-
-type SupportRequestContext = z.infer<typeof requestContextSchema>
-
-const listAccounts = createTool({
-  id: 'list-accounts',
-  description: 'List accounts available to the current user',
-  inputSchema: z.object({}),
-  outputSchema: z.array(z.object({ id: z.string(), name: z.string() })),
-  requestContextSchema,
-  execute: async (_, { requestContext }) => {
-    const scope = requestContext.get('toolScope')
-
-    if (!scope) throw new Error('Tool scope is missing')
-
-    return accounts.list({
-      tenantId: scope.tenantId,
-      accountIds: scope.accountIds,
-    })
-  },
-})
-
-const supportAgent = new Agent({
-  id: 'support-agent',
-  name: 'Support Agent',
-  instructions: 'Help users with the accounts available to them.',
-  model: '__GATEWAY_OPENAI_MODEL__',
-  requestContextSchema,
-  tools: ({ requestContext }) => {
-    const scope = requestContext.get('toolScope')
-    return scope.accountIds.length > 0 ? { listAccounts } : {}
-  },
-})
-
-export async function runSupportAgent(userId: string, question: string) {
-  const toolScope = await authorization.getToolScope(userId)
-  const requestContext = new RequestContext<SupportRequestContext>()
-  requestContext.set('toolScope', toolScope)
-
-  return supportAgent.stream(question, { requestContext })
-}
+```mermaid
+flowchart LR
+  accTitle: Establish trusted context before an agent run
+  accDescr: An application checks access, derives a scope, and stores it in request context before the agent resolves dynamic setup and runs processors and tools.
+  request((request)) --> authorize([check access<br/>derive scope])
+  authorize --> context([populate<br/>request context])
+  context --> agent([start agent run])
+  agent --> setup([dynamic setup])
+  setup --> consumers([processors<br/>and tools])
 ```
 
-Create one context per independent request unless you intentionally want to share its values. See [Request context](/docs/server/request-context) for server middleware, schemas, and reserved identity values.
+The context carries the result of the authorization check. It doesn't replace authorization at the application boundary.
 
-`processInput` may still mutate the same live context for later processor hooks or tool execution. Use that for loop-downstream state, not for values required by initial validation, skills, already-resolved processor instances, or dynamic tools whose regular preparation may be running concurrently.
+| The value must affect | Establish it | Why |
+| - | - | - |
+| Validation, model, instructions, skills, workspace, input processors used by `processInput`, or dynamic tools | Before `generate()` or `stream()`, usually in server middleware or caller code | These consumers resolve before or concurrently with `processInput`. |
+| Later loop processor factories, processor hooks, or tool execution | Before `generate()` or `stream()` when practical, or in `processInput` | These consumers receive the same live context after input processing. |
+| Resumed durable work | At the trusted request or resume boundary | Initial input processors may not run again, and non-serializable values must be reconstructed. |
+| Model reasoning | In model-visible instructions or messages | `RequestContext` is runtime data and isn't automatically added to the prompt. |
 
-`RequestContext` is runtime data. The model doesn't see its values unless instructions, messages, a processor, or a tool explicitly puts them into model-visible content.
+Create one context per independent request unless you intentionally want to share its values. See [Request context](/docs/server/request-context) for schema and middleware guidance, including reserved identity values.
+
+`processInput` remains useful for message transformation and loop-downstream state. A mutation there can reach later processor hooks and tool execution. It can't change initial validation or completed skill and input-processor resolution, and dynamic tool preparation may already be running.
 
 ## Inside each model step
 

--- a/docs/src/content/en/docs/guides/agent-lifecycle.mdx
+++ b/docs/src/content/en/docs/guides/agent-lifecycle.mdx
@@ -138,7 +138,7 @@ Processor methods don't all modify the same representation:
 - `processLLMRequest` changes only the prompt sent for that provider call. Use it for temporary provider-facing changes that shouldn't alter stored conversation history.
 - `processOutputStream` changes streamed chunks. Processor state can carry data across chunks and later output callbacks for the same request.
 - `processToolResult` runs before a raw tool result enters the message list, allowing validation or redaction before later model steps or persistence.
-- [`processOutputResult`](/reference/processors/processor-interface#processoutputresult) can change returned messages or metadata during finalization.
+- During finalization, [`processOutputResult`](/reference/processors/processor-interface#processoutputresult) can change returned messages and their message metadata.
 
 ## How the loop decides to continue
 

--- a/docs/src/content/en/docs/guides/agent-lifecycle.mdx
+++ b/docs/src/content/en/docs/guides/agent-lifecycle.mdx
@@ -97,7 +97,22 @@ Create one context per independent request unless you intentionally want to shar
 
 ## The agent loop
 
-The loop works with the messages accumulated so far. Each iteration gives those messages to the model. A final answer can end the loop. When the model requests a tool, Mastra runs it and adds the result to the conversation. The result can lead to another model step.
+The loop works with the messages accumulated so far.
+
+```mermaid
+flowchart LR
+  accTitle: Model and tool work inside the agent loop
+  accDescr: Mastra prepares the model input and processes the response. A final answer moves to finalization, while a tool call runs the tool, processes its result, and starts another iteration.
+  input([prepare<br/>model input]) --> model([call model])
+  model --> output([process<br/>model output])
+  output --> decision{tool call?}
+  decision -->|no| final([finalization])
+  decision -->|yes| tools([run tools])
+  tools --> results([process<br/>tool results])
+  results --> next([next iteration])
+```
+
+Tool results join the accumulated messages before another iteration, while a final answer leaves the loop for finalization.
 
 ### Around each model step
 

--- a/docs/src/content/en/docs/guides/agent-lifecycle.mdx
+++ b/docs/src/content/en/docs/guides/agent-lifecycle.mdx
@@ -1,24 +1,32 @@
 ---
 title: "Agent lifecycle"
-description: "Follow an agent run from initial preparation to final response, including processor timing and how RequestContext values flow through each phase."
+description: "Follow an agent run from preparation through the model loop and finalization, including processor timing and durable resume behavior."
 packages:
   - "@mastra/core"
 ---
 
 # Agent lifecycle
 
-The agent lifecycle describes what happens during an agent run. A run begins when you call `generate()` or `stream()` and ends after Mastra produces the final result. Mastra prepares the agent before calling the model. If the model requests a tool, Mastra runs it and may call the model again. This repeats until the run is complete.
+When you call `generate()` or `stream()`, Mastra starts an agent run. It prepares the agent and its input before calling the model. If the model requests a tool, Mastra runs it and may call the model again. When the work is complete, Mastra finalizes and returns the result.
 
-Preparation, the model loop, and finalization form the three main phases described here. [Processor callbacks](/docs/agents/processors) can inspect or change the run within each phase. The timing also determines which parts of the run can use values from [`RequestContext`](/docs/server/request-context).
+This guide breaks that work into preparation, loop execution, and finalization. It explains where [processors](/docs/agents/processors) run, what can cause another model call, and how regular and durable runs differ.
 
-Use this lifecycle as a mental model when you customize or debug an agent. The overview below shows the complete run before the following sections examine each phase in detail.
+## Runs, iterations, and model steps
+
+Work happens at three levels:
+
+- **Run**: One call to `generate()` or `stream()` and the work it starts. A run ends with a result or error, or it can suspend and resume when durable execution waits for external input.
+- **Loop iteration**: One pass through the agent loop. It starts with a model step. Requested tool work follows before Mastra decides whether to continue.
+- **Model step**: One request to the model provider and the response it produces. Input and output processors run around this request.
+
+A run contains one or more loop iterations. If the model returns a final answer, the run can stop after the current iteration. If the model requests a tool, Mastra processes the tool result and can begin another iteration so the model can use it.
 
 ## Lifecycle overview
 
 ```mermaid
 flowchart LR
   accTitle: Lifecycle of a Mastra agent run
-  accDescr: A caller supplies request context, Mastra validates and prepares the run, then repeats model and tool work until a stop condition is reached before finalizing the response.
+  accDescr: Mastra prepares an agent run, repeats model and tool work while needed, then finalizes and returns the result.
   caller((agent call)) --> setup([validate context<br/>resolve setup])
   setup --> prepare([prepare tools,<br/>memory and input])
   prepare --> model([run model step])
@@ -29,27 +37,32 @@ flowchart LR
   tools --> model
 ```
 
-The diagram shows the main phases, not internal workflow steps. Mastra may prepare tools while it prepares the input and memory. Durable runs can save and restore their state. Regular runs continue in the current process.
+The diagram shows the public mental model, not internal workflow steps. Validation and dynamic setup are part of preparation, and tool preparation can overlap input and memory preparation. A regular run keeps working in the current process. A durable run can save its state and restore it later.
 
-## Before the loop
+## Preparation
 
-`generate()` and `stream()` first validate the supplied `RequestContext` against the agent's `requestContextSchema`. Validation happens before dynamic default options, so a default-options callback can't add a missing required value in time.
+Preparation turns the agent definition and the current request into a runnable model interaction. During this phase, Mastra:
 
-Mastra then reuses the caller's `RequestContext` instance throughout the run. Dynamic configuration, processors, and tool execution receive that live instance rather than independent per-callback copies. A mutation can therefore be visible later in the same run, subject to when each consumer resolves.
+- Validates the supplied [`RequestContext`](/docs/server/request-context).
+- Resolves the model, instructions, workspace, skills, and other dynamic configuration.
+- Builds the message list from the current input and configured memory.
+- Prepares tools and the processors used during the loop.
 
-Preparation doesn't have one strictly linear order:
+By the end of preparation, the run has the messages, tools, and processor configuration needed for its first model step, although these tasks don't all happen in one strict sequence.
 
-| Work | Timing | What this means for `RequestContext` |
+| Preparation work | Timing | What this means for `RequestContext` |
 | - | - | - |
-| Validation, workspace, model, and instructions | Before `processInput` | Required values must already exist at the call boundary. |
-| Memory-, workspace-, and skills-derived processor instances used for `processInput` | Resolved before `processInput` | Mutating context inside `processInput` can't change how these instances were selected. |
+| Validation, workspace, model, and instructions | Before `processInput` | Required values must already exist when the run starts. |
+| Memory-, workspace-, and skills-derived processor instances used for `processInput` | Resolved before `processInput` | A context change inside `processInput` can't change how these instances were selected. |
 | Dynamic skill resolution | Before `processInput` | Skill selection can't depend on a value first added by `processInput`. |
 | Tool conversion in a regular run | In parallel with memory and input preparation | A dynamic `tools` callback has no guaranteed ordering relative to `processInput`. |
 | `processInput` | Once during initial input preparation | It can transform messages and establish state for later loop callbacks and tool execution. |
-| Effective input, LLM-request, and error processor factories used by the loop | After the regular preparation branches join | These factories can observe earlier context mutations, but this doesn't make `processInput` a safe setup point for every resolver. |
-| Durable preparation | Before durable loop execution | The placement differs from the regular path, and resumed work may skip initial input processing. |
+| Effective input, LLM-request, and error processor factories used by the loop | After the regular preparation branches join | These factories can observe earlier context changes, but `processInput` isn't a safe setup point for every resolver. |
+| Durable preparation | Before durable loop execution | Its placement differs from the regular path, and resumed work may skip initial input processing. |
 
-This ordering is why caller-side or middleware enrichment is the reliable choice for authorization, tenant scope, feature flags, and other values that must be visible everywhere.
+`generate()` and `stream()` validate `RequestContext` before resolving dynamic default options. A default-options callback therefore can't add a missing required value in time for validation.
+
+In a regular run, Mastra reuses the caller's `RequestContext` instance throughout execution. Dynamic configuration, processors, and tool execution receive that live instance rather than separate copies. Whether a change is visible depends on whether the consumer has already resolved.
 
 ## Choose the `RequestContext` boundary
 
@@ -77,13 +90,17 @@ The context carries the result of the authorization check. It doesn't replace au
 | Resumed durable work | At the trusted request or resume boundary | Initial input processors may not run again, and non-serializable values must be reconstructed. |
 | Model reasoning | In model-visible instructions or messages | `RequestContext` is runtime data and isn't automatically added to the prompt. |
 
-Create one context per independent request unless you intentionally want to share its values. See [Request context](/docs/server/request-context) for schema and middleware guidance, including reserved identity values.
+Create one context per independent request unless you intentionally want to share its values. The [Request context guide](/docs/server/request-context) explains schemas and server middleware.
 
-`processInput` remains useful for message transformation and loop-downstream state. A mutation there can reach later processor hooks and tool execution. It can't change initial validation or completed skill and input-processor resolution, and dynamic tool preparation may already be running.
+`processInput` remains useful for message transformation and state needed later in the loop. A change there can reach later processor hooks and tool execution. It can't change initial validation or completed skill and input-processor resolution, and dynamic tool preparation may already be running.
 
-## Inside each model step
+## The agent loop
 
-Each model step follows this public callback sequence:
+The loop works with the messages accumulated so far. Each iteration gives those messages to the model. A final answer can end the loop. When the model requests a tool, Mastra runs it and adds the result to the conversation. The result can lead to another model step.
+
+### Around each model step
+
+Processor callbacks run in this public sequence:
 
 1. `processInputStep` receives the accumulated message list before the next model call.
 1. `processLLMRequest` receives the provider-facing prompt after message conversion.
@@ -91,11 +108,11 @@ Each model step follows this public callback sequence:
 1. `processLLMResponse` runs after the provider stream for that step completes.
 1. `processOutputStep` runs after the model step, before locally executed tools.
 1. If the model requested local or client tools, Mastra processes their input and handles any configured approval. It then executes the tool or waits for its result.
-1. `processToolResult` receives each local or client tool result before the raw result is persisted to the message list.
+1. `processToolResult` receives each local or client tool result before the raw result enters the message list.
 
-A provider-executed tool can return its result differently. If a deferred provider result arrives during a later model stream, `processToolResult` runs inline when that result arrives rather than at one universal post-step position.
+Provider-executed tools can return results differently. If a deferred provider result arrives during a later model stream, `processToolResult` runs when that result arrives. It doesn't have one universal position after every model step.
 
-See the [Processor interface](/reference/processors/processor-interface) for callback arguments and return types.
+The [Processor interface](/reference/processors/processor-interface) documents callback arguments and return types.
 
 ### Callback timing
 
@@ -112,58 +129,67 @@ See the [Processor interface](/reference/processors/processor-interface) for cal
 | Tool `onInputAvailable` | Once when tool input is complete | Runs after arguments are parsed and validated, before execution. |
 | Tool execution | Once per local tool call | Receives the live `RequestContext`. Approval or suspension can delay execution. |
 | Tool `onOutput` | Once after successful local execution | Receives the tool output. |
-| `processToolResult` | Per local/client result, or when a deferred provider result arrives | Can inspect, redact, or abort before a raw tool result is persisted. |
+| `processToolResult` | Per local/client result, or when a deferred provider result arrives | Can inspect, redact, or abort before a raw tool result enters the message list. |
 | `processAPIError` | On eligible provider API errors | Can update request state and request another provider attempt. |
 | `onIterationComplete` | Once after each completed loop iteration | Observes the iteration result and can influence whether execution continues. |
 | `processOutputResult` | Once at finalization | Post-processes the completed agent result before it's returned. |
 
-### Understand what persists
+### What changes persist
 
 Processor methods don't all modify the same representation:
 
 - `processInput` and `processInputStep` work with the live message list. Their changes can affect later model steps and may be saved by memory processors.
-- `processLLMRequest` changes only the prompt sent for that provider call. Use it for transient provider-facing changes that shouldn't alter stored conversation history.
+- `processLLMRequest` changes only the prompt sent for that provider call. Use it for temporary provider-facing changes that shouldn't alter stored conversation history.
 - `processOutputStream` changes streamed chunks. Processor state can carry data across chunks and later output callbacks for the same request.
 - `processToolResult` runs before a raw tool result enters the message list, allowing validation or redaction before later model steps or persistence.
 - `processOutputResult` can change the final returned messages or metadata during finalization.
 
-## Continue or stop
+## How the loop decides to continue
 
-After a model step and any requested tool work, Mastra decides whether another model step is needed. The loop can continue when tool results need to be sent back to the model or when an iteration hook explicitly requests more work.
+After the model step and any requested tool work, Mastra decides whether the run needs another iteration. Tool results often cause another model call because the model must use those results to produce its next response.
 
-Execution stops when a configured condition is met. These conditions can include:
+The loop stops when a configured or terminal condition is reached. These conditions can include:
 
 - A final model response that doesn't request another tool.
 - A custom `stopWhen` condition evaluated against accumulated steps.
 - The `maxSteps` limit.
-- Task-completion, goal, or delegation outcomes.
+- Task-completion, goal, or [subagent](/docs/subagents) delegation outcomes.
 - A terminal provider finish reason, error, processor tripwire, or abort.
 
-These checks cooperate rather than forming a public, exhaustive internal order. Treat `maxSteps` as a bound on model steps and use `stopWhen` for application-specific completion rules.
+These checks work together rather than forming a public, exhaustive internal order. Treat `maxSteps` as a bound on model steps and use `stopWhen` for application-specific completion rules.
 
-When the loop stops normally, final output processing runs once, memory and other completion side effects run as configured, and `generate()` resolves or the stream closes with the final result.
+## Finalization
+
+A normal stop moves the run into finalization. `processOutputResult` runs once on the completed result. During the same finalization pass, memory output processors run last so they can persist the final form. When finalization completes, `generate()` resolves or the stream closes.
+
+Finalization is separate from a model step. It operates on the result of the whole run rather than the response from one provider call.
 
 ## Errors, retries, and aborts
 
-Provider API rejections can reach `processAPIError`. An error processor may adjust the request or messages and request a retry. Error-processor retries have their own default budget. Set `maxProcessorRetries` explicitly when you need a specific limit.
+A provider API rejection can reach `processAPIError`. An error processor may change the request or messages and request another provider attempt. Error-processor retries have their own default budget. Set `maxProcessorRetries` explicitly when you need a specific limit.
 
-Calling `abort()` from an input or output processor raises a tripwire. Set `retry: true` to let an eligible input-step or output-step check replay the model step with feedback. `maxProcessorRetries` bounds replay attempts. A tripwire without a retry stops normal execution and is exposed in the result or stream.
+Calling `abort()` from an input or output processor raises a tripwire. Set `retry: true` to let an eligible input-step or output-step check replay the model step with feedback. `maxProcessorRetries` bounds replay attempts. A tripwire without a retry stops normal execution and is included in the result or stream.
 
-An external abort signal is passed through provider calls and tool lifecycle work. Aborting stops further loop execution and emits the appropriate stream termination. Mastra preserves the partial result where supported. Errors that aren't recovered by a processor propagate to the caller.
+An external abort signal passes through provider calls and tool lifecycle work. When triggered, it stops further loop execution and terminates the stream while preserving the partial result where supported. Errors that no processor recovers propagate to the caller.
 
 See [Processors](/docs/agents/processors#retry-mechanism) for retry configuration, tripwires, and API error handling.
 
-## Durable suspend and resume
+## Regular and durable runs
 
-Durable execution crosses serialization boundaries. Mastra snapshots serializable `RequestContext` entries for durable work, so functions, class instances, open connections, and other non-serializable values shouldn't be expected to survive a suspension, process restart, or cross-process transport.
+A regular `Agent` run keeps the loop in the current process. If that process ends, the in-memory execution ends with it.
 
-Reconstruct those values from stable identifiers at a trusted request or resume boundary. Initial `processInput` processing may be skipped when a durable run resumes because the conversation state already lives in the durable snapshot. Don't depend on a one-time `processInput` side effect being replayed.
+A [durable agent](/docs/harness/durable-agents) wraps the same agent loop in a workflow. It persists run state and publishes events through PubSub so supported runtimes can recover work and clients can reconnect. Persistent production backends are required when that state and event history must survive process restarts.
 
-For authorization and tool scoping, repeat the authoritative enrichment step whenever an external request resumes a run, and store only the serializable scope needed by downstream components. See [Durable agents](/docs/harness/durable-agents) for persistence and recovery behavior.
+Durable execution also lets a run suspend, such as while a tool waits for approval, and resume later from stored state across serialization boundaries that don't exist in a regular in-process run.
 
-## Related documentation
+Mastra snapshots serializable `RequestContext` entries for durable work. Functions, class instances, open connections, and similar non-serializable values shouldn't be expected to survive either suspension or transport into another process. Reconstruct them from stable identifiers at a trusted request or resume boundary.
+
+Initial `processInput` processing may be skipped when a durable run resumes because the conversation state already exists in the durable snapshot. Don't depend on a one-time `processInput` side effect running again. For authorization and tool scoping, repeat the authoritative enrichment step whenever an external request resumes a run and store only the serializable scope needed downstream.
+
+## What to read next
 
 - [Request context](/docs/server/request-context): Define, validate, and populate runtime context.
+- [Authentication and identity](/docs/guides/authentication-identity): Keep trusted identity and authorization data outside model-controlled input.
 - [Processors](/docs/agents/processors): Configure processors, retries, and tripwires.
 - [Processor interface](/reference/processors/processor-interface): Review callback arguments and return values.
 - [Tools](/docs/agents/tools): Configure tool execution, approval, and lifecycle hooks.

--- a/docs/src/content/en/docs/server/request-context.mdx
+++ b/docs/src/content/en/docs/server/request-context.mdx
@@ -510,6 +510,7 @@ requestContextSchema: z.object({
 
 ## Related
 
+- [Agent lifecycle](/docs/guides/agent-lifecycle): Understand when context values become visible during an agent run
 - [Agent Request Context](/docs/memory/overview#switch-memory-per-request)
 - [Workflow Request Context](../workflows/overview#using-requestcontext)
 - [Server Middleware](/docs/server/middleware)

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -670,6 +670,14 @@ const sidebars = {
             },
             {
               type: 'doc',
+              id: 'guides/agent-lifecycle',
+              label: 'Agent lifecycle',
+              customProps: {
+                tags: ['new'],
+              },
+            },
+            {
+              type: 'doc',
               id: 'guides/authentication-identity',
               label: 'Authentication',
               customProps: {

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -11,89 +11,27 @@ The `Processor` interface defines the contract for all processors in Mastra. Pro
 
 ## When processor methods run
 
-Processor methods run at different points in the agent execution lifecycle:
+For a conceptual walkthrough of preparation, the agent loop, tool execution, and finalization, see the [agent lifecycle guide](/docs/guides/agent-lifecycle).
 
-```
-┌────────────────────────────────────────────────────────────────────┐
-│                        Agent Execution Flow                        │
-├────────────────────────────────────────────────────────────────────┤
-│                                                                    │
-│  User Input                                                        │
-│      │                                                             │
-│      ▼                                                             │
-│  ┌────────────────────────┐                                        │
-│  │  processInput          │  ← Runs ONCE at start                  │
-│  └───────────┬────────────┘                                        │
-│              │                                                     │
-│              ▼                                                     │
-│  ┌──────────────────────────────────────────────────────────────┐  │
-│  │                        Agentic Loop                          │  │
-│  │                                                              │  │
-│  │  ┌────────────────────────┐                                  │  │
-│  │  │  processInputStep      │  ← Runs at EACH step             │  │
-│  │  └───────────┬────────────┘                                  │  │
-│  │              │                                               │  │
-│  │              ▼                                               │  │
-│  │  ┌────────────────────────┐                                  │  │
-│  │  │  processLLMRequest     │  ← Before provider call          │  │
-│  │  └───────────┬────────────┘                                  │  │
-│  │              │                                               │  │
-│  │              ▼                                               │  │
-│  │        LLM Execution ──── API Error? ───┐                    │  │
-│  │              │                          │                    │  │
-│  │              │              ┌───────────┴──────────┐         │  │
-│  │              │              │  processAPIError     │         │  │
-│  │              │              └──────────────────────┘         │  │
-│  │              │                (retry loops back to LLM)      │  │
-│  │              ▼                                               │  │
-│  │  ┌────────────────────────┐                                  │  │
-│  │  │  processOutputStream   │  ← Runs on EACH stream chunk     │  │
-│  │  └───────────┬────────────┘                                  │  │
-│  │              │                                               │  │
-│  │              ▼                                               │  │
-│  │  ┌────────────────────────┐                                  │  │
-│  │  │  processLLMResponse    │  ← After stream completes        │  │
-│  │  └───────────┬────────────┘                                  │  │
-│  │              │                                               │  │
-│  │              ▼                                               │  │
-│  │  ┌────────────────────────┐                                  │  │
-│  │  │  processOutputStep     │  ← Runs after EACH LLM step      │  │
-│  │  └───────────┬────────────┘                                  │  │
-│  │              │                                               │  │
-│  │              ▼                                               │  │
-│  │        Tool Execution (if needed)                            │  │
-│  │              │                                               │  │
-│  │              ▼                                               │  │
-│  │  ┌────────────────────────┐                                  │  │
-│  │  │  processToolResult     │  ← Runs per tool, after each     │  │
-│  │  └───────────┬────────────┘    tool.execute() returns        │  │
-│  │              │                                               │  │
-│  │              └──────── Loop back if tools called ────────────│  │
-│  │                                                              │  │
-│  └──────────────────────────────────────────────────────────────┘  │
-│              │                                                     │
-│              ▼                                                     │
-│  ┌────────────────────────┐                                        │
-│  │  processOutputResult   │  ← Runs ONCE after completion          │
-│  └────────────────────────┘                                        │
-│              │                                                     │
-│              ▼                                                     │
-│        Final Response                                              │
-│                                                                    │
-└────────────────────────────────────────────────────────────────────┘
-```
+## Callback timing
 
-| Method | When it runs | Use case |
+| Callback or operation | Frequency | Position and visibility |
 | - | - | - |
-| `processInput` | Once at the start, before the agentic loop | Validate/transform initial user input, add context |
-| `processInputStep` | At each step of the agentic loop, before each LLM call | Transform messages between steps, handle tool results |
-| `processLLMRequest` | After LLM request conversion, before the provider call | Rewrite the outbound `LanguageModelV2Prompt` for the current call without persisting changes |
-| `processAPIError` | When an LLM API call fails | Inspect API rejections, optionally mutate state/messages, and request a retry |
-| `processOutputStream` | On each streaming chunk during LLM response | Filter/modify streaming content, detect patterns in real-time |
-| `processLLMResponse` | After the LLM step completes and stream chunks are collected | Capture or cache the full response, run post-call side effects paired with `processLLMRequest` |
-| `processOutputStep` | After each LLM response, before tool execution | Validate output quality, implement guardrails with retry |
-| `processToolResult` | Per tool, after a locally executed tool returns or a provider-executed result arrives, before the raw result is persisted to `messageList` | Inspect tool output and enforce security policies |
-| `processOutputResult` | Once after generation completes | Post-process final response, log results |
+| `processInput` | Once per initial request | During input preparation before the loop. Resuming from a durable snapshot may skip it. |
+| `processInputStep` | Once per model step | Before the provider request. It sees messages and tool results accumulated so far. |
+| `processLLMRequest` | Once per provider call | Last processor stage for rewriting the provider-facing prompt. Its prompt changes aren't written back to the message list. |
+| `processOutputStream` | Per streamed chunk | Runs while model output arrives. Data chunks are included when the processor opts in. |
+| `processLLMResponse` | Once per completed provider stream | Receives the completed response for the current model step. |
+| `processOutputStep` | Once per model step | Runs after the model response and before locally executed tools. |
+| Tool [`onInputStart`](/reference/tools/create-tool#oninputstart) | When streamed tool input begins | Runs before complete tool arguments are available. |
+| Tool [`onInputDelta`](/reference/tools/create-tool#oninputdelta) | Per streamed tool-input chunk | Observes incremental tool arguments. |
+| Tool [`onInputAvailable`](/reference/tools/create-tool#oninputavailable) | Once when tool input is complete | Runs after arguments are parsed and validated, before execution. |
+| Tool execution | Once per local tool call | Receives the live [`RequestContext`](/docs/server/request-context). Approval or suspension can delay execution. |
+| Tool [`onOutput`](/reference/tools/create-tool#onoutput) | Once after successful local execution | Receives the tool output. |
+| `processToolResult` | Per local/client result, or when a deferred provider result arrives | Can inspect, redact, or abort before a raw tool result enters the message list. |
+| `processAPIError` | On eligible provider API errors | Can update request state and request another provider attempt. |
+| [`onIterationComplete`](/reference/agents/generate#parameters) | Once after each completed loop iteration | Observes the iteration result and can influence whether execution continues. |
+| `processOutputResult` | Once at finalization | Post-processes the completed agent result before it's returned. |
 
 ## Interface definition
 


### PR DESCRIPTION
Adds a conceptual guide to the agent lifecycle, from preparation through loop execution and finalization. It explains the relationship between runs, iterations, and model steps, shows where RequestContext and processor callbacks become visible, and contrasts regular and durable execution.

The guide includes Mermaid diagrams for the full lifecycle, trusted context setup, and the model/tool loop. It links each API's first mention to its canonical reference and connects the existing RequestContext and processors documentation to the new guide.

Moves the detailed callback timing table into the Processor interface reference and replaces its duplicated execution-flow diagram with a link back to the guide.

Validated with the docs formatter, Remark, Vale, sidebar and frontmatter validation, 162 docs tests, and a production docs build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a guide that explains how an agent starts, runs model and tool steps, and finishes. It also connects related documentation and clarifies regular and durable execution.

## Changes

- Added the **Agent lifecycle** guide.
- Documented:
  - Agent preparation and finalization.
  - Runs, iterations, and model steps.
  - `RequestContext` and processor callbacks.
  - Model and tool loop behavior.
  - Continuation and stopping conditions.
  - Retries, aborts, and API errors.
  - Regular and durable execution.
  - Persistence guidance.
  - Runs that finalize without a final assistant message.
- Added Mermaid diagrams for the lifecycle, trusted context setup, and model/tool loop.
- Moved callback timing details to the Processor interface reference.
- Added callback frequency, ordering, visibility, streaming, tool hook, deferred result, error handling, and finalization details.
- Added links between the lifecycle, processor, and `RequestContext` documentation.
- Added the guide to the Guides sidebar with the `new` tag.
- Clarified that `processOutputResult` modifies returned messages and their message-level metadata.

## Validation

- Formatting, Remark, Vale, sidebar, and frontmatter checks passed.
- 162 documentation tests passed.
- The production documentation build passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->