### PR TITLE
fix(playground): fix typecheck failure in thread rail turns hook

### DIFF
--- a/packages/playground-ui/src/domains/traces/hooks/use-trace-spans.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-trace-spans.ts
@@ -1,6 +1,6 @@
 import type { MastraClient } from '@mastra/client-js';
 import { useMastraClient } from '@mastra/react';
-import { queryOptions, useQuery } from '@tanstack/react-query';
+import { queryOptions, useQueries, useQuery } from '@tanstack/react-query';
 import type { UseQueryResult } from '@tanstack/react-query';
 import type { SearchableSpan } from '../types';
 import { selectSearchableSpans } from '../utils';
@@ -48,5 +48,30 @@ export function useTraceSpans(
     ...traceSpansQueryOptions(client, traceId),
     // Builds each span's search haystack once per fetch, cached with the query.
     select: selectSearchableSpans,
+  });
+}
+
+export type TraceSpansData = Awaited<ReturnType<MastraClient['getTrace']>>;
+
+/**
+ * Observes the `trace-spans` query of several traces at once and projects each one with `select`.
+ * Traces still loading (or failed) yield `fallback(traceId)` so the result always lines up with `traceIds`.
+ */
+export function useTraceSpansQueries<T>(
+  traceIds: string[],
+  select: (traceId: string, data: TraceSpansData) => T,
+  fallback: (traceId: string) => T,
+): T[] {
+  const client = useMastraClient();
+
+  return useQueries({
+    queries: traceIds.map(traceId => ({
+      ...traceSpansQueryOptions(client, traceId),
+      select: (data: TraceSpansData) => select(traceId, data),
+    })),
+    combine: results =>
+      results.map((result, index) =>
+        result.data === undefined ? fallback(traceIds[index] ?? '') : (result.data as T),
+      ),
   });
 }

--- a/packages/playground/src/domains/traces/hooks/use-thread-rail-turns.ts
+++ b/packages/playground/src/domains/traces/hooks/use-thread-rail-turns.ts
@@ -1,15 +1,9 @@
-import type { MastraClient } from '@mastra/client-js';
 import { buildThreadRailTurns } from '@mastra/playground-ui/components/ThreadRail';
 import type { ThreadRailTurn } from '@mastra/playground-ui/components/ThreadRail';
-import { traceSpansQueryOptions } from '@mastra/playground-ui/domains/traces/hooks/use-trace-spans';
-import { useMastraClient } from '@mastra/react';
-import { useQueries } from '@tanstack/react-query';
-import type { UseQueryOptions } from '@tanstack/react-query';
+import { useTraceSpansQueries } from '@mastra/playground-ui/domains/traces/hooks/use-trace-spans';
+import type { TraceSpansData } from '@mastra/playground-ui/domains/traces/hooks/use-trace-spans';
 
 import { formatTraceThreadMessages } from '@/domains/traces/components/format-trace-thread-messages';
