### PR TITLE
feat(connect): @mastra/connect — live mode for connect() (auto tool pickup)

### DIFF
--- a/.changeset/swift-otters-pulse.md
+++ b/.changeset/swift-otters-pulse.md
@@ -1,0 +1,16 @@
+---
+'@mastra/connect': minor
+---
+
+Add live mode to `connect()`: `connect({ live: true })` returns a resolver compatible with an agent's dynamic `tools` argument, backed by a TTL cache (stale-while-revalidate, default 30s, configurable via `ttlMs`) over the project's platform connections. Integrations attached to — or detached from — the project on the Mastra platform are picked up (or dropped) by running agents without a server restart. The resolver also exposes `invalidate()` and `refresh()` for manual control. Configuration errors still throw eagerly at `connect()` time; per-integration problems (needs re-auth, ambiguity, not attached yet) downgrade to warn-and-skip so one bad integration never takes down the whole toolset.
+
+```ts
+import { Agent } from '@mastra/core/agent'
+import { connect } from '@mastra/connect'
+
+const agent = new Agent({
+  // Resolved per generate/stream — newly attached integrations appear automatically.
+  tools: connect({ live: true, ttlMs: 30_000 }),
+  model: 'openai/gpt-5-mini',
+})
+```

--- a/packages/connect/src/__tests__/connect.live.test.ts
+++ b/packages/connect/src/__tests__/connect.live.test.ts
@@ -1,0 +1,404 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { connect } from '../connect.js';
+import type { ConnectOptions } from '../connect.js';
+import { MastraConnectError } from '../errors.js';
+import { PROVIDERS } from '../registry.js';
+import type { ProviderKey, ProviderRegistration } from '../registry.js';
+
+const TOKEN = 'fake-test-token';
+
+const originalRegistrations: Partial<Record<ProviderKey, ProviderRegistration>> = {};
+
+function stubProvider(key: ProviderKey, integrationId: string, envVar: string) {
+  const createTools = vi.fn().mockReturnValue({ [`${key}_fake_tool`]: { id: `${key}_fake_tool` } } as never);
+  if (!(key in originalRegistrations)) {
+    originalRegistrations[key] = PROVIDERS[key];
+  }
+  PROVIDERS[key] = { integrationId, envVar, createTools };
+  return { createTools };
+}
+
+function makeConnection(overrides?: Record<string, unknown>) {
+  return {
+    id: 'c_lin1',
+    integrationId: 'linear',
+    status: 'active',
+    connectedByUserId: 'user_1',
+    connectedAt: '2026-09-01T00:00:00Z',
+    createdAt: '2026-09-01T00:00:00Z',
+    accountLabel: 'Acme',
+    ...overrides,
+  };
+}
+
+function liveOptions(
+  connections: () => unknown[],
+  extra?: { ttlMs?: number; integrations?: ConnectOptions['integrations'] },
+) {
+  const fetchMock = vi.fn().mockImplementation(async () => Response.json({ connections: connections() }));
+  return {
+    fetchMock,
+    options: {
+      projectId: 'proj_1',
+      live: true as const,
+      client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+      ...extra,
+    },
+  };
+}
+
+/** Lets pending microtasks (background SWR refreshes) settle without advancing the fake clock. */
+function flush(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  for (const [key, registration] of Object.entries(originalRegistrations)) {
+    PROVIDERS[key as ProviderKey] = registration;
+  }
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  warnSpy.mockRestore();
+});
+
+describe('connect live mode', () => {
+  it('returns a resolver function with invalidate/refresh, not a promise', () => {
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    const tools = connect(liveOptions(() => []).options);
+    expect(typeof tools).toBe('function');
+    expect(typeof tools.invalidate).toBe('function');
+    expect(typeof tools.refresh).toBe('function');
+  });
+
+  it('resolves toolsets from the project connections on first resolution', async () => {
+    const { createTools } = stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    const { options } = liveOptions(() => [makeConnection()]);
+    const tools = connect(options);
+    const result = await tools({ requestContext: {} });
+    expect(Object.keys(result)).toEqual(['linear']);
+    expect(createTools).toHaveBeenCalledWith(expect.objectContaining({ connectionId: 'c_lin1' }));
+  });
+
+  it('serves the cached snapshot within the TTL without refetching', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    const { options, fetchMock } = liveOptions(() => [makeConnection()], { ttlMs: 30_000 });
+    const tools = connect(options);
+
+    const start = Date.now();
+    await tools();
+    vi.setSystemTime(start + 29_999);
+    await tools();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves stale toolsets immediately after TTL and picks up an attached integration on the next resolution', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    stubProvider('notion', 'notion', 'MASTRA_NOTION_CONNECTION_ID');
+    let connections = [makeConnection()];
+    const { options, fetchMock } = liveOptions(() => connections, { ttlMs: 1_000 });
+    const tools = connect(options);
+
+    const start = Date.now();
+    const first = await tools();
+    expect(Object.keys(first)).toEqual(['linear']);
+
+    // Attach Notion on the platform, then let the snapshot go stale.
+    connections = [makeConnection(), makeConnection({ id: 'c_not1', integrationId: 'notion' })];
+    vi.setSystemTime(start + 1_001);
+
+    // Stale-while-revalidate: this call serves the old snapshot and refreshes in the background.
+    const stale = await tools();
+    expect(Object.keys(stale)).toEqual(['linear']);
+    await flush();
+
+    const fresh = await tools();
+    expect(Object.keys(fresh).sort()).toEqual(['linear', 'notion']);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops a detached integration on the next refresh', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    stubProvider('notion', 'notion', 'MASTRA_NOTION_CONNECTION_ID');
+    let connections = [makeConnection(), makeConnection({ id: 'c_not1', integrationId: 'notion' })];
+    const { options } = liveOptions(() => connections, { ttlMs: 1_000 });
+    const tools = connect(options);
+
+    const start = Date.now();
+    await tools();
+    connections = [makeConnection()];
+    vi.setSystemTime(start + 1_001);
+    await tools();
+    await flush();
+
+    const fresh = await tools();
+    expect(Object.keys(fresh)).toEqual(['linear']);
+  });
+
+  it('keeps the stale snapshot and warns when a background refresh fails', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    let fail = false;
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(async () =>
+        fail ? Promise.reject(new Error('network down')) : Response.json({ connections: [makeConnection()] }),
+      );
+    const tools = connect({
+      projectId: 'proj_1',
+      live: true,
+      ttlMs: 1_000,
+      client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+    });
+
+    const start = Date.now();
+    await tools();
+    fail = true;
+    vi.setSystemTime(start + 1_001);
+
+    const result = await tools();
+    expect(Object.keys(result)).toEqual(['linear']);
+    await flush();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('platform refresh failed'));
+
+    // Still served from cache afterwards.
+    const again = await tools();
+    expect(Object.keys(again)).toEqual(['linear']);
+  });
+
+  it('rejects when the platform is unreachable and nothing is cached', async () => {
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ title: 'internal error' }), {
+        status: 500,
+        headers: { 'content-type': 'application/problem+json' },
+      }),
+    );
+    const tools = connect({
+      projectId: 'proj_1',
+      live: true,
+      client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+    });
+    await expect(tools()).rejects.toMatchObject({ code: 'platform_error' });
+  });
+
+  it('performs a single fetch for concurrent cold resolutions', async () => {
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    let resolveFetch!: (response: Response) => void;
+    const fetchMock = vi.fn(() => new Promise<Response>(resolve => (resolveFetch = resolve)));
+    const tools = connect({
+      projectId: 'proj_1',
+      live: true,
+      client: { accessToken: TOKEN, baseUrl: 'https://example.test', fetch: fetchMock as unknown as typeof fetch },
+    });
+
+    const p1 = tools();
+    const p2 = tools();
+    resolveFetch(Response.json({ connections: [makeConnection()] }));
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(Object.keys(r1)).toEqual(['linear']);
+    expect(r2).toBe(r1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidate() forces a refetch on the next resolution', async () => {
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    const { options, fetchMock } = liveOptions(() => [makeConnection()], { ttlMs: 60_000 });
+    const tools = connect(options);
+
+    await tools();
+    tools.invalidate();
+    await tools();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('refresh() fetches immediately and updates the cache', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    stubProvider('notion', 'notion', 'MASTRA_NOTION_CONNECTION_ID');
+    let connections = [makeConnection()];
+    const { options, fetchMock } = liveOptions(() => connections, { ttlMs: 60_000 });
+    const tools = connect(options);
+
+    await tools();
+    connections = [makeConnection(), makeConnection({ id: 'c_not1', integrationId: 'notion' })];
+    const fresh = await tools.refresh();
+    expect(Object.keys(fresh).sort()).toEqual(['linear', 'notion']);
+
+    // The refreshed snapshot now serves within the TTL without another fetch.
+    const next = await tools();
+    expect(next).toBe(fresh);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('warns once for an allowlisted provider with no connection yet, then picks it up once attached', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    stubProvider('notion', 'notion', 'MASTRA_NOTION_CONNECTION_ID');
+    const notionConnection = makeConnection({ id: 'c_not1', integrationId: 'notion' });
+    let connections = [notionConnection];
+    const { options } = liveOptions(() => connections, {
+      ttlMs: 1_000,
+      integrations: { linear: true, notion: true },
+    });
+    const tools = connect(options);
+
+    const start = Date.now();
+    const first = await tools();
+    expect(Object.keys(first)).toEqual(['notion']);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('will appear automatically'));
+
+    // Still missing after another refresh: the warning is not repeated.
+    vi.setSystemTime(start + 1_001);
+    await tools();
+    await flush();
+    const missingWarns = warnSpy.mock.calls.filter(call => String(call[0]).includes('will appear automatically'));
+    expect(missingWarns).toHaveLength(1);
+
+    // Attach Linear: it shows up without a restart.
+    connections = [notionConnection, makeConnection()];
+    const after = await tools.refresh();
+    expect(Object.keys(after).sort()).toEqual(['linear', 'notion']);
+  });
+
+  it('warns and skips a needs_reauth connection instead of rejecting', async () => {
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    const { options } = liveOptions(() => [makeConnection({ status: 'needs_reauth' })]);
+    const tools = connect(options);
+
+    await expect(tools()).resolves.toEqual({});
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('re-authentication'));
+  });
+
+  it('warns and skips a directed needs_reauth connection instead of rejecting', async () => {
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    const { options } = liveOptions(() => [makeConnection({ status: 'needs_reauth' })], {
+      integrations: { linear: { connectionId: 'c_lin1' } },
+    });
+    const tools = connect(options);
+
+    await expect(tools()).resolves.toEqual({});
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('needs re-authentication'));
+  });
+
+  it('warns and skips an ambiguous explicit provider instead of throwing multiple_connections', async () => {
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    const { options } = liveOptions(() => [makeConnection(), makeConnection({ id: 'c_lin2' })], {
+      integrations: { linear: true },
+    });
+    const tools = connect(options);
+
+    await expect(tools()).resolves.toEqual({});
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('multiple connections found'));
+  });
+
+  it('lets the env var pick among multiple connections in live mode', async () => {
+    const { createTools } = stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    vi.stubEnv('MASTRA_LINEAR_CONNECTION_ID', 'c_lin2');
+    const { options } = liveOptions(() => [makeConnection(), makeConnection({ id: 'c_lin2' })]);
+    const tools = connect(options);
+
+    await tools();
+    expect(createTools).toHaveBeenCalledWith(expect.objectContaining({ connectionId: 'c_lin2' }));
+  });
+
+  it('warns and skips unsupported platform integrations in undirected live mode', async () => {
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    const { options } = liveOptions(() => [
+      makeConnection(),
+      makeConnection({ id: 'c_unk1', integrationId: 'salesforce' }),
+    ]);
+    const tools = connect(options);
+
+    const result = await tools();
+    expect(Object.keys(result)).toEqual(['linear']);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('salesforce'));
+  });
+
+  it('warns once per unsupported integration across refreshes', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    const { options } = liveOptions(
+      () => [makeConnection(), makeConnection({ id: 'c_unk1', integrationId: 'salesforce' })],
+      { ttlMs: 1_000 },
+    );
+    const tools = connect(options);
+
+    const start = Date.now();
+    await tools();
+    vi.setSystemTime(start + 1_001);
+    await tools();
+    await flush();
+    await tools.refresh();
+
+    const unsupportedWarns = warnSpy.mock.calls.filter(call => String(call[0]).includes('salesforce'));
+    expect(unsupportedWarns).toHaveLength(1);
+  });
+
+  it('warns and skips a provider whose builder throws (e.g. invalid allowTools) instead of rejecting', async () => {
+    const { createTools } = stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    createTools.mockImplementation(() => {
+      throw new Error('Unknown tool: linear_nope');
+    });
+    const { options } = liveOptions(() => [makeConnection()]);
+    const tools = connect(options);
+
+    await expect(tools()).resolves.toEqual({});
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown tool: linear_nope'));
+  });
+
+  it('throws missing_project_id synchronously at connect() time', () => {
+    vi.stubEnv('MASTRA_PROJECT_ID', '');
+    expect(() => connect({ live: true, client: { accessToken: TOKEN } })).toThrow(MastraConnectError);
+  });
+
+  it('throws missing_access_token synchronously at connect() time', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
+    expect(() => connect({ live: true, projectId: 'proj_1' })).toThrow(MastraConnectError);
+  });
+
+  it('throws synchronously for unknown integration keys', () => {
+    expect(() =>
+      connect({
+        live: true,
+        projectId: 'proj_1',
+        integrations: { bogus: true } as never,
+        client: { accessToken: TOKEN },
+      }),
+    ).toThrow(/Unknown integration 'bogus'/);
+  });
+
+  it('throws invalid_options synchronously for a bad ttlMs', () => {
+    for (const ttlMs of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => connect({ live: true, projectId: 'proj_1', ttlMs, client: { accessToken: TOKEN } })).toThrow(
+        /ttlMs/,
+      );
+    }
+  });
+
+  it('accepts ttlMs of 0 and revalidates on every resolution', async () => {
+    stubProvider('linear', 'linear', 'MASTRA_LINEAR_CONNECTION_ID');
+    const { options, fetchMock } = liveOptions(() => [makeConnection()], { ttlMs: 0 });
+    const tools = connect(options);
+
+    await tools();
+    await tools();
+    await flush();
+    await tools();
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/connect/src/connect.ts
+++ b/packages/connect/src/connect.ts
@@ -17,10 +17,40 @@ export interface ConnectOptions {
   /**
    * Integration allowlist. When provided, only listed providers are returned:
    * `true` (or an options object) includes a provider, `false` excludes it.
-   * Providers listed but absent from the project's connections throw.
+   * In snapshot mode, providers listed but absent from the project's
+   * connections throw; in live mode they are skipped (with a one-time warning)
+   * until a connection is attached.
    */
   integrations?: Partial<Record<ProviderKey, ConnectIntegrationOptions | boolean>>;
   client?: ConnectClientOptions;
+}
+
+export interface ConnectLiveOptions extends ConnectOptions {
+  /**
+   * Live mode: instead of resolving toolsets once, connect() returns a
+   * resolver compatible with an agent's dynamic `tools` argument. Mastra
+   * invokes it on every generate/stream, and it serves a cached snapshot of
+   * the project's toolsets, revalidating from the platform every `ttlMs`.
+   * Integrations attached to (or detached from) the project on the Mastra
+   * platform are picked up (or dropped) by running agents without a restart.
+   */
+  live: true;
+  /** How long a resolved snapshot stays fresh, in milliseconds. Default 30_000. `0` revalidates on every resolution. */
+  ttlMs?: number;
+}
+
+/**
+ * Live toolset resolver returned by `connect({ live: true })`. Pass it
+ * straight to an agent's dynamic `tools` argument: Mastra calls it per
+ * generate/stream, so project integrations attached or detached on the
+ * platform are reflected without restarting the server.
+ */
+export interface ConnectLiveTools {
+  (ctx?: { requestContext?: unknown; mastra?: unknown }): Promise<Record<string, ToolsInput>>;
+  /** Drops the cached snapshot; the next resolution fetches fresh from the platform. */
+  invalidate(): void;
+  /** Fetches toolsets from the platform now and updates the cache. */
+  refresh(): Promise<Record<string, ToolsInput>>;
 }
 
 interface ResolvedIntegrationRequest {
@@ -30,11 +60,28 @@ interface ResolvedIntegrationRequest {
   options: ConnectIntegrationOptions;
 }
 
+const DEFAULT_LIVE_TTL_MS = 30_000;
+
 /**
  * Discovers the project's platform connections and returns a toolset per
  * connected provider, suitable for an agent's `toolsets` option.
+ *
+ * With `live: true`, returns a resolver instead of a one-time snapshot (see
+ * {@link ConnectLiveOptions}).
  */
-export async function connect(options?: ConnectOptions): Promise<Record<string, ToolsInput>> {
+export function connect(options: ConnectLiveOptions): ConnectLiveTools;
+export function connect(options?: ConnectOptions): Promise<Record<string, ToolsInput>>;
+export function connect(
+  options?: ConnectOptions | ConnectLiveOptions,
+): Promise<Record<string, ToolsInput>> | ConnectLiveTools {
+  if (options && 'live' in options && options.live) {
+    return createLiveConnect(options);
+  }
+
+  return connectSnapshot(options);
+}
+
+async function connectSnapshot(options?: ConnectOptions): Promise<Record<string, ToolsInput>> {
   const projectId = options?.projectId?.trim() || process.env.MASTRA_PROJECT_ID?.trim();
   if (!projectId) {
     throw new MastraConnectError('missing_project_id', 'Missing project id: set MASTRA_PROJECT_ID or pass projectId.');
@@ -43,19 +90,13 @@ export async function connect(options?: ConnectOptions): Promise<Record<string, 
   const client = resolveClient(options?.client);
   const connections = await listProjectConnections(client, projectId);
 
-  const byIntegrationId = new Map<string, ProjectConnection[]>();
-  for (const connection of connections) {
-    const list = byIntegrationId.get(connection.integrationId) ?? [];
-    list.push(connection);
-    byIntegrationId.set(connection.integrationId, list);
-  }
-
-  const requests = buildRequests(options?.integrations, byIntegrationId);
+  const byIntegrationId = groupByIntegrationId(connections);
+  const requests = buildRequests(options?.integrations, byIntegrationId, { requireConnected: true });
 
   const result: Record<string, ToolsInput> = {};
   for (const request of requests) {
     const candidates = byIntegrationId.get(request.registration.integrationId) ?? [];
-    const connectionId = resolveProviderConnection(request, candidates);
+    const connectionId = resolveProviderConnection(request, candidates, true);
     if (!connectionId) continue; // warned + skipped
     result[request.key] = request.registration.createTools({
       connectionId,
@@ -66,10 +107,152 @@ export async function connect(options?: ConnectOptions): Promise<Record<string, 
   return result;
 }
 
-/** Builds the list of providers to resolve: the allowlist when given, else every supported connected provider. */
+/**
+ * Builds the live resolver. Configuration errors (missing project id/token,
+ * unknown integration keys, bad ttlMs) throw here — at connect() call time —
+ * so they surface at startup, never on a request path.
+ */
+function createLiveConnect(options: ConnectLiveOptions): ConnectLiveTools {
+  const projectId = options.projectId?.trim() || process.env.MASTRA_PROJECT_ID?.trim();
+  if (!projectId) {
+    throw new MastraConnectError('missing_project_id', 'Missing project id: set MASTRA_PROJECT_ID or pass projectId.');
+  }
+  if (options.ttlMs !== undefined && (!Number.isFinite(options.ttlMs) || options.ttlMs < 0)) {
+    throw new MastraConnectError(
+      'invalid_options',
+      `Invalid ttlMs (${options.ttlMs}): expected a finite number of milliseconds >= 0.`,
+    );
+  }
+  const ttlMs = options.ttlMs ?? DEFAULT_LIVE_TTL_MS;
+
+  const client = resolveClient(options.client);
+  validateIntegrationKeys(options.integrations);
+
+  const warnedMissing = new Set<ProviderKey>();
+  const warnedUnsupported = new Set<string>();
+  let cache: { snapshot: Record<string, ToolsInput>; fetchedAt: number } | undefined;
+  let inflight: Promise<Record<string, ToolsInput>> | undefined;
+
+  const refresh = (): Promise<Record<string, ToolsInput>> => {
+    if (!inflight) {
+      inflight = (async () => {
+        try {
+          const connections = await listProjectConnections(client, projectId);
+          const snapshot = mapLiveToolsets(connections, options, warnedMissing, warnedUnsupported);
+          cache = { snapshot, fetchedAt: Date.now() };
+          return snapshot;
+        } catch (error) {
+          if (cache) {
+            console.warn(
+              `[@mastra/connect] Keeping cached toolsets (fetched ${Date.now() - cache.fetchedAt}ms ago); platform refresh failed: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
+            return cache.snapshot;
+          }
+          throw error;
+        } finally {
+          inflight = undefined;
+        }
+      })();
+    }
+    return inflight;
+  };
+
+  const resolve = async (): Promise<Record<string, ToolsInput>> => {
+    if (cache && Date.now() - cache.fetchedAt < ttlMs) {
+      return cache.snapshot;
+    }
+    if (cache) {
+      // Stale: serve the snapshot now and revalidate in the background.
+      void refresh().catch(() => {});
+      return cache.snapshot;
+    }
+    return refresh();
+  };
+
+  return Object.assign(resolve, {
+    invalidate: (): void => {
+      cache = undefined;
+    },
+    refresh,
+  });
+}
+
+/** Maps one platform connection list snapshot to toolsets, downgrading every per-provider failure to warn+skip. */
+function mapLiveToolsets(
+  connections: ProjectConnection[],
+  options: ConnectLiveOptions,
+  warnedMissing: Set<ProviderKey>,
+  warnedUnsupported: Set<string>,
+): Record<string, ToolsInput> {
+  const byIntegrationId = groupByIntegrationId(connections);
+  const requests = buildRequests(options.integrations, byIntegrationId, {
+    requireConnected: false,
+    warnedUnsupported,
+  });
+
+  const result: Record<string, ToolsInput> = {};
+  for (const request of requests) {
+    try {
+      const candidates = byIntegrationId.get(request.registration.integrationId) ?? [];
+      if (candidates.length === 0) {
+        if (!warnedMissing.has(request.key)) {
+          warnedMissing.add(request.key);
+          console.warn(
+            `[@mastra/connect] No ${request.key} connection in this project yet; its tools will appear automatically once one is attached.`,
+          );
+        }
+        continue;
+      }
+      const connectionId = resolveProviderConnection(request, candidates, false);
+      if (!connectionId) continue; // warned + skipped
+      result[request.key] = request.registration.createTools({
+        connectionId,
+        allowTools: request.options.allowTools,
+        client: options.client,
+      });
+    } catch (error) {
+      console.warn(
+        `[@mastra/connect] Skipping ${request.key}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+  return result;
+}
+
+function groupByIntegrationId(connections: ProjectConnection[]): Map<string, ProjectConnection[]> {
+  const byIntegrationId = new Map<string, ProjectConnection[]>();
+  for (const connection of connections) {
+    const list = byIntegrationId.get(connection.integrationId) ?? [];
+    list.push(connection);
+    byIntegrationId.set(connection.integrationId, list);
+  }
+  return byIntegrationId;
+}
+
+function validateIntegrationKeys(integrations: ConnectOptions['integrations']): void {
+  if (!integrations) return;
+  for (const key of Object.keys(integrations)) {
+    if (!PROVIDERS[key as ProviderKey]) {
+      throw new MastraConnectError(
+        'connection_not_found',
+        `Unknown integration '${key}' in connect() options: no such provider is supported by @mastra/connect.`,
+      );
+    }
+  }
+}
+
+/**
+ * Builds the list of providers to resolve: the allowlist when given, else
+ * every supported connected provider. With `requireConnected: false` (live
+ * mode), allowlisted providers without a connection yet are kept so they can
+ * appear once a connection is attached.
+ */
 function buildRequests(
   integrations: ConnectOptions['integrations'],
   byIntegrationId: Map<string, ProjectConnection[]>,
+  opts: { requireConnected: boolean; warnedUnsupported?: Set<string> },
 ): ResolvedIntegrationRequest[] {
   if (integrations) {
     const requests: ResolvedIntegrationRequest[] = [];
@@ -84,10 +267,15 @@ function buildRequests(
       }
       const options = value === true ? {} : value;
       if (!byIntegrationId.has(registration.integrationId)) {
-        throw new MastraConnectError(
-          'connection_not_found',
-          `No ${key} connection found in this project. Connect ${key} on the Mastra platform or remove it from connect() integrations.`,
-        );
+        if (opts.requireConnected) {
+          throw new MastraConnectError(
+            'connection_not_found',
+            `No ${key} connection found in this project. Connect ${key} on the Mastra platform or remove it from connect() integrations.`,
+          );
+        }
+        // Live mode: keep the request; mapping warns once and skips until attached.
+        requests.push({ key, registration, explicit: true, options });
+        continue;
       }
       requests.push({ key, registration, explicit: true, options });
     }
@@ -98,10 +286,15 @@ function buildRequests(
   for (const integrationId of byIntegrationId.keys()) {
     const found = findProviderByIntegrationId(integrationId);
     if (!found) {
-      const ids = (byIntegrationId.get(integrationId) ?? []).map(connection => connection.id).join(', ');
-      console.warn(
-        `[@mastra/connect] Skipping unsupported integration '${integrationId}' (connection ${ids}): no toolset is registered for it.`,
-      );
+      // Live mode re-runs this mapping on every refresh: warn once per
+      // integration id instead of spamming the log on every TTL cycle.
+      if (!opts.warnedUnsupported?.has(integrationId)) {
+        opts.warnedUnsupported?.add(integrationId);
+        const ids = (byIntegrationId.get(integrationId) ?? []).map(connection => connection.id).join(', ');
+        console.warn(
+          `[@mastra/connect] Skipping unsupported integration '${integrationId}' (connection ${ids}): no toolset is registered for it.`,
+        );
+      }
       continue;
     }
     requests.push({ key: found.key, registration: found.registration, explicit: false, options: {} });
@@ -117,20 +310,29 @@ function readEnvConnectionId(registration: ProviderRegistration): string | undef
  * Resolves the connection to use for one provider, per the contract:
  * option/env var wins; else a single active connection; ambiguity throws for
  * explicitly requested providers and warns+skips otherwise. A needs_reauth
- * connection is never silently mapped.
+ * connection is never silently mapped. With `strict: false` (live mode) every
+ * throw is downgraded to warn+skip so one bad integration never takes down
+ * the whole toolset resolution.
  */
 function resolveProviderConnection(
   request: ResolvedIntegrationRequest,
   candidates: ProjectConnection[],
+  strict: boolean,
 ): string | undefined {
   const directed = request.options.connectionId?.trim() || readEnvConnectionId(request.registration);
   if (directed) {
     const match = candidates.find(connection => connection.id === directed);
     if (match?.status === 'needs_reauth') {
-      throw new MastraConnectError(
-        'needs_reauth',
-        `Connection ${directed} (${request.key}) needs re-authentication. Reconnect it on the Mastra platform.`,
+      if (strict) {
+        throw new MastraConnectError(
+          'needs_reauth',
+          `Connection ${directed} (${request.key}) needs re-authentication. Reconnect it on the Mastra platform.`,
+        );
+      }
+      console.warn(
+        `[@mastra/connect] Skipping ${request.key}: connection ${directed} needs re-authentication. Reconnect it on the Mastra platform.`,
       );
+      return undefined;
     }
     return directed;
   }
@@ -141,7 +343,7 @@ function resolveProviderConnection(
   if (active.length === 0) {
     const reauth = candidates.filter(connection => connection.status === 'needs_reauth');
     if (reauth.length > 0) {
-      if (request.explicit) {
+      if (request.explicit && strict) {
         throw new MastraConnectError(
           'needs_reauth',
           `All ${request.key} connections need re-authentication (${reauth.map(connection => connection.id).join(', ')}). Reconnect on the Mastra platform.`,
@@ -153,7 +355,7 @@ function resolveProviderConnection(
       return undefined;
     }
     // No usable candidates (e.g. only connections in an unknown status).
-    if (request.explicit) {
+    if (request.explicit && strict) {
       throw new MastraConnectError(
         'connection_not_found',
         `No usable ${request.key} connection found in this project (${candidates.map(connection => `${connection.id}: ${connection.status}`).join(', ')}).`,
@@ -166,7 +368,7 @@ function resolveProviderConnection(
   }
 
   const ids = active.map(connection => connection.id).join(', ');
-  if (request.explicit) {
+  if (request.explicit && strict) {
     throw new MastraConnectError(
       'multiple_connections',
       `Multiple ${request.key} connections found (${ids}). Set ${request.registration.envVar} or pass integrations.${request.key}.connectionId to choose one.`,

--- a/packages/connect/src/errors.ts
+++ b/packages/connect/src/errors.ts
@@ -2,6 +2,7 @@ export type MastraConnectErrorCode =
   | 'missing_access_token'
   | 'missing_project_id'
   | 'missing_connection_id'
+  | 'invalid_options'
   | 'connection_not_found'
   | 'multiple_connections'
   | 'needs_reauth'

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,5 +1,5 @@
 export { connect } from './connect.js';
-export type { ConnectOptions, ConnectIntegrationOptions } from './connect.js';
+export type { ConnectOptions, ConnectIntegrationOptions, ConnectLiveOptions, ConnectLiveTools } from './connect.js';
 export { credential } from './credential.js';
 export { MastraConnectError } from './errors.js';
 export type { MastraConnectErrorCode } from './errors.js';


### PR DESCRIPTION
Segment 5 of the @mastra/connect plan set (see `.mastracode/plans/mastra-connect/05-live-connect.md`).

## What

`connect({ live: true })` returns a resolver compatible with an agent's dynamic `tools` argument (Mastra invokes it per generate/stream), backed by a TTL cache with stale-while-revalidate over `GET /v2/projects/:projectId/connections` (default 30s, configurable via `ttlMs`).

The goal: when someone attaches a new integration to a project on the Mastra platform, a running agent/server gets its tools automatically — no restart, no redeploy, no push infrastructure.

```ts
import { Agent } from '@mastra/core/agent'
import { connect } from '@mastra/connect'

const agent = new Agent({
  tools: connect({ live: true, ttlMs: 30_000 }),
  model: 'openai/gpt-5-mini',
})
```

## Semantics

- **Attach** → toolset appears within TTL (or immediately via `tools.refresh()` / `tools.invalidate()`).
- **Detach** → toolset drops at the next resolution; in-flight proxy calls fail with `connection_not_found`.
- **Fresh cache** → served without a platform call. **Stale cache** → served immediately, revalidated in the background (single-flight).
- **Platform failure** → keeps serving the last good snapshot with a warning; rejects only when nothing was ever cached.
- Configuration errors (project id, access token, unknown integration keys, invalid `ttlMs` → new `invalid_options` error code) throw eagerly at `connect()` time, never per request.
- Per-integration problems (needs re-auth, ambiguous connections, not attached yet, unsupported, builder errors) downgrade to warn-once + skip so one bad integration never takes down resolution on a long-running server.
- Snapshot-mode `connect()` is unchanged (all existing tests green).

## Verification

- 197 tests / 14 files pass (23 new live-mode tests: TTL, SWR attach/detach, single-flight, failure paths, warn-once, eager validation).
- `tsc --noEmit`, oxlint+eslint, `turbo build` all green.
- Changeset: `swift-otters-pulse.md` (minor).

Per plan amendments A1/A3: proof demos and segment-scoped adversarial review skipped; careful self-review substituted (warn-once for unsupported integrations across refreshes was found and fixed during it).

Stack: #22992 (core) → #22999 (OAuth wave) → #23005 (API-key wave) → **this PR** → #23007 (docs, to be rebased on top).