### PR TITLE
fix(core): keep background schema injection builder-local to avoid cross-agent leaks

### DIFF
--- a/.changeset/tidy-tools-share-schema.md
+++ b/.changeset/tidy-tools-share-schema.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Stop `_background` from leaking between agents that share one tool instance. `CoreToolBuilder` no longer writes the spliced input schema back onto the shared tool object — the injected schema now lives on the builder, so each agent's model-facing parameters only advertise the injected keys when that agent actually opted in.

--- a/packages/core/src/tools/tool-builder/background-override-injection.test.ts
+++ b/packages/core/src/tools/tool-builder/background-override-injection.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { z as z3 } from 'zod/v3';
 import { z as z4 } from 'zod/v4';
 import { RequestContext } from '../../request-context';
-import { isStandardSchemaWithJSON, standardSchemaToJSONSchema, toStandardSchema } from '../../schema';
+import { toStandardSchema } from '../../schema';
 import { createTool } from '../../tools';
 import { CoreToolBuilder } from './builder';
 
@@ -32,13 +32,17 @@ function baseOptions() {
   };
 }
 
-function extractJsonProperties(tool: { inputSchema?: unknown }) {
-  const schema = tool.inputSchema;
-  expect(schema).toBeDefined();
-  expect(isStandardSchemaWithJSON(schema)).toBe(true);
-  const json = standardSchemaToJSONSchema(schema as any, { io: 'input' });
-  expect(json && typeof json === 'object' && (json as any).type === 'object').toBe(true);
-  return (json as any).properties as Record<string, any>;
+// The spliced schema now lives on the builder (not on the user's shared tool
+// object), so assertions read the built tool's model-facing `parameters`.
+function extractJsonProperties(builder: CoreToolBuilder) {
+  const built = builder.build();
+  const parameters = built.parameters as {
+    jsonSchema?: { type?: string; properties?: Record<string, any> };
+  };
+  expect(parameters?.jsonSchema).toBeDefined();
+  const json = parameters.jsonSchema!;
+  expect(json && typeof json === 'object' && json.type === 'object').toBe(true);
+  return json.properties!;
 }
 
 describe('CoreToolBuilder background override injection', () => {
@@ -79,13 +83,13 @@ describe('CoreToolBuilder background override injection', () => {
         execute: vi.fn(),
       });
 
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: baseOptions(),
         backgroundTaskEnabled: true,
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('query');
       expect(properties).toHaveProperty('_background');
     });
@@ -141,17 +145,17 @@ describe('CoreToolBuilder background override injection', () => {
         execute,
       });
 
-      new CoreToolBuilder({
+      const built = new CoreToolBuilder({
         originalTool: tool,
         options: baseOptions(),
         backgroundTaskEnabled: true,
-      });
+      }).build();
 
-      const schema = tool.inputSchema as any;
-      const result = schema['~standard'].validate({ query: 'ok', _background: { enabled: 'yes' } });
-      const resolved = result && typeof result.then === 'function' ? await result : result;
-      expect(resolved).toHaveProperty('issues');
-      expect((resolved as { issues: readonly unknown[] }).issues.length).toBeGreaterThan(0);
+      const parameters = built.parameters as { validate?: (value: unknown) => unknown };
+      expect(typeof parameters.validate).toBe('function');
+      const result = parameters.validate!({ query: 'ok', _background: { enabled: 'yes' } });
+      const resolved = result && typeof (result as Promise<unknown>).then === 'function' ? await result : result;
+      expect(resolved).toHaveProperty('success', false);
     });
   });
 
@@ -175,14 +179,13 @@ describe('CoreToolBuilder background override injection', () => {
         backgroundTaskEnabled: true,
       });
 
