### PR TITLE
fix(factory): resolve Linear agent tools from the bound run's project

### DIFF
--- a/.changeset/linear-tools-board-runs.md
+++ b/.changeset/linear-tools-board-runs.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Linear agent tools never reaching a Factory board run. `buildLinearAgentTools` resolved the org from the session `resourceId`, which for a bound run is the per-work-item session id rather than the factory project id `resolveOrgId` looks up — so every board run was handed an empty tool set and lost `linear_get_issue` and `linear_create_comment` without any error. The project now comes from the bound run's controller state, falling back to `resourceId` for project-scoped sessions.

--- a/mastracode/factory/src/integrations/linear/agent-tools.test.ts
+++ b/mastracode/factory/src/integrations/linear/agent-tools.test.ts
@@ -25,8 +25,23 @@ const ORG_ID = 'org-1';
 function requestContextFor(resourceId: string | undefined): RequestContext {
   const ctx = new RequestContext();
   if (resourceId !== undefined) {
-    ctx.set('controller', { resourceId });
+    ctx.set('controller', { resourceId, getState: () => ({}) });
   }
+  return ctx;
+}
+
+/**
+ * A Factory board run: bound per work item, so the session resourceId is the
+ * work-item session id and the project it belongs to is carried in controller
+ * state instead.
+ */
+function boardRunRequestContextFor(sessionId: string, factoryProjectId: string | undefined): RequestContext {
+  const ctx = new RequestContext();
+  ctx.set('controller', {
+    resourceId: sessionId,
+    threadId: sessionId,
+    getState: () => (factoryProjectId === undefined ? {} : { factoryProjectId }),
+  });
   return ctx;
 }
 
