### PR TITLE
fix(memory): harden reminder sidekick continuity

### DIFF
--- a/.changeset/cyan-melons-hunt.md
+++ b/.changeset/cyan-melons-hunt.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Improved the reliability of experimental Subconscious memory behavior.

--- a/.changeset/honest-ants-fold.md
+++ b/.changeset/honest-ants-fold.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved agent message delivery reliability during run completion.

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -2997,6 +2997,50 @@ describe('Agent signals', () => {
     }
   });
 
+  it('queues sendMessage while a successful run is still completing', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const streamMock = vi.fn().mockResolvedValue({ runId: 'completion-follow-up-run' });
+    const agent = {
+      id: 'completion-window-agent',
+      stream: streamMock,
+    } as unknown as Agent<any, any, any, any>;
+    const runId = 'completion-window-run';
+    const threadId = 'completion-window-thread';
+    const resourceId = 'completion-window-user';
+    let finishRun!: () => void;
+    const finished = new Promise<void>(resolve => {
+      finishRun = resolve;
+    });
+
+    runtime.registerRun(
+      agent,
+      {
+        runId,
+        status: 'success',
+        fullStream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: 'finish', runId, payload: {} });
+            controller.close();
+          },
+        }),
+        _waitUntilFinished: () => finished,
+      } as any,
+      { memory: { thread: threadId, resource: resourceId } } as any,
+    );
+
+    const result = runtime.sendMessage(agent, 'Follow up during completion', { resourceId, threadId });
+
+    await expect(result.accepted).resolves.toMatchObject({ action: 'deliver', runId });
+    expect(streamMock).not.toHaveBeenCalled();
+
+    finishRun();
+    await waitForCondition(() => streamMock.mock.calls.length === 1);
+    expect(streamMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'user', contents: 'Follow up during completion' }),
+      expect.objectContaining({ memory: { thread: threadId, resource: resourceId } }),
+    );
+  });
+
   it('restores a queued signal when the drain follow-up stream fails', async () => {
     const runtime = new AgentThreadStreamRuntime();
     const streamMock = vi.fn().mockRejectedValue(new Error('connection error: ECONNRESET'));

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -496,6 +496,7 @@ export class AgentThreadStreamRuntime {
 
   #isThreadBlockingRun(state: AgentThreadRuntimeState, record: AgentThreadRunRecord<any>) {
     return (
+      record.lifecycle === 'running' ||
       record.output.status === 'running' ||
       record.output.status === 'suspended' ||
       record.lifecycle === 'suspending' ||

--- a/packages/memory/integration-tests/src/subconscious-libsql.test.ts
+++ b/packages/memory/integration-tests/src/subconscious-libsql.test.ts
@@ -205,6 +205,7 @@ describe('Subconscious LibSQL integration', () => {
     await storage.init();
 
     let streamCall = 0;
+    let reminderAgentCalls = 0;
     let sentReminder = false;
     const reminder = 'Project Atlas launches January 15. Source KnowledgeRecord: record-atlas-launch.';
     const model = new MockLanguageModelV2({
@@ -212,7 +213,9 @@ describe('Subconscious LibSQL integration', () => {
         streamCall += 1;
         const prompt = JSON.stringify(options.prompt);
         const eventId = prompt.match(/Passive reminder check (subconscious:remind:[^"\\\\]+:event)/)?.[1];
-        if (eventId && !sentReminder) {
+        const isReminderAgent = prompt.includes('For a useful grounded passive reminder');
+        if (isReminderAgent) reminderAgentCalls += 1;
+        if (isReminderAgent && eventId && !sentReminder) {
           sentReminder = true;
           const input = JSON.stringify({ eventId, reminder, sourceIds: ['record-atlas-launch'] });
           return {
@@ -309,7 +312,8 @@ describe('Subconscious LibSQL integration', () => {
 
     expect(result.observed).toBe(true);
     expect(getModel).not.toHaveBeenCalled();
-    expect(streamCall).toBe(3);
+    expect(streamCall).toBeGreaterThan(reminderAgentCalls);
+    expect(reminderAgentCalls).toBe(2);
     expect(parentSendSignal).toHaveBeenCalledTimes(2);
     expect(parentSendSignal).toHaveBeenNthCalledWith(
       1,
@@ -375,7 +379,8 @@ describe('Subconscious LibSQL integration', () => {
       doStream: async options => {
         const prompt = JSON.stringify(options.prompt);
         const eventId = prompt.match(/Passive reminder check (subconscious:remind:[^"\\\\]+:event)/)?.[1];
-        if (eventId && !sentReminder) {
+        const isReminderAgent = prompt.includes('For a useful grounded passive reminder');
+        if (isReminderAgent && eventId && !sentReminder) {
           sentReminder = true;
           const input = JSON.stringify({
             eventId,
@@ -504,7 +509,7 @@ describe('Subconscious LibSQL integration', () => {
     ]);
   });
 
-  it('persists a direct ask_memory turn and correlated terminal reply through LibSQL', async () => {
+  it('continues ask_memory through serialized sidekick history and delivers the correlated reply', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'subconscious-question-libsql-'));
     directories.push(directory);
     const databaseUrl = `file:${join(directory, 'memory.db')}`;
@@ -531,7 +536,7 @@ describe('Subconscious LibSQL integration', () => {
           /Memory question (subconscious:remind:[^\\n"]+:reply)/,
         )?.[1];
         const chunks =
-          streamCall === 1 && replyId
+          streamCall === 2 && replyId
             ? [
                 { type: 'stream-start' as const, warnings: [] },
                 {
@@ -600,12 +605,10 @@ describe('Subconscious LibSQL integration', () => {
       agent: { agentId: parentAgent.id, threadId: parentThreadId, resourceId, messages: [] },
       requestContext,
     } as any)) as { accepted: boolean; replyId: string; status: string };
-    for (let attempt = 0; attempt < 50 && parentSendSignal.mock.calls.length < 2; attempt += 1) {
-      await new Promise(resolve => setTimeout(resolve, 10));
-    }
+    await vi.waitFor(() => expect(parentSendSignal).toHaveBeenCalledTimes(2), { timeout: 5_000 });
 
     expect(result).toMatchObject({ accepted: true, status: 'pending' });
-    expect(parentSendSignal).toHaveBeenCalledTimes(2);
+    expect(streamCall).toBe(3);
     expect(parentSendSignal.mock.calls[0]![0]).toMatchObject({ id: `${result.replyId}:terminal:signal` });
     const reminderThreadId = getRemindThreadId(parentThreadId);
     const history = await (await storage.getStore('memory'))!.listMessages({
@@ -616,6 +619,11 @@ describe('Subconscious LibSQL integration', () => {
     expect(
       history.messages.some(item => getRemindMessageText(item).startsWith(`Memory question ${result.replyId}\n`)),
     ).toBe(true);
+    expect(
+      history.messages.filter(item =>
+        getRemindMessageText(item).startsWith('Continue these unanswered memory questions (attempt 1):'),
+      ),
+    ).toHaveLength(1);
     expect(
       history.messages.some(item =>
         item.content.parts.some(
@@ -659,6 +667,7 @@ describe('Subconscious LibSQL integration', () => {
       resourceId,
       parentThreadId,
       parentAgent: { sendSignal: vi.fn() } as any,
+      memory,
       maxSteps: 5,
       getReminderAgent: () => ({ id: 'reminder-agent', sendMessage }) as any,
     });
@@ -679,28 +688,54 @@ describe('Subconscious LibSQL integration', () => {
       expect.objectContaining({ threadId: reminderThread.id, resourceId }),
     );
 
-    const terminalMarker: MastraDBMessage = {
-      id: 'subconscious:remind:reply-1:terminal',
-      role: 'assistant',
+    const continuation2 = message(
+      reminderThread.id,
+      resourceId,
+      'Continue these unanswered memory questions (attempt 2): reply-1. Reply to each with reply_to_memory_question.',
+    );
+    continuation2.createdAt = new Date(3_000);
+    await memory.saveMessages({ messages: [continuation2] });
+    const exhaustedHistory = await (await storage.getStore('memory'))!.listMessages({
       threadId: reminderThread.id,
       resourceId,
-      createdAt: new Date(3_000),
-      content: {
-        format: 2,
-        parts: [
-          {
-            type: 'text',
-            text: 'Memory question reply-1 terminal: unable to answer after two continuation attempts',
-          },
-        ],
-      },
-    };
-    await memory.saveMessages({ messages: [terminalMarker] });
+      perPage: false,
+    });
+    const terminalParentSignal = vi.fn((signal: any, options: any) => {
+      const action = options.ifActive?.behavior === 'persist' ? 'persist' : 'discard';
+      return {
+        signal,
+        accepted: Promise.resolve({ action }),
+        persisted: action === 'persist' ? Promise.resolve() : undefined,
+      } as any;
+    });
+    const terminalProcessor = new RemindContinuationProcessor({
+      threadId: reminderThread.id,
+      resourceId,
+      parentThreadId,
+      parentAgent: { sendSignal: terminalParentSignal } as any,
+      memory,
+      maxSteps: 5,
+      getReminderAgent: () => ({ id: 'reminder-agent', sendMessage: vi.fn() }) as any,
+    });
+    await terminalProcessor.processOutputResult({
+      state: {},
+      messages: exhaustedHistory.messages,
+      messageList: { get: { all: { db: () => exhaustedHistory.messages } }, add: vi.fn() },
+      result: { text: '', usage: {}, finishReason: 'stop', steps: [] },
+      requestContext: new RequestContext(),
+    } as any);
+    await vi.waitFor(() => expect(terminalParentSignal).toHaveBeenCalledTimes(2));
+
     const reconstructedHistory = await (await storage.getStore('memory'))!.listMessages({
       threadId: reminderThread.id,
       resourceId,
       perPage: false,
     });
+    expect(
+      reconstructedHistory.messages.some(item =>
+        getRemindMessageText(item).startsWith('Memory question reply-1 terminal: unable to answer'),
+      ),
+    ).toBe(true);
     const reconstructedSendMessage = vi.fn();
     const reconstructedParentSignal = vi.fn();
     const reconstructedProcessor = new RemindContinuationProcessor({
@@ -708,6 +743,7 @@ describe('Subconscious LibSQL integration', () => {
       resourceId,
       parentThreadId,
       parentAgent: { sendSignal: reconstructedParentSignal } as any,
+      memory,
       maxSteps: 5,
       getReminderAgent: () => ({ id: 'reminder-agent', sendMessage: reconstructedSendMessage }) as any,
     });

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -299,6 +299,7 @@ export class Memory extends MastraMemory {
   private _omEngineInstance: ObservationalMemory | null | undefined;
   private _mastraInstance: Mastra | undefined;
   private _knowledgeSemanticIndex?: Promise<KnowledgeSemanticIndexCoordinator>;
+  private readonly constructorOptions?: MemoryOptions;
 
   /**
    * Every vector cleanup that deleteThread or deleteMessages started in the background.
@@ -333,7 +334,7 @@ export class Memory extends MastraMemory {
     // Only join an engine that already exists — never instantiate one just to drain it.
     const engine = this._omEngine ? await this._omEngine : this._omEngineInstance;
     await engine?.settled();
-    // Observational-memory cycles can start further vector cleanup; drain once more.
+    // Observational-memory work can start further vector cleanup; drain once more.
     await this.pendingVectorCleanup;
   }
 
@@ -363,12 +364,20 @@ export class Memory extends MastraMemory {
 
   /** @internal Creates isolated memory for a derived subconscious agent. */
   createSubconsciousMemory(): Memory {
+    const observationalMemory = this.constructorOptions?.observationalMemory;
+    const sidekickObservationalMemory =
+      observationalMemory && typeof observationalMemory === 'object'
+        ? { ...observationalMemory, experimental_subconscious: undefined }
+        : observationalMemory;
     const memory = new Memory({
       storage: this.storage,
       vector: this.vector,
       embedder: this.embedder,
       embedderOptions: this.embedderOptions,
-      options: { observationalMemory: false },
+      options: {
+        ...this.constructorOptions,
+        observationalMemory: sidekickObservationalMemory,
+      },
     });
     if (this._mastraInstance) memory.__registerMastra(this._mastraInstance);
     return memory;
@@ -443,6 +452,7 @@ export class Memory extends MastraMemory {
 
   constructor(config: MemoryConstructorConfig = {}) {
     super({ name: 'Memory', ...config } as { name: string } & SharedMemoryConfig);
+    this.constructorOptions = config.options;
 
     const mergedConfig = this.getMergedThreadConfig({
       workingMemory: config.options?.workingMemory || {

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-continuation.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-continuation.test.ts
@@ -28,7 +28,35 @@ function message(
   };
 }
 
-function createHarness() {
+function signalMessage(
+  id: string,
+  contents: string,
+  metadata:
+    | { type: 'question'; replyId: string; askedAt: number }
+    | { type: 'continuation'; replyIds: string[]; attempt: number },
+): MastraDBMessage {
+  return {
+    id,
+    role: 'signal',
+    threadId: reminderThreadId,
+    resourceId,
+    createdAt: new Date(),
+    content: {
+      format: 2,
+      parts: [],
+      metadata: {
+        signal: {
+          type: 'user',
+          tagName: 'user',
+          contents,
+          metadata: { [REMIND_MESSAGE_METADATA_KEY]: metadata },
+        },
+      },
+    },
+  };
+}
+
+function createHarness(continuationAction: 'wake' | 'deliver' = 'wake') {
   const parentAgent = {
     sendSignal: vi.fn((signal: unknown, options: { ifActive: { behavior: string } }) => {
       const action = options.ifActive.behavior === 'persist' ? 'persist' : 'discard';
@@ -41,7 +69,11 @@ function createHarness() {
   } as any;
   const consumeStream = vi.fn(async () => undefined);
   const sendMessage = vi.fn(() => ({
-    accepted: Promise.resolve({ action: 'wake', runId: 'sidekick-run', output: { consumeStream } }),
+    accepted: Promise.resolve(
+      continuationAction === 'wake'
+        ? { action: 'wake', runId: 'sidekick-run', output: { consumeStream } }
+        : { action: 'deliver', runId: 'sidekick-run' },
+    ),
   }));
   const reminderAgent = { id: 'reminder-agent', sendMessage } as any;
   const processor = new RemindContinuationProcessor({
@@ -49,6 +81,7 @@ function createHarness() {
     resourceId,
     parentThreadId,
     parentAgent,
+    memory: { saveMessages: vi.fn(async () => ({ messages: [] })) } as any,
     maxSteps: 7,
     getReminderAgent: () => reminderAgent,
   });
@@ -67,7 +100,7 @@ function resultArgs(messages: MastraDBMessage[], steps: unknown[] = []) {
 }
 
 describe('Subconscious reminder continuation', () => {
-  it('sends a direct continuation for an unanswered question', async () => {
+  it('dispatches a continuation without making processOutputResult wait for it', async () => {
     const { processor, sendMessage, consumeStream } = createHarness();
     const question = message('question-1', { type: 'question', replyId: 'reply-1', askedAt: Date.now() });
 
@@ -88,7 +121,73 @@ describe('Subconscious reminder continuation', () => {
         ifIdle: expect.objectContaining({ behavior: 'wake' }),
       }),
     );
-    expect(consumeStream).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(consumeStream).toHaveBeenCalledOnce());
+  });
+
+  it('returns before continuation acceptance and wake consumption finish', async () => {
+    const { processor, sendMessage, consumeStream } = createHarness();
+    let accept!: (result: unknown) => void;
+    sendMessage.mockReturnValue({ accepted: new Promise(resolve => (accept = resolve)) } as any);
+    const question = message('question-1', { type: 'question', replyId: 'reply-1', askedAt: Date.now() });
+    const args = resultArgs([question]);
+
+    await expect(processor.processOutputResult(args)).resolves.toBe(args.messages);
+    expect(consumeStream).not.toHaveBeenCalled();
+
+    accept({ action: 'wake', runId: 'sidekick-run', output: { consumeStream } });
+    await vi.waitFor(() => expect(consumeStream).toHaveBeenCalledOnce());
+  });
+
+  it('accepts active delivery as a serialized continuation model opportunity', async () => {
+    const { processor, sendMessage, consumeStream } = createHarness('deliver');
+    const question = message('question-1', { type: 'question', replyId: 'reply-1', askedAt: Date.now() });
+
+    await processor.processOutputResult(resultArgs([question]));
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ contents: expect.stringContaining('(attempt 1): reply-1') }),
+      expect.objectContaining({
+        ifActive: { behavior: 'deliver' },
+        ifIdle: expect.objectContaining({ behavior: 'wake' }),
+      }),
+    );
+    expect(consumeStream).not.toHaveBeenCalled();
+  });
+
+  it('reports detached continuation routing errors without rejecting processOutputResult', async () => {
+    const { processor, sendMessage } = createHarness();
+    sendMessage.mockReturnValue({ accepted: Promise.reject(new Error('routing failed')) });
+    const question = message('question-1', { type: 'question', replyId: 'reply-1', askedAt: Date.now() });
+    const args = resultArgs([question]);
+    args.writer = { custom: vi.fn().mockRejectedValue(new Error('writer failed')) };
+
+    await expect(processor.processOutputResult(args)).resolves.toBe(args.messages);
+
+    await vi.waitFor(() =>
+      expect(args.writer.custom).toHaveBeenCalledWith({
+        type: 'data-subconscious-error',
+        data: { error: 'remind: routing failed', agent: 'remind' },
+      }),
+    );
+  });
+
+  it('continues a question persisted by sendMessage as a user-authored signal row', async () => {
+    const { processor, sendMessage } = createHarness();
+    const replyId = 'reply-signal';
+    const question = signalMessage(`question-${replyId}`, `Memory question ${replyId}\n\nWhat did I decide?`, {
+      type: 'question',
+      replyId,
+      askedAt: Date.now(),
+    });
+
+    await processor.processOutputResult(resultArgs([question]));
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contents: `Continue these unanswered memory questions (attempt 1): ${replyId}. Reply to each with reply_to_memory_question.`,
+      }),
+      expect.objectContaining({ threadId: reminderThreadId, resourceId }),
+    );
   });
 
   it('increments continuation attempts from messages already in the MessageList', async () => {
@@ -155,7 +254,7 @@ describe('Subconscious reminder continuation', () => {
 
     await processor.processOutputResult(resultArgs(messages));
 
-    expect(sendMessage).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(2));
     expect(sendMessage.mock.calls.map(call => call[0].metadata[REMIND_MESSAGE_METADATA_KEY])).toEqual(
       expect.arrayContaining([
         { type: 'continuation', replyIds: ['reply-2'], attempt: 1 },
@@ -174,6 +273,7 @@ describe('Subconscious reminder continuation', () => {
 
     const args = resultArgs(messages);
     await processor.processOutputResult(args);
+    await vi.waitFor(() => expect(args.messageList.add).toHaveBeenCalledOnce());
     await processor.processOutputResult(resultArgs(messages));
 
     const terminalMarker = (args.messageList.add as ReturnType<typeof vi.fn>).mock.calls[0]![0] as MastraDBMessage;

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-questions.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-questions.test.ts
@@ -45,6 +45,34 @@ function replyToolContext(messages: unknown[] = []) {
   return context;
 }
 
+function signalMessage(
+  replyId: string,
+  metadata:
+    | { type: 'question'; replyId: string; askedAt: number }
+    | { type: 'continuation'; replyIds: string[]; attempt: number },
+): MastraDBMessage {
+  return {
+    id: `${replyId}:signal`,
+    role: 'signal',
+    type: 'user',
+    threadId: `subconscious:${parentThreadId}:remind`,
+    resourceId,
+    createdAt: new Date(),
+    content: {
+      format: 2,
+      parts: [],
+      metadata: {
+        signal: {
+          type: 'user',
+          tagName: 'user',
+          contents: `Memory question ${replyId}\n\nWhat did I decide?`,
+          metadata: { [REMIND_MESSAGE_METADATA_KEY]: metadata },
+        },
+      },
+    },
+  };
+}
+
 function questionMessage(replyId: string): MastraDBMessage {
   return {
     id: `${replyId}:message`,
@@ -168,6 +196,39 @@ describe('Subconscious reminder questions', () => {
     const result = await tool.execute?.(
       { replyId: 'reply-1', answer: 'January 15.', moreComing: false },
       replyToolContext([providerMessage]),
+    );
+
+    expect(result).toMatchObject({ delivered: true, replyId: 'reply-1', moreComing: false });
+  });
+
+  it('authorizes replies from persisted reminder history when the tool context omits earlier messages', async () => {
+    const memory = new Memory({ storage: new InMemoryStore() });
+    const reminderThreadId = `subconscious:${parentThreadId}:remind`;
+    await memory.createThread({ threadId: reminderThreadId, resourceId });
+    await memory.saveMessages({ messages: [questionMessage('reply-1')] });
+    const parentAgent = createParentAgent();
+    const tool = createReplyToMemoryQuestionTool({ memory, parentAgent, parentThreadId, resourceId });
+
+    const result = await tool.execute?.(
+      { replyId: 'reply-1', answer: 'January 15.', moreComing: false },
+      replyToolContext(),
+    );
+
+    expect(result).toMatchObject({ delivered: true, replyId: 'reply-1', moreComing: false });
+  });
+
+  it('authorizes replies during continuation runs from user-authored signal metadata', async () => {
+    const parentAgent = createParentAgent();
+    const tool = createReplyToMemoryQuestionTool({ parentAgent, parentThreadId, resourceId });
+    const continuation = signalMessage('reply-1', {
+      type: 'continuation',
+      replyIds: ['reply-1'],
+      attempt: 1,
+    });
+
+    const result = await tool.execute?.(
+      { replyId: 'reply-1', answer: 'January 15.', moreComing: false },
+      replyToolContext([continuation]),
     );
 
     expect(result).toMatchObject({ delivered: true, replyId: 'reply-1', moreComing: false });

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
@@ -3,7 +3,7 @@ import { RequestContext } from '@mastra/core/request-context';
 import { InMemoryStore } from '@mastra/core/storage';
 import { describe, expect, it, vi } from 'vitest';
 
-import { Memory } from '../../..';
+import { Memory, Subconscious } from '../../..';
 import { applyExtractorHooks } from '../extracted-values';
 import { buildExtractorOutputSections, Extractor } from '../extractor';
 import { SubconsciousRemindExtractor } from '../subconscious';
@@ -527,17 +527,32 @@ describe('Subconscious remind', () => {
     }
   });
 
-  it('copies vector and embedding configuration into reconstructed sidekick memory', () => {
+  it('copies observational, vector, and embedding configuration without recursive Subconscious agents', async () => {
     const vector = { id: 'vector' } as any;
     const embedder = { specificationVersion: 'v2', modelId: 'embedder' } as any;
     const embedderOptions = { providerOptions: { test: { dimensions: 16 } } };
-    const memory = new Memory({ storage: new InMemoryStore(), vector, embedder, embedderOptions });
+    const memory = new Memory({
+      storage: new InMemoryStore(),
+      vector,
+      embedder,
+      embedderOptions,
+      options: {
+        observationalMemory: {
+          model: createModel('observed'),
+          experimental_subconscious: new Subconscious({ observation: ['remind'] }),
+        },
+      },
+    });
 
     const sidekick = memory.createSubconsciousMemory();
+    const sidekickConfig = (sidekick as any).threadConfig.observationalMemory;
 
     expect((sidekick as any).vector).toBe(vector);
     expect((sidekick as any).embedder).toBe(embedder);
     expect((sidekick as any).embedderOptions).toBe(embedderOptions);
+    expect(sidekickConfig).toBeTruthy();
+    expect(sidekickConfig.experimental_subconscious).toBeUndefined();
+    await expect(sidekick.omEngine).resolves.not.toBeNull();
   });
 
   it.each([

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-agent.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-agent.ts
@@ -217,6 +217,7 @@ export function createReminderAgent(options: {
             resourceId: options.resourceId,
             parentThreadId: options.parentThreadId,
             parentAgent: options.parentAgent,
+            memory: options.memory,
             maxSteps: options.maxSteps ?? 50,
             getReminderAgent: () => reminderAgent,
           }),

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-continuation.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-continuation.ts
@@ -1,14 +1,15 @@
 import type { Agent, MastraDBMessage } from '@mastra/core/agent';
-import type {
-  ProcessOutputResultArgs,
-  ProcessOutputStepArgs,
-  Processor,
-  ProcessorStreamWriter,
-} from '@mastra/core/processors';
+import type { ProcessOutputResultArgs, ProcessOutputStepArgs, Processor } from '@mastra/core/processors';
 
+import type { Memory } from '../../..';
 import { withOmInternalThreadId } from '../internal-request-context';
 import { publishSubconsciousError } from './activity';
-import { getRemindMessageMetadata, getRemindMessageText, REMIND_MESSAGE_METADATA_KEY } from './remind-protocol';
+import {
+  getRemindMessageMetadata,
+  getRemindMessageText,
+  isUserAuthoredRemindMessage,
+  REMIND_MESSAGE_METADATA_KEY,
+} from './remind-protocol';
 
 const NUDGE_AFTER_MS = 20_000;
 const MAX_CONTINUATION_ATTEMPTS = 2;
@@ -59,7 +60,7 @@ function terminalReplies(messages: MastraDBMessage[], result?: ProcessOutputResu
 function messageMetadata(message: MastraDBMessage) {
   const metadata = getRemindMessageMetadata(message);
   if (metadata) return metadata;
-  if (message.role !== 'user') return undefined;
+  if (!isUserAuthoredRemindMessage(message)) return undefined;
 
   const text = getRemindMessageText(message);
   const question = text.match(/^Memory question (\S+)\n/);
@@ -75,6 +76,11 @@ function messageMetadata(message: MastraDBMessage) {
     replyIds: continuation[2].split(', ').filter(Boolean),
     attempt: Number(continuation[1]),
   };
+}
+
+function isMessageInProcessorScope(message: MastraDBMessage, threadId: string, resourceId: string): boolean {
+  if (message.threadId === undefined && message.resourceId === undefined) return true;
+  return message.threadId === threadId && message.resourceId === resourceId;
 }
 
 function getPendingQuestions(messages: MastraDBMessage[], answered = terminalReplies(messages)): PendingQuestion[] {
@@ -94,12 +100,6 @@ function getPendingQuestions(messages: MastraDBMessage[], answered = terminalRep
   return [...pending.values()];
 }
 
-function consumeWakeOutput(output: { consumeStream(): Promise<unknown> }, writer?: ProcessorStreamWriter): void {
-  void output.consumeStream().catch(async error => {
-    await publishSubconsciousError({ error: `remind: ${errorText(error)}`, agent: 'remind', writer });
-  });
-}
-
 export class RemindContinuationProcessor implements Processor<'remind-continuation'> {
   readonly id = 'remind-continuation';
   readonly name = 'Reminder Continuation Processor';
@@ -111,6 +111,7 @@ export class RemindContinuationProcessor implements Processor<'remind-continuati
       resourceId: string;
       parentThreadId: string;
       parentAgent: Agent;
+      memory: Memory;
       maxSteps: number;
       getReminderAgent(): Agent;
     },
@@ -121,7 +122,7 @@ export class RemindContinuationProcessor implements Processor<'remind-continuati
 
     const messages = args.messageList.get.all
       .db()
-      .filter(message => message.threadId === this.options.threadId && message.resourceId === this.options.resourceId);
+      .filter(message => isMessageInProcessorScope(message, this.options.threadId, this.options.resourceId));
     const pending = getPendingQuestions(messages);
     if (pending.length === 0) return args.messages;
 
@@ -158,9 +159,7 @@ export class RemindContinuationProcessor implements Processor<'remind-continuati
     try {
       const messages = args.messageList.get.all
         .db()
-        .filter(
-          message => message.threadId === this.options.threadId && message.resourceId === this.options.resourceId,
-        );
+        .filter(message => isMessageInProcessorScope(message, this.options.threadId, this.options.resourceId));
       const pending = getPendingQuestions(messages, terminalReplies(messages, args.result));
       if (pending.length === 0) return args.messages;
 
@@ -171,14 +170,27 @@ export class RemindContinuationProcessor implements Processor<'remind-continuati
         group.push(question);
         byAttempt.set(question.attempt, group);
       }
-      for (const questions of byAttempt.values()) await this.dispatchContinuation(questions, args);
+      for (const questions of byAttempt.values()) {
+        void this.dispatchContinuation(questions, args).catch(error => this.reportError(error, args));
+      }
       for (const question of pending.filter(question => question.attempt >= MAX_CONTINUATION_ATTEMPTS)) {
-        await this.deliverUnableToAnswer(question.replyId, args.messageList);
+        if (this.deliveredTerminalReplies.has(question.replyId)) continue;
+        this.deliveredTerminalReplies.add(question.replyId);
+        const marker = this.addUnableToAnswerMarker(question.replyId, args.messageList);
+        void this.deliverUnableToAnswer(question.replyId, marker).catch(error => this.reportError(error, args));
       }
     } catch (error) {
-      await publishSubconsciousError({ error: `remind: ${errorText(error)}`, agent: 'remind', writer: args.writer });
+      void this.reportError(error, args);
     }
     return args.messages;
+  }
+
+  private async reportError(error: unknown, args: ProcessOutputResultArgs): Promise<void> {
+    await publishSubconsciousError({
+      error: `remind: ${errorText(error)}`,
+      agent: 'remind',
+      writer: args.writer,
+    }).catch(() => {});
   }
 
   private async dispatchContinuation(questions: PendingQuestion[], args: ProcessOutputResultArgs): Promise<void> {
@@ -207,17 +219,15 @@ export class RemindContinuationProcessor implements Processor<'remind-continuati
       },
     );
     const accepted = await delivery.accepted;
-    if (accepted.action !== 'wake' && accepted.action !== 'deliver') {
+    if (accepted.action === 'wake') {
+      await accepted.output.consumeStream();
+    } else if (accepted.action !== 'deliver') {
       throw new Error(`Reminder continuation was not accepted (${accepted.action}).`);
     }
-    if (accepted.action === 'wake') consumeWakeOutput(accepted.output, args.writer);
   }
 
-  private async deliverUnableToAnswer(
-    replyId: string,
-    messageList: ProcessOutputResultArgs['messageList'],
-  ): Promise<void> {
-    if (this.deliveredTerminalReplies.has(replyId)) return;
+  private async deliverUnableToAnswer(replyId: string, marker: MastraDBMessage): Promise<void> {
+    await this.options.memory.saveMessages({ messages: [marker] });
     const signal = {
       id: `${replyId}:terminal:signal`,
       type: 'reactive' as const,
@@ -252,25 +262,29 @@ export class RemindContinuationProcessor implements Processor<'remind-continuati
     });
     const delivered = await delivery.accepted;
     if (delivered.action === 'blocked') throw new Error('Terminal reminder failure delivery was blocked.');
-    this.deliveredTerminalReplies.add(replyId);
-    messageList.add(
-      {
-        id: `subconscious:remind:${replyId}:terminal`,
-        role: 'assistant',
-        threadId: this.options.threadId,
-        resourceId: this.options.resourceId,
-        createdAt: new Date(),
-        content: {
-          format: 2,
-          parts: [
-            {
-              type: 'text',
-              text: `Memory question ${replyId} terminal: unable to answer after two continuation attempts`,
-            },
-          ],
-        },
+  }
+
+  private addUnableToAnswerMarker(
+    replyId: string,
+    messageList: ProcessOutputResultArgs['messageList'],
+  ): MastraDBMessage {
+    const marker: MastraDBMessage = {
+      id: `subconscious:remind:${replyId}:terminal`,
+      role: 'assistant',
+      threadId: this.options.threadId,
+      resourceId: this.options.resourceId,
+      createdAt: new Date(),
+      content: {
+        format: 2,
+        parts: [
+          {
+            type: 'text',
+            text: `Memory question ${replyId} terminal: unable to answer after two continuation attempts`,
+          },
+        ],
       },
-      'response',
-    );
+    };
+    messageList.add(marker, 'response');
+    return marker;
   }
 }

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-protocol.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-protocol.ts
@@ -62,6 +62,10 @@ export async function ensureOwnedRemindThread(options: {
   return created;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
 function isString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
 }
@@ -90,14 +94,29 @@ function parseMetadata(value: unknown): RemindMessageMetadata | undefined {
   }
 }
 
+export function isUserAuthoredRemindMessage(message: MastraDBMessage): boolean {
+  if (message.role === 'user') return true;
+  if (message.role !== 'signal' || !isRecord(message.content.metadata)) return false;
+  const signal = message.content.metadata.signal;
+  return isRecord(signal) && (signal.type === 'user' || signal.type === 'user-message' || signal.tagName === 'user');
+}
+
 export function getRemindMessageMetadata(message: MastraDBMessage): RemindMessageMetadata | undefined {
-  const metadata = message.content.metadata as Record<string, unknown> | undefined;
-  return parseMetadata(metadata?.[REMIND_MESSAGE_METADATA_KEY]);
+  const metadata = message.content.metadata;
+  if (!isRecord(metadata)) return undefined;
+  const direct = parseMetadata(metadata[REMIND_MESSAGE_METADATA_KEY]);
+  if (direct) return direct;
+  const signal = metadata.signal;
+  if (!isRecord(signal) || !isRecord(signal.metadata)) return undefined;
+  return parseMetadata(signal.metadata[REMIND_MESSAGE_METADATA_KEY]);
 }
 
 export function getRemindMessageText(message: MastraDBMessage): string {
-  return message.content.parts
+  const text = message.content.parts
     .filter((part): part is Extract<typeof part, { type: 'text' }> => part.type === 'text')
     .map(part => part.text)
     .join('\n');
+  if (text || !isRecord(message.content.metadata)) return text;
+  const signal = message.content.metadata.signal;
+  return isRecord(signal) && typeof signal.contents === 'string' ? signal.contents : '';
 }

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-questions.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-questions.ts
@@ -17,6 +17,7 @@ import {
   ensureOwnedRemindThread,
   getRemindMessageMetadata,
   getRemindThreadId,
+  isUserAuthoredRemindMessage,
   REMIND_MESSAGE_METADATA_KEY,
 } from './remind-protocol';
 import type { ResolvedSubconsciousAgent } from './types';
@@ -42,10 +43,16 @@ function errorText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function consumeWakeOutput(output: { consumeStream(): Promise<unknown> }, writer?: ProcessorStreamWriter): void {
-  void output.consumeStream().catch(async error => {
+async function consumeWakeOutput(
+  output: { consumeStream(): Promise<unknown>; _waitUntilFinished?(): Promise<void> },
+  writer?: ProcessorStreamWriter,
+): Promise<void> {
+  try {
+    await output.consumeStream();
+    await output._waitUntilFinished?.();
+  } catch (error) {
     await publishSubconsciousError({ error: `remind: ${errorText(error)}`, agent: 'remind', writer });
-  });
+  }
 }
 
 function messageText(message: unknown): string {
@@ -91,10 +98,11 @@ function trustedQuestion(messages: unknown, replyId: string, threadId: string, r
   if (!Array.isArray(messages)) return false;
   return messages.some(message => {
     const dbMessage = inScopeMessage(message, threadId, resourceId);
-    if (!dbMessage) return false;
+    if (!dbMessage || !isUserAuthoredRemindMessage(dbMessage)) return false;
     const metadata = getRemindMessageMetadata(dbMessage);
     if (metadata?.type === 'question' && metadata.replyId === replyId) return true;
-    return dbMessage.role === 'user' && messageText(message).startsWith(`Memory question ${replyId}\n`);
+    if (metadata?.type === 'continuation' && metadata.replyIds.includes(replyId)) return true;
+    return messageText(message).startsWith(`Memory question ${replyId}\n`);
   });
 }
 
@@ -201,6 +209,7 @@ export function createAskMemoryTool(options: {
         const reminderMemory = options.memory.createSubconsciousMemory();
         const reminderThread = await ensureOwnedRemindThread({ memory: reminderMemory, parentThreadId, resourceId });
         const replyTool = createReplyToMemoryQuestionTool({
+          memory: reminderMemory,
           parentAgent,
           parentThreadId,
           resourceId,
@@ -245,7 +254,9 @@ export function createAskMemoryTool(options: {
         if (accepted.action !== 'wake' && accepted.action !== 'deliver') {
           throw new Error(`Reminder question ${replyId} was not accepted for processing (${accepted.action}).`);
         }
-        if (accepted.action === 'wake') consumeWakeOutput(accepted.output, context.writer);
+        if (accepted.action === 'wake') {
+          void consumeWakeOutput(accepted.output, context.writer);
+        }
         return { accepted: true, replyId, status: 'pending' } satisfies AskMemoryResult;
       } catch (error) {
         const message = errorText(error);
@@ -257,6 +268,7 @@ export function createAskMemoryTool(options: {
 }
 
 export function createReplyToMemoryQuestionTool(options: {
+  memory?: Memory;
   parentAgent: Agent;
   parentThreadId: string;
   resourceId: string;
@@ -290,13 +302,30 @@ export function createReplyToMemoryQuestionTool(options: {
         moreComing: boolean;
         outcome?: 'answer' | 'unable-to-answer' | 'error';
       };
-      const messages = context.agent?.messages;
       const reminderThreadId = getRemindThreadId(options.parentThreadId);
-      if (
-        context.agent?.threadId !== reminderThreadId ||
-        context.agent.resourceId !== options.resourceId ||
-        !trustedQuestion(messages, replyId, reminderThreadId, options.resourceId)
-      ) {
+      if (context.agent?.threadId !== reminderThreadId || context.agent.resourceId !== options.resourceId) {
+        return { delivered: false, replyId, reason: 'question-not-in-current-conversation' };
+      }
+
+      let messages = Array.isArray(context.agent.messages) ? context.agent.messages : [];
+      if (options.memory) {
+        try {
+          const recalled = await options.memory.recall({
+            threadId: reminderThreadId,
+            resourceId: options.resourceId,
+            perPage: false,
+          });
+          messages = [...recalled.messages, ...messages];
+        } catch (error) {
+          await publishSubconsciousError({
+            error: `remind: ${errorText(error)}`,
+            agent: 'remind',
+            writer: context.writer,
+          });
+          return { delivered: false, replyId, reason: 'question-history-unavailable', error: errorText(error) };
+        }
+      }
+      if (!trustedQuestion(messages, replyId, reminderThreadId, options.resourceId)) {
         return { delivered: false, replyId, reason: 'question-not-in-current-conversation' };
       }
       if (!moreComing && hasTerminalReply(messages, replyId, reminderThreadId, options.resourceId)) {

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -146,6 +146,7 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
           const recentMessages = context.recentMessages?.trim() || '(none)';
           const replyTool = context.mainAgent
             ? createReplyToMemoryQuestionTool({
+                memory: remindMemory,
                 parentAgent: context.mainAgent,
                 parentThreadId: context.threadId,
                 resourceId,
@@ -187,7 +188,9 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
             },
           );
           const accepted = await delivery.accepted;
-          if (accepted.action === 'wake') await accepted.output.consumeStream();
+          if (accepted.action === 'wake') {
+            await accepted.output.consumeStream();
+          }
           if (accepted.action !== 'wake' && accepted.action !== 'deliver') {
             throw new Error(`Reminder event ${eventId} was not accepted for processing (${accepted.action}).`);
           }


### PR DESCRIPTION
Keeps the reminder sidekick's conversation usable across runs: it retains Observational Memory in its own Memory instance, recognizes persisted native signal messages, and checks scoped history when answering earlier `ask_memory` questions.

Continuation dispatch stays fire-and-forget, with bounded attempts and a persisted terminal marker before best-effort parent delivery. Core also keeps a finishing run thread-blocking until its lifecycle completes, so messages arriving during finalization are serialized rather than lost. This builds on the merged Subconscious guidance and resource-ownership changes in #23039 and #23042.

Verified after rebase with 47 reminder unit tests, 6 LibSQL integration tests, the targeted Core completion-window regression, Memory lint/typecheck, and the Memory build (15/15 tasks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The reminder sidekick now remembers its own work between runs. It also delivers follow-up messages reliably, even while the main run is finishing.

## Changes

- Preserve Observational Memory settings in sidekick `Memory` instances.
- Recognize persisted reminder signal messages and user-authored reminder messages.
- Search scoped, persisted reminder history when answering earlier `ask_memory` questions.
- Dispatch continuations asynchronously with bounded attempts and isolated error handling.
- Persist terminal failure markers to prevent duplicate continuation delivery.
- Keep finalizing Core runs thread-blocking until lifecycle completion.
- Add regression and integration coverage for continuation delivery, retries, history lookup, terminal markers, and completion-window behavior.
- Add patch changesets for `@mastra/memory` and `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->