-      expect(isStandardSchemaWithJSON(tool.inputSchema)).toBe(true);
-      const json = standardSchemaToJSONSchema(tool.inputSchema as any, { io: 'input' });
-      expect(json.properties).toMatchObject({
+      const built = builder.build();
+      const json = (built.parameters as { jsonSchema?: { properties?: Record<string, unknown> } }).jsonSchema;
+      expect(json?.properties).toMatchObject({
         query: expect.anything(),
         _background: expect.anything(),
       });
 
-      const built = builder.build();
       const result = await built.execute!(
         { query: 'docs', _background: { enabled: 'yes' } },
         { toolCallId: 'call-1', messages: [] },
@@ -214,7 +217,7 @@ describe('CoreToolBuilder background override injection', () => {
         ok: true,
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('query');
       expect(properties).toHaveProperty('_background');
     });
@@ -245,7 +248,7 @@ describe('CoreToolBuilder background override injection', () => {
         ok: true,
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('query');
       expect(properties).toHaveProperty('_background');
     });
@@ -260,12 +263,12 @@ describe('CoreToolBuilder background override injection', () => {
         execute: vi.fn(),
       });
 
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: baseOptions(),
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('message');
       expect(properties).toHaveProperty('suspendedToolRunId');
       expect(properties).toHaveProperty('resumeData');
@@ -289,12 +292,12 @@ describe('CoreToolBuilder background override injection', () => {
         execute: vi.fn(),
       });
 
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: baseOptions(),
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('suspendedToolRunId');
       expect(properties).toHaveProperty('resumeData');
     });
@@ -310,13 +313,13 @@ describe('CoreToolBuilder background override injection', () => {
         execute: vi.fn(),
       });
 
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: baseOptions(),
         backgroundTaskEnabled: true,
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('message');
       expect(properties).toHaveProperty('_background');
       expect(properties).toHaveProperty('suspendedToolRunId');
@@ -340,19 +343,19 @@ describe('CoreToolBuilder background override injection', () => {
 
     it('does NOT inject _background when the manager is enabled but the tool has no opt-in', () => {
       const tool = makeTool();
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: { ...baseOptions(), backgroundConfig: undefined },
         backgroundTaskEnabled: true,
       });
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('query');
       expect(properties).not.toHaveProperty('_background');
     });
 
     it('injects _background when the agent config whitelists the tool', () => {
       const tool = makeTool();
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: {
           ...baseOptions(),
@@ -361,13 +364,13 @@ describe('CoreToolBuilder background override injection', () => {
         },
         backgroundTaskEnabled: true,
       });
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('_background');
     });
 
     it('resolves agent whitelist entries for agent- prefixed tool names', () => {
       const tool = makeTool('agent-biExecutor');
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: {
           ...baseOptions(),
@@ -377,13 +380,13 @@ describe('CoreToolBuilder background override injection', () => {
         },
         backgroundTaskEnabled: true,
       });
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('_background');
     });
 
     it('does NOT inject _background when the agent whitelists other tools only', () => {
       const tool = makeTool();
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: {
           ...baseOptions(),
@@ -392,7 +395,7 @@ describe('CoreToolBuilder background override injection', () => {
         },
         backgroundTaskEnabled: true,
       });
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).not.toHaveProperty('_background');
     });
 

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -250,6 +250,17 @@ export class CoreToolBuilder extends MastraBase {
   private originalTool: ToolToConvert;
   private options: ToolOptions;
   private logType?: LogType;
+  /**
+   * Builder-local copy of the user's input schema with the framework-injected
+   * keys (`_background`, `suspendedToolRunId`, `resumeData`) spliced in.
+   *
+   * It must NOT be written back onto `originalTool.inputSchema`: `createTool()`
+   * results are commonly module-level singletons shared across several agents,
+   * while background eligibility is resolved per agent — a write-back would
+   * leak one agent's injected keys into every other agent's model-facing
+   * parameters (issue #22843).
+   */
+  private injectedInputSchema?: StandardSchemaWithJSON;
 
   constructor(input: {
     originalTool: ToolToConvert;
@@ -320,7 +331,7 @@ export class CoreToolBuilder extends MastraBase {
                 .optional(),
             });
           }
-          this.originalTool.inputSchema = toStandardSchema(nextSchema);
+          this.injectedInputSchema = toStandardSchema(nextSchema);
         } else {
           // Normalize to Standard Schema, extract JSON Schema, splice overrides.
           const standardSchema = isStandardSchemaWithJSON(schema) ? schema : toStandardSchema(schema);
@@ -351,11 +362,7 @@ export class CoreToolBuilder extends MastraBase {
             // `.transform()` / `.default()` / `.refine()` etc.) while exposing
             // the spliced JSON Schema for provider serialization. See
             // https://github.com/mastra-ai/mastra/pull/16915#discussion_r3282520408
-            this.originalTool.inputSchema = buildJsonOverrideSchema(
-              schema,
-              { ...jsonSchema, properties },
-              injectedKeys,
-            );
+            this.injectedInputSchema = buildJsonOverrideSchema(schema, { ...jsonSchema, properties }, injectedKeys);
           }
         }
       }