@@ -155,6 +170,36 @@ describe('buildLinearAgentTools — exposure gating', () => {
   it('exposes nothing when there is no controller context', async () => {
     const tools = await buildLinearAgentTools({ linear, requestContext: requestContextFor(undefined) });
     expect(tools).toEqual({});
+  });
+
+  it('exposes the Linear tools to a board run, whose resourceId is not the project id', async () => {
+    await seedProject();
+    await seedConnection();
+    const tools = await buildLinearAgentTools({
+      linear,
+      requestContext: boardRunRequestContextFor('work-item-session-1', PROJECT_ID),
+    });
+    expect(tools).toHaveProperty('linear_get_issue');
+    expect(tools).toHaveProperty('linear_create_comment');
+  });
+
+  it('exposes nothing to a board run whose project org has not connected Linear', async () => {
+    await seedProject();
+    const tools = await buildLinearAgentTools({
+      linear,
+      requestContext: boardRunRequestContextFor('work-item-session-1', PROJECT_ID),
+    });
+    expect(tools).toEqual({});
+  });
+
+  it('falls back to the resourceId when controller state carries no project', async () => {
+    await seedProject();
+    await seedConnection();
+    const tools = await buildLinearAgentTools({
+      linear,
+      requestContext: boardRunRequestContextFor(PROJECT_ID, undefined),
+    });
+    expect(tools).toHaveProperty('linear_get_issue');
   });
 
   it('does not cache a transient database failure as "not a project"', async () => {

--- a/mastracode/factory/src/integrations/linear/agent-tools.ts
+++ b/mastracode/factory/src/integrations/linear/agent-tools.ts
@@ -2,9 +2,9 @@
  * Linear tools exposed to the coding agent.
  *
  * Wired into the agent through the SDK's async `extraTools` provider: on each
- * tool-set resolution we map the session's resourceId (the factory project id)
- * to its owning org and only expose the Linear tools when that org has a
- * Linear connection. Projects whose org never connected Linear (or when the
+ * tool-set resolution we map the session to the factory project it belongs to,
+ * that project to its owning org, and only expose the Linear tools when that
+ * org has a Linear connection. Projects whose org never connected Linear (or when the
  * feature is disabled) see no Linear tools at all — the model is never shown
  * tools it can't use.
  *
@@ -20,6 +20,12 @@ import { z } from 'zod';
 
 import type { LinearIntegration } from './integration.js';
 import { LinearReauthRequiredError } from './integration.js';
+
+/**
+ * The slice of controller state these tools resolve against. Optional because a
+ * project-scoped session carries no factory state at all.
+ */
+type LinearToolsControllerContext = AgentControllerRequestContext<{ factoryProjectId?: string }>;
 
 function createLinearGetIssueTool(linear: LinearIntegration, orgId: string) {
   return createTool({
@@ -108,8 +114,20 @@ export async function buildLinearAgentTools({
 }): Promise<Record<string, ReturnType<typeof createLinearGetIssueTool> | ReturnType<typeof createLinearCommentTool>>> {
   if (!linear.authEnabled) return {};
 
-  const ctx = requestContext.get('controller') as AgentControllerRequestContext | undefined;
-  const resourceId = ctx?.resourceId;
+  const ctx = requestContext.get('controller') as LinearToolsControllerContext | undefined;
+  if (!ctx) return {};
+
+  // A Factory board run is bound per work item, so its session resourceId is
+  // the work-item session id — not the project id `resolveOrgId` looks up in
+  // `factory_projects`. Reading `resourceId` alone therefore resolved no org
+  // for any board run, and every one of them was handed an empty tool set: the
+  // agent silently lost `linear_get_issue` and triaged from the issue title.
+  //
+  // A bound run's controller state carries the project it belongs to (the same
+  // field `getFactorySessionCoordinates` reads), so prefer that, and fall back
+  // to the resourceId for a project-scoped session where it is already the
+  // project id.
+  const resourceId = ctx.getState().factoryProjectId ?? ctx.resourceId;
   if (!resourceId) return {};
 
   const orgId = await linear.resolveOrgId(resourceId);


### PR DESCRIPTION
Fixes #23054

## Problem

`buildLinearAgentTools` resolves the org from the session `resourceId`:

```ts
const resourceId = ctx?.resourceId;
if (!resourceId) return {};
const orgId = await linear.resolveOrgId(resourceId);
if (!orgId) return {};
```

and `resolveOrgId` looks that id up in `factory_projects`:

```ts
orgId = (await this.projects.getById({ id: resourceId }))?.orgId ?? null;
```

That is correct for a project-scoped session. For a **Factory board run** it is not: the run is bound per work item, so `factory_run_bindings.resource_id` is the work-item session id — the same uuid as the thread — and never a project id. The lookup misses, `orgId` is `null`, and the builder returns `{}`.

So no board run has ever received `linear_get_issue` or `linear_create_comment`.

## Why it went unnoticed

It fails silently. There is no error and no log — the agent is simply handed a smaller tool set, notices the tool is absent, and carries on. On the deployment where this surfaced, the triage agent said so in its own transcript:

> The Linear MCP tool isn't in my available tools, so I'll work from the issue title and my prior triage notes.

The bundled `factory-triage` skill instructs the agent to call `linear_get_issue`. It never could, so every Linear issue that factory triaged was triaged from its one-line title rather than its body, description and comments.

The tool-invocation counts across that message store:

| tool | times invoked |
|---|---|
| `factory_transition_work_item` | 74 |
| `linear_get_issue` | **0** |

Both are merged into the same `extraTools` map in `factory.ts`; `createFactoryTransitionTools` is merged unconditionally and the Linear ones are gated. The Linear OAuth connection was healthy throughout (scope `comments:create read`, token unexpired, intake ingesting issues normally), so the other three gates pass — it is specifically `resolveOrgId`.

## Fix

A bound run's controller state carries the project it belongs to. That is the same field `getFactorySessionCoordinates` reads in `rules/binding-context.ts`, and the same one `isFactorySessionContext` uses to classify a run as org work. So prefer it, and fall back to `resourceId` for a project-scoped session, where it already is the project id:

```ts
const resourceId = ctx.getState().factoryProjectId ?? ctx.resourceId;
```

Three tests: a board run gets the tools; a board run whose org has no Linear connection still gets none; and the `resourceId` fallback keeps working when controller state carries no project.

I also corrected the module docblock, which asserted the resourceId *is* the factory project id — that claim is the premise the bug rested on.

## Verification

- `pnpm vitest run src/integrations/linear/agent-tools.test.ts` → **21 passed**
- Reverting only the source change (tests untouched) → **1 failed**, `AssertionError: expected {} to have property "linear_get_issue"` — the new test catches exactly the empty tool set
- `pnpm check` (tsc --noEmit) → clean
- `pnpm lint` (oxlint + eslint) → clean
- Applied to a live self-hosted Factory on 0.12.0: `linear_get_issue` went from **0 invocations ever to 7 across 5 threads within minutes, 0 errors**, with triage agents now fetching real issue bodies

## A note on `getFactorySessionCoordinates`

My first draft used that helper instead of reading the field directly, which would have been more idiomatic. It crashes on this file's existing test fixtures: they build `{ resourceId }` with no `getState`, and the helper calls `context?.getState().factoryProjectId` with the optional chain on `context` but not on the call. Production contexts always have `getState`, so this is latent rather than live — but it does mean the helper is riskier to call from a new code path than it looks. Flagging it rather than changing it here, since it is outside this fix's scope.

I have added `getState` to the shared fixture in this file so it matches what a real controller context provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory board runs now receive the Linear tools they need. The code uses the board run’s Factory project ID instead of its work-item session ID.

## Changes

- Resolve the Linear organization from `controller.state.factoryProjectId`.
- Fall back to `controller.resourceId` for project-scoped sessions.
- Preserve empty tool output when the organization has no Linear connection.
- Add tests for board runs, missing Linear connections, and fallback resolution.
- Update module documentation, shared fixtures, and the `@mastra/factory` changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->