### PR TITLE
fix(factory): render Slack emoji and full mentions

### DIFF
--- a/.changeset/beige-crabs-lead.md
+++ b/.changeset/beige-crabs-lead.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Slack emoji rendering and preserved full Slack mention labels in Factory comments without changing existing stored comments.

--- a/.changeset/fresh-phones-smoke.md
+++ b/.changeset/fresh-phones-smoke.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed full Slack mention highlighting in Factory comments and thread messages.

--- a/.changeset/olive-bananas-joke.md
+++ b/.changeset/olive-bananas-joke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed mention highlighting to use complete supplied labels, including spaces and pronouns, while preserving code and links.

--- a/.changeset/pretty-forks-build.md
+++ b/.changeset/pretty-forks-build.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Preserved Slack mention display labels in channel message metadata so thread interfaces can highlight complete names.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/MessageBubble.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/MessageBubble.tsx
@@ -58,6 +58,15 @@ export function channelOrigin(entry: MessageEntry): { platform: string; authorNa
   return { platform, authorName };
 }
 
+function channelMentionLabels(entry: MessageEntry): string[] {
+  const mastra = entry.message.content.providerMetadata?.mastra;
+  const channels = isRecord(mastra) ? mastra.channels : undefined;
+  const slack = isRecord(channels) && isRecord(channels.slack) ? channels.slack : undefined;
+  return Array.isArray(slack?.mentions)
+    ? slack.mentions.flatMap(mention => (isRecord(mention) && typeof mention.label === 'string' ? [mention.label] : []))
+    : [];
+}
+
 export function ChannelOriginBadge({ origin }: { origin: { platform: string; authorName?: string } }) {
   const label = CHANNEL_PLATFORM_LABEL[origin.platform] ?? origin.platform;
   return (
@@ -173,7 +182,11 @@ export function MessageBubble({
       if (!part.text.trim()) return null;
       if (entry.message.role === 'user') {
         const activation = parseSkillActivation(part.text);
-        return activation ? <SkillMessage activation={activation} /> : <MarkdownRenderer>{part.text}</MarkdownRenderer>;
+        return activation ? (
+          <SkillMessage activation={activation} />
+        ) : (
+          <MarkdownRenderer mentionLabels={channelMentionLabels(entry)}>{part.text}</MarkdownRenderer>
+        );
       }
 
       return (

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ChannelOriginBadge.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ChannelOriginBadge.msw.test.tsx
@@ -9,7 +9,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import type { MessageEntry } from '../../services/transcript';
-import { channelOrigin, ChannelOriginBadge } from '../MessageBubble';
+import { channelOrigin, ChannelOriginBadge, MessageBubble } from '../MessageBubble';
 
 function userEntry(providerMetadata?: Record<string, unknown>): MessageEntry {
   return {
@@ -56,6 +56,24 @@ describe('channelOrigin', () => {
 });
 
 describe('ChannelOriginBadge', () => {
+  it('renders the complete Slack mention label in a thread message', () => {
+    const entry = userEntry({
+      mastra: {
+        channels: {
+          slack: {
+            author: { userId: 'U1', fullName: 'Daniel Lew' },
+            mentions: [{ id: 'U2', label: '@Eric (he/him)' }],
+          },
+        },
+      },
+    });
+    entry.message.content.parts = [{ type: 'text', text: 'Ask @Eric (he/him) about German' }];
+    const { container } = render(
+      <MessageBubble entry={entry} suspensions={new Map()} isSubmitting={false} onRespond={() => {}} />,
+    );
+    expect(screen.getByText('@Eric (he/him)').tagName).toBe('SPAN');
+    expect(container.textContent).toContain('Ask @Eric (he/him) about German');
+  });
   it('renders the Slack label with the author', () => {
     render(<ChannelOriginBadge origin={{ platform: 'slack', authorName: 'Caleb Barnes' }} />);
 

--- a/mastracode/factory-ui/src/ui/domains/factory/components/feed/CommentRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/feed/CommentRow.tsx
@@ -215,7 +215,13 @@ export function CommentRow({
           />
         ) : (
           <div ref={bodyRef} className="text-ui-sm">
-            <MarkdownRenderer>{comment.body}</MarkdownRenderer>
+            <MarkdownRenderer
+              mentionLabels={comment.mentions.flatMap(mention =>
+                mention.kind === 'slack-user' ? [mention.label] : [],
+              )}
+            >
+              {comment.body}
+            </MarkdownRenderer>
             {comment.editedAt ? <span className="text-ui-xs text-icon2 ml-1">(edited)</span> : null}
           </div>
         )}

--- a/mastracode/factory/package.json
+++ b/mastracode/factory/package.json
@@ -62,6 +62,7 @@
     "chat": "^4.34.0",
     "@octokit/rest": "^22.0.1",
     "hono": "^4.12.8",
+    "node-emoji": "2.2.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/mastracode/factory/src/integrations/slack/slack.test.ts
+++ b/mastracode/factory/src/integrations/slack/slack.test.ts
@@ -1043,6 +1043,20 @@ describe('Slack aside ingest', () => {
     expect(deps.feed.createComment).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves the full mentioned Slack display name on imported comments', async () => {
+    const { thread, deps } = makeAsideDeps();
+    thread.adapter.getUser = vi.fn().mockResolvedValue({
+      userId: 'U123', userName: 'Eric (he/him)', fullName: 'Eric', isBot: false,
+    });
+    const message = makeAside('aside: ask @Eric (he/him)');
+    message.raw.text = 'aside: ask <@U123>';
+    await createHandlers(deps).onSubscribedMessage!(thread, message, vi.fn(), handlerCtx());
+    expect(deps.feed.createComment.mock.calls[0][0]).toMatchObject({
+      body: 'ask @Eric (he/him)',
+      mentions: [{ kind: 'slack-user', id: 'U123', label: '@Eric (he/him)' }],
+    });
+  });
+
   it('stores an unlinked sender aside under their Slack identity, silently (no Connect card)', async () => {
     process.env.MASTRACODE_PUBLIC_URL = 'https://mc.example.com';
     const { thread, deps } = makeAsideDeps({ link: null });

--- a/mastracode/factory/src/integrations/slack/slack.ts
+++ b/mastracode/factory/src/integrations/slack/slack.ts
@@ -8,6 +8,7 @@ import type {
   ResolveResourceId,
   ResolveThreadId,
 } from '@mastra/core/channels';
+import { resolveSlackMentions } from '@mastra/core/channels';
 import type { Mastra } from '@mastra/core/mastra';
 import { createSlackAdapter } from '@mastra/slack';
 import type { SlackAdapterChannelConfig } from '@mastra/slack';
@@ -733,6 +734,10 @@ async function ingestAside(
       workItemId: workItem.id,
       author: actorFromChannelAuthor(external, link),
       body,
+      mentions: (await resolveSlackMentions(thread.adapter, message.raw)).map(mention => ({
+        kind: 'slack-user',
+        ...mention,
+      })),
       occurredAt: message.metadata.dateSent,
       externalSource: slackCommentSource(thread.id, message.id, teamId),
     });

--- a/mastracode/factory/src/storage/domains/comments/base.test.ts
+++ b/mastracode/factory/src/storage/domains/comments/base.test.ts
@@ -21,6 +21,18 @@ const alice: FactoryActorRef = {
 const bob: FactoryActorRef = { kind: 'user', id: 'user-bob', displayName: 'Bob' };
 
 describe('WorkItemCommentsStorage', () => {
+  it('round-trips Slack mention labels without creating notification recipients', async () => {
+    const seed = await createFactoryStorageForTests();
+    const created = await seed.comments.create({
+      ...scope,
+      author: alice,
+      body: 'Ask @Eric (he/him)',
+      mentions: [{ kind: 'slack-user', id: 'U1', label: '@Eric (he/him)' }],
+    });
+    const fetched = await seed.comments.get({ orgId: scope.orgId, commentId: created.id });
+    expect(fetched?.mentions).toEqual([{ kind: 'slack-user', id: 'U1', label: '@Eric (he/him)' }]);
+    expect(await seed.comments.listMentionsForComment(created.id)).toEqual([]);
+  });
   it('round-trips a comment including the flattened author and reply columns', async () => {
     const seed = await createFactoryStorageForTests();
     const parent = await seed.comments.create({ ...scope, author: bob, body: 'original take' });

--- a/mastracode/factory/src/storage/domains/comments/base.ts
+++ b/mastracode/factory/src/storage/domains/comments/base.ts
@@ -25,10 +25,7 @@ export { WORK_ITEM_ACTIVITY_SCHEMA, WORK_ITEM_COMMENT_MENTIONS_SCHEMA, WORK_ITEM
 
 export type WorkItemCommentKind = 'comment';
 
-export interface FactoryMentionRef {
-  kind: 'user';
-  id: string;
-}
+export type FactoryMentionRef = { kind: 'user'; id: string } | { kind: 'slack-user'; id: string; label: string };
 
 export interface WorkItemCommentReplyRef {
   commentId: string;
@@ -628,7 +625,7 @@ export class WorkItemCommentsStorage extends FactoryStorageDomain {
     // must not report as "added" either — they would re-report on every edit.
     const skippedIds = new Set([comment.author.id, ...(input.editorId ? [input.editorId] : [])]);
     const addedMentions = comment.mentions.filter(
-      mention => !existingKeys.has(mentionKey(mention)) && !skippedIds.has(mention.id),
+      mention => mention.kind === 'user' && !existingKeys.has(mentionKey(mention)) && !skippedIds.has(mention.id),
     );
     const removedMentions = existing.map(toMentionRef).filter(mention => !nextKeys.has(mentionKey(mention)));
 
@@ -815,7 +812,7 @@ export class WorkItemCommentsStorage extends FactoryStorageDomain {
     occurredAt = comment.occurredAt,
   ): Promise<void> {
     for (const mention of mentions) {
-      if (mention.id === comment.author.id) continue;
+      if (mention.kind !== 'user' || mention.id === comment.author.id) continue;
       await this.ops.upsertOne<WorkItemMentionDbRow>(
         'work_item_comment_mentions',
         ['comment_id', 'mentioned_kind', 'mentioned_id'],

--- a/mastracode/factory/src/storage/domains/comments/wire.test.ts
+++ b/mastracode/factory/src/storage/domains/comments/wire.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import type { WorkItemCommentRow } from './base.js';
+import { toWireComment } from './wire.js';
+
+function comment(body: string, integrationId = 'slack'): WorkItemCommentRow {
+  const date = new Date('2026-09-04T19:00:00.000Z');
+  return {
+    id: 'comment-1',
+    orgId: 'org-1',
+    factoryProjectId: 'factory-1',
+    workItemId: 'item-1',
+    kind: 'comment',
+    body,
+    bodyFormat: 'markdown',
+    author: { kind: 'user', id: 'slack:U-abhi', displayName: 'Abhi Aiyer' },
+    replyTo: null,
+    mentions: [],
+    externalSource: { integrationId, type: 'message', externalId: 'C-1:1700.99' },
+    sourceKey: null,
+    occurredAt: date,
+    editedAt: null,
+    deletedAt: null,
+    deletedBy: null,
+    revision: 1,
+    createdAt: date,
+    updatedAt: date,
+  };
+}
+
+describe('Slack comment emoji rendering', () => {
+  it('decodes the heart in an already stored Slack comment without changing storage', () => {
+    const stored = comment(':heart: u @Yujohn Nattrass');
+
+    expect(toWireComment(stored, 'viewer-1').body).toBe('❤️ u @Yujohn Nattrass');
+    expect(stored.body).toBe(':heart: u @Yujohn Nattrass');
+  });
+
+  it.each([
+    [':+1: :thumbsup: :tada:', '👍 👍 🎉'],
+    [':slightly_smiling_face: :rocket:', '🙂 🚀'],
+    [':+1::skin-tone-4:', '👍🏽'],
+    ['❤️ 👍🏽 👨‍👩‍👧‍👦', '❤️ 👍🏽 👨‍👩‍👧‍👦'],
+    [':mastra_custom_emoji: hello', ':mastra_custom_emoji: hello'],
+  ])('renders %s as %s', (body, expected) => {
+    expect(toWireComment(comment(body), 'viewer-1').body).toBe(expected);
+  });
+
+  it.each(['github', 'linear'])('preserves shortcodes from %s', integrationId => {
+    expect(toWireComment(comment(':heart:', integrationId), 'viewer-1').body).toBe(':heart:');
+  });
+
+  it('preserves shortcodes in locally written comments', () => {
+    const local = { ...comment(':heart:'), externalSource: null };
+    expect(toWireComment(local, 'viewer-1').body).toBe(':heart:');
+  });
+});

--- a/mastracode/factory/src/storage/domains/comments/wire.ts
+++ b/mastracode/factory/src/storage/domains/comments/wire.ts
@@ -1,3 +1,6 @@
+import { defaultEmojiResolver } from 'chat';
+import { emojify } from 'node-emoji';
+
 import type { FactoryActorKind, FactoryActorRef } from './actor.js';
 import type { FactoryMentionRef, WorkItemCommentReplyRef, WorkItemCommentRow } from './base.js';
 
@@ -38,6 +41,14 @@ export interface WireCommentPage {
 
 const LOCAL_SOURCE_KEY_PREFIX = 'local:comment:';
 
+function slackEmojiFallback(name: string): string {
+  const tone = /^skin-tone-([2-6])$/.exec(name);
+  if (tone) return String.fromCodePoint(0x1f3f9 + Number(tone[1]));
+
+  const emoji = defaultEmojiResolver.toGChat(defaultEmojiResolver.fromSlack(name));
+  return emoji === name ? `:${name}:` : emoji;
+}
+
 function toWireAuthor({ kind, id, displayName, avatarUrl }: FactoryActorRef): WireCommentAuthor {
   return {
     kind,
@@ -56,7 +67,10 @@ export function toWireComment(comment: WorkItemCommentRow, viewerId: string): Wi
     id: comment.id,
     workItemId: comment.workItemId,
     kind: comment.kind,
-    body: comment.body,
+    body:
+      comment.externalSource?.integrationId === 'slack'
+        ? emojify(comment.body, { fallback: slackEmojiFallback })
+        : comment.body,
     bodyFormat: comment.bodyFormat,
     author: toWireAuthor(comment.author),
     ...(comment.replyTo ? { replyTo: comment.replyTo } : {}),

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -21,6 +21,8 @@ import { createTool } from '../tools/tool';
 
 import { chatModule, getChatModule } from './chat-lazy';
 import { resolveSlackTopLevelThreadId } from './compat/slack';
+import { resolveSlackMentions } from './slack-mentions';
+import type { SlackMention } from './slack-mentions';
 import { ChannelSessionRejectedError } from './errors';
 
 import { formatArgsSummary, formatToolApproved, formatToolDenied, stripToolPrefix } from './formatting';
@@ -1006,6 +1008,7 @@ export class AgentChannels {
     eventType: string;
     messageId: string | undefined;
     actor: { userId: string; userName?: string; fullName?: string; isBot?: boolean | 'unknown' };
+    mentions?: SlackMention[];
   }): {
     channelContext: ChannelContext;
     attributes: Record<string, string | undefined>;
@@ -1048,6 +1051,7 @@ export class AgentChannels {
         channels: {
           [platform]: {
             ...(messageId !== undefined ? { messageId } : {}),
+            ...(params.mentions?.length ? { mentions: params.mentions.map(({ id, label }) => ({ id, label })) } : {}),
             author: {
               userId: actor.userId,
               ...(actor.userName !== undefined ? { userName: actor.userName } : {}),
@@ -1312,6 +1316,7 @@ export class AgentChannels {
       eventType: chatThread.isDM ? 'message' : 'mention',
       messageId: message.id,
       actor: message.author,
+      mentions: await resolveSlackMentions(chatThread.adapter, message.raw),
     });
 
     // NOTE: `requestContext` is constructed per message at the handler boundary

--- a/packages/core/src/channels/index.ts
+++ b/packages/core/src/channels/index.ts
@@ -1,3 +1,5 @@
+export { resolveSlackMentions } from './slack-mentions';
+export type { SlackMention } from './slack-mentions';
 export { AgentChannels } from './agent-channels';
 export { AgentControllerChannels } from './agent-controller-channels';
 export type {

--- a/packages/core/src/channels/slack-mentions.test.ts
+++ b/packages/core/src/channels/slack-mentions.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { resolveSlackMentions } from './slack-mentions';
+
+const getUser = vi.fn(async (id: string) => ({
+  userId: id,
+  userName: id === 'U1' ? 'Yujohn Nattrass' : 'Eric (he/him)',
+  fullName: 'Different legal name',
+  isBot: false,
+}));
+
+describe('resolveSlackMentions', () => {
+  it('resolves exact Slack display names and deduplicates IDs', async () => {
+    getUser.mockClear();
+    expect(await resolveSlackMentions({ name: 'slack', getUser }, { text: '<@U1> and <@U2> and <@U1>' })).toEqual([
+      { id: 'U1', label: '@Yujohn Nattrass' },
+      { id: 'U2', label: '@Eric (he/him)' },
+    ]);
+    expect(getUser).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles raw event envelopes and labeled tokens', async () => {
+    expect(await resolveSlackMentions({ name: 'slack', getUser }, { event: { text: '<@U1|old name>' } })).toEqual([
+      { id: 'U1', label: '@Yujohn Nattrass' },
+    ]);
+  });
+
+  it('does not infer mentions from plain names or other platforms', async () => {
+    getUser.mockClear();
+    expect(await resolveSlackMentions({ name: 'slack', getUser }, { text: '@Eric (he/him)' })).toEqual([]);
+    expect(await resolveSlackMentions({ name: 'discord', getUser }, { text: '<@U1>' })).toEqual([]);
+    expect(await resolveSlackMentions({ name: 'slack', getUser }, null)).toEqual([]);
+    expect(getUser).not.toHaveBeenCalled();
+  });
+
+  it('omits unavailable members', async () => {
+    expect(await resolveSlackMentions({ name: 'slack', getUser: async () => null }, { text: '<@U1>' })).toEqual([]);
+  });
+});

--- a/packages/core/src/channels/slack-mentions.ts
+++ b/packages/core/src/channels/slack-mentions.ts
@@ -1,0 +1,23 @@
+import type { Adapter } from 'chat';
+
+export interface SlackMention {
+  id: string;
+  label: string;
+}
+
+export async function resolveSlackMentions(
+  adapter: Pick<Adapter, 'name' | 'getUser'>,
+  raw: unknown,
+): Promise<SlackMention[]> {
+  if (adapter.name !== 'slack' || !adapter.getUser || typeof raw !== 'object' || raw === null) return [];
+  const event = 'event' in raw && typeof raw.event === 'object' && raw.event !== null ? raw.event : raw;
+  if (!('text' in event) || typeof event.text !== 'string') return [];
+  const ids = [...new Set([...event.text.matchAll(/<@([UW][A-Z0-9]+)(?:\|[^>]+)?>/g)].map(match => match[1]!))];
+  const mentions = await Promise.all(
+    ids.map(async id => {
+      const user = await adapter.getUser!(id);
+      return user ? { id, label: `@${user.userName || id}` } : undefined;
+    }),
+  );
+  return mentions.filter(mention => mention !== undefined);
+}

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
@@ -106,6 +106,64 @@ describe('MarkdownRenderer', () => {
     expect(container.querySelector('del')).toBeTruthy();
   });
 
+  it('wraps mention text only when highlighting is enabled', () => {
+    const { rerender, container } = render(<MarkdownRenderer>{'Hello @Abhi, thanks @ana-maria!'}</MarkdownRenderer>);
+    expect(container.querySelector('p span')).toBeNull();
+
+    rerender(
+      <MarkdownRenderer mentionLabels={['@Abhi', '@ana-maria', '@Zoë']}>
+        {'Hello @Abhi, thanks @ana-maria!'}
+      </MarkdownRenderer>,
+    );
+    expect([...container.querySelectorAll('p span')].map(node => node.textContent)).toEqual(['@Abhi', '@ana-maria']);
+    expect(container.textContent).toBe('Hello @Abhi, thanks @ana-maria!');
+  });
+
+  it('leaves email addresses, links, and code untouched when highlighting mentions', () => {
+    const { container } = render(
+      <MarkdownRenderer mentionLabels={['@Abhi', '@ana-maria', '@Zoë']}>
+        {'hello@example.com [@Abhi](https://example.com) `@Abhi` and @Zoë'}
+      </MarkdownRenderer>,
+    );
+    expect(container.querySelector('a span')).toBeNull();
+    expect(container.querySelector('code span')).toBeNull();
+    expect([...container.querySelectorAll('p > span')].map(node => node.textContent)).toEqual(['@Zoë']);
+  });
+
+  it('highlights full labels with spaces and pronouns without guessing historical mentions', () => {
+    const { container } = render(
+      <MarkdownRenderer mentionLabels={['@Eric', '@Eric (he/him)', '@Yujohn Nattrass']}>
+        {'Ask @Eric (he/him) and @Yujohn Nattrass, not @Yujohn or @Erica. mail@Eric stays plain.'}
+      </MarkdownRenderer>,
+    );
+    expect([...container.querySelectorAll('p > span')].map(node => node.textContent)).toEqual([
+      '@Eric (he/him)',
+      '@Yujohn Nattrass',
+    ]);
+    expect(container.textContent).toBe(
+      'Ask @Eric (he/him) and @Yujohn Nattrass, not @Yujohn or @Erica. mail@Eric stays plain.',
+    );
+  });
+
+  it('highlights a leading full name and ignores invalid labels and nested matches', () => {
+    const { container } = render(
+      <MarkdownRenderer mentionLabels={['', '@', 'plain', '@A @B', '@B']}>
+        {'@A @B says @ plain'}
+      </MarkdownRenderer>,
+    );
+    expect([...container.querySelectorAll('p > span')].map(node => node.textContent)).toEqual(['@A @B']);
+    expect(container.textContent).toBe('@A @B says @ plain');
+  });
+
+  it('does not highlight mentions inside fenced code', () => {
+    const { container } = render(
+      <TooltipProvider>
+        <MarkdownRenderer mentionLabels={['@Eric']}>{'```text\n@Eric\n```'}</MarkdownRenderer>
+      </TooltipProvider>,
+    );
+    expect(container.querySelector('pre .text-accent1')).toBeNull();
+  });
+
   it('names itself so a host stylesheet can reach its markup', () => {
     const { container } = render(<MarkdownRenderer>{'Hello'}</MarkdownRenderer>);
 

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
@@ -7,6 +7,7 @@ import remend from 'remend';
 
 import { rehypeArriving } from './arriving';
 import { splitBlocks } from './blocks';
+import { rehypeMentions } from './mentions';
 import { useSettledWords } from './use-settled';
 import { CodeBlock } from '@/ds/components/CodeBlock';
 import { cn } from '@/lib/utils';
@@ -19,6 +20,7 @@ export interface MarkdownRendererProps {
   children: string;
   className?: string;
   externalLinkTarget?: MarkdownExternalLinkTarget;
+  mentionLabels?: string[];
   /** The text is a prefix of one still being written: close the markers the stream has not reached. */
   streaming?: boolean;
 }
@@ -46,6 +48,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
   children,
   className,
   externalLinkTarget = 'tab',
+  mentionLabels,
   streaming = false,
 }: MarkdownRendererProps) {
   const shown = decodeEscapedNewlines(children);
@@ -72,6 +75,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
           content={index === last ? mended : block}
           settledWords={settledWords(spans[index])}
           components={components}
+          mentionLabels={mentionLabels}
         />
       ))}
     </div>
@@ -83,15 +87,15 @@ const MarkdownBlock = memo(function MarkdownBlock({
   components,
   content,
   settledWords,
+  mentionLabels,
 }: {
   components: Components;
   content: string;
   settledWords?: number;
+  mentionLabels?: string[];
 }) {
-  const rehypePlugins = useMemo(
-    () => (settledWords === undefined ? SETTLED : [rehypeArriving(settledWords)]),
-    [settledWords],
-  );
+  const rehypePlugins: Options['rehypePlugins'] = mentionLabels?.length ? [[rehypeMentions, mentionLabels]] : [];
+  if (settledWords !== undefined) rehypePlugins.push(rehypeArriving(settledWords));
 
   return (
     <Markdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={rehypePlugins} components={components}>
@@ -99,8 +103,6 @@ const MarkdownBlock = memo(function MarkdownBlock({
     </Markdown>
   );
 });
-
-const SETTLED: Options['rehypePlugins'] = [];
 
 interface WordSpan {
   start: number;

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/mentions.ts
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/mentions.ts
@@ -1,0 +1,44 @@
+import type { ExtraProps } from 'react-markdown';
+
+type MarkdownElement = NonNullable<ExtraProps['node']>;
+type MarkdownChild = MarkdownElement['children'][number];
+
+function highlight(nodes: MarkdownChild[], labels: string[]): MarkdownChild[] {
+  return nodes.flatMap(node => {
+    if (node.type === 'element') {
+      if (!['a', 'code', 'pre'].includes(node.tagName)) node.children = highlight(node.children, labels);
+      return [node];
+    }
+    if (node.type !== 'text') return [node];
+
+    const result: MarkdownChild[] = [];
+    let offset = 0;
+    for (let index = node.value.indexOf('@'); index !== -1; index = node.value.indexOf('@', index + 1)) {
+      if (index < offset || /[\p{L}\p{N}_.@/]/u.test(node.value[index - 1] ?? '')) continue;
+      const label = labels.find(
+        candidate =>
+          node.value.startsWith(candidate, index) && !/[\p{L}\p{N}_]/u.test(node.value[index + candidate.length] ?? ''),
+      );
+      if (!label) continue;
+      result.push({ type: 'text', value: node.value.slice(offset, index) });
+      result.push({
+        type: 'element',
+        tagName: 'span',
+        properties: { className: ['text-accent1'] },
+        children: [{ type: 'text', value: label }],
+      });
+      offset = index + label.length;
+    }
+    result.push({ type: 'text', value: node.value.slice(offset) });
+    return result;
+  });
+}
+
+export function rehypeMentions(labels: string[]) {
+  const longestFirst = labels
+    .filter(label => label.startsWith('@') && label.length > 1)
+    .sort((a, b) => b.length - a.length);
+  return (tree: { children: MarkdownChild[] }) => {
+    tree.children = highlight(tree.children, longestFirst);
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2393,6 +2393,9 @@ importers:
       hono:
         specifier: 4.12.34
         version: 4.12.34
+      node-emoji:
+        specifier: 2.2.0
+        version: 2.2.0
       zod:
         specifier: ^4.3.6
         version: 4.4.3


### PR DESCRIPTION
Fixes [PLTFRM-1605](https://linear.app/kepler-crm/issue/PLTFRM-1605/fix-emoji-rendering-in-factory-comments).

Slack comments now render emoji shortcodes as Unicode. Full mentions, including spaces and pronouns, use the existing accent color in comments and thread messages. Unknown emoji stay unchanged. Mention highlighting applies to newly ingested messages; older messages without labels stay plain text. No migration or profile links.

```diff
 Slack message
-  Store @Display Name as plain text only
+  Preserve the exact label alongside comment or channel metadata
 Factory rendering
+  Decode Slack comment emoji at the wire boundary
+  Accent full labels in comments and thread bubbles
```

Focused tests pass: core 71, Factory 90, renderer 44, thread UI 6. All four package typechecks pass. Agent Browser and Playwright verified emoji, full mentions, quoting, and code/link exclusions in the local sample-data preview. The broader Factory suite has six failures outside the changed paths in Factory preparation, bundled skills, dispatcher prompts, and the Linear integration. Design-system mutation checks pass their threshold, with remaining survivors.

Screenshots use the actual comment and thread components with sample Slack data. Before uses the branch's original components; after uses this change. Each pair has the same viewport, pixel ratio, zoom, and crop.

| | Light | Dark |
| --- | --- | --- |
| Before | ![Factory comment and Slack thread before emoji and mention rendering fixes, light theme](https://github.com/user-attachments/assets/f118b3f1-0d18-4235-92a4-10f194aca6b4) | ![Factory comment and Slack thread before emoji and mention rendering fixes, dark theme](https://github.com/user-attachments/assets/2cd82721-6eed-4e96-bc70-f396a9836f4a) |
| After | ![Factory comment and Slack thread with full accented Slack names and decoded comment emoji, light theme](https://github.com/user-attachments/assets/40df6f78-597d-4c4b-bcc8-73267b62c643) | ![Factory comment and Slack thread with full accented Slack names and decoded comment emoji, dark theme](https://github.com/user-attachments/assets/4a97b751-6e4d-4bb9-843d-f0072483a4bf) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory now displays Slack emoji and full user mentions correctly. Mentions keep their complete labels, including spaces and pronouns, without changing older stored comments.

## Changes

- Decode Slack emoji shortcodes at the wire boundary.
- Preserve unknown emoji and non-Slack comment content.
- Resolve Slack mentions and retain their full labels in comments and thread messages.
- Highlight mentions while excluding links, inline code, and fenced code.
- Keep Slack mentions out of notification-recipient rows.
- Add focused tests and patch changesets.

## Validation

- Focused tests and package typechecks pass.
- Agent Browser and Playwright verified emoji, mentions, quoting, and code/link exclusions.
- Six broader Factory suite failures remain outside the changed paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->