### PR TITLE
feat(factory): light board cards with a drifting beam instead of a running head

### DIFF
--- a/.changeset/beam-card-session-marker.md
+++ b/.changeset/beam-card-session-marker.md
@@ -2,4 +2,9 @@
 '@mastra/factory': patch
 ---
 
-Refreshed the live-session marker on board cards. A card with a running session showed a single point of light crawling round its outline; it now shows pools of light resting on that outline, drifting while the agent works and parking once the session is waiting on you, at which point the whole outline comes up lit behind them.
+Refreshed the live-session marker on board cards.
+
+A card with a running session used to show one point of light crawling round its outline. It now shows pools of light resting on that outline.
+
+- While the agent works, the pools drift along the rim.
+- Once the session is waiting on you, they park and the whole rim comes up lit.

--- a/.changeset/beam-card-session-marker.md
+++ b/.changeset/beam-card-session-marker.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Refreshed the live-session marker on board cards. A card with a running session showed a single point of light crawling round its outline; it now shows pools of light resting on that outline, drifting while the agent works and parking once the session is waiting on you, at which point the whole outline comes up lit behind them.

--- a/.changeset/board-card-corner.md
+++ b/.changeset/board-card-corner.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Tightened the board card's corner. The radius now lives in one token instead of being repeated on every card-shaped surface, and it is tied to the buttons inside the card: a card's corner is the pill's radius plus the padding around it, so the two stay concentric.

--- a/.changeset/card-actions-keep-their-width.md
+++ b/.changeset/card-actions-keep-their-width.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed board card buttons breaking their labels across two lines. The actions on a card now keep their width and the worker's name gives way instead, so "Re-review" and "Open session" stay on one line in a narrow column.

