### PR TITLE
test(factory): realign the assertions the supervisor and domain-label changes left behind

### DIFF
--- a/mastracode/factory-ui/src/ui/pages/__tests__/SupervisorPage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/SupervisorPage.msw.test.tsx
@@ -166,7 +166,14 @@ describe('SupervisorPage', () => {
 
       const composer = screen.getByRole('region', { name: 'Supervisor composer' });
       await waitFor(() =>
-        expect(within(composer).getByRole<HTMLTextAreaElement>('textbox').value).toContain('#22874 (dec-1)'),
+        expect(within(composer).getByRole<HTMLTextAreaElement>('textbox').value).toContain(
+          JSON.stringify({
+            id: 'dec-1',
+            kind: 'decision-failed',
+            title: 'Plan step could not start',
+            workItemNumber: 22874,
+          }),
+        ),
       );
     });
   });

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -268,8 +268,6 @@ describe('MastraFactory.prepare', () => {
     const blockingCalls = controllerMock.onSessionCreated.mock.calls.filter(
       call => (call[1] as { blocking?: boolean } | undefined)?.blocking === true,
     );
-    expect(blockingCalls).toHaveLength(2);
-    const blockingCall = blockingCalls[0];
 
     // Seed the owner's web session row and stored memory settings through the
     // same storage domains the factory registered.
@@ -317,6 +315,7 @@ describe('MastraFactory.prepare', () => {
 
     const session = {
       identity: { getResourceId: () => 'session-1' },
+      thread: {},
       om: {
         observer: { modelId: () => undefined, switchModel: vi.fn().mockResolvedValue(undefined) },
         reflector: { modelId: () => undefined, switchModel: vi.fn().mockResolvedValue(undefined) },
@@ -324,7 +323,7 @@ describe('MastraFactory.prepare', () => {
       state: { get: () => ({}), set: vi.fn().mockResolvedValue(undefined) },
     };
 
-    await (blockingCall![0] as (session: unknown) => Promise<void>)(session);
+    for (const [listener] of blockingCalls) await (listener as (session: unknown) => Promise<void>)(session);
 
     expect(session.om.observer.switchModel).toHaveBeenCalledWith({ modelId: 'anthropic/claude-haiku-4-5' });
     expect(session.om.reflector.switchModel).toHaveBeenCalledWith({ modelId: 'anthropic/claude-haiku-4-5' });
@@ -1006,7 +1005,7 @@ describe('MastraFactory.prepare integrations', () => {
       integrations: [fakeIntegration({ id: 'custom', workers })],
     });
     const args = await factory.prepare();
-    expect(args.workers).toEqual([worker]);
+    expect(args.workers?.map(entry => entry.name)).toEqual(['factory-supervisor-health', 'custom-poller']);
     // The workers factory gets the same integration context shape as routes().
     const ctx = workers.mock.calls[0]![0];
     expect(ctx.stateSigner).toBeDefined();
@@ -1042,14 +1041,14 @@ describe('MastraFactory.prepare integrations', () => {
     expect(args).not.toHaveProperty('workers');
   });
 
-  it('omits the workers option when no integration contributes workers', async () => {
+  it("keeps the supervisor's own worker when no integration contributes one", async () => {
     const factory = new MastraFactory({
       secretEncryption,
       storage: fakeStorage(),
       integrations: [fakeIntegration({ id: 'custom' })],
     });
     const args = await factory.prepare();
-    expect(args).not.toHaveProperty('workers');
+    expect(args.workers?.map(entry => entry.name)).toEqual(['factory-supervisor-health']);
   });
 
   /**

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -431,11 +431,10 @@ describe('bundled Factory skill assets', () => {
     expect(triage).toContain('Remove only conflicting alternatives from these explicit labels');
     expect(triage).toContain('On every initial run and refresh, keep exactly the selected effort label');
     expect(triage).toContain('Do not add, remove, or derive any `trio-*` labels');
-    expect(triage).toContain("gh label list --repo mastra-ai/mastra --limit 1000 --json name --jq '.[].name'");
-    expect(triage).toContain("gh label create '@mastra/core' --repo mastra-ai/mastra");
-    expect(triage).toContain('gh issue edit "$ISSUE" --repo mastra-ai/mastra --add-label \'@mastra/core\'');
-    expect(triage.indexOf("gh label create '@mastra/core'")).toBeLessThan(
-      triage.indexOf('gh issue edit "$ISSUE" --repo mastra-ai/mastra --add-label \'@mastra/core\''),
+    expect(triage).toContain('| `@mastra/core`');
+    expect(triage).toContain('gh label create "$LABEL" --repo mastra-ai/mastra');
+    expect(triage.indexOf('gh label create "$LABEL"')).toBeLessThan(
+      triage.indexOf('gh issue edit "$ISSUE" --repo mastra-ai/mastra --add-label'),
     );
     expect(triage).toContain('Apply only these label mutations.');
     expect(triage).toContain(


### PR DESCRIPTION
**─────── TLDR ───────**
> Five tests on `main` assert things the code stopped doing; this repairs the assertions so a red suite is a real regression again.

No behavior changes — three test files, and the skill prose they read is untouched. Each one drifted when a PR changed the thing it pins and updated a different test instead.

`factory.test.ts`, three tests — #23001 gave every ready Factory a `factory-supervisor-health` worker and a third blocking `onSessionCreated` listener. The worker list is never empty now, and the OM seed is no longer the first blocking listener.

`workspace.test.ts:434` — #22753 replaced the triage skill's `gh label list … | grep -Fxq '@mastra/core'` existence check with a domain-label table and a `gh label create … || true` loop. The assertion still pinned the removed command, so it has been red since 1 September.

`SupervisorPage.msw.test.tsx:169` — `findingPrompt` now hands the composer an untrusted-evidence JSON block instead of `#22874 (dec-1)`. Its unit test in `supervisor.test.ts` was updated; the page test was not.

### Decisions

- **the OM test now runs every blocking listener instead of indexing one** — the index broke the moment a listener joined; the fixture gained a bare `thread` so the model-pack listener bails as it does for a non-interactive session

---

> ████████████ **tests** `+17 −12` — the whole diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates stale test expectations so they match recent application changes. It changes tests only and does not change application behavior or skill prose.

## Changes

- Updated factory tests for the `factory-supervisor-health` worker and all blocking `onSessionCreated` listeners.
- Added `thread` to the session fixture used by the model-pack listener test.
- Updated triage skill assertions for the new domain-label table and label-creation loop.
- Updated the supervisor composer test to expect a structured finding JSON payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->