### PR TITLE
fix(factory-ui): prioritize active card sessions

### DIFF
--- a/mastracode/factory-ui/src/ui/__tests__/BoardCardSessionLiveness.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardCardSessionLiveness.msw.test.tsx
@@ -217,6 +217,45 @@ describe('Board card session liveness', () => {
     await waitFor(() => expect(card.querySelector('[data-live-session-indicator="working"]')).not.toBeNull());
   });
 
+  it('hides Retry while the bound session is working, even for a retryable failure', async () => {
+    // A retryable failed decision would normally put Retry first on the card.
+    // While the session owns the branch, Open session is the only action.
+    stubFactoryWithBoundSession();
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/decisions`, () =>
+        HttpResponse.json({
+          decisions: [
+            {
+              id: 'decision-1',
+              evaluationId: 'evaluation-1',
+              workItemId: ITEM_ID,
+              type: 'invokeSkill',
+              status: 'failed',
+              attempts: 5,
+              failureOccurrence: 1,
+              source: null,
+              failureCode: 'repository_clone_failed',
+              canRetry: true,
+              lastError: 'Command failed with ENOENT',
+              createdAt: '2026-07-18T00:00:00.000Z',
+              updatedAt: '2026-07-18T00:01:00.000Z',
+              completedAt: null,
+            },
+          ],
+        }),
+      ),
+      http.get('*/api/agent-controller/:controllerId/active-runs', () =>
+        HttpResponse.json({ runs: [{ runId: 'run-1', resourceId: SESSION_ID, threadId: SESSION_ID }] }),
+      ),
+    );
+    renderWorkBoard();
+
+    const card = await screen.findByTestId('work-item-card');
+    await waitFor(() => expect(card.querySelector('[data-live-session-indicator="working"]')).not.toBeNull());
+    expect(within(card).getByRole('link', { name: 'Open session' })).toBeInTheDocument();
+    expect(within(card).queryByRole('button', { name: 'Retry' })).toBeNull();
+  });
+
   it('walks idle → working → idle as a run starts and finishes', async () => {
     const { refetchGate } = stubFactoryWithBoundSession();
     refetchGate.resolve();

--- a/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.test.ts
@@ -152,13 +152,25 @@ describe('boardCardStatus', () => {
     ).toEqual({ kind: 'waiting', label: 'Re-review', decisionId: 'decision-9' });
   });
 
-  it('lets an effect the server is already working through outrank the parked run', () => {
+  it('lets active work outrank the parked run', () => {
     expect(
       boardCardStatus({
         proposal: { label: 'Re-review', decisionId: 'decision-9' },
         decision: decision({ type: 'transition', status: 'pending' }),
       }),
     ).toEqual({ kind: 'busy', label: 'Moving this card automatically…' });
+    expect(
+      boardCardStatus({
+        proposal: { label: 'Re-review', decisionId: 'decision-9' },
+        sessionStatus: 'working',
+      }),
+    ).toEqual({ kind: 'idle' });
+    expect(
+      boardCardStatus({
+        proposal: { label: 'Re-review', decisionId: 'decision-9' },
+        sessionStatus: 'initializing',
+      }),
+    ).toEqual({ kind: 'idle' });
   });
 
   it('names the held classification so the card says why it waits on a person', () => {

--- a/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.ts
@@ -126,6 +126,10 @@ export function boardCardStatus(input: BoardCardStatusInput): BoardCardStatus {
   if (decision && !runAnnouncedByWick(decision, input.sessionStatus)) {
     return { kind: 'busy', label: automationCopy(decision).busy };
   }
+  // A live session owns the card, so parked suggestions wait until it stops.
+  if (input.sessionStatus === 'initializing' || input.sessionStatus === 'working') {
+    return { kind: 'idle' };
+  }
   // Nothing is moving on its own. A held card's live question is the
   // maintainer's decision, even when a run has been suggested for it: the
   // card cannot start that run until it is accepted.

--- a/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.test.ts
@@ -206,6 +206,8 @@ describe('cardActions', () => {
     expect(labels(cardActions({ ...idle, session, retry, run }))).toEqual(['Retry', 'Open session', 'Investigate']);
     expect(labels(cardActions({ ...idle, running: true, session, run }))).toEqual(['Open session']);
     expect(labels(cardActions({ ...idle, running: true, waiting: true, session, run }))).toEqual(['Open session']);
+    expect(labels(cardActions({ ...idle, running: true, session, retry, run }))).toEqual(['Open session']);
+    expect(labels(cardActions({ ...idle, running: true, retry }))).toEqual([]);
     expect(cardActions(idle)).toEqual([]);
   });
 
@@ -215,5 +217,6 @@ describe('cardActions', () => {
     expect(lit(cardActions({ ...idle, session, run }))).toEqual([]);
     expect(lit(cardActions({ ...idle, session, retry, run }))).toEqual(['Retry']);
     expect(lit(cardActions({ ...idle, running: true, waiting: true, session, run }))).toEqual([]);
+    expect(lit(cardActions({ ...idle, running: true, session, retry, run }))).toEqual([]);
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.test.ts
@@ -205,10 +205,7 @@ describe('cardActions', () => {
     expect(labels(cardActions({ ...idle, session, run }))).toEqual(['Investigate', 'Open session']);
     expect(labels(cardActions({ ...idle, session, retry, run }))).toEqual(['Retry', 'Open session', 'Investigate']);
     expect(labels(cardActions({ ...idle, running: true, session, run }))).toEqual(['Open session']);
-    expect(labels(cardActions({ ...idle, running: true, waiting: true, session, run }))).toEqual([
-      'Investigate',
-      'Open session',
-    ]);
+    expect(labels(cardActions({ ...idle, running: true, waiting: true, session, run }))).toEqual(['Open session']);
     expect(cardActions(idle)).toEqual([]);
   });
 
@@ -217,6 +214,6 @@ describe('cardActions', () => {
     const lit = (actions: CardAction[]) => actions.filter(action => action.urgent).map(action => action.label);
     expect(lit(cardActions({ ...idle, session, run }))).toEqual([]);
     expect(lit(cardActions({ ...idle, session, retry, run }))).toEqual(['Retry']);
-    expect(lit(cardActions({ ...idle, running: true, waiting: true, session, run }))).toEqual(['Investigate']);
+    expect(lit(cardActions({ ...idle, running: true, waiting: true, session, run }))).toEqual([]);
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.ts
@@ -150,8 +150,7 @@ export function cardPrimaryAction({
 }
 
 export type CardAction = { label: string; ariaLabel?: string; disabled?: boolean; urgent?: boolean } & (
-  | { href: string }
-  | { start: () => void }
+  { href: string } | { start: () => void }
 );
 
 export function sessionLink(href: string | undefined): CardAction | undefined {
@@ -207,8 +206,8 @@ export function cardActions({
   retry?: CardAction;
   run?: CardAction;
 }): CardAction[] {
-  // A running session owns the branch, so no rival run beside it; a waiting suggestion is still the user's to release.
-  const nextRun = running && !waiting ? undefined : run;
+  // A running session owns the branch, so no rival run or parked suggestion can start beside it.
+  const nextRun = running ? undefined : run;
   const main = retry ?? nextRun ?? session;
   if (main === undefined) return [];
   const rest = [session, nextRun].filter(action => action !== undefined).filter(action => action !== main);

--- a/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.ts
@@ -150,7 +150,8 @@ export function cardPrimaryAction({
 }
 
 export type CardAction = { label: string; ariaLabel?: string; disabled?: boolean; urgent?: boolean } & (
-  { href: string } | { start: () => void }
+  | { href: string }
+  | { start: () => void }
 );
 
 export function sessionLink(href: string | undefined): CardAction | undefined {
@@ -200,17 +201,18 @@ export function cardActions({
   run,
 }: {
   running: boolean;
-  /** The run is a parked suggestion or a held card's decision: it needs the user, so it outranks a running session. */
+  /** The run is a parked suggestion or a held card's decision: it needs the user, so it lights up once nothing is running. */
   waiting: boolean;
   session?: CardAction;
   retry?: CardAction;
   run?: CardAction;
 }): CardAction[] {
-  // A running session owns the branch, so no rival run or parked suggestion can start beside it.
+  // A running session owns the branch, so no retry, rival run, or parked suggestion can start beside it.
+  const nextRetry = running ? undefined : retry;
   const nextRun = running ? undefined : run;
-  const main = retry ?? nextRun ?? session;
+  const main = nextRetry ?? nextRun ?? session;
   if (main === undefined) return [];
   const rest = [session, nextRun].filter(action => action !== undefined).filter(action => action !== main);
-  const urgent = (action: CardAction) => action === retry || (waiting && action === run);
+  const urgent = (action: CardAction) => action === nextRetry || (waiting && action === nextRun);
   return [main, ...rest].map(action => ({ ...action, urgent: urgent(action) }));
 }


### PR DESCRIPTION
## Summary
- hide parked run suggestions and retry buttons while a card session is initializing or working
- make Open session the only card action while active work owns the branch
- add regression coverage for active sessions with pending suggestions and retryable failures

## Test plan
- `pnpm vitest run src/ui/domains/factory src/ui/__tests__/BoardCardSessionLiveness.msw.test.tsx src/ui/__tests__/BoardPageCardClickStartsRun.msw.test.tsx src/ui/__tests__/BoardPagePendingStates.msw.test.tsx` — 275 passed
- `pnpm typecheck` — clean
- `oxfmt --check` and `oxlint` on changed files — clean (previous Lint failure was an oxfmt formatting diff in `cardPrimaryAction.ts`)
- Negative control: restoring retry-while-running fails the new unit and MSW cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a card session is starting or working, the card shows only “Open session.” This prevents run and retry suggestions from competing with the active session.

## Changes

- Prioritize `initializing` and `working` sessions over held cards and pending proposals.
- Hide run and retry actions while a session is active.
- Add regression tests for active sessions with pending suggestions and retryable failed decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->