### PR TITLE
fix(playground): restore model switcher on agent thread page

### DIFF
--- a/.changeset/restore-thread-model-switcher.md
+++ b/.changeset/restore-thread-model-switcher.md
@@ -1,5 +1,0 @@
----
-'@mastra/playground': patch
----
-
-Restore the model switcher in the agent thread chat composer. The `/agents/:agentId/threads/:threadId` page is mounted outside `AgentLayout` and was missing the `PlaygroundModelProvider`, so the provider/model pill and model settings disappeared and model overrides were never sent with chat requests.

--- a/.changeset/restore-thread-model-switcher.md
+++ b/.changeset/restore-thread-model-switcher.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground': patch
+---
+
+Restore the model switcher in the agent thread chat composer. The `/agents/:agentId/threads/:threadId` page is mounted outside `AgentLayout` and was missing the `PlaygroundModelProvider`, so the provider/model pill and model settings disappeared and model overrides were never sent with chat requests.

--- a/packages/playground/src/pages/agents/agent/__tests__/thread-page.msw.test.tsx
+++ b/packages/playground/src/pages/agents/agent/__tests__/thread-page.msw.test.tsx
@@ -74,7 +74,7 @@ const agentResponse = {
   tools: {},
   workflows: {},
   provider: 'openai',
-  modelId: 'openai/gpt-5-mini',
+  modelId: 'gpt-5-mini',
   modelVersion: 'v2',
   supportsMemory: true,
   defaultOptions: {},
@@ -126,6 +126,17 @@ function installHandlers() {
     ),
     http.get(`${BASE_URL}/api/observability/traces/light`, emptyTraces),
     http.get(`${BASE_URL}/api/observability/traces`, emptyTraces),
+    http.get(`${BASE_URL}/api/agents/providers`, () =>
+      HttpResponse.json({
+        providers: [
+          { id: 'openai', name: 'OpenAI', envVar: 'OPENAI_API_KEY', connected: true, models: ['gpt-5-mini'] },
+        ],
+      }),
+    ),
+    http.get(`${BASE_URL}/api/editor/builder/settings`, () =>
+      HttpResponse.json({ enabled: false, modelPolicy: { active: false } }),
+    ),
+    http.get(`${BASE_URL}/api/editor/builder/models/available`, () => HttpResponse.json({ providers: [] })),
   );
 }
 