@@ -380,8 +387,10 @@ export class CoreToolBuilder extends MastraBase {
       return schema;
     }
 
-    // For Mastra tools, inputSchema might also be a function
-    let schema = this.originalTool.inputSchema;
+    // For Mastra tools, inputSchema might also be a function. Prefer the
+    // builder-local injected schema (see `injectedInputSchema`) so per-agent
+    // injections never depend on mutation of the shared tool object.
+    let schema = this.injectedInputSchema ?? this.originalTool.inputSchema;
 
     if (isStandardSchemaWithJSON(schema)) {
       return schema;
@@ -759,7 +768,14 @@ export class CoreToolBuilder extends MastraBase {
           result = await executeWithContext({
             span: toolSpan,
             fn: async () => {
-              if (inputValidationSchema) {
+              if (inputValidationSchema || this.injectedInputSchema) {
+                // The injected keys are only declared on the builder-local
+                // schema. `Tool.execute` validates against the user's original
+                // schema, which would strip them (breaking sub-agent/workflow
+                // resume via `suspendedToolRunId`), so once this builder has
+                // validated the args itself — against the injected schema or a
+                // compat-processed version of it — mark the context to skip
+                // that second validation.
                 markBuilderValidatedInput(toolContext);
               }
               return tool?.execute?.(args, toolContext);

--- a/packages/core/src/tools/tool-builder/cross-agent-background-leak.test.ts
+++ b/packages/core/src/tools/tool-builder/cross-agent-background-leak.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z as z4 } from 'zod/v4';
+import { RequestContext } from '../../request-context';
+import { createTool } from '../../tools';
+import { CoreToolBuilder } from './builder';
+
+function baseOptions(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'shared-tool',
+    backgroundConfig: { enabled: true },
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      trackException: vi.fn(),
+    } as any,
+    requestContext: new RequestContext(),
+    ...overrides,
+  };
+}
+
+function modelFacingProperties(built: { parameters?: unknown }) {
+  const parameters = built.parameters as { jsonSchema?: { type?: string; properties?: Record<string, unknown> } };
+  expect(parameters?.jsonSchema).toBeDefined();
+  return parameters.jsonSchema!.properties as Record<string, unknown>;
+}
+
+describe('CoreToolBuilder cross-agent _background leak (issue #22843)', () => {
+  it('does not leak _background into an agent that did not opt in', () => {
+    const tool = createTool({
+      id: 'shared-search',
+      description: 'Shared search tool',
+      inputSchema: z4.object({ query: z4.string() }),
+      execute: vi.fn(),
+    });
+    const before = tool.inputSchema;
+
+    const eligible = new CoreToolBuilder({
+      originalTool: tool,
+      options: baseOptions(),
+      backgroundTaskEnabled: true,
+    }).build();
+    expect(modelFacingProperties(eligible)).toHaveProperty('_background');
+
+    const ineligible = new CoreToolBuilder({
+      originalTool: tool,
+      options: baseOptions({ backgroundConfig: undefined }),
+      backgroundTaskEnabled: true,
+    }).build();
+    expect(modelFacingProperties(ineligible)).not.toHaveProperty('_background');
+
+    expect(tool.inputSchema).toBe(before);
+  });
+
+  it('is order-independent when the opted-out agent converts first', () => {
+    const tool = createTool({
+      id: 'shared-search',
+      description: 'Shared search tool',
+      inputSchema: z4.object({ query: z4.string() }),
+      execute: vi.fn(),
+    });
+
+    const ineligible = new CoreToolBuilder({
+      originalTool: tool,
+      options: baseOptions({ backgroundConfig: undefined }),
+      backgroundTaskEnabled: true,
+    }).build();
+    expect(modelFacingProperties(ineligible)).not.toHaveProperty('_background');
+
+    const eligible = new CoreToolBuilder({
+      originalTool: tool,
+      options: baseOptions(),
+      backgroundTaskEnabled: true,
+    }).build();
+    expect(modelFacingProperties(eligible)).toHaveProperty('_background');
+  });
+});


### PR DESCRIPTION
Fixes #22843

Problem
When two agents share one createTool() result, the agent that opts into background execution leaks _background into the other agent's model-facing parameters. Reproduced: eligible agent converts first, then an opted-out agent converts the same tool — the second build advertises _background even though that agent never opted in. Order-dependent shared-state mutation; retry/fallback and provider compat layers see keys the runtime never honors for that agent.

Root cause
CoreToolBuilder's constructor spliced the injected keys and wrote the result back onto the shared object (this.originalTool.inputSchema = ...). getParameters() then read from that shared object, so the first eligible conversion permanently polluted every later conversion of the same tool, and repeated conversions re-wrapped the schema.

Fix
- The spliced schema now lives in a builder-local injectedInputSchema field; the shared tool object is never mutated.
- getParameters() prefers the builder-local schema, falling back to the original.
- The execute path marks builder-validated input when either a compat validation schema or the injected schema exists, so suspendedToolRunId/resumeData still reach sub-agent and workflow resume (Tool.execute validates against the user's original schema and would otherwise strip them).
- Related test expectations in background-override-injection.test.ts now read the built tool's model-facing parameters instead of the shared tool object. Related prior work: #22853 (closed by automation).

Regression test
- packages/core/src/tools/tool-builder/cross-agent-background-leak.test.ts: shared z4 tool converted by an eligible then an ineligible builder asserts no _background on the second build and no mutation of the shared object; plus the reverse order.
- Failing-before: 1 failed / 1 passed on pristine main (eligible-first leaks). Passing-after: 2 passed.

Verification
- pnpm --filter ./packages/core exec vitest run src/tools/tool-builder/ (5 files, 97 passed, 1 skipped)
- pnpm --filter ./packages/core exec vitest run src/tools/ (449 passed; 6 failures in code-mode.e2e.test.ts LocalSandbox also fail on pristine main, environment-related, unrelated to this change)
- pnpm --filter ./packages/core check (clean)

Scope
- No public API change. No behavior change when a tool converts for a single agent. Only the shared-instance cross-agent path changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Each agent now gets its own tool schema. A background-only field cannot appear in another agent’s tool, even when both agents share the same tool. Resume data also remains available during tool execution.

## Changes

- Store injected schemas on each `CoreToolBuilder` instead of mutating the shared tool.
- Use the builder-local schema for `getParameters()`.
- Preserve builder-validated input and compatibility schemas during execution.
- Preserve framework fields such as `suspendedToolRunId` and `resumeData`.
- Add regression tests for both tool conversion orders and schema immutability.
- Update existing tests to inspect built tool parameters.
- Add a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->