-
-type TraceSpansData = Awaited<ReturnType<MastraClient['getTrace']>>;
-type TraceSpansQueryKey = ReturnType<typeof traceSpansQueryOptions>['queryKey'];
 
 export const fallbackRailTurn = (traceId: string): ThreadRailTurn => ({
   key: traceId,
@@ -19,34 +13,16 @@ export const fallbackRailTurn = (traceId: string): ThreadRailTurn => ({
   hiddenFileCount: 0,
 });
 
+const selectRailTurn = (traceId: string, data: TraceSpansData): ThreadRailTurn => {
+  const [turn] = buildThreadRailTurns(formatTraceThreadMessages(data?.spans ?? []));
+  return turn ? { ...turn, key: traceId, messageId: traceId } : fallbackRailTurn(traceId);
+};
+
 /**
  * One rail stop per trace, summarised from the turn its spans reconstruct. Shares the
  * `trace-spans` query (options included, so the two observers agree on freshness); the stop is keyed by the
  * trace id so the rail can track rows rather than message ids.
  */
 export function useThreadRailTurns(traceIds: string[]): ThreadRailTurn[] {
-  const client = useMastraClient();
-
-  const queries = traceIds.map(
-    (traceId): UseQueryOptions<TraceSpansData, Error, ThreadRailTurn, TraceSpansQueryKey> => {
-      const { queryKey, queryFn, enabled, staleTime, gcTime } = traceSpansQueryOptions(client, traceId);
-      return {
-        queryKey,
-        queryFn,
-        enabled,
-        staleTime,
-        gcTime,
-        select: data => {
-          const [turn] = buildThreadRailTurns(formatTraceThreadMessages(data?.spans ?? []));
-          return turn ? { ...turn, key: traceId, messageId: traceId } : fallbackRailTurn(traceId);
-        },
-      };
-    },
-  );
-
-  return useQueries({
-    queries,
-    combine: (results): ThreadRailTurn[] =>
-      results.map((result, index) => result.data ?? fallbackRailTurn(traceIds[index]!)),
-  });
+  return useTraceSpansQueries(traceIds, selectRailTurn, fallbackRailTurn);
 }

--- a/packages/playground/src/domains/traces/hooks/use-thread-rail-turns.ts
+++ b/packages/playground/src/domains/traces/hooks/use-thread-rail-turns.ts
@@ -9,6 +9,7 @@ import type { UseQueryOptions } from '@tanstack/react-query';
 import { formatTraceThreadMessages } from '@/domains/traces/components/format-trace-thread-messages';
 
 type TraceSpansData = Awaited<ReturnType<MastraClient['getTrace']>>;
+type TraceSpansQueryKey = ReturnType<typeof traceSpansQueryOptions>['queryKey'];
 
 export const fallbackRailTurn = (traceId: string): ThreadRailTurn => ({
   key: traceId,
@@ -26,20 +27,22 @@ export const fallbackRailTurn = (traceId: string): ThreadRailTurn => ({
 export function useThreadRailTurns(traceIds: string[]): ThreadRailTurn[] {
   const client = useMastraClient();
 
-  const queries = traceIds.map((traceId): UseQueryOptions<TraceSpansData, Error, ThreadRailTurn> => {
-    const { queryKey, queryFn, enabled, staleTime, gcTime } = traceSpansQueryOptions(client, traceId);
-    return {
-      queryKey,
-      queryFn,
-      enabled,
-      staleTime,
-      gcTime,
-      select: data => {
-        const [turn] = buildThreadRailTurns(formatTraceThreadMessages(data?.spans ?? []));
-        return turn ? { ...turn, key: traceId, messageId: traceId } : fallbackRailTurn(traceId);
-      },
-    };
-  });
+  const queries = traceIds.map(
+    (traceId): UseQueryOptions<TraceSpansData, Error, ThreadRailTurn, TraceSpansQueryKey> => {
+      const { queryKey, queryFn, enabled, staleTime, gcTime } = traceSpansQueryOptions(client, traceId);
+      return {
+        queryKey,
+        queryFn,
+        enabled,
+        staleTime,
+        gcTime,
+        select: data => {
+          const [turn] = buildThreadRailTurns(formatTraceThreadMessages(data?.spans ?? []));
+          return turn ? { ...turn, key: traceId, messageId: traceId } : fallbackRailTurn(traceId);
+        },
+      };
+    },
+  );
 
   return useQueries({
     queries,

--- a/packages/playground/src/domains/traces/hooks/use-thread-rail-turns.ts
+++ b/packages/playground/src/domains/traces/hooks/use-thread-rail-turns.ts
@@ -1,10 +1,14 @@
+import type { MastraClient } from '@mastra/client-js';
 import { buildThreadRailTurns } from '@mastra/playground-ui/components/ThreadRail';
 import type { ThreadRailTurn } from '@mastra/playground-ui/components/ThreadRail';
 import { traceSpansQueryOptions } from '@mastra/playground-ui/domains/traces/hooks/use-trace-spans';
 import { useMastraClient } from '@mastra/react';
 import { useQueries } from '@tanstack/react-query';
+import type { UseQueryOptions } from '@tanstack/react-query';
 
 import { formatTraceThreadMessages } from '@/domains/traces/components/format-trace-thread-messages';
+
+type TraceSpansData = Awaited<ReturnType<MastraClient['getTrace']>>;
 
 export const fallbackRailTurn = (traceId: string): ThreadRailTurn => ({
   key: traceId,
@@ -22,14 +26,24 @@ export const fallbackRailTurn = (traceId: string): ThreadRailTurn => ({
 export function useThreadRailTurns(traceIds: string[]): ThreadRailTurn[] {
   const client = useMastraClient();
 
-  return useQueries({
-    queries: traceIds.map(traceId => ({
-      ...traceSpansQueryOptions(client, traceId),
-      select: (data: Awaited<ReturnType<typeof client.getTrace>>): ThreadRailTurn => {
+  const queries = traceIds.map((traceId): UseQueryOptions<TraceSpansData, Error, ThreadRailTurn> => {
+    const { queryKey, queryFn, enabled, staleTime, gcTime } = traceSpansQueryOptions(client, traceId);
+    return {
+      queryKey,
+      queryFn,
+      enabled,
+      staleTime,
+      gcTime,
+      select: data => {
         const [turn] = buildThreadRailTurns(formatTraceThreadMessages(data?.spans ?? []));
         return turn ? { ...turn, key: traceId, messageId: traceId } : fallbackRailTurn(traceId);
       },
-    })),
-    combine: results => results.map((result, index) => result.data ?? fallbackRailTurn(traceIds[index]!)),
+    };
+  });
+
+  return useQueries({
+    queries,
+    combine: (results): ThreadRailTurn[] =>
+      results.map((result, index) => result.data ?? fallbackRailTurn(traceIds[index]!)),
   });
 }


### PR DESCRIPTION
## Summary

The playground build was failing at typecheck in `use-thread-rail-turns.ts`: `useQueries` could not infer the query data type from the spread `traceSpansQueryOptions(...)` combined with a `select`, so `combine` resolved to `{}[]` instead of `ThreadRailTurn[]`.

This types each query explicitly as `UseQueryOptions<TraceSpansData, Error, ThreadRailTurn>` (reusing `queryKey`/`queryFn`/`enabled`/`staleTime`/`gcTime` from the shared options so cache freshness stays consistent with other observers). No runtime behavior change.

No changeset: `@internal/playground` is private.

## Test plan

- [x] `pnpm turbo build --filter @internal/playground` passes (typecheck + vite build)
- [x] eslint + prettier clean on the modified file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The playground could not determine the data type for several trace queries. This change moves that query handling into a shared hook so typechecking succeeds without changing runtime behavior.

## Changes

- Added the generic `useTraceSpansQueries` hook in `playground-ui`.
- Kept shared query options for consistent caching.
- Moved trace-span selection and fallback handling into `use-thread-rail-turns.ts`.
- Preserved result ordering and fallback behavior.

## Validation

- Playground build, lint, and formatting checks pass.
- No changeset was added because `@internal/playground` is private.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->