@@ -142,6 +153,17 @@ describe('Standalone thread page', () => {
     renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);
 
     expect(await screen.findByText('Tonight we cook carbonara.')).not.toBeNull();
+  });
+
+  it('renders the composer model switcher with the agent model', async () => {
+    installHandlers();
+    renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);
+
+    await screen.findByText('Tonight we cook carbonara.');
+    // Provider + model pill (needs PlaygroundModelProvider, which this page must supply itself).
+    expect(await screen.findByText('OpenAI')).not.toBeNull();
+    expect(await screen.findByText('gpt-5-mini')).not.toBeNull();
+    expect(await screen.findByTestId('composer-model-settings-trigger')).not.toBeNull();
   });
 
   it('shows the thread list next to the chat', async () => {

--- a/packages/playground/src/pages/agents/agent/thread.tsx
+++ b/packages/playground/src/pages/agents/agent/thread.tsx
@@ -24,12 +24,14 @@ import { WorkingMemoryProvider } from '@/domains/agents/context/agent-working-me
 import { BrowserSessionProvider } from '@/domains/agents/context/browser-session-provider';
 import { BrowserToolCallsProvider } from '@/domains/agents/context/browser-tool-calls-context';
 import { MemoryTimelineProvider } from '@/domains/agents/context/memory-timeline-context';
+import { PlaygroundModelProvider } from '@/domains/agents/context/playground-model-context';
 import { useAgent } from '@/domains/agents/hooks/use-agent';
 import { buildAgentDefaultSettings } from '@/domains/agents/utils/agent-default-settings';
 import { getAgentSuggestedPrompts } from '@/domains/agents/utils/agent-suggested-prompts';
 import { usePermissions } from '@/domains/auth/hooks/use-permissions';
 import { ThreadAside } from '@/domains/conversation/components/thread-aside';
 import { ThreadInputProvider } from '@/domains/conversation/context/ThreadInputContext';
+import { cleanProviderId } from '@/domains/llm/utils';
 import { useDeleteThread, useMemory, useThreads } from '@/domains/memory/hooks/use-memory';
 import { TracingSettingsProvider } from '@/domains/observability/context/tracing-settings-context';
 import { SchemaRequestContextProvider } from '@/domains/request-context/context/schema-request-context';
@@ -127,102 +129,113 @@ function AgentThread() {
     }
   };
 
+  // This page lives outside AgentLayout, so it must provide the model selection
+  // context itself or the composer model switcher never renders.
+  const defaultProvider = cleanProviderId(agent.provider ?? '');
+  const defaultModel = agent.modelId ?? '';
+
   return (
     <TracingSettingsProvider entityId={agentId!} entityType="agent">
       <AgentSettingsProvider agentId={agentId!} defaultSettings={defaultSettings}>
         <SchemaRequestContextProvider>
-          <WorkingMemoryProvider agentId={agentId!} threadId={actualThreadId} resourceId={agentId!}>
-            <BrowserToolCallsProvider key={`browser-${agentId}-${actualThreadId}`}>
-              <BrowserSessionProvider
-                key={`session-${agentId}-${actualThreadId}`}
-                agentId={agentId!}
-                threadId={actualThreadId}
-                enabled={Boolean(agent?.hasBrowser ?? agent?.browserTools?.length)}
-              >
-                <ThreadInputProvider>
-                  <ObservationalMemoryProvider>
-                    <MemoryTimelineProvider key={`memory-timeline-${agentId}-${actualThreadId}`}>
-                      <ActivatedSkillsProvider key={`${agentId}-${actualThreadId}`}>
-                        <MainSidebarProvider storageKey="agent-thread">
-                          <div className="bg-surface1 h-full lg:grid lg:grid-cols-[auto_1fr] lg:grid-rows-[1fr]">
-                            <ThreadSidebar
-                              agentId={agentId!}
-                              agentName={agent.name}
-                              threads={sidebarThreads}
-                              threadId={actualThreadId}
-                              isLoading={isThreadsLoading}
-                            />
-                            <div key={actualThreadId} className="relative min-h-0">
-                              <div className="rounded-studio-frame border-border1 bg-surface2 shadow-main-frame m-1.5 flex h-[calc(100%-0.75rem)] min-h-0 flex-col overflow-hidden border [--studio-frame-inset:0.5rem] [--studio-frame-radius:1.5rem] lg:m-2 lg:ml-0 lg:h-[calc(100%-1rem)]">
-                                <Header>
-                                  <HeaderTitle>Thread</HeaderTitle>
-                                  {/* "new" is not a stored thread yet, so there is nothing to trace. */}
-                                  {!isNewThread && (
-                                    <HeaderAction>
-                                      {!isAdvancedVariant && (
-                                        <Button
-                                          variant="outline"
-                                          className="hidden lg:inline-flex"
-                                          onClick={() => setTracesAside(tracesAside === 'open' ? 'closing' : 'open')}
-                                        >
-                                          <ChartNoAxesGantt />
-                                          Traces
-                                        </Button>
-                                      )}
-                                      <Switch
-                                        id="thread-advanced-view"
-                                        checked={isAdvancedVariant}
-                                        onCheckedChange={setAdvancedVariant}
+          <PlaygroundModelProvider
+            key={`${agentId}:${defaultProvider}/${defaultModel}`}
+            defaultProvider={defaultProvider}
+            defaultModel={defaultModel}
+          >
+            <WorkingMemoryProvider agentId={agentId!} threadId={actualThreadId} resourceId={agentId!}>
+              <BrowserToolCallsProvider key={`browser-${agentId}-${actualThreadId}`}>
+                <BrowserSessionProvider
+                  key={`session-${agentId}-${actualThreadId}`}
+                  agentId={agentId!}
+                  threadId={actualThreadId}
+                  enabled={Boolean(agent?.hasBrowser ?? agent?.browserTools?.length)}
+                >
+                  <ThreadInputProvider>
+                    <ObservationalMemoryProvider>
+                      <MemoryTimelineProvider key={`memory-timeline-${agentId}-${actualThreadId}`}>
+                        <ActivatedSkillsProvider key={`${agentId}-${actualThreadId}`}>
+                          <MainSidebarProvider storageKey="agent-thread">
+                            <div className="bg-surface1 h-full lg:grid lg:grid-cols-[auto_1fr] lg:grid-rows-[1fr]">
+                              <ThreadSidebar
+                                agentId={agentId!}
+                                agentName={agent.name}
+                                threads={sidebarThreads}
+                                threadId={actualThreadId}
+                                isLoading={isThreadsLoading}
+                              />
+                              <div key={actualThreadId} className="relative min-h-0">
+                                <div className="rounded-studio-frame border-border1 bg-surface2 shadow-main-frame m-1.5 flex h-[calc(100%-0.75rem)] min-h-0 flex-col overflow-hidden border [--studio-frame-inset:0.5rem] [--studio-frame-radius:1.5rem] lg:m-2 lg:ml-0 lg:h-[calc(100%-1rem)]">
+                                  <Header>
+                                    <HeaderTitle>Thread</HeaderTitle>
+                                    {/* "new" is not a stored thread yet, so there is nothing to trace. */}
+                                    {!isNewThread && (
+                                      <HeaderAction>
+                                        {!isAdvancedVariant && (
+                                          <Button
+                                            variant="outline"
+                                            className="hidden lg:inline-flex"
+                                            onClick={() => setTracesAside(tracesAside === 'open' ? 'closing' : 'open')}
+                                          >
+                                            <ChartNoAxesGantt />
+                                            Traces
+                                          </Button>
+                                        )}
+                                        <Switch
+                                          id="thread-advanced-view"
+                                          checked={isAdvancedVariant}
+                                          onCheckedChange={setAdvancedVariant}
+                                        />
+                                        <label htmlFor="thread-advanced-view" className="text-ui-sm text-neutral4">
+                                          Advanced view
+                                        </label>
+                                      </HeaderAction>
+                                    )}
+                                  </Header>
+                                  <div
+                                    className={cn(
+                                      'relative grid min-h-0 flex-1',
+                                      // The advanced view manages its own scroll container.
+                                      !isAdvancedVariant && 'overflow-y-auto pt-6',
+                                    )}
+                                  >
+                                    {isAdvancedVariant ? (
+                                      <ThreadViewByTrace threadId={actualThreadId} />
+                                    ) : (
+                                      <AgentChat
+                                        agentId={agentId!}
+                                        agentName={agent?.name}
+                                        modelVersion={agent?.modelVersion}
+                                        supportsMemory={agent?.supportsMemory}
+                                        threadId={actualThreadId}
+                                        memory={hasMemory}
+                                        refreshThreadList={handleRefreshThreadList}
+                                        modelList={agent?.modelList}
+                                        messageId={messageId}
+                                        suggestedPrompts={suggestedPrompts}
+                                        isNewThread={isNewThread}
                                       />
-                                      <label htmlFor="thread-advanced-view" className="text-ui-sm text-neutral4">
-                                        Advanced view
-                                      </label>
-                                    </HeaderAction>
-                                  )}
-                                </Header>
-                                <div
-                                  className={cn(
-                                    'relative grid min-h-0 flex-1',
-                                    // The advanced view manages its own scroll container.
-                                    !isAdvancedVariant && 'overflow-y-auto pt-6',
-                                  )}
-                                >
-                                  {isAdvancedVariant ? (
-                                    <ThreadViewByTrace threadId={actualThreadId} />
-                                  ) : (
-                                    <AgentChat
-                                      agentId={agentId!}
-                                      agentName={agent?.name}
-                                      modelVersion={agent?.modelVersion}
-                                      supportsMemory={agent?.supportsMemory}
-                                      threadId={actualThreadId}
-                                      memory={hasMemory}
-                                      refreshThreadList={handleRefreshThreadList}
-                                      modelList={agent?.modelList}
-                                      messageId={messageId}
-                                      suggestedPrompts={suggestedPrompts}
-                                      isNewThread={isNewThread}
-                                    />
-                                  )}
+                                    )}
+                                  </div>
                                 </div>
+                                {!isNewThread && !isAdvancedVariant && tracesAside !== 'closed' && (
+                                  <ThreadTracesAside
+                                    threadId={actualThreadId}
+                                    state={tracesAside}
+                                    onStateChange={setTracesAside}
+                                  />
+                                )}
                               </div>
-                              {!isNewThread && !isAdvancedVariant && tracesAside !== 'closed' && (
-                                <ThreadTracesAside
-                                  threadId={actualThreadId}
-                                  state={tracesAside}
-                                  onStateChange={setTracesAside}
-                                />
-                              )}
                             </div>
-                          </div>
-                        </MainSidebarProvider>
-                      </ActivatedSkillsProvider>
-                    </MemoryTimelineProvider>
-                  </ObservationalMemoryProvider>
-                </ThreadInputProvider>
-              </BrowserSessionProvider>
-            </BrowserToolCallsProvider>
-          </WorkingMemoryProvider>
+                          </MainSidebarProvider>
+                        </ActivatedSkillsProvider>
+                      </MemoryTimelineProvider>
+                    </ObservationalMemoryProvider>
+                  </ThreadInputProvider>
+                </BrowserSessionProvider>
+              </BrowserToolCallsProvider>
+            </WorkingMemoryProvider>
+          </PlaygroundModelProvider>
         </SchemaRequestContextProvider>
       </AgentSettingsProvider>
     </TracingSettingsProvider>


### PR DESCRIPTION
## Summary

The provider/model switcher in the chat composer disappeared on the agent thread page (`/agents/:agentId/threads/:threadId`).

That route is mounted under `MinimalRootLayout` instead of `AgentLayout`, so it never received the `PlaygroundModelProvider`. Without the context, `ComposerModelSwitcher` and `ComposerModelWarning` rendered `null`, and `modelOverride` was never forwarded to `ChatProvider` — so users could not switch models from the thread page at all.

This PR provides `PlaygroundModelProvider` directly from the thread page (same construction as `AgentLayout`, keyed on agent + default provider/model) and adds a regression test.

## Changes

- `packages/playground/src/pages/agents/agent/thread.tsx`: wrap the page in `PlaygroundModelProvider`
- `packages/playground/src/pages/agents/agent/__tests__/thread-page.msw.test.tsx`: new "renders the composer model switcher with the agent model" test + MSW handlers for `/api/agents/providers` and builder settings
- Changeset (patch, `@mastra/playground`)

## Test plan

- [x] `vitest run thread-page.msw.test.tsx` — 23/23 pass; the new test fails without the fix
- [x] `tsc --noEmit` in `packages/playground`
- [ ] Manual: open Studio → agent → thread → provider/model pill and settings gear are visible; changing the model sends `modelOverride` on the stream request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The agent thread page can show the model switcher again. It now receives the model information needed to display the current provider, model, settings, and apply model changes to chat requests.

## Changes

- Wrapped the agent thread page with `PlaygroundModelProvider`.
- Forwarded the selected `modelOverride` to `ChatProvider`.
- Added MSW handlers for provider and builder-model requests.
- Added a regression test for the composer model switcher.
- Added a patch changeset for `@mastra/playground`.

## Validation

- Vitest checks pass.
- TypeScript checks pass.
- Manual verification is pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->