--- a/mastracode/factory-ui/src/ui/domains/factory/components/BoardCardParts.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/BoardCardParts.tsx
@@ -152,7 +152,7 @@ export function CardActions({
   const [main] = actions;
   return (
     <div className="mt-auto flex items-center justify-between gap-2">
-      <div className="board-card-actions relative z-10 flex">
+      <div className="board-card-actions relative z-10 flex shrink-0">
         {actions.map(action => (
           <CardActionButton key={action.label} action={action} main={action === main} beforeStart={beforeStart} />
         ))}

--- a/mastracode/factory-ui/src/ui/domains/factory/components/BoardColumnEmptyState.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/BoardColumnEmptyState.tsx
@@ -87,7 +87,7 @@ export function BoardColumnEmptyState({
       }
     : boardColumnEmptyCopy(stage, kind, hasIntakeSource);
   return (
-    <div className="border-border1 flex min-h-24 flex-col justify-center rounded-3xl border border-dashed px-4 py-4">
+    <div className="border-border1 flex min-h-24 flex-col justify-center rounded-card border border-dashed px-4 py-4">
       <Txt as="p" variant="ui-sm" className="text-icon4 m-0 font-medium">
         {copy.title}
       </Txt>

--- a/mastracode/factory-ui/src/ui/domains/factory/components/BoardColumnEmptyState.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/BoardColumnEmptyState.tsx
@@ -87,7 +87,7 @@ export function BoardColumnEmptyState({
       }
     : boardColumnEmptyCopy(stage, kind, hasIntakeSource);
   return (
-    <div className="border-border1 flex min-h-24 flex-col justify-center rounded-card border border-dashed px-4 py-4">
+    <div className="border-border1 rounded-card flex min-h-24 flex-col justify-center border border-dashed px-4 py-4">
       <Txt as="p" variant="ui-sm" className="text-icon4 m-0 font-medium">
         {copy.title}
       </Txt>

--- a/mastracode/factory-ui/src/ui/domains/factory/components/CandidateCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/CandidateCard.tsx
@@ -87,14 +87,14 @@ export function CandidateCard({
           })
         }
         // Offscreen cards skip layout and paint; an Intake column can hold hundreds.
-        className="group border-border1/50 bg-neutral6/5 hover:bg-surface3 relative flex min-h-36 cursor-grab flex-col gap-3 rounded-3xl border p-2.5 transition-colors outline-none [contain-intrinsic-size:auto_9rem] [content-visibility:auto] active:cursor-grabbing"
+        className="group border-border1/50 bg-neutral6/5 hover:bg-surface3 relative flex min-h-36 cursor-grab flex-col gap-3 rounded-card border p-2 transition-colors outline-none [contain-intrinsic-size:auto_9rem] [content-visibility:auto] active:cursor-grabbing"
       >
         <button
           type="button"
           draggable={false}
           aria-label={`Details for ${candidate.title}`}
           aria-expanded={morph.open}
-          className="focus-visible:outline-accent1 absolute inset-0 cursor-pointer rounded-3xl outline-none focus-visible:outline-2 focus-visible:outline-offset-2"
+          className="focus-visible:outline-accent1 absolute inset-0 cursor-pointer rounded-card outline-none focus-visible:outline-2 focus-visible:outline-offset-2"
           onClick={morph.openDetails}
         />
         <CandidateCardRows

--- a/mastracode/factory-ui/src/ui/domains/factory/components/CandidateCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/CandidateCard.tsx
@@ -87,14 +87,14 @@ export function CandidateCard({
           })
         }
         // Offscreen cards skip layout and paint; an Intake column can hold hundreds.
-        className="group border-border1/50 bg-neutral6/5 hover:bg-surface3 relative flex min-h-36 cursor-grab flex-col gap-3 rounded-card border p-2 transition-colors outline-none [contain-intrinsic-size:auto_9rem] [content-visibility:auto] active:cursor-grabbing"
+        className="group border-border1/50 bg-neutral6/5 hover:bg-surface3 rounded-card relative flex min-h-36 cursor-grab flex-col gap-3 border p-2 transition-colors outline-none [contain-intrinsic-size:auto_9rem] [content-visibility:auto] active:cursor-grabbing"
       >
         <button
           type="button"
           draggable={false}
           aria-label={`Details for ${candidate.title}`}
           aria-expanded={morph.open}
-          className="focus-visible:outline-accent1 absolute inset-0 cursor-pointer rounded-card outline-none focus-visible:outline-2 focus-visible:outline-offset-2"
+          className="focus-visible:outline-accent1 rounded-card absolute inset-0 cursor-pointer outline-none focus-visible:outline-2 focus-visible:outline-offset-2"
           onClick={morph.openDetails}
         />
         <CandidateCardRows

--- a/mastracode/factory-ui/src/ui/domains/factory/components/CardDetailsPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/CardDetailsPanel.tsx
@@ -78,7 +78,7 @@ export function CardDetailsPanel({
           ref={morph.panelRef}
           className="board-card-details flex flex-col p-0"
         >
-          <div className="board-card-copy group border-border1 bg-surface3 shadow-dialog relative z-10 flex min-h-36 shrink-0 flex-col gap-3 rounded-card border p-2">
+          <div className="board-card-copy group border-border1 bg-surface3 shadow-dialog rounded-card relative z-10 flex min-h-36 shrink-0 flex-col gap-3 border p-2">
             {header}
           </div>
           <div className="board-card-tray border-border1 bg-surface3 shadow-dialog relative flex flex-col overflow-hidden rounded-xl border">

--- a/mastracode/factory-ui/src/ui/domains/factory/components/CardDetailsPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/CardDetailsPanel.tsx
@@ -78,7 +78,7 @@ export function CardDetailsPanel({
           ref={morph.panelRef}
           className="board-card-details flex flex-col p-0"
         >
-          <div className="board-card-copy group border-border1 bg-surface3 shadow-dialog relative z-10 flex min-h-36 shrink-0 flex-col gap-3 rounded-3xl border p-2.5">
+          <div className="board-card-copy group border-border1 bg-surface3 shadow-dialog relative z-10 flex min-h-36 shrink-0 flex-col gap-3 rounded-card border p-2">
             {header}
           </div>
           <div className="board-card-tray border-border1 bg-surface3 shadow-dialog relative flex flex-col overflow-hidden rounded-xl border">

--- a/mastracode/factory-ui/src/ui/domains/factory/components/InlineWorkItemComposer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/InlineWorkItemComposer.tsx
@@ -50,7 +50,7 @@ export function InlineWorkItemComposer({ stage, stageLabel, onCreate, onClose }:
       aria-label={`New work item in ${stageLabel}`}
       aria-busy={submitting}
       className={cn(
-        'relative flex flex-col gap-3 rounded-3xl border border-border1/50 bg-neutral6/5 p-2.5 outline-none transition-colors focus-within:border-neutral5/50 motion-reduce:transition-none',
+        'relative flex flex-col gap-3 rounded-card border border-border1/50 bg-neutral6/5 p-2 outline-none transition-colors focus-within:border-neutral5/50 motion-reduce:transition-none',
         error !== undefined && 'border-error',
       )}
       onSubmit={event => void submit(event)}

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -223,7 +223,7 @@ export function WorkItemCard({
           if (!evaluating) setDragPayload(event, { kind: 'work-item', id: item.id, fromStage: columnStage });
         }}
         className={cn(
-          'group relative flex min-h-36 flex-col gap-3 rounded-3xl border border-border1/50 bg-neutral6/5 p-2.5 outline-none transition-colors hover:bg-surface3',
+          'group relative flex min-h-36 flex-col gap-3 rounded-card border border-border1/50 bg-neutral6/5 p-2 outline-none transition-colors hover:bg-surface3',
           // `content-visibility` clips at the padding box, which the wick's ring has to reach past.
           wickStatus ? 'border-transparent' : '[content-visibility:auto] [contain-intrinsic-size:auto_9rem]',
           evaluating ? 'cursor-wait' : 'cursor-grab active:cursor-grabbing',
@@ -238,7 +238,7 @@ export function WorkItemCard({
           draggable={false}
           aria-label={`Details for ${item.title}`}
           aria-expanded={morph.open}
-          className="focus-visible:outline-accent1 absolute inset-0 cursor-pointer rounded-3xl outline-none focus-visible:outline-2 focus-visible:outline-offset-2"
+          className="focus-visible:outline-accent1 absolute inset-0 cursor-pointer rounded-card outline-none focus-visible:outline-2 focus-visible:outline-offset-2"
           onClick={morph.openDetails}
         />
         <WorkItemCardRows

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -238,7 +238,7 @@ export function WorkItemCard({
           draggable={false}
           aria-label={`Details for ${item.title}`}
           aria-expanded={morph.open}
-          className="focus-visible:outline-accent1 absolute inset-0 cursor-pointer rounded-card outline-none focus-visible:outline-2 focus-visible:outline-offset-2"
+          className="focus-visible:outline-accent1 rounded-card absolute inset-0 cursor-pointer outline-none focus-visible:outline-2 focus-visible:outline-offset-2"
           onClick={morph.openDetails}
         />
         <WorkItemCardRows

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
@@ -177,7 +177,6 @@
 
 .session-wick {
   --belt-beat: 1.4s;
-
   --wick-phase: 0s;
 
   /* What a hot spot is made of, and how hard the pools push. On black, light is

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
@@ -180,6 +180,13 @@
 
   --wick-phase: 0s;
 
+  /* What a hot spot is made of, and how hard the pools push. On black, light is
+   * whiter than the hue it carries; on white there is no whiter, so the hot
+   * spots deepen instead and every pool has to push harder to be seen. */
+  --wick-hot: white;
+  --wick-lit: 1;
+  --wick-halo: 0.26;
+
   /* Each clock centred on zero and scaled by the drift: at rest every pool sits
    * at its base size in its base place, and the card is lit but still. */
   --wick-ka: calc((var(--wick-a) - 0.5) * var(--wick-drift));
@@ -192,49 +199,81 @@
     radial-gradient(
       ellipse calc(30% * (1 + 0.5 * var(--wick-ka))) calc(11% * (1 + 0.4 * var(--wick-ka))) at
         calc(27% + var(--wick-ka) * 58px) 0%,
-      color-mix(in oklab, color-mix(in oklab, white 62%, var(--belt-hue)) 92%, transparent),
+      color-mix(
+        in oklab,
+        color-mix(in oklab, var(--wick-hot) 62%, var(--belt-hue)) calc(92% * var(--wick-lit)),
+        transparent
+      ),
       transparent
     ),
     radial-gradient(
       ellipse calc(26% * (1 + 0.5 * var(--wick-kb))) calc(8% * (1 + 0.4 * var(--wick-kb))) at
         calc(72% + var(--wick-kb) * 52px) 0%,
-      color-mix(in oklab, color-mix(in oklab, white 45%, var(--belt-hue)) 62%, transparent),
+      color-mix(
+        in oklab,
+        color-mix(in oklab, var(--wick-hot) 45%, var(--belt-hue)) calc(62% * var(--wick-lit)),
+        transparent
+      ),
       transparent
     ),
     radial-gradient(
       ellipse calc(7% * (1 + 0.5 * var(--wick-kc))) calc(26% * (1 + 0.4 * var(--wick-kc))) at 100%
         calc(34% + var(--wick-kc) * 44px),
-      color-mix(in oklab, color-mix(in oklab, white 55%, var(--belt-hue)) 82%, transparent),
+      color-mix(
+        in oklab,
+        color-mix(in oklab, var(--wick-hot) 55%, var(--belt-hue)) calc(82% * var(--wick-lit)),
+        transparent
+      ),
       transparent
     ),
     radial-gradient(
       ellipse calc(6% * (1 + 0.5 * var(--wick-ka))) calc(20% * (1 + 0.4 * var(--wick-ka))) at 100%
         calc(74% + var(--wick-ka) * 38px),
-      color-mix(in oklab, color-mix(in oklab, white 40%, var(--belt-hue)) 58%, transparent),
+      color-mix(
+        in oklab,
+        color-mix(in oklab, var(--wick-hot) 40%, var(--belt-hue)) calc(58% * var(--wick-lit)),
+        transparent
+      ),
       transparent
     ),
     radial-gradient(
       ellipse calc(31% * (1 + 0.5 * var(--wick-kb))) calc(9% * (1 + 0.4 * var(--wick-kb))) at
         calc(66% + var(--wick-kb) * 58px) 100%,
-      color-mix(in oklab, color-mix(in oklab, white 58%, var(--belt-hue)) 88%, transparent),
+      color-mix(
+        in oklab,
+        color-mix(in oklab, var(--wick-hot) 58%, var(--belt-hue)) calc(88% * var(--wick-lit)),
+        transparent
+      ),
       transparent
     ),
     radial-gradient(
       ellipse calc(22% * (1 + 0.5 * var(--wick-kc))) calc(7% * (1 + 0.4 * var(--wick-kc))) at
         calc(24% + var(--wick-kc) * 48px) 100%,
-      color-mix(in oklab, color-mix(in oklab, white 42%, var(--belt-hue)) 55%, transparent),
+      color-mix(
+        in oklab,
+        color-mix(in oklab, var(--wick-hot) 42%, var(--belt-hue)) calc(55% * var(--wick-lit)),
+        transparent
+      ),
       transparent
     ),
     radial-gradient(
       ellipse calc(7% * (1 + 0.5 * var(--wick-kc))) calc(23% * (1 + 0.4 * var(--wick-kc))) at 0%
         calc(62% + var(--wick-kc) * 42px),
-      color-mix(in oklab, color-mix(in oklab, white 50%, var(--belt-hue)) 78%, transparent),
+      color-mix(
+        in oklab,
+        color-mix(in oklab, var(--wick-hot) 50%, var(--belt-hue)) calc(78% * var(--wick-lit)),
+        transparent
+      ),
       transparent
     ),
     radial-gradient(
       ellipse calc(6% * (1 + 0.5 * var(--wick-kb))) calc(17% * (1 + 0.4 * var(--wick-kb))) at 0%
         calc(28% + var(--wick-kb) * 38px),
-      color-mix(in oklab, color-mix(in oklab, white 38%, var(--belt-hue)) 52%, transparent),
+      color-mix(
+        in oklab,
+        color-mix(in oklab, var(--wick-hot) 38%, var(--belt-hue)) calc(52% * var(--wick-lit)),
+        transparent
+      ),
       transparent
     );
 
@@ -275,7 +314,9 @@
   padding: 1px;
   background:
     var(--wick-beam),
-    linear-gradient(color-mix(in oklab, var(--belt-hue) calc(var(--wick-fill) * 62%), transparent) 0 0),
+    linear-gradient(
+      color-mix(in oklab, var(--belt-hue) calc(var(--wick-fill) * 62% * var(--wick-lit)), transparent) 0 0
+    ),
     linear-gradient(color-mix(in oklab, var(--border1) 50%, transparent) 0 0);
   mask:
     linear-gradient(#000 0 0) content-box,
@@ -291,8 +332,17 @@
   inset: -6px;
   border-radius: inherit;
   background: var(--wick-beam);
-  opacity: 0.26;
+  opacity: var(--wick-halo);
   filter: blur(9px);
+}
+
+/* Light mode: the pools deepen into the hue instead of whitening out of it, and
+ * they push about a quarter harder — a tint that reads as light on black reads
+ * as haze on white. */
+html.light .session-wick {
+  --wick-hot: color-mix(in oklab, black 30%, var(--belt-hue));
+  --wick-lit: 1.15;
+  --wick-halo: 0.16;
 }
 
 /* Cards mount together, so a board would breathe in one voice. Four phases dealt

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
@@ -326,6 +326,12 @@
 /* The same pools blurred and let out past the card, which is what turns a lit
  * edge into a lit card. Kept short: cards sit 10px apart in a column. */
 .session-wick::before {
+  /* The halo does not travel with the rim. Under a 9px blur its own drift is
+   * invisible, and animating it would mean re-blurring eight gradients every
+   * frame for nothing: parked, the browser paints this layer once and the only
+   * thing moving per frame is the 1px rim above it. */
+  --wick-drift: 0;
+
   content: '';
   position: absolute;
   inset: -6px;

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
@@ -186,6 +186,39 @@
   --wick-lit: 1;
   --wick-halo: 0.26;
 
+  position: absolute;
+
+  /* The beam sits on the card's border, not on a line inside it: the card turns
+   * its own 1px border transparent and the ring paints that exact strip — same
+   * box, same radius, same width, resting colour included. Reaching the border
+   * box means reaching out of the padding box, so a card carrying a wick drops
+   * `content-visibility`, whose clip stops there. The radius is inherited rather
+   * than named: the card owns it, and a guess is a corner that misses. */
+  inset: -1px;
+  border-radius: inherit;
+  pointer-events: none;
+
+  /* One clock per group, none a multiple of another, each started mid-phase so
+   * the three are never together on the first frame either. */
+  animation:
+    session-wick-a 5.2s ease-in-out calc(-1.2s + var(--wick-phase)) infinite,
+    session-wick-b 6.8s ease-in-out calc(-4.7s + var(--wick-phase)) infinite,
+    session-wick-c 8.6s ease-in-out calc(-6.3s + var(--wick-phase)) infinite,
+    session-wick-breathe calc(var(--belt-beat) * 4) ease-in-out var(--wick-phase) infinite;
+  transition:
+    --wick-fill 700ms cubic-bezier(0.4, 0, 0.2, 1),
+    --wick-drift 700ms cubic-bezier(0.4, 0, 0.2, 1),
+    --belt-sway 700ms cubic-bezier(0.4, 0, 0.2, 1),
+    --belt-hue 520ms ease;
+}
+
+/* Declared on the pseudo-elements, not on the wick itself: a custom property has
+ * its `var()`s substituted where it is declared, so a beam built on the parent
+ * would reach both pseudos with the parent's drift already baked in and the
+ * halo could never park. Here each one substitutes its own.
+ */
+.session-wick::before,
+.session-wick::after {
   /* Each clock centred on zero and scaled by the drift: at rest every pool sits
    * at its base size in its base place, and the card is lit but still. */
   --wick-ka: calc((var(--wick-a) - 0.5) * var(--wick-drift));
@@ -275,31 +308,6 @@
       ),
       transparent
     );
-
-  position: absolute;
-
-  /* The beam sits on the card's border, not on a line inside it: the card turns
-   * its own 1px border transparent and the ring paints that exact strip — same
-   * box, same radius, same width, resting colour included. Reaching the border
-   * box means reaching out of the padding box, so a card carrying a wick drops
-   * `content-visibility`, whose clip stops there. The radius is inherited rather
-   * than named: the card owns it, and a guess is a corner that misses. */
-  inset: -1px;
-  border-radius: inherit;
-  pointer-events: none;
-
-  /* One clock per group, none a multiple of another, each started mid-phase so
-   * the three are never together on the first frame either. */
-  animation:
-    session-wick-a 5.2s ease-in-out calc(-1.2s + var(--wick-phase)) infinite,
-    session-wick-b 6.8s ease-in-out calc(-4.7s + var(--wick-phase)) infinite,
-    session-wick-c 8.6s ease-in-out calc(-6.3s + var(--wick-phase)) infinite,
-    session-wick-breathe calc(var(--belt-beat) * 4) ease-in-out var(--wick-phase) infinite;
-  transition:
-    --wick-fill 700ms cubic-bezier(0.4, 0, 0.2, 1),
-    --wick-drift 700ms cubic-bezier(0.4, 0, 0.2, 1),
-    --belt-sway 700ms cubic-bezier(0.4, 0, 0.2, 1),
-    --belt-hue 520ms ease;
 }
 
 /* The rim itself: the pools, the fill coming up under them, and the resting

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
@@ -1,7 +1,7 @@
 /* Three markers, one grammar: the row's belt travels or breathes down the
- * sidebar; the card's wick runs a lit head round its outline until the whole rim
- * comes up under it. Working and ready differ by amplitude — travel, breath, fill — so a run
- * finishing morphs instead of cutting; initializing is working in the setup hue,
+ * sidebar; the card's beam drifts pools of light along its outline until they
+ * park and the whole rim comes up under them. Working and ready differ by
+ * amplitude — travel, breath, fill — so a run finishing morphs instead of cutting; initializing is working in the setup hue,
  * one 520ms colour slide away. The amplitudes rest on one rule: a rate has to be
  * expressed as a distance, never as an `animation-duration`. Durations cannot
  * cross-fade; lengths can. */
@@ -24,16 +24,16 @@
   initial-value: currentcolor;
 }
 
-/* How much of the wick's rim is already lit behind the travelling head. The head
- * never stops; at 1 the rim it is running on has caught up with it. */
+/* How much of the wick's rim is lit behind the pools. At 1 the whole outline has
+ * caught up with them. */
 @property --wick-fill {
   syntax: '<number>';
   inherits: true;
   initial-value: 0;
 }
 
-/* How much of the travelling head is drawn. At 0 the rim is all there is. */
-@property --wick-head {
+/* How far the beam's pools travel along the rim. At 0 they are parked. */
+@property --wick-drift {
   syntax: '<number>';
   inherits: true;
   initial-value: 1;
@@ -51,7 +51,7 @@
   --belt-pitch: 9px;
   --belt-sway: 0;
   --wick-fill: 0;
-  --wick-head: 1;
+  --wick-drift: 1;
   --belt-hue: var(--positive1);
 }
 
@@ -61,7 +61,7 @@
   --belt-pitch: 9px;
   --belt-sway: 0;
   --wick-fill: 0;
-  --wick-head: 1;
+  --wick-drift: 1;
   --belt-hue: var(--warning1);
 }
 
@@ -71,7 +71,7 @@
   --belt-pitch: 0px;
   --belt-sway: 1;
   --wick-fill: 1;
-  --wick-head: 1;
+  --wick-drift: 0;
   --belt-hue: var(--accent3);
 }
 
@@ -152,64 +152,194 @@
   }
 }
 
-/* The card's wick. The head never stops — an angle cannot cross-fade its sweep
- * without snapping at the loop seam, so `--wick-fill` brings the rim up under
- * it. */
-@property --wick-run {
-  syntax: '<angle>';
-  inherits: false;
-  initial-value: 0deg;
+/* The card's beam. Eight pools of light resting on the card's own outline,
+ * breathing on three clocks that never line up. A pool is a size and a place,
+ * both of which cross-fade; the old head was an angle, and an angle snaps at the
+ * loop seam. `--wick-drift` is how far the pools are allowed to travel along the
+ * rim, so parking them is one amplitude going to zero. */
+@property --wick-a {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 0.5;
+}
+
+@property --wick-b {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 0.5;
+}
+
+@property --wick-c {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 0.5;
 }
 
 .session-wick {
   --belt-beat: 1.4s;
 
-  /* Lap length, in belt beats. Long, because the head is crossing a whole card
-   * rather than a 6px rail: it has to read as travelling, not as spinning. */
-  --wick-lap: 6;
+  --wick-phase: 0s;
+
+  /* Each clock centred on zero and scaled by the drift: at rest every pool sits
+   * at its base size in its base place, and the card is lit but still. */
+  --wick-ka: calc((var(--wick-a) - 0.5) * var(--wick-drift));
+  --wick-kb: calc((var(--wick-b) - 0.5) * var(--wick-drift));
+  --wick-kc: calc((var(--wick-c) - 0.5) * var(--wick-drift));
+
+  /* Two pools a side, sized in percentages so a tall card lights the same way a
+   * short one does. The whitened ones are the hot spots: light, not paint. */
+  --wick-beam:
+    radial-gradient(
+      ellipse calc(30% * (1 + 0.5 * var(--wick-ka))) calc(11% * (1 + 0.4 * var(--wick-ka))) at
+        calc(27% + var(--wick-ka) * 58px) 0%,
+      color-mix(in oklab, color-mix(in oklab, white 62%, var(--belt-hue)) 92%, transparent),
+      transparent
+    ),
+    radial-gradient(
+      ellipse calc(26% * (1 + 0.5 * var(--wick-kb))) calc(8% * (1 + 0.4 * var(--wick-kb))) at
+        calc(72% + var(--wick-kb) * 52px) 0%,
+      color-mix(in oklab, color-mix(in oklab, white 45%, var(--belt-hue)) 62%, transparent),
+      transparent
+    ),
+    radial-gradient(
+      ellipse calc(7% * (1 + 0.5 * var(--wick-kc))) calc(26% * (1 + 0.4 * var(--wick-kc))) at 100%
+        calc(34% + var(--wick-kc) * 44px),
+      color-mix(in oklab, color-mix(in oklab, white 55%, var(--belt-hue)) 82%, transparent),
+      transparent
+    ),
+    radial-gradient(
+      ellipse calc(6% * (1 + 0.5 * var(--wick-ka))) calc(20% * (1 + 0.4 * var(--wick-ka))) at 100%
+        calc(74% + var(--wick-ka) * 38px),
+      color-mix(in oklab, color-mix(in oklab, white 40%, var(--belt-hue)) 58%, transparent),
+      transparent
+    ),
+    radial-gradient(
+      ellipse calc(31% * (1 + 0.5 * var(--wick-kb))) calc(9% * (1 + 0.4 * var(--wick-kb))) at
+        calc(66% + var(--wick-kb) * 58px) 100%,
+      color-mix(in oklab, color-mix(in oklab, white 58%, var(--belt-hue)) 88%, transparent),
+      transparent
+    ),
+    radial-gradient(
+      ellipse calc(22% * (1 + 0.5 * var(--wick-kc))) calc(7% * (1 + 0.4 * var(--wick-kc))) at
+        calc(24% + var(--wick-kc) * 48px) 100%,
+      color-mix(in oklab, color-mix(in oklab, white 42%, var(--belt-hue)) 55%, transparent),
+      transparent
+    ),
+    radial-gradient(
+      ellipse calc(7% * (1 + 0.5 * var(--wick-kc))) calc(23% * (1 + 0.4 * var(--wick-kc))) at 0%
+        calc(62% + var(--wick-kc) * 42px),
+      color-mix(in oklab, color-mix(in oklab, white 50%, var(--belt-hue)) 78%, transparent),
+      transparent
+    ),
+    radial-gradient(
+      ellipse calc(6% * (1 + 0.5 * var(--wick-kb))) calc(17% * (1 + 0.4 * var(--wick-kb))) at 0%
+        calc(28% + var(--wick-kb) * 38px),
+      color-mix(in oklab, color-mix(in oklab, white 38%, var(--belt-hue)) 52%, transparent),
+      transparent
+    );
 
   position: absolute;
 
-  /* The ring is the card's border, not a line inside it: the card turns its own
-   * 1px border transparent and the wick paints that exact strip — same box,
-   * same radius, same width, resting colour included. Reaching the border box
-   * means reaching out of the padding box, so a card carrying a wick drops
-   * `content-visibility`, whose clip stops there. The radius is inherited
-   * rather than named: the card owns it, and a guess is a corner that misses. */
+  /* The beam sits on the card's border, not on a line inside it: the card turns
+   * its own 1px border transparent and the ring paints that exact strip — same
+   * box, same radius, same width, resting colour included. Reaching the border
+   * box means reaching out of the padding box, so a card carrying a wick drops
+   * `content-visibility`, whose clip stops there. The radius is inherited rather
+   * than named: the card owns it, and a guess is a corner that misses. */
   inset: -1px;
   border-radius: inherit;
-  padding: 1px;
   pointer-events: none;
+
+  /* One clock per group, none a multiple of another, each started mid-phase so
+   * the three are never together on the first frame either. */
+  animation:
+    session-wick-a 5.2s ease-in-out calc(-1.2s + var(--wick-phase)) infinite,
+    session-wick-b 6.8s ease-in-out calc(-4.7s + var(--wick-phase)) infinite,
+    session-wick-c 8.6s ease-in-out calc(-6.3s + var(--wick-phase)) infinite,
+    session-wick-breathe calc(var(--belt-beat) * 4) ease-in-out var(--wick-phase) infinite;
+  transition:
+    --wick-fill 700ms cubic-bezier(0.4, 0, 0.2, 1),
+    --wick-drift 700ms cubic-bezier(0.4, 0, 0.2, 1),
+    --belt-sway 700ms cubic-bezier(0.4, 0, 0.2, 1),
+    --belt-hue 520ms ease;
+}
+
+/* The rim itself: the pools, the fill coming up under them, and the resting
+ * border under both. Masked down to the 1px strip, which is why it cannot be the
+ * same box as the halo — a mask clips the halo too. */
+.session-wick::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
   background:
-    conic-gradient(
-      from var(--wick-run),
-      transparent 0deg 120deg,
-      color-mix(in oklab, var(--belt-hue) calc(var(--wick-head) * 12%), transparent) 250deg,
-      color-mix(in oklab, var(--belt-hue) calc(var(--wick-head) * 45%), transparent) 330deg,
-      color-mix(in oklab, var(--belt-hue) calc(var(--wick-head) * 80%), transparent) 352deg,
-      color-mix(in oklab, var(--belt-hue) calc(var(--wick-head) * 100%), transparent) 358deg,
-      color-mix(in oklab, color-mix(in oklab, white 55%, var(--belt-hue)) calc(var(--wick-head) * 100%), transparent)
-        360deg
-    ),
+    var(--wick-beam),
     linear-gradient(color-mix(in oklab, var(--belt-hue) calc(var(--wick-fill) * 62%), transparent) 0 0),
     linear-gradient(color-mix(in oklab, var(--border1) 50%, transparent) 0 0);
   mask:
     linear-gradient(#000 0 0) content-box,
     linear-gradient(#000 0 0);
   mask-composite: exclude;
-  transition:
-    --wick-fill 700ms cubic-bezier(0.4, 0, 0.2, 1),
-    --wick-head 700ms cubic-bezier(0.4, 0, 0.2, 1),
-    --belt-sway 700ms cubic-bezier(0.4, 0, 0.2, 1),
-    --belt-hue 520ms ease;
-  animation:
-    session-wick-run calc(var(--belt-beat) * var(--wick-lap)) linear infinite,
-    session-wick-breathe calc(var(--belt-beat) * 4) ease-in-out infinite;
 }
 
-@keyframes session-wick-run {
-  to {
-    --wick-run: 360deg;
+/* The same pools blurred and let out past the card, which is what turns a lit
+ * edge into a lit card. Kept short: cards sit 10px apart in a column. */
+.session-wick::before {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border-radius: inherit;
+  background: var(--wick-beam);
+  opacity: 0.26;
+  filter: blur(9px);
+}
+
+/* Cards mount together, so a board would breathe in one voice. Four phases dealt
+ * by where the card sits break that up without threading a seed through the
+ * component. */
+:nth-child(2n) > .session-wick {
+  --wick-phase: -1.7s;
+}
+
+:nth-child(3n) > .session-wick {
+  --wick-phase: -3.4s;
+}
+
+:nth-child(5n) > .session-wick {
+  --wick-phase: -0.9s;
+}
+
+@keyframes session-wick-a {
+  0%,
+  100% {
+    --wick-a: 0;
+  }
+
+  50% {
+    --wick-a: 1;
+  }
+}
+
+@keyframes session-wick-b {
+  0%,
+  100% {
+    --wick-b: 0;
+  }
+
+  50% {
+    --wick-b: 1;
+  }
+}
+
+@keyframes session-wick-c {
+  0%,
+  100% {
+    --wick-c: 0;
+  }
+
+  50% {
+    --wick-c: 1;
   }
 }
 

--- a/mastracode/factory-ui/src/ui/tailwind.css
+++ b/mastracode/factory-ui/src/ui/tailwind.css
@@ -40,6 +40,15 @@
   --color-pr-merged: var(--pr-merged);
 }
 
+/* The board card's corner. It is not a free number: a card is a rounded box with
+ * a capsule pill sitting in its bottom corner, and the two only look concentric
+ * while the card's radius is the pill's plus the padding between them —
+ * `1.375rem = 0.875rem (h-form-sm capsule) + 0.5rem (p-2)`. Move one, move all
+ * three. */
+@theme {
+  --radius-card: 1.375rem;
+}
+
 /* Merged pull requests read purple everywhere; the DS accent ramp has no purple.
  * Brightens on near-black, darkens on white so it stays legible in both themes. */
 :root {


### PR DESCRIPTION
**─────── TLDR ───────**
> A card with a live session no longer has one bright dot crawling its outline — light now pools all round the rim, drifting while the agent works and parking when it is your turn.

The marker read as a loading spinner stretched over a card: one head, one lap, and a dark rim everywhere it was not. What the card should say is that it is lit, not that something is going round it.

So the head is gone. Eight pools of light sit on the card's own border, each breathing on one of three clocks that never line up, and a short halo lets the light out past the card. Working is those pools travelling along the rim; ready is them parked with the whole rim up behind them. Same amplitudes as before, so a session finishing its turn still morphs rather than cutting.

Three fixes ride along from looking at the result on a real board: the light theme needed its own recipe, the buttons under the card were wrapping, and the corner is now a token instead of a literal repeated seven times.

### Behavior changed

a card whose agent is working
&nbsp;&nbsp;├─ **was** — one lit head crawling the outline, the rest of the rim dark
&nbsp;&nbsp;└─ **now** — pools of light drift along the rim, halo spilling a little past the card

a card waiting on you
&nbsp;&nbsp;├─ **was** — the same head, still crawling, rim lit behind it
&nbsp;&nbsp;└─ **now** — the pools park and the whole outline comes up lit

either of those, in the light theme
&nbsp;&nbsp;├─ **was** — a whitened tint on a white card: nearly nothing to see
&nbsp;&nbsp;└─ **now** — the hot spots deepen into the hue instead, and the rim carries the contrast

a card's buttons in a narrow column
&nbsp;&nbsp;├─ **was** — pills squeezed until "Re-review" broke across two lines inside its own pill
&nbsp;&nbsp;└─ **now** — the pills keep their width, the worker's name truncates a little further

reduced motion
&nbsp;&nbsp;└─ **unchanged** — still three coverages, none / part / whole, and nothing moves

### Shape changed

| | | |
|---|---|---|
| **−** | `rounded-3xl` ×7, `p-2.5` ×4 | the corner was a literal on every card-shaped surface |
| **+** | `--radius-card` | one token at 22px — the pill's 14 plus the padding's 8 |
| **−** | `--wick-head`, `session-wick-run` | the angle the head swept; nothing sweeps now |
| **+** | `--wick-drift` | takes its place — how far the pools travel, `0` parked |
| **+** | `--wick-a` `--wick-b` `--wick-c` | one number per clock, the only thing animating |
| **+** | `--wick-hot` `--wick-lit` `--wick-halo` | what a hot spot is made of and how hard it pushes — one `html.light` block reads them |
| **+** | `.session-wick::after` + `::before` | the rim mask clips its own children, so the halo needs its own box |

every card-shaped surface now reads the one token, so the next move is one line
&nbsp;&nbsp;&nbsp;&nbsp;`WorkItemCard.tsx` · `CandidateCard.tsx` · `CardDetailsPanel.tsx` · `InlineWorkItemComposer.tsx` · `BoardColumnEmptyState.tsx`

the marker itself exports nothing new — same class names, same `data-live-session-indicator`

### Decisions

- **the card's corner is tied to the pill, not picked** — a capsule in the corner reads concentric only at `card = pill + padding`, so 24/10 became 22/8; tighter than that means shrinking the pills too
- **halo let 6px past the card, cut to a sixth of that in light** — a lit edge alone reads flat on black, and the same blur reads as haze on white, so there the rim carries it
- **phase dealt by `:nth-child` rather than a seed prop** — a board mounts its cards together and they breathed in one voice; delete the three rules if you would rather thread an id down

### Not verified

- [ ] the marker was seen only in a standalone harness pointed at this stylesheet, never on a real board — staging a `working` and a `ready` card needs live sessions
- [ ] the pill fix is reasoned from the flex rule and a `w-80` column, not watched rendering at every card width
- [ ] no measurement with many running cards at once — the halo is pinned to zero drift so its blur rasterizes once, but the rim's gradient still repaints per frame

---

> ██████████████████ **source** `+251 −57` — one stylesheet carries 234 of it
> ██ **changeset** `+20` — three


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Board cards now show several soft lights moving around their edges instead of one bright dot. The lights show session activity while keeping card controls readable and consistent.

## Changes

- Replaced the session marker animation with eight drifting light pools.
- Added stationary halos, illuminated rims, staggered phases, and reduced-motion states.
- Increased pool intensity and hot-spot contrast in light mode.
- Added the shared `--radius-card` token and `rounded-card` utility.
- Updated board card components to use the new radius and padding values.
- Prevented card action controls from shrinking.
- Preserved component class names and `data-live-session-indicator` usage.
- Added changesets for the session marker, card radius, and action width updates.
- No tests were added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->