### PR TITLE
feat(factory): supervisor notification emit path (COR-1195)

### DIFF
--- a/.changeset/brown-parts-follow.md
+++ b/.changeset/brown-parts-follow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Added a supervisor notification emit path for the Factory. When the health sweep opens or reopens a finding, the Factory now sends a notification signal to that project's supervisor session (creating the session first if it has never been reached) so an idle supervisor wakes up instead of waiting for someone to open the Attention rail. Supervisor-actionable findings (failed or stuck decisions, stalled starts, orphaned or missing seats) wake the supervisor at high priority; findings that wait on a person stay low priority. A notification-woken supervisor turn can now resolve its factory scope from trusted session state and registers the supervisor read tools, where previously it registered none.

--- a/.changeset/calm-owls-answer.md
+++ b/.changeset/calm-owls-answer.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Server-started turns on a factory-owned session (a notification wake, a scheduled sweep) can now resolve model credentials. When no signed-in person is on the request, the tenant is read from the session itself: the factory organization stamped on its state, resolved org-first, then its owner's own credentials. A signed-in person on the request is still resolved on their own identity, and a session missing any of project, organization, or owner stays unresolved.

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -13,6 +13,7 @@ import type { VersionControl } from './capabilities/version-control.js';
 import { MastraFactory } from './factory.js';
 import type { FactoryIntegration, IntegrationContext } from './integrations/base.js';
 import type * as projectRoutesModule from './routes/projects.js';
+import { FactorySupervisorHealthWorker } from './supervisor/health-worker.js';
 import type * as surfaceModule from './routes/surface.js';
 import type * as tenantCredentialsModule from './routes/tenant-credentials.js';
 import { defaultFactoryRules, DEFAULT_FACTORY_RULE_VERSION } from './rules/defaults.js';
@@ -268,8 +269,9 @@ describe('MastraFactory.prepare', () => {
     const blockingCalls = controllerMock.onSessionCreated.mock.calls.filter(
       call => (call[1] as { blocking?: boolean } | undefined)?.blocking === true,
     );
-    expect(blockingCalls).toHaveLength(2);
-    const blockingCall = blockingCalls[0];
+    // Supervisor hydration (#23001), OM settings, and model-pack seeding all
+    // register as blocking session-created listeners.
+    expect(blockingCalls).toHaveLength(3);
 
     // Seed the owner's web session row and stored memory settings through the
     // same storage domains the factory registered.
@@ -324,7 +326,13 @@ describe('MastraFactory.prepare', () => {
       state: { get: () => ({}), set: vi.fn().mockResolvedValue(undefined) },
     };
 
-    await (blockingCall![0] as (session: unknown) => Promise<void>)(session);
+    // Select the OM-seeding listener by behavior, not registration index: the
+    // supervisor hydration listener no-ops for non-supervisor resource ids, so
+    // invoking in order until the observer model is seeded lands on the right one.
+    for (const call of blockingCalls) {
+      await (call![0] as (session: unknown) => Promise<void>)(session);
+      if (session.om.observer.switchModel.mock.calls.length > 0) break;
+    }
 
     expect(session.om.observer.switchModel).toHaveBeenCalledWith({ modelId: 'anthropic/claude-haiku-4-5' });
     expect(session.om.reflector.switchModel).toHaveBeenCalledWith({ modelId: 'anthropic/claude-haiku-4-5' });
@@ -1006,7 +1014,10 @@ describe('MastraFactory.prepare integrations', () => {
       integrations: [fakeIntegration({ id: 'custom', workers })],
     });
     const args = await factory.prepare();
-    expect(args.workers).toEqual([worker]);
+    // The factory always contributes its supervisor health worker (#23001)
+    // alongside integration workers.
+    expect(args.workers).toContain(worker);
+    expect(args.workers!.some(w => w instanceof FactorySupervisorHealthWorker)).toBe(true);
     // The workers factory gets the same integration context shape as routes().
     const ctx = workers.mock.calls[0]![0];
     expect(ctx.stateSigner).toBeDefined();
@@ -1042,14 +1053,16 @@ describe('MastraFactory.prepare integrations', () => {
     expect(args).not.toHaveProperty('workers');
   });
 
-  it('omits the workers option when no integration contributes workers', async () => {
+  it('contributes only the supervisor health worker when no integration contributes workers', async () => {
     const factory = new MastraFactory({
       secretEncryption,
       storage: fakeStorage(),
       integrations: [fakeIntegration({ id: 'custom' })],
     });
     const args = await factory.prepare();
-    expect(args).not.toHaveProperty('workers');
+    // #23001: the factory's own supervisor health worker is always present.
+    expect(args.workers).toHaveLength(1);
+    expect(args.workers![0]).toBeInstanceOf(FactorySupervisorHealthWorker);
   });
 
   /**

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -13,7 +13,6 @@ import type { VersionControl } from './capabilities/version-control.js';
 import { MastraFactory } from './factory.js';
 import type { FactoryIntegration, IntegrationContext } from './integrations/base.js';
 import type * as projectRoutesModule from './routes/projects.js';
-import { FactorySupervisorHealthWorker } from './supervisor/health-worker.js';
 import type * as surfaceModule from './routes/surface.js';
 import type * as tenantCredentialsModule from './routes/tenant-credentials.js';
 import { defaultFactoryRules, DEFAULT_FACTORY_RULE_VERSION } from './rules/defaults.js';
@@ -25,6 +24,7 @@ import type { MemorySettingsStorage } from './storage/domains/memory-settings/ba
 import type { FactoryProjectsStorage } from './storage/domains/projects/base.js';
 import type { SourceControlStorage } from './storage/domains/source-control/base.js';
 import type { WorkItemsStorage } from './storage/domains/work-items/base.js';
+import { FactorySupervisorHealthWorker } from './supervisor/health-worker.js';
 /** A real in-memory FactoryStorage with init spied for boot-order assertions. */
 function fakeStorage(): LibSQLFactoryStorage {
   const storage = new LibSQLFactoryStorage({ url: ':memory:', id: 'factory-test-storage' });
@@ -586,6 +586,154 @@ describe('MastraFactory.prepare', () => {
     await expect(extraTools({ requestContext })).resolves.toHaveProperty('factory_transition_work_item');
     lookup.mockResolvedValue(null);
     await expect(extraTools({ requestContext })).resolves.toEqual({});
+  });
+
+  const SUPERVISOR_READ_TOOLS = [
+    'factory_overview',
+    'factory_health_check',
+    'factory_inspect_work_item',
+    'factory_list_attention',
+    'factory_read_session',
+  ];
+  const SUPERVISOR_HUMAN_WRITE_TOOLS = [
+    'factory_retry_decision',
+    'factory_dismiss_decision',
+    'factory_resolve_proposal',
+    'factory_transition_work_item',
+    'factory_reconcile_labels',
+    'factory_revoke_binding',
+    'factory_signal_session',
+  ];
+
+  /**
+   * A notification-woken supervisor turn carries only the controller context
+   * (no factory auth user). It must still get hands: the read tools register
+   * from the hydration-stamped session state, while the human-gated write
+   * tools stay off. An authenticated turn keeps today's full set.
+   */
+  it('registers supervisor read tools on a signal turn from trusted session state, never the human write tools', async () => {
+    const storage = fakeStorage();
+    const config = await prepareFactory({ storage });
+    const projects = storage.getDomain<FactoryProjectsStorage>('projects');
+    const project = await projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'p' } });
+    const extraTools = config.extraTools as (args: {
+      requestContext: RequestContext;
+    }) => Promise<Record<string, unknown>>;
+    const controller = (state: Record<string, unknown>) => ({
+      resourceId: `factory-supervisor:${project.id}`,
+      threadId: `factory-supervisor:${project.id}`,
+      scope: '/worktree',
+      state,
+      getState: () => state,
+    });
+
+    // Signal turn: controller context only, state stamped by hydrateSupervisorSession.
+    const signalTurn = new RequestContext();
+    signalTurn.set('controller', controller({ factoryProjectId: project.id, factoryOrgId: 'org-1' }));
+    const signalTools = Object.keys(await extraTools({ requestContext: signalTurn }));
+    expect(signalTools.sort()).toEqual([...SUPERVISOR_READ_TOOLS].sort());
+
+    // Forged/foreign state: org does not own the project → no supervisor tools at all.
+    const forged = new RequestContext();
+    forged.set('controller', controller({ factoryProjectId: project.id, factoryOrgId: 'org-other' }));
+    expect(await extraTools({ requestContext: forged })).toEqual({});
+
+    // Authenticated human turn: read + the seven approval-gated write tools.
+    const humanTurn = new RequestContext();
+    humanTurn.set('user', { workosId: 'user-1', organizationId: 'org-1' });
+    humanTurn.set('controller', controller({ factoryProjectId: project.id, factoryOrgId: 'org-1' }));
+    const humanTools = Object.keys(await extraTools({ requestContext: humanTurn }));
+    expect(humanTools.sort()).toEqual([...SUPERVISOR_READ_TOOLS, ...SUPERVISOR_HUMAN_WRITE_TOOLS].sort());
+  });
+
+  /**
+   * The sweep's notify handle must route through the mounted controller:
+   * ensure-create the supervisor session, then send on it. A never-created
+   * session would otherwise wake with no model.
+   */
+  it('wires the health worker to notify the supervisor session through the controller', async () => {
+    const storage = fakeStorage();
+    const factory = new MastraFactory({ secretEncryption, storage });
+    const args = await factory.prepare();
+    const worker = args.workers!.find(
+      (w): w is FactorySupervisorHealthWorker => w instanceof FactorySupervisorHealthWorker,
+    )!;
+    const projects = storage.getDomain<FactoryProjectsStorage>('projects');
+    const workItems = storage.getDomain<WorkItemsStorage>('work-items');
+    const project = await projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'p' } });
+    const now = new Date();
+    const { item } = await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: { title: 'Fix login', stages: ['building'], sessions: {}, metadata: {} },
+    });
+    await workItems.commitRuleEvaluation({
+      orgId: 'org-1',
+      factoryProjectId: project.id,
+      workItemId: item.id,
+      ingress: { identity: 'wiring-failure', triggerType: 'test' },
+      ruleSetVersion: 'rules-v1',
+      expectedRevision: item.revision,
+      actor: { type: 'system', id: 'rules' },
+      outcome: { status: 'accepted' },
+      decisions: [{ type: 'sendMessage', role: 'work', message: 'Notify.', idempotencyKey: 'wiring-failure' }],
+      causalChain: [],
+      now,
+    });
+    const [claimed] = await workItems.claimDeferredDecisions({
+      ownerId: 'worker-1',
+      now,
+      leaseExpiresAt: new Date(now.getTime() + 60_000),
+      limit: 1,
+    });
+    await workItems.failDeferredDecision({
+      id: claimed!.id,
+      orgId: 'org-1',
+      factoryProjectId: project.id,
+      ownerId: 'worker-1',
+      now,
+      availableAt: now,
+      lastError: 'No active Factory binding for role work.',
+      failureCode: 'session_unavailable',
+      terminal: true,
+    });
+
+    const sendNotificationSignal = vi.fn(async () => {});
+    const session = { sendNotificationSignal };
+    const getSessionByResource = vi.fn(async () => undefined);
+    const createSession = vi.fn(async () => session);
+    Object.assign(controllerMock, { getSessionByResource, createSession });
+    try {
+      await worker.init({
+        pubsub: {} as never,
+        storage: {} as never,
+        logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+      });
+      await worker.start();
+      await new Promise(resolve => setTimeout(resolve, 0));
+      await worker.stop();
+    } finally {
+      delete (controllerMock as Record<string, unknown>).getSessionByResource;
+      delete (controllerMock as Record<string, unknown>).createSession;
+    }
+
+    const resourceId = `factory-supervisor:${project.id}`;
+    expect(getSessionByResource).toHaveBeenCalledWith(resourceId);
+    expect(createSession).toHaveBeenCalledWith({ id: resourceId, resourceId, threadId: resourceId });
+    expect(sendNotificationSignal).toHaveBeenCalledTimes(1);
+    expect(sendNotificationSignal.mock.calls[0]![0]).toMatchObject({
+      source: 'factory',
+      kind: 'supervisor-finding',
+      priority: 'high',
+      payload: { kind: 'decision-failed' },
+    });
+    const { rows } = await workItems.listSupervisorFindingPage({
+      orgId: 'org-1',
+      factoryProjectId: project.id,
+      limit: 10,
+    });
+    expect(rows[0]?.lastNotifiedAt).toBeInstanceOf(Date);
   });
 
   it('serves the not-registered /web/channel-accounts stub when no slack integration is registered', async () => {

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -613,7 +613,13 @@ describe('MastraFactory.prepare', () => {
    */
   it('registers supervisor read tools on a signal turn from trusted session state, never the human write tools', async () => {
     const storage = fakeStorage();
-    const config = await prepareFactory({ storage });
+    // A project-scoped integration tool (Linear-style) must reach the
+    // authenticated human turn but never the unattributed signal turn.
+    const integration = fakeIntegration({
+      id: 'custom',
+      agentTools: vi.fn(async () => ({ custom_write: { description: 'writes somewhere' } as never })),
+    });
+    const config = await prepareFactory({ storage, integrations: [integration] });
     const projects = storage.getDomain<FactoryProjectsStorage>('projects');
     const project = await projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'p' } });
     const extraTools = config.extraTools as (args: {
@@ -643,7 +649,9 @@ describe('MastraFactory.prepare', () => {
     humanTurn.set('user', { workosId: 'user-1', organizationId: 'org-1' });
     humanTurn.set('controller', controller({ factoryProjectId: project.id, factoryOrgId: 'org-1' }));
     const humanTools = Object.keys(await extraTools({ requestContext: humanTurn }));
-    expect(humanTools.sort()).toEqual([...SUPERVISOR_READ_TOOLS, ...SUPERVISOR_HUMAN_WRITE_TOOLS].sort());
+    expect(humanTools.sort()).toEqual(
+      [...SUPERVISOR_READ_TOOLS, ...SUPERVISOR_HUMAN_WRITE_TOOLS, 'custom_write'].sort(),
+    );
   });
 
   /**

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -654,6 +654,28 @@ describe('MastraFactory.prepare', () => {
     );
   });
 
+  it('gives a supervisor session no tools when the factory domain is unavailable, even with tool integrations', async () => {
+    const storage = fakeStorage();
+    vi.spyOn(storage, 'isDomainReady').mockReturnValue(false);
+    const integration = fakeIntegration({
+      id: 'custom',
+      agentTools: vi.fn(async () => ({ custom_write: { description: 'writes somewhere' } as never })),
+    });
+    const config = await prepareFactory({ storage, integrations: [integration] });
+    const extraTools = config.extraTools as (args: {
+      requestContext: RequestContext;
+    }) => Promise<Record<string, unknown>>;
+    const context = (resourceId: string) => {
+      const requestContext = new RequestContext();
+      const state = { factoryProjectId: 'p-1', factoryOrgId: 'org-1' };
+      requestContext.set('controller', { resourceId, threadId: resourceId, scope: '/', state, getState: () => state });
+      return requestContext;
+    };
+    expect(await extraTools({ requestContext: context('factory-supervisor:p-1') })).toEqual({});
+    // A non-supervisor session keeps its integration tools in the degraded state.
+    expect(Object.keys(await extraTools({ requestContext: context('resource-1') }))).toEqual(['custom_write']);
+  });
+
   /**
    * The sweep's notify handle must route through the mounted controller:
    * ensure-create the supervisor session, then send on it. A never-created

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -750,7 +750,8 @@ describe('MastraFactory.prepare', () => {
 
     const resourceId = `factory-supervisor:${project.id}`;
     expect(getSessionByResource).toHaveBeenCalledWith(resourceId);
-    expect(createSession).toHaveBeenCalledWith({ id: resourceId, resourceId, threadId: resourceId });
+    // Owned by the project's creator so the wake's turn can resolve credentials.
+    expect(createSession).toHaveBeenCalledWith({ id: resourceId, resourceId, threadId: resourceId, ownerId: 'user-1' });
     expect(sendNotificationSignal).toHaveBeenCalledTimes(1);
     expect(sendNotificationSignal.mock.calls[0]![0]).toMatchObject({
       source: 'factory',

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -833,6 +833,21 @@ export class MastraFactory {
                         }),
                       );
                     }
+                    // A signal-woken supervisor turn has no human behind it:
+                    // its toolset is exactly the supervisor read tools (plus
+                    // the approval-free v1 tools as they land). Integration
+                    // tools scope by project, not by person, so they would
+                    // otherwise hand an unattributed turn external writes.
+                    if (supervisorScope.via === 'session-state') return tools;
+                  } else if (
+                    typeof requestContext?.get === 'function' &&
+                    parseSupervisorResourceId(
+                      (requestContext.get('controller') as { resourceId?: string } | undefined)?.resourceId,
+                    )
+                  ) {
+                    // A supervisor session that cannot prove its scope gets
+                    // nothing at all, integration tools included.
+                    return tools;
                   }
                 }
                 for (const { integration, ready, ensureReady } of toolIntegrations) {

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -104,6 +104,7 @@ import { WorkItemsStorage } from './storage/domains/work-items/base.js';
 import type { WorkItemRow } from './storage/domains/work-items/base.js';
 import { FactorySupervisorHealthWorker } from './supervisor/health-worker.js';
 import { SUPERVISOR_INSTRUCTIONS } from './supervisor/instructions.js';
+import { notifySupervisor } from './supervisor/notify.js';
 import { createFactorySupervisorReadTools } from './supervisor/read-tools.js';
 import { hydrateSupervisorSession, parseSupervisorResourceId, resolveSupervisorScope } from './supervisor/session.js';
 import { createFactorySupervisorWriteTools } from './supervisor/write-tools.js';
@@ -1107,7 +1108,16 @@ export class MastraFactory {
     // an unavailable integration must not run.
     const integrationWorkers = [
       ...(factoryReady
-        ? [new FactorySupervisorHealthWorker({ projects: factoryProjectsStorage, workItems: workItemsStorage })]
+        ? [
+            new FactorySupervisorHealthWorker({
+              projects: factoryProjectsStorage,
+              workItems: workItemsStorage,
+              // The sweep's doorbell: ensure-creates the supervisor session
+              // through the controller, then emits via the code agent's
+              // notification stack (same send handle the dispatcher uses).
+              notify: input => notifySupervisor({ controller: prepared.base.controller }, input),
+            }),
+          ]
         : []),
       ...integrationRegistrations
         .filter(({ integration, ready }) => ready && integration.workers)

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -796,7 +796,10 @@ export class MastraFactory {
                         },
                       }),
                     );
-                    if (userId) {
+                    // The approval-gated write tools stamp the human who asked
+                    // (approvedBy, actor.type 'human'); a signal turn has no
+                    // such person, so it never gets them.
+                    if (supervisorScope.via === 'auth' && userId) {
                       mergeTools(
                         'factory-supervisor-write',
                         createFactorySupervisorWriteTools({

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -755,6 +755,15 @@ export class MastraFactory {
                     tools[name] = tool;
                   }
                 };
+                const isSupervisorSession =
+                  typeof requestContext?.get === 'function' &&
+                  parseSupervisorResourceId(
+                    (requestContext.get('controller') as { resourceId?: string } | undefined)?.resourceId,
+                  ) !== null;
+                // A supervisor session is authorized below through its scope;
+                // with the factory domain unavailable nothing can vouch for it,
+                // so it gets no tools rather than the integration set.
+                if (isSupervisorSession && !(workItemsStorage && transitionService)) return tools;
                 if (workItemsStorage && transitionService) {
                   mergeTools(
                     'factory',
@@ -839,12 +848,7 @@ export class MastraFactory {
                     // tools scope by project, not by person, so they would
                     // otherwise hand an unattributed turn external writes.
                     if (supervisorScope.via === 'session-state') return tools;
-                  } else if (
-                    typeof requestContext?.get === 'function' &&
-                    parseSupervisorResourceId(
-                      (requestContext.get('controller') as { resourceId?: string } | undefined)?.resourceId,
-                    )
-                  ) {
+                  } else if (isSupervisorSession) {
                     // A supervisor session that cannot prove its scope gets
                     // nothing at all, integration tools included.
                     return tools;

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -1138,7 +1138,15 @@ export class MastraFactory {
               // through the controller, then emits via the code agent's
               // notification stack (same send handle the dispatcher uses).
               notify: input =>
-                notifySupervisor({ controller: prepared.base.controller, projects: factoryProjectsStorage }, input),
+                notifySupervisor(
+                  {
+                    controller: prepared.base.controller,
+                    projects: factoryProjectsStorage,
+                    primeCredentials: tenant =>
+                      primeTenantCredentials({ tenant, credentials: modelCredentialsStorage }),
+                  },
+                  input,
+                ),
             }),
           ]
         : []),

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -1137,7 +1137,8 @@ export class MastraFactory {
               // The sweep's doorbell: ensure-creates the supervisor session
               // through the controller, then emits via the code agent's
               // notification stack (same send handle the dispatcher uses).
-              notify: input => notifySupervisor({ controller: prepared.base.controller }, input),
+              notify: input =>
+                notifySupervisor({ controller: prepared.base.controller, projects: factoryProjectsStorage }, input),
             }),
           ]
         : []),

--- a/mastracode/factory/src/storage/domains/work-items/base.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.test.ts
@@ -750,18 +750,15 @@ describe('supervisor finding notification stamps', () => {
   it('lists only open, un-stamped findings oldest first', async () => {
     const storage = await makeStorage();
     const t0 = new Date('2030-01-01T00:00:00.000Z');
-    await storage.syncSupervisorFindings({
-      ...scope,
-      findings: [finding('decision-failed:a'), finding('decision-failed:b'), finding('decision-failed:c')],
-      now: t0,
-    });
+    const keys = ['decision-failed:a', 'decision-failed:b', 'decision-failed:c', 'decision-failed:d'];
+    await storage.syncSupervisorFindings({ ...scope, findings: keys.map(finding), now: t0 });
     await storage.markSupervisorFindingNotified({
       ...scope,
       findingKey: 'decision-failed:b',
       occurrence: 0,
       notifiedAt: t0,
     });
-    // Resolve `c` by syncing a snapshot without it.
+    // Resolve `c` and `d` by syncing a snapshot without them; `d` stays resolved.
     await storage.syncSupervisorFindings({
       ...scope,
       findings: [finding('decision-failed:a'), finding('decision-failed:b')],
@@ -776,7 +773,14 @@ describe('supervisor finding notification stamps', () => {
 
     const rows = await storage.listUnnotifiedSupervisorFindings({ ...scope, limit: 10 });
     expect(rows.map(row => row.findingKey)).toEqual(['decision-failed:a', 'decision-failed:c']);
-    expect(await storage.listUnnotifiedSupervisorFindings({ ...scope, limit: 1 })).toHaveLength(1);
+    const firstPage = await storage.listUnnotifiedSupervisorFindings({ ...scope, limit: 1 });
+    expect(firstPage.map(row => row.findingKey)).toEqual(['decision-failed:a']);
+    const nextPage = await storage.listUnnotifiedSupervisorFindings({
+      ...scope,
+      limit: 1,
+      after: { openedAt: firstPage[0]!.openedAt, id: firstPage[0]!.id },
+    });
+    expect(nextPage.map(row => row.findingKey)).toEqual(['decision-failed:c']);
   });
 
   it('is occurrence-safe: a stale stamp after resolve/reopen is a silent no-op', async () => {

--- a/mastracode/factory/src/storage/domains/work-items/base.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.test.ts
@@ -747,6 +747,38 @@ describe('supervisor finding notification stamps', () => {
     expect((await getRow(storage, 'decision-failed:item-1'))?.lastNotifiedAt?.getTime()).toBe(notifiedAt.getTime());
   });
 
+  it('lists only open, un-stamped findings oldest first', async () => {
+    const storage = await makeStorage();
+    const t0 = new Date('2030-01-01T00:00:00.000Z');
+    await storage.syncSupervisorFindings({
+      ...scope,
+      findings: [finding('decision-failed:a'), finding('decision-failed:b'), finding('decision-failed:c')],
+      now: t0,
+    });
+    await storage.markSupervisorFindingNotified({
+      ...scope,
+      findingKey: 'decision-failed:b',
+      occurrence: 0,
+      notifiedAt: t0,
+    });
+    // Resolve `c` by syncing a snapshot without it.
+    await storage.syncSupervisorFindings({
+      ...scope,
+      findings: [finding('decision-failed:a'), finding('decision-failed:b')],
+      now: new Date('2030-01-01T00:01:00.000Z'),
+    });
+    // Reopen `c` later: it comes back un-stamped and newer than `a`.
+    await storage.syncSupervisorFindings({
+      ...scope,
+      findings: [finding('decision-failed:a'), finding('decision-failed:b'), finding('decision-failed:c')],
+      now: new Date('2030-01-01T00:02:00.000Z'),
+    });
+
+    const rows = await storage.listUnnotifiedSupervisorFindings({ ...scope, limit: 10 });
+    expect(rows.map(row => row.findingKey)).toEqual(['decision-failed:a', 'decision-failed:c']);
+    expect(await storage.listUnnotifiedSupervisorFindings({ ...scope, limit: 1 })).toHaveLength(1);
+  });
+
   it('is occurrence-safe: a stale stamp after resolve/reopen is a silent no-op', async () => {
     const storage = await makeStorage();
     await openFinding(storage, 'decision-failed:item-1', new Date('2030-01-01T00:00:00.000Z'));

--- a/mastracode/factory/src/storage/domains/work-items/base.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.test.ts
@@ -709,3 +709,117 @@ describe('getBySource', () => {
     expect(await storage.getBySource(slackThread)).toBeNull();
   });
 });
+
+describe('supervisor finding notification stamps', () => {
+  const finding = (key: string) => ({
+    id: key,
+    kind: 'decision-failed' as const,
+    workItemId: 'item-1',
+    workItemNumber: null,
+    title: 'A decision failed',
+    evidence: '[run_awaiting_input] failed after 1 attempt(s)',
+    ageMs: 1_000,
+    suggestedRepair: { action: 'retry-decision' as const, decisionId: 'decision-1' },
+  });
+  const scope = { orgId: 'org1', factoryProjectId: 'p1' };
+
+  async function openFinding(storage: WorkItemsStorage, key: string, now: Date) {
+    await storage.syncSupervisorFindings({ ...scope, findings: [finding(key)], now });
+  }
+
+  async function getRow(storage: WorkItemsStorage, key: string) {
+    const page = await storage.listSupervisorFindingPage({ ...scope, limit: 10 });
+    return page.rows.find(row => row.findingKey === key);
+  }
+
+  it('round-trips last_notified_at through the stamp method', async () => {
+    const storage = await makeStorage();
+    await openFinding(storage, 'decision-failed:item-1', new Date('2030-01-01T00:00:00.000Z'));
+    expect((await getRow(storage, 'decision-failed:item-1'))?.lastNotifiedAt).toBeNull();
+
+    const notifiedAt = new Date('2030-01-01T00:01:00.000Z');
+    await storage.markSupervisorFindingNotified({
+      ...scope,
+      findingKey: 'decision-failed:item-1',
+      occurrence: 0,
+      notifiedAt,
+    });
+    expect((await getRow(storage, 'decision-failed:item-1'))?.lastNotifiedAt?.getTime()).toBe(notifiedAt.getTime());
+  });
+
+  it('is occurrence-safe: a stale stamp after resolve/reopen is a silent no-op', async () => {
+    const storage = await makeStorage();
+    await openFinding(storage, 'decision-failed:item-1', new Date('2030-01-01T00:00:00.000Z'));
+
+    // The finding resolves (absent from the next sweep) and reopens (present
+    // again) between the emit and the stamp: occurrence advances to 1.
+    await storage.syncSupervisorFindings({ ...scope, findings: [], now: new Date('2030-01-01T00:02:00.000Z') });
+    await openFinding(storage, 'decision-failed:item-1', new Date('2030-01-01T00:03:00.000Z'));
+    const reopened = await getRow(storage, 'decision-failed:item-1');
+    expect(reopened?.occurrence).toBe(1);
+
+    // The stale stamp was emitted for occurrence 0 — it must not land.
+    await storage.markSupervisorFindingNotified({
+      ...scope,
+      findingKey: 'decision-failed:item-1',
+      occurrence: 0,
+      notifiedAt: new Date('2030-01-01T00:04:00.000Z'),
+    });
+    expect((await getRow(storage, 'decision-failed:item-1'))?.lastNotifiedAt).toBeNull();
+  });
+
+  it('stamps only once: a second stamp on an already-stamped row is a no-op', async () => {
+    const storage = await makeStorage();
+    await openFinding(storage, 'decision-failed:item-1', new Date('2030-01-01T00:00:00.000Z'));
+    const first = new Date('2030-01-01T00:01:00.000Z');
+    await storage.markSupervisorFindingNotified({
+      ...scope,
+      findingKey: 'decision-failed:item-1',
+      occurrence: 0,
+      notifiedAt: first,
+    });
+    await storage.markSupervisorFindingNotified({
+      ...scope,
+      findingKey: 'decision-failed:item-1',
+      occurrence: 0,
+      notifiedAt: new Date('2030-01-01T00:05:00.000Z'),
+    });
+    expect((await getRow(storage, 'decision-failed:item-1'))?.lastNotifiedAt?.getTime()).toBe(first.getTime());
+  });
+
+  it('reopen clears the stamp so a reopened incident re-emits', async () => {
+    const storage = await makeStorage();
+    await openFinding(storage, 'decision-failed:item-1', new Date('2030-01-01T00:00:00.000Z'));
+    await storage.markSupervisorFindingNotified({
+      ...scope,
+      findingKey: 'decision-failed:item-1',
+      occurrence: 0,
+      notifiedAt: new Date('2030-01-01T00:01:00.000Z'),
+    });
+
+    await storage.syncSupervisorFindings({ ...scope, findings: [], now: new Date('2030-01-01T00:02:00.000Z') });
+    await openFinding(storage, 'decision-failed:item-1', new Date('2030-01-01T00:03:00.000Z'));
+
+    const reopened = await getRow(storage, 'decision-failed:item-1');
+    expect(reopened?.occurrence).toBe(1);
+    expect(reopened?.lastNotifiedAt).toBeNull();
+  });
+
+  it('auto-resolve leaves the stamp untouched on the resolved row', async () => {
+    const storage = await makeStorage();
+    await openFinding(storage, 'decision-failed:item-1', new Date('2030-01-01T00:00:00.000Z'));
+    const notifiedAt = new Date('2030-01-01T00:01:00.000Z');
+    await storage.markSupervisorFindingNotified({
+      ...scope,
+      findingKey: 'decision-failed:item-1',
+      occurrence: 0,
+      notifiedAt,
+    });
+
+    // Resolve via reconciliation (finding absent from the sweep).
+    await storage.syncSupervisorFindings({ ...scope, findings: [], now: new Date('2030-01-01T00:02:00.000Z') });
+    // Resolved rows leave the open page; the stamp is not cleared by resolution
+    // itself (only reopen clears it).
+    expect(await getRow(storage, 'decision-failed:item-1')).toBeUndefined();
+  });
+});

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -246,6 +246,7 @@ export interface FactorySupervisorFindingRecord {
   openedAt: Date;
   updatedAt: Date;
   resolvedAt: Date | null;
+  lastNotifiedAt: Date | null;
 }
 export type FactoryAttentionReceiptAction = 'read' | 'archive' | 'restore';
 
@@ -896,6 +897,7 @@ const FACTORY_GOVERNANCE_SCHEMAS: CollectionSchema[] = [
       opened_at: { type: 'timestamp' },
       updated_at: { type: 'timestamp' },
       resolved_at: { type: 'timestamp', nullable: true },
+      last_notified_at: { type: 'timestamp', nullable: true },
     },
     uniqueIndexes: [
       {
@@ -1088,6 +1090,7 @@ function toSupervisorFinding(row: GovernanceDbRow): FactorySupervisorFindingReco
     openedAt: row.opened_at as Date,
     updatedAt: row.updated_at as Date,
     resolvedAt: (row.resolved_at as Date | null) ?? null,
+    lastNotifiedAt: (row.last_notified_at as Date | null) ?? null,
   };
 }
 
@@ -1239,6 +1242,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
             opened_at: input.now,
             updated_at: input.now,
             resolved_at: null,
+            last_notified_at: null,
           });
           changed = true;
           continue;
@@ -1252,6 +1256,9 @@ export class WorkItemsStorage extends FactoryStorageDomain {
           opened_at: current.resolved_at !== null ? input.now : current.opened_at,
           updated_at: input.now,
           resolved_at: null,
+          // A reopened incident re-rings the doorbell: clear the notification
+          // stamp so the next sweep emits for it again.
+          last_notified_at: current.resolved_at !== null ? null : current.last_notified_at,
         }));
         changed = true;
       }
@@ -1279,6 +1286,31 @@ export class WorkItemsStorage extends FactoryStorageDomain {
       },
     );
     return { rows: rows.slice(0, input.limit).map(toSupervisorFinding), hasMore: rows.length > input.limit };
+  }
+
+  async markSupervisorFindingNotified(input: {
+    orgId: string;
+    factoryProjectId: string;
+    findingKey: string;
+    occurrence: number;
+    notifiedAt: Date;
+  }): Promise<void> {
+    // Occurrence-safe conditional stamp: a resolve/reopen between send and
+    // stamp must not suppress the new occurrence's notification, so the stamp
+    // only lands on the exact occurrence that was emitted, while it is still
+    // open and still un-stamped. No matching row is a silent no-op.
+    await this.#db.updateAtomic<GovernanceDbRow>(
+      'factory_supervisor_findings',
+      {
+        org_id: input.orgId,
+        factory_project_id: input.factoryProjectId,
+        finding_key: input.findingKey,
+        occurrence: input.occurrence,
+        resolved_at: null,
+        last_notified_at: null,
+      },
+      () => ({ last_notified_at: input.notifiedAt }),
+    );
   }
 
   async countOpenSupervisorFindings(input: { orgId: string; factoryProjectId: string }): Promise<number> {

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -1289,14 +1289,15 @@ export class WorkItemsStorage extends FactoryStorageDomain {
   }
 
   /**
-   * Open findings whose notification stamp is null, oldest first, so a sweep
-   * can drain them page by page: stamped rows leave this set, so re-querying
-   * after each page never re-reads the same rows.
+   * Open findings whose notification stamp is null, oldest first, keyset
+   * paginated by `(opened_at, id)` so a sweep can walk them exactly once
+   * regardless of which rows it manages to stamp along the way.
    */
   async listUnnotifiedSupervisorFindings(input: {
     orgId: string;
     factoryProjectId: string;
     limit: number;
+    after?: { openedAt: Date; id: string };
   }): Promise<FactorySupervisorFindingRecord[]> {
     const rows = await this.#db.findMany<GovernanceDbRow>(
       'factory_supervisor_findings',
@@ -1312,6 +1313,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
           ['id', 'asc'],
         ],
         limit: input.limit,
+        ...(input.after ? { cursor: { values: [input.after.openedAt, input.after.id] } } : {}),
       },
     );
     return rows.map(toSupervisorFinding);

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -1288,6 +1288,35 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     return { rows: rows.slice(0, input.limit).map(toSupervisorFinding), hasMore: rows.length > input.limit };
   }
 
+  /**
+   * Open findings whose notification stamp is null, oldest first, so a sweep
+   * can drain them page by page: stamped rows leave this set, so re-querying
+   * after each page never re-reads the same rows.
+   */
+  async listUnnotifiedSupervisorFindings(input: {
+    orgId: string;
+    factoryProjectId: string;
+    limit: number;
+  }): Promise<FactorySupervisorFindingRecord[]> {
+    const rows = await this.#db.findMany<GovernanceDbRow>(
+      'factory_supervisor_findings',
+      {
+        org_id: input.orgId,
+        factory_project_id: input.factoryProjectId,
+        resolved_at: null,
+        last_notified_at: null,
+      },
+      {
+        orderBy: [
+          ['opened_at', 'asc'],
+          ['id', 'asc'],
+        ],
+        limit: input.limit,
+      },
+    );
+    return rows.map(toSupervisorFinding);
+  }
+
   async markSupervisorFindingNotified(input: {
     orgId: string;
     factoryProjectId: string;

--- a/mastracode/factory/src/supervisor/health-worker.test.ts
+++ b/mastracode/factory/src/supervisor/health-worker.test.ts
@@ -10,7 +10,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkItemRow } from '../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
 import type { FactoryStorageTestSeed } from '../storage/test-utils.js';
-import { FactorySupervisorHealthWorker } from './health-worker.js';
+import { EMIT_PAGE_SIZE, FactorySupervisorHealthWorker } from './health-worker.js';
 import type { NotifySupervisorInput } from './notify.js';
 
 let seed: FactoryStorageTestSeed;
@@ -168,6 +168,27 @@ describe('FactorySupervisorHealthWorker emit call site', () => {
     await sweep(worker);
     expect(notify).toHaveBeenCalledTimes(2);
     expect((await openFindings()).rows[0]?.lastNotifiedAt).toBeInstanceOf(Date);
+  });
+
+  it('drains more than one page of un-notified findings in a single sweep', async () => {
+    const count = EMIT_PAGE_SIZE + 3;
+    const base = Date.now();
+    for (let i = 0; i < count; i += 1) {
+      await seedFailure(await seedWorkItem(), new Date(base + i));
+    }
+    const notify = vi.fn(async (_input: NotifySupervisorInput) => {});
+    const worker = new FactorySupervisorHealthWorker({ projects: seed.projects, workItems: seed.workItems, notify });
+    await worker.init(createDeps());
+
+    await sweep(worker);
+
+    expect(notify).toHaveBeenCalledTimes(count);
+    const unnotified = await seed.workItems.listUnnotifiedSupervisorFindings({
+      orgId: 'org1',
+      factoryProjectId: PROJECT_ID,
+      limit: 10,
+    });
+    expect(unnotified).toEqual([]);
   });
 
   it('sweeps cleanly with no notify handle wired', async () => {

--- a/mastracode/factory/src/supervisor/health-worker.test.ts
+++ b/mastracode/factory/src/supervisor/health-worker.test.ts
@@ -191,6 +191,39 @@ describe('FactorySupervisorHealthWorker emit call site', () => {
     expect(unnotified).toEqual([]);
   });
 
+  it('attempts every row once per sweep even when an entire leading page fails', async () => {
+    const count = EMIT_PAGE_SIZE + 2;
+    const base = Date.now();
+    for (let i = 0; i < count; i += 1) {
+      await seedFailure(await seedWorkItem(), new Date(base + i));
+    }
+    // Every row on the first page fails; the two rows behind it must still be reached.
+    let calls = 0;
+    const notify = vi.fn(async (_input: NotifySupervisorInput) => {
+      calls += 1;
+      if (calls <= EMIT_PAGE_SIZE) throw new Error('storage down');
+    });
+    const worker = new FactorySupervisorHealthWorker({ projects: seed.projects, workItems: seed.workItems, notify });
+    await worker.init(createDeps());
+
+    await sweep(worker);
+
+    expect(notify).toHaveBeenCalledTimes(count);
+    const stillUnnotified = await seed.workItems.listUnnotifiedSupervisorFindings({
+      orgId: 'org1',
+      factoryProjectId: PROJECT_ID,
+      limit: count,
+    });
+    expect(stillUnnotified).toHaveLength(EMIT_PAGE_SIZE);
+    // Next sweep retries exactly the failed rows.
+    notify.mockImplementation(async () => {});
+    await sweep(worker);
+    expect(notify).toHaveBeenCalledTimes(count + EMIT_PAGE_SIZE);
+    expect(
+      await seed.workItems.listUnnotifiedSupervisorFindings({ orgId: 'org1', factoryProjectId: PROJECT_ID, limit: 5 }),
+    ).toEqual([]);
+  });
+
   it('sweeps cleanly with no notify handle wired', async () => {
     await seedFailure(await seedWorkItem(), new Date());
     const worker = new FactorySupervisorHealthWorker({ projects: seed.projects, workItems: seed.workItems });

--- a/mastracode/factory/src/supervisor/health-worker.test.ts
+++ b/mastracode/factory/src/supervisor/health-worker.test.ts
@@ -1,0 +1,182 @@
+/**
+ * The sweep's emit call site against real storage: after reconciliation, every
+ * open finding whose notification stamp is null is emitted once and stamped;
+ * stamped rows are silent on later sweeps; a reopened finding re-rings.
+ */
+
+import type { WorkerDeps } from '@mastra/core/worker';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { WorkItemRow } from '../storage/domains/work-items/base.js';
+import { createFactoryStorageForTests } from '../storage/test-utils.js';
+import type { FactoryStorageTestSeed } from '../storage/test-utils.js';
+import { FactorySupervisorHealthWorker } from './health-worker.js';
+import type { NotifySupervisorInput } from './notify.js';
+
+let seed: FactoryStorageTestSeed;
+let PROJECT_ID = '';
+
+function createDeps(): WorkerDeps & { warn: ReturnType<typeof vi.fn> } {
+  const warn = vi.fn();
+  return {
+    pubsub: {} as WorkerDeps['pubsub'],
+    storage: {} as WorkerDeps['storage'],
+    logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() } as unknown as WorkerDeps['logger'],
+    warn,
+  };
+}
+
+async function seedWorkItem(): Promise<WorkItemRow> {
+  const { item } = await seed.workItems.upsert({
+    orgId: 'org1',
+    userId: 'u1',
+    factoryProjectId: PROJECT_ID,
+    input: { title: 'Fix login', stages: ['building'], sessions: {}, metadata: {} },
+  });
+  return item;
+}
+
+async function seedFailure(workItem: WorkItemRow, now: Date) {
+  await seed.workItems.commitRuleEvaluation({
+    orgId: 'org1',
+    factoryProjectId: PROJECT_ID,
+    workItemId: workItem.id,
+    ingress: { identity: `sweep-failure-${now.getTime()}`, triggerType: 'test' },
+    ruleSetVersion: 'rules-v1',
+    expectedRevision: (await seed.workItems.get({ orgId: 'org1', id: workItem.id }))?.revision ?? workItem.revision,
+    actor: { type: 'system', id: 'rules' },
+    outcome: { status: 'accepted' },
+    decisions: [
+      { type: 'sendMessage', role: 'work', message: 'Notify.', idempotencyKey: `sweep-failure-${now.getTime()}` },
+    ],
+    causalChain: [],
+    now,
+  });
+  const [claimed] = await seed.workItems.claimDeferredDecisions({
+    ownerId: 'worker-1',
+    now,
+    leaseExpiresAt: new Date(now.getTime() + 60_000),
+    limit: 1,
+  });
+  if (!claimed) throw new Error('Expected a deferred decision');
+  await seed.workItems.failDeferredDecision({
+    id: claimed.id,
+    orgId: claimed.orgId,
+    factoryProjectId: claimed.factoryProjectId,
+    ownerId: 'worker-1',
+    now,
+    availableAt: now,
+    lastError: 'No active Factory binding for role work.',
+    failureCode: 'session_unavailable',
+    terminal: true,
+  });
+}
+
+/** One full sweep: start fires the immediate tick; stop waits for it. */
+async function sweep(worker: FactorySupervisorHealthWorker) {
+  await worker.start();
+  await new Promise(resolve => setTimeout(resolve, 0));
+  await worker.stop();
+}
+
+function openFindings() {
+  return seed.workItems.listSupervisorFindingPage({ orgId: 'org1', factoryProjectId: PROJECT_ID, limit: 50 });
+}
+
+beforeEach(async () => {
+  seed = await createFactoryStorageForTests();
+  const project = await seed.projects.create({ orgId: 'org1', userId: 'u1', input: { name: 'org1 project' } });
+  PROJECT_ID = project.id;
+});
+
+describe('FactorySupervisorHealthWorker emit call site', () => {
+  it('emits once for a newly opened finding and stamps last_notified_at', async () => {
+    await seedFailure(await seedWorkItem(), new Date());
+    const notify = vi.fn(async (_input: NotifySupervisorInput) => {});
+    const worker = new FactorySupervisorHealthWorker({ projects: seed.projects, workItems: seed.workItems, notify });
+    await worker.init(createDeps());
+
+    await sweep(worker);
+
+    const { rows } = await openFindings();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.lastNotifiedAt).toBeInstanceOf(Date);
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0]?.[0]).toMatchObject({
+      projectId: PROJECT_ID,
+      findingKey: rows[0]?.findingKey,
+      kind: 'decision-failed',
+    });
+    expect(notify.mock.calls[0]?.[0].summary).toContain('session_unavailable');
+  });
+
+  it('does not re-emit for a still-open finding that is already stamped', async () => {
+    await seedFailure(await seedWorkItem(), new Date());
+    const notify = vi.fn(async (_input: NotifySupervisorInput) => {});
+    const worker = new FactorySupervisorHealthWorker({ projects: seed.projects, workItems: seed.workItems, notify });
+    await worker.init(createDeps());
+
+    await sweep(worker);
+    await sweep(worker);
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect((await openFindings()).rows).toHaveLength(1);
+  });
+
+  it('re-emits when a resolved finding reopens (reopen clears the stamp)', async () => {
+    await seedFailure(await seedWorkItem(), new Date());
+    const notify = vi.fn(async (_input: NotifySupervisorInput) => {});
+    const worker = new FactorySupervisorHealthWorker({ projects: seed.projects, workItems: seed.workItems, notify });
+    await worker.init(createDeps());
+
+    await sweep(worker);
+    const [first] = (await openFindings()).rows;
+    // Resolve the row out-of-band (an empty snapshot auto-resolves every open row).
+    await seed.workItems.syncSupervisorFindings({
+      orgId: 'org1',
+      factoryProjectId: PROJECT_ID,
+      findings: [],
+      now: new Date(),
+    });
+    expect((await openFindings()).rows).toHaveLength(0);
+
+    // The failed decision is still there, so the next sweep recomputes the same finding → reopen.
+    await sweep(worker);
+
+    const [reopened] = (await openFindings()).rows;
+    expect(reopened?.findingKey).toBe(first?.findingKey);
+    expect(first?.occurrence).toBe(0);
+    expect(reopened?.occurrence).toBe(1);
+    expect(reopened?.lastNotifiedAt).toBeInstanceOf(Date);
+    expect(notify).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs and skips a failing emit, leaving the row un-stamped for the next sweep', async () => {
+    await seedFailure(await seedWorkItem(), new Date());
+    const notify = vi.fn(async (_input: NotifySupervisorInput) => {}).mockRejectedValueOnce(new Error('storage down'));
+    const worker = new FactorySupervisorHealthWorker({ projects: seed.projects, workItems: seed.workItems, notify });
+    const deps = createDeps();
+    await worker.init(deps);
+
+    await sweep(worker);
+    expect(deps.warn).toHaveBeenCalledWith(
+      'Factory supervisor notify failed',
+      expect.objectContaining({ error: 'storage down' }),
+    );
+    expect((await openFindings()).rows[0]?.lastNotifiedAt).toBeNull();
+
+    await sweep(worker);
+    expect(notify).toHaveBeenCalledTimes(2);
+    expect((await openFindings()).rows[0]?.lastNotifiedAt).toBeInstanceOf(Date);
+  });
+
+  it('sweeps cleanly with no notify handle wired', async () => {
+    await seedFailure(await seedWorkItem(), new Date());
+    const worker = new FactorySupervisorHealthWorker({ projects: seed.projects, workItems: seed.workItems });
+    await worker.init(createDeps());
+    await sweep(worker);
+    const { rows } = await openFindings();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.lastNotifiedAt).toBeNull();
+  });
+});

--- a/mastracode/factory/src/supervisor/health-worker.ts
+++ b/mastracode/factory/src/supervisor/health-worker.ts
@@ -106,12 +106,16 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
    */
   async #emitUnnotified(scope: { orgId: string; factoryProjectId: string }): Promise<void> {
     if (!this.#notify) return;
-    // Drain page by page: stamped rows drop out of the query, so the next
-    // page is always fresh. A page that stamps nothing (every emit failed)
-    // ends the drain — those rows retry on the next sweep.
+    // Walk the un-notified rows once, oldest first, by keyset cursor: each
+    // row is attempted at most once per sweep and a failing row never blocks
+    // the rows behind it (it stays un-stamped and retries next sweep).
+    let after: { openedAt: Date; id: string } | undefined;
     for (;;) {
-      const rows = await this.#workItems.listUnnotifiedSupervisorFindings({ ...scope, limit: EMIT_PAGE_SIZE });
-      let stamped = 0;
+      const rows = await this.#workItems.listUnnotifiedSupervisorFindings({
+        ...scope,
+        limit: EMIT_PAGE_SIZE,
+        ...(after ? { after } : {}),
+      });
       for (const row of rows) {
         try {
           await this.#notify({
@@ -126,7 +130,6 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
             occurrence: row.occurrence,
             notifiedAt: new Date(),
           });
-          stamped += 1;
         } catch (error) {
           this.deps?.logger.warn('Factory supervisor notify failed', {
             findingKey: row.findingKey,
@@ -134,7 +137,9 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
           });
         }
       }
-      if (rows.length < EMIT_PAGE_SIZE || stamped === 0) return;
+      const last = rows[rows.length - 1];
+      if (rows.length < EMIT_PAGE_SIZE || !last) return;
+      after = { openedAt: last.openedAt, id: last.id };
     }
   }
 }

--- a/mastracode/factory/src/supervisor/health-worker.ts
+++ b/mastracode/factory/src/supervisor/health-worker.ts
@@ -6,6 +6,8 @@ import { runFactoryHealthCheck } from './health.js';
 import type { NotifySupervisorInput } from './notify.js';
 
 export const DEFAULT_SUPERVISOR_HEALTH_INTERVAL_MS = 5 * 60_000;
+/** Un-notified findings emitted per storage read during a sweep's drain. */
+export const EMIT_PAGE_SIZE = 100;
 
 export class FactorySupervisorHealthWorker extends MastraWorker {
   readonly name = 'factory-supervisor-health';
@@ -104,28 +106,35 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
    */
   async #emitUnnotified(scope: { orgId: string; factoryProjectId: string }): Promise<void> {
     if (!this.#notify) return;
-    const page = await this.#workItems.listSupervisorFindingPage({ ...scope, limit: 100 });
-    for (const row of page.rows) {
-      if (row.lastNotifiedAt) continue;
-      try {
-        await this.#notify({
-          projectId: scope.factoryProjectId,
-          findingKey: row.findingKey,
-          kind: findingText(row, 'kind') ?? 'unknown',
-          summary: findingText(row, 'evidence') ?? findingText(row, 'title') ?? row.findingKey,
-        });
-        await this.#workItems.markSupervisorFindingNotified({
-          ...scope,
-          findingKey: row.findingKey,
-          occurrence: row.occurrence,
-          notifiedAt: new Date(),
-        });
-      } catch (error) {
-        this.deps?.logger.warn('Factory supervisor notify failed', {
-          findingKey: row.findingKey,
-          error: error instanceof Error ? error.message : String(error),
-        });
+    // Drain page by page: stamped rows drop out of the query, so the next
+    // page is always fresh. A page that stamps nothing (every emit failed)
+    // ends the drain — those rows retry on the next sweep.
+    for (;;) {
+      const rows = await this.#workItems.listUnnotifiedSupervisorFindings({ ...scope, limit: EMIT_PAGE_SIZE });
+      let stamped = 0;
+      for (const row of rows) {
+        try {
+          await this.#notify({
+            projectId: scope.factoryProjectId,
+            findingKey: row.findingKey,
+            kind: findingText(row, 'kind') ?? 'unknown',
+            summary: findingText(row, 'evidence') ?? findingText(row, 'title') ?? row.findingKey,
+          });
+          await this.#workItems.markSupervisorFindingNotified({
+            ...scope,
+            findingKey: row.findingKey,
+            occurrence: row.occurrence,
+            notifiedAt: new Date(),
+          });
+          stamped += 1;
+        } catch (error) {
+          this.deps?.logger.warn('Factory supervisor notify failed', {
+            findingKey: row.findingKey,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
       }
+      if (rows.length < EMIT_PAGE_SIZE || stamped === 0) return;
     }
   }
 }

--- a/mastracode/factory/src/supervisor/health-worker.ts
+++ b/mastracode/factory/src/supervisor/health-worker.ts
@@ -1,8 +1,9 @@
 import { MastraWorker } from '@mastra/core/worker';
 
 import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
-import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import type { FactorySupervisorFindingRecord, WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { runFactoryHealthCheck } from './health.js';
+import type { NotifySupervisorInput } from './notify.js';
 
 export const DEFAULT_SUPERVISOR_HEALTH_INTERVAL_MS = 5 * 60_000;
 
@@ -12,15 +13,23 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
   readonly #projects: FactoryProjectsStorage;
   readonly #workItems: WorkItemsStorage;
   readonly #intervalMs: number;
+  readonly #notify: ((input: NotifySupervisorInput) => Promise<void>) | undefined;
   #running = false;
   #timer: ReturnType<typeof setTimeout> | undefined;
   #inFlight: Promise<void> | undefined;
 
-  constructor(input: { projects: FactoryProjectsStorage; workItems: WorkItemsStorage; intervalMs?: number }) {
+  constructor(input: {
+    projects: FactoryProjectsStorage;
+    workItems: WorkItemsStorage;
+    intervalMs?: number;
+    /** Emits one supervisor notification per un-notified open finding. Optional so tests can construct the worker without wiring the controller. */
+    notify?: (input: NotifySupervisorInput) => Promise<void>;
+  }) {
     super();
     this.#projects = input.projects;
     this.#workItems = input.workItems;
     this.#intervalMs = input.intervalMs ?? DEFAULT_SUPERVISOR_HEALTH_INTERVAL_MS;
+    this.#notify = input.notify;
   }
 
   async start(): Promise<void> {
@@ -76,10 +85,52 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
             findings: report.findings,
             now,
           });
+          await this.#emitUnnotified({ orgId: project.orgId, factoryProjectId: project.id });
         }
       }),
     );
     const failure = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
     if (failure) throw failure.reason;
   }
+
+  /**
+   * Emit for every open finding whose `last_notified_at` is null, then stamp.
+   * The null-stamp rule alone covers newly opened rows, reopened rows (reopen
+   * clears the stamp), and a crash between writing the row and emitting (row
+   * persisted, stamp never happened). The stamp is occurrence-safe inside the
+   * storage domain, so a resolve/reopen racing the send never suppresses the
+   * new occurrence's notification. One failing emit is logged and skipped —
+   * the un-stamped row retries on the next sweep.
+   */
+  async #emitUnnotified(scope: { orgId: string; factoryProjectId: string }): Promise<void> {
+    if (!this.#notify) return;
+    const page = await this.#workItems.listSupervisorFindingPage({ ...scope, limit: 100 });
+    for (const row of page.rows) {
+      if (row.lastNotifiedAt) continue;
+      try {
+        await this.#notify({
+          projectId: scope.factoryProjectId,
+          findingKey: row.findingKey,
+          kind: findingText(row, 'kind') ?? 'unknown',
+          summary: findingText(row, 'evidence') ?? findingText(row, 'title') ?? row.findingKey,
+        });
+        await this.#workItems.markSupervisorFindingNotified({
+          ...scope,
+          findingKey: row.findingKey,
+          occurrence: row.occurrence,
+          notifiedAt: new Date(),
+        });
+      } catch (error) {
+        this.deps?.logger.warn('Factory supervisor notify failed', {
+          findingKey: row.findingKey,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+}
+
+function findingText(row: FactorySupervisorFindingRecord, key: string): string | undefined {
+  const value = row.finding[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }

--- a/mastracode/factory/src/supervisor/notify.test.ts
+++ b/mastracode/factory/src/supervisor/notify.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SUPERVISOR_HIGH_PRIORITY_KINDS, notifySupervisor, supervisorNotificationPriority } from './notify.js';
+import { supervisorResourceId, supervisorThreadId } from './session.js';
+
+function makeController(options: { existing?: boolean } = {}) {
+  const sent: unknown[] = [];
+  const session = { sendNotificationSignal: vi.fn(async (input: unknown) => void sent.push(input)) };
+  const events: string[] = [];
+  let creating: Promise<typeof session> | undefined;
+  const controller = {
+    getSessionByResource: vi.fn(async () => {
+      events.push('lookup');
+      return options.existing ? session : undefined;
+    }),
+    // Mirrors the real controller: get-or-create with in-flight coalescing.
+    createSession: vi.fn(async (input: { id: string; resourceId: string; threadId: string }) => {
+      if (!creating) {
+        events.push(`create:${input.resourceId}:${input.threadId}`);
+        creating = Promise.resolve(session);
+      }
+      return creating;
+    }),
+  };
+  return { controller: controller as never, sent, events, session, calls: controller };
+}
+
+const base = { projectId: 'proj-1', findingKey: 'decision-failed:dec-1', kind: 'decision-failed', summary: 'boom' };
+
+describe('supervisorNotificationPriority', () => {
+  it('wakes the supervisor (high) for supervisor-actionable kinds only', () => {
+    for (const kind of SUPERVISOR_HIGH_PRIORITY_KINDS) expect(supervisorNotificationPriority(kind)).toBe('high');
+    expect([...SUPERVISOR_HIGH_PRIORITY_KINDS].sort()).toEqual(
+      ['decision-failed', 'decision-stuck', 'seat-missing', 'seat-orphaned', 'start-stalled'].sort(),
+    );
+    for (const kind of ['proposal-waiting', 'held-waiting', 'label-drift', 'unknown']) {
+      expect(supervisorNotificationPriority(kind)).toBe('low');
+    }
+  });
+});
+
+describe('notifySupervisor', () => {
+  it('creates the supervisor session before sending when it has never been reached', async () => {
+    const { controller, events, sent } = makeController();
+    await notifySupervisor({ controller }, base);
+    expect(events).toEqual(['lookup', `create:${supervisorResourceId('proj-1')}:${supervisorThreadId('proj-1')}`]);
+    expect(sent).toHaveLength(1);
+  });
+
+  it('does not create when the session already exists', async () => {
+    const { controller, calls, sent } = makeController({ existing: true });
+    await notifySupervisor({ controller }, base);
+    expect(calls.createSession).not.toHaveBeenCalled();
+    expect(sent).toHaveLength(1);
+  });
+
+  it('shares one creation across concurrent emits for a never-created project', async () => {
+    const { controller, events, sent } = makeController();
+    await Promise.all([
+      notifySupervisor({ controller }, base),
+      notifySupervisor({ controller }, { ...base, findingKey: 'seat-missing:wi-2', kind: 'seat-missing' }),
+    ]);
+    expect(events.filter(event => event.startsWith('create:'))).toHaveLength(1);
+    expect(sent).toHaveLength(2);
+  });
+
+  it('sends a thin signal keyed by finding key with kind-derived priority', async () => {
+    const { controller, sent } = makeController({ existing: true });
+    await notifySupervisor({ controller }, { ...base, failureCode: 'run_awaiting_input' });
+    expect(sent[0]).toEqual({
+      source: 'factory',
+      kind: 'supervisor-finding',
+      summary: 'boom',
+      priority: 'high',
+      coalesceKey: 'decision-failed:dec-1',
+      payload: { findingKey: 'decision-failed:dec-1', kind: 'decision-failed', failureCode: 'run_awaiting_input' },
+    });
+  });
+
+  it('uses low priority for human-facing kinds and omits failureCode when absent', async () => {
+    const { controller, sent } = makeController({ existing: true });
+    await notifySupervisor({ controller }, { ...base, kind: 'proposal-waiting', findingKey: 'proposal-waiting:x' });
+    expect(sent[0]).toMatchObject({
+      priority: 'low',
+      payload: { findingKey: 'proposal-waiting:x', kind: 'proposal-waiting' },
+    });
+    expect((sent[0] as { payload: Record<string, unknown> }).payload).not.toHaveProperty('failureCode');
+  });
+
+  it('honours an explicit priority override', async () => {
+    const { controller, sent } = makeController({ existing: true });
+    await notifySupervisor({ controller }, { ...base, kind: 'label-drift', priority: 'high' });
+    expect(sent[0]).toMatchObject({ priority: 'high' });
+  });
+
+  it('propagates send failures to the caller (the sweep isolates them per row)', async () => {
+    const { controller, session } = makeController({ existing: true });
+    session.sendNotificationSignal.mockRejectedValueOnce(new Error('storage down'));
+    await expect(notifySupervisor({ controller }, base)).rejects.toThrow('storage down');
+  });
+});

--- a/mastracode/factory/src/supervisor/notify.test.ts
+++ b/mastracode/factory/src/supervisor/notify.test.ts
@@ -14,15 +14,18 @@ function makeController(options: { existing?: boolean } = {}) {
       return options.existing ? session : undefined;
     }),
     // Mirrors the real controller: get-or-create with in-flight coalescing.
-    createSession: vi.fn(async (input: { id: string; resourceId: string; threadId: string }) => {
+    createSession: vi.fn(async (input: { id: string; resourceId: string; threadId: string; ownerId?: string }) => {
       if (!creating) {
-        events.push(`create:${input.resourceId}:${input.threadId}`);
+        events.push(`create:${input.resourceId}:${input.threadId}:${input.ownerId}`);
         creating = Promise.resolve(session);
       }
       return creating;
     }),
   };
-  return { controller: controller as never, sent, events, session, calls: controller };
+  const projects = {
+    getById: vi.fn(async ({ id }: { id: string }) => (id === 'proj-1' ? { id, createdBy: 'user-creator' } : null)),
+  };
+  return { controller: controller as never, projects, sent, events, session, calls: controller };
 }
 
 const base = { projectId: 'proj-1', findingKey: 'decision-failed:dec-1', kind: 'decision-failed', summary: 'boom' };
@@ -41,32 +44,46 @@ describe('supervisorNotificationPriority', () => {
 
 describe('notifySupervisor', () => {
   it('creates the supervisor session before sending when it has never been reached', async () => {
-    const { controller, events, sent } = makeController();
-    await notifySupervisor({ controller }, base);
-    expect(events).toEqual(['lookup', `create:${supervisorResourceId('proj-1')}:${supervisorThreadId('proj-1')}`]);
+    const { controller, projects, events, sent } = makeController();
+    await notifySupervisor({ controller, projects }, base);
+    // Owned by the project's creator, so a server-started turn on it can
+    // resolve model credentials (org first, then the owner's own).
+    expect(events).toEqual([
+      'lookup',
+      `create:${supervisorResourceId('proj-1')}:${supervisorThreadId('proj-1')}:user-creator`,
+    ]);
     expect(sent).toHaveLength(1);
   });
 
+  it('refuses to create a session for a project that does not exist', async () => {
+    const { controller, projects, sent, calls } = makeController();
+    await expect(notifySupervisor({ controller, projects }, { ...base, projectId: 'proj-9' })).rejects.toThrow(
+      'does not exist',
+    );
+    expect(calls.createSession).not.toHaveBeenCalled();
+    expect(sent).toHaveLength(0);
+  });
+
   it('does not create when the session already exists', async () => {
-    const { controller, calls, sent } = makeController({ existing: true });
-    await notifySupervisor({ controller }, base);
+    const { controller, projects, calls, sent } = makeController({ existing: true });
+    await notifySupervisor({ controller, projects }, base);
     expect(calls.createSession).not.toHaveBeenCalled();
     expect(sent).toHaveLength(1);
   });
 
   it('shares one creation across concurrent emits for a never-created project', async () => {
-    const { controller, events, sent } = makeController();
+    const { controller, projects, events, sent } = makeController();
     await Promise.all([
-      notifySupervisor({ controller }, base),
-      notifySupervisor({ controller }, { ...base, findingKey: 'seat-missing:wi-2', kind: 'seat-missing' }),
+      notifySupervisor({ controller, projects }, base),
+      notifySupervisor({ controller, projects }, { ...base, findingKey: 'seat-missing:wi-2', kind: 'seat-missing' }),
     ]);
     expect(events.filter(event => event.startsWith('create:'))).toHaveLength(1);
     expect(sent).toHaveLength(2);
   });
 
   it('sends a thin signal keyed by finding key with kind-derived priority', async () => {
-    const { controller, sent } = makeController({ existing: true });
-    await notifySupervisor({ controller }, { ...base, failureCode: 'run_awaiting_input' });
+    const { controller, projects, sent } = makeController({ existing: true });
+    await notifySupervisor({ controller, projects }, { ...base, failureCode: 'run_awaiting_input' });
     expect(sent[0]).toEqual({
       source: 'factory',
       kind: 'supervisor-finding',
@@ -78,8 +95,11 @@ describe('notifySupervisor', () => {
   });
 
   it('uses low priority for human-facing kinds and omits failureCode when absent', async () => {
-    const { controller, sent } = makeController({ existing: true });
-    await notifySupervisor({ controller }, { ...base, kind: 'proposal-waiting', findingKey: 'proposal-waiting:x' });
+    const { controller, projects, sent } = makeController({ existing: true });
+    await notifySupervisor(
+      { controller, projects },
+      { ...base, kind: 'proposal-waiting', findingKey: 'proposal-waiting:x' },
+    );
     expect(sent[0]).toMatchObject({
       priority: 'low',
       payload: { findingKey: 'proposal-waiting:x', kind: 'proposal-waiting' },
@@ -88,14 +108,14 @@ describe('notifySupervisor', () => {
   });
 
   it('honours an explicit priority override', async () => {
-    const { controller, sent } = makeController({ existing: true });
-    await notifySupervisor({ controller }, { ...base, kind: 'label-drift', priority: 'high' });
+    const { controller, projects, sent } = makeController({ existing: true });
+    await notifySupervisor({ controller, projects }, { ...base, kind: 'label-drift', priority: 'high' });
     expect(sent[0]).toMatchObject({ priority: 'high' });
   });
 
   it('propagates send failures to the caller (the sweep isolates them per row)', async () => {
-    const { controller, session } = makeController({ existing: true });
+    const { controller, projects, session } = makeController({ existing: true });
     session.sendNotificationSignal.mockRejectedValueOnce(new Error('storage down'));
-    await expect(notifySupervisor({ controller }, base)).rejects.toThrow('storage down');
+    await expect(notifySupervisor({ controller, projects }, base)).rejects.toThrow('storage down');
   });
 });

--- a/mastracode/factory/src/supervisor/notify.test.ts
+++ b/mastracode/factory/src/supervisor/notify.test.ts
@@ -23,7 +23,9 @@ function makeController(options: { existing?: boolean } = {}) {
     }),
   };
   const projects = {
-    getById: vi.fn(async ({ id }: { id: string }) => (id === 'proj-1' ? { id, createdBy: 'user-creator' } : null)),
+    getById: vi.fn(async ({ id }: { id: string }) =>
+      id === 'proj-1' ? { id, orgId: 'org-1', createdBy: 'user-creator' } : null,
+    ),
   };
   return { controller: controller as never, projects, sent, events, session, calls: controller };
 }
@@ -53,6 +55,27 @@ describe('notifySupervisor', () => {
       `create:${supervisorResourceId('proj-1')}:${supervisorThreadId('proj-1')}:user-creator`,
     ]);
     expect(sent).toHaveLength(1);
+  });
+
+  it("primes the creator's org-first credentials before ringing, and rings even when priming fails", async () => {
+    const { controller, projects, sent } = makeController({ existing: true });
+    const primeCredentials = vi.fn(async () => {});
+    await notifySupervisor({ controller, projects, primeCredentials }, base);
+    expect(primeCredentials).toHaveBeenCalledWith({ orgId: 'org-1', userId: 'user-creator' });
+    expect(sent).toHaveLength(1);
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      primeCredentials.mockRejectedValueOnce(new Error('credentials down'));
+      await notifySupervisor({ controller, projects, primeCredentials }, base);
+      expect(sent).toHaveLength(2);
+      expect(warn).toHaveBeenCalledWith(
+        '[Factory Supervisor] could not prime credentials for the wake',
+        expect.objectContaining({ error: 'credentials down' }),
+      );
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('refuses to create a session for a project that does not exist', async () => {

--- a/mastracode/factory/src/supervisor/notify.ts
+++ b/mastracode/factory/src/supervisor/notify.ts
@@ -1,0 +1,78 @@
+/**
+ * The supervisor emit path: notification signals to the per-factory
+ * supervisor session. The notification is the doorbell, never the source of
+ * truth — the woken turn reads the finding rows for the real state. Core's
+ * coalescing (`coalesceKey` = finding key) is the storm control; there is no
+ * factory-side emit gate.
+ */
+
+import type { MastraCodeState } from '@mastra/code-sdk/schema';
+import type { AgentController } from '@mastra/core/agent-controller';
+import type { NotificationPriority } from '@mastra/core/notifications';
+
+import { supervisorResourceId, supervisorThreadId } from './session.js';
+
+/**
+ * Finding kinds the supervisor can act on itself — these wake it (high).
+ * Everything else is inherently waiting on a person and stays low (persisted,
+ * summarized, no wake).
+ */
+export const SUPERVISOR_HIGH_PRIORITY_KINDS: ReadonlySet<string> = new Set([
+  'decision-failed',
+  'decision-stuck',
+  'start-stalled',
+  'seat-orphaned',
+  'seat-missing',
+]);
+
+export function supervisorNotificationPriority(kind: string): NotificationPriority {
+  return SUPERVISOR_HIGH_PRIORITY_KINDS.has(kind) ? 'high' : 'low';
+}
+
+type SupervisorNotifyController = Pick<AgentController<MastraCodeState>, 'getSessionByResource' | 'createSession'>;
+
+export interface NotifySupervisorInput {
+  projectId: string;
+  findingKey: string;
+  kind: string;
+  summary: string;
+  failureCode?: string;
+  /** Overrides the kind-derived priority (dispatcher call sites pass high explicitly). */
+  priority?: NotificationPriority;
+}
+
+/**
+ * Emit one notification signal to a project's supervisor session, creating
+ * the session first when it has never been reached. Creation must come first:
+ * delivery-time stream options resolve through `getSessionByResource`, so a
+ * notification sent before the session exists produces a wake with no model.
+ * `createSession` is get-or-create with in-flight coalescing in the
+ * controller, so concurrent emits for a never-created project share one
+ * creation, and `hydrateSupervisorSession` (a session-created listener) stamps
+ * scope, instructions and factory defaults on the way in.
+ */
+export async function notifySupervisor(
+  deps: { controller: SupervisorNotifyController },
+  input: NotifySupervisorInput,
+): Promise<void> {
+  const resourceId = supervisorResourceId(input.projectId);
+  const session =
+    (await deps.controller.getSessionByResource(resourceId)) ??
+    (await deps.controller.createSession({
+      id: resourceId,
+      resourceId,
+      threadId: supervisorThreadId(input.projectId),
+    }));
+  await session.sendNotificationSignal({
+    source: 'factory',
+    kind: 'supervisor-finding',
+    summary: input.summary,
+    priority: input.priority ?? supervisorNotificationPriority(input.kind),
+    coalesceKey: input.findingKey,
+    payload: {
+      findingKey: input.findingKey,
+      kind: input.kind,
+      ...(input.failureCode ? { failureCode: input.failureCode } : {}),
+    },
+  });
+}

--- a/mastracode/factory/src/supervisor/notify.ts
+++ b/mastracode/factory/src/supervisor/notify.ts
@@ -36,6 +36,13 @@ export interface SupervisorNotifyDependencies {
   controller: SupervisorNotifyController;
   /** Names the session's owner at creation: the supervisor runs as the project's creator. */
   projects: Pick<FactoryProjectsStorage, 'getById'>;
+  /**
+   * Hydrates the per-tenant credential snapshot the woken turn's model
+   * resolution reads synchronously. A wake is not an HTTP request, so nothing
+   * else primes it; without this the first wake after boot finds an empty
+   * snapshot and fails with "no usable credential".
+   */
+  primeCredentials?: (tenant: { orgId: string; userId: string }) => Promise<void>;
 }
 
 export interface NotifySupervisorInput {
@@ -68,16 +75,27 @@ export async function notifySupervisor(
   input: NotifySupervisorInput,
 ): Promise<void> {
   const resourceId = supervisorResourceId(input.projectId);
-  const session = (await deps.controller.getSessionByResource(resourceId)) ?? (await createSupervisorSession());
-  async function createSupervisorSession() {
-    const project = await deps.projects.getById({ id: input.projectId });
-    if (!project) throw new Error(`Factory project ${input.projectId} does not exist`);
-    return deps.controller.createSession({
+  const project = await deps.projects.getById({ id: input.projectId });
+  if (!project) throw new Error(`Factory project ${input.projectId} does not exist`);
+  const session =
+    (await deps.controller.getSessionByResource(resourceId)) ??
+    (await deps.controller.createSession({
       id: resourceId,
       resourceId,
       threadId: supervisorThreadId(input.projectId),
       ownerId: project.createdBy,
-    });
+    }));
+  if (deps.primeCredentials) {
+    try {
+      await deps.primeCredentials({ orgId: project.orgId, userId: project.createdBy });
+    } catch (error) {
+      // The ring still goes out: the notification is durable and the turn
+      // reports its own credential failure if the snapshot stays empty.
+      console.warn('[Factory Supervisor] could not prime credentials for the wake', {
+        projectId: input.projectId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
   await session.sendNotificationSignal({
     source: 'factory',

--- a/mastracode/factory/src/supervisor/notify.ts
+++ b/mastracode/factory/src/supervisor/notify.ts
@@ -10,6 +10,7 @@ import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentController } from '@mastra/core/agent-controller';
 import type { NotificationPriority } from '@mastra/core/notifications';
 
+import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
 import { supervisorResourceId, supervisorThreadId } from './session.js';
 
 /**
@@ -31,6 +32,12 @@ export function supervisorNotificationPriority(kind: string): NotificationPriori
 
 type SupervisorNotifyController = Pick<AgentController<MastraCodeState>, 'getSessionByResource' | 'createSession'>;
 
+export interface SupervisorNotifyDependencies {
+  controller: SupervisorNotifyController;
+  /** Names the session's owner at creation: the supervisor runs as the project's creator. */
+  projects: Pick<FactoryProjectsStorage, 'getById'>;
+}
+
 export interface NotifySupervisorInput {
   projectId: string;
   findingKey: string;
@@ -50,19 +57,28 @@ export interface NotifySupervisorInput {
  * controller, so concurrent emits for a never-created project share one
  * creation, and `hydrateSupervisorSession` (a session-created listener) stamps
  * scope, instructions and factory defaults on the way in.
+ *
+ * The session is owned by the project's creator. A turn the server starts on
+ * it (this very wake) has no person attached, so model credentials resolve
+ * from the session itself: the project's org first, then its owner's own
+ * credentials, the same order a board run uses.
  */
 export async function notifySupervisor(
-  deps: { controller: SupervisorNotifyController },
+  deps: SupervisorNotifyDependencies,
   input: NotifySupervisorInput,
 ): Promise<void> {
   const resourceId = supervisorResourceId(input.projectId);
-  const session =
-    (await deps.controller.getSessionByResource(resourceId)) ??
-    (await deps.controller.createSession({
+  const session = (await deps.controller.getSessionByResource(resourceId)) ?? (await createSupervisorSession());
+  async function createSupervisorSession() {
+    const project = await deps.projects.getById({ id: input.projectId });
+    if (!project) throw new Error(`Factory project ${input.projectId} does not exist`);
+    return deps.controller.createSession({
       id: resourceId,
       resourceId,
       threadId: supervisorThreadId(input.projectId),
-    }));
+      ownerId: project.createdBy,
+    });
+  }
   await session.sendNotificationSignal({
     source: 'factory',
     kind: 'supervisor-finding',

--- a/mastracode/factory/src/supervisor/session.test.ts
+++ b/mastracode/factory/src/supervisor/session.test.ts
@@ -160,6 +160,38 @@ describe('resolveSupervisorScope on signal turns (no factory auth)', () => {
       }),
     ).resolves.toBeNull();
   });
+
+  it('fails closed for an authenticated caller with no org instead of borrowing session state', async () => {
+    const { projects, project } = await seedProject();
+    const context = new RequestContext();
+    context.set('user', { workosId: 'user-1' });
+    const state = { factoryProjectId: project.id, factoryOrgId: 'org-1' };
+    context.set('controller', {
+      resourceId: supervisorResourceId(project.id),
+      threadId: 'thread-1',
+      scope: '/',
+      state,
+      getState: () => state,
+    });
+    await expect(resolveSupervisorScope({ requestContext: context, projects })).resolves.toBeNull();
+  });
+
+  it('reads live state over the request-time snapshot on a signal turn', async () => {
+    const { projects, project } = await seedProject();
+    const context = new RequestContext();
+    context.set('controller', {
+      resourceId: supervisorResourceId(project.id),
+      threadId: 'thread-1',
+      scope: '/',
+      state: {},
+      getState: () => ({ factoryProjectId: project.id, factoryOrgId: 'org-1' }),
+    });
+    await expect(resolveSupervisorScope({ requestContext: context, projects })).resolves.toEqual({
+      orgId: 'org-1',
+      factoryProjectId: project.id,
+      via: 'session-state',
+    });
+  });
 });
 
 describe('hydrateSupervisorSession', () => {

--- a/mastracode/factory/src/supervisor/session.test.ts
+++ b/mastracode/factory/src/supervisor/session.test.ts
@@ -10,15 +10,22 @@ import {
   supervisorThreadId,
 } from './session.js';
 
-function requestContext(overrides: Partial<{ orgId: string; resourceId: string }> = {}) {
+function requestContext(
+  overrides: Partial<{ orgId: string; resourceId: string; user: boolean; state: Record<string, unknown> }> = {},
+) {
   const context = new RequestContext();
-  context.set('user', { workosId: 'user-1', organizationId: overrides.orgId ?? 'org-1' });
+  // `user: false` models a signal-driven turn (e.g. notification delivery),
+  // whose reconstructed context carries only the controller entry.
+  if (overrides.user !== false) {
+    context.set('user', { workosId: 'user-1', organizationId: overrides.orgId ?? 'org-1' });
+  }
   context.set('controller', {
     resourceId: overrides.resourceId ?? 'resource-1',
     threadId: 'thread-1',
     scope: '/',
     session: { id: 'session-1', ownerId: 'code', modeId: 'build' },
-    getState: () => ({}),
+    state: overrides.state ?? {},
+    getState: () => overrides.state ?? {},
   });
   return context;
 }
@@ -52,7 +59,7 @@ describe('resolveSupervisorScope', () => {
         requestContext: requestContext({ resourceId: supervisorResourceId(project.id) }),
         projects,
       }),
-    ).resolves.toEqual({ orgId: 'org-1', factoryProjectId: project.id });
+    ).resolves.toEqual({ orgId: 'org-1', factoryProjectId: project.id, via: 'auth' });
   });
 
   it('yields nothing for ordinary sessions, foreign orgs, or unknown projects', async () => {
@@ -67,6 +74,88 @@ describe('resolveSupervisorScope', () => {
     await expect(
       resolveSupervisorScope({
         requestContext: requestContext({ resourceId: supervisorResourceId('missing') }),
+        projects,
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe('resolveSupervisorScope on signal turns (no factory auth)', () => {
+  it('trusts hydration-stamped state once storage confirms ownership', async () => {
+    const { projects, project } = await seedProject();
+    await expect(
+      resolveSupervisorScope({
+        requestContext: requestContext({
+          user: false,
+          resourceId: supervisorResourceId(project.id),
+          state: { factoryProjectId: project.id, factoryOrgId: 'org-1' },
+        }),
+        projects,
+      }),
+    ).resolves.toEqual({ orgId: 'org-1', factoryProjectId: project.id, via: 'session-state' });
+  });
+
+  it('yields nothing without stamped state', async () => {
+    const { projects, project } = await seedProject();
+    await expect(
+      resolveSupervisorScope({
+        requestContext: requestContext({ user: false, resourceId: supervisorResourceId(project.id) }),
+        projects,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('rejects state whose project id does not match the resourceId', async () => {
+    const { projects, project } = await seedProject();
+    await expect(
+      resolveSupervisorScope({
+        requestContext: requestContext({
+          user: false,
+          resourceId: supervisorResourceId(project.id),
+          state: { factoryProjectId: 'some-other-project', factoryOrgId: 'org-1' },
+        }),
+        projects,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('rejects forged state naming an org that does not own the project', async () => {
+    const { projects, project } = await seedProject();
+    await expect(
+      resolveSupervisorScope({
+        requestContext: requestContext({
+          user: false,
+          resourceId: supervisorResourceId(project.id),
+          state: { factoryProjectId: project.id, factoryOrgId: 'org-evil' },
+        }),
+        projects,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('rejects stale state when the project no longer exists', async () => {
+    const { projects } = await seedProject();
+    await expect(
+      resolveSupervisorScope({
+        requestContext: requestContext({
+          user: false,
+          resourceId: supervisorResourceId('deleted-project'),
+          state: { factoryProjectId: 'deleted-project', factoryOrgId: 'org-1' },
+        }),
+        projects,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('never falls back to state for an authenticated caller with a foreign org', async () => {
+    const { projects, project } = await seedProject();
+    await expect(
+      resolveSupervisorScope({
+        requestContext: requestContext({
+          orgId: 'org-2',
+          resourceId: supervisorResourceId(project.id),
+          state: { factoryProjectId: project.id, factoryOrgId: 'org-1' },
+        }),
         projects,
       }),
     ).resolves.toBeNull();

--- a/mastracode/factory/src/supervisor/session.test.ts
+++ b/mastracode/factory/src/supervisor/session.test.ts
@@ -212,7 +212,7 @@ describe('hydrateSupervisorSession', () => {
     };
   }
 
-  it('stamps the project and org and applies the factory default model', async () => {
+  it('stamps the project, org, and the creator it runs as, and applies the factory default model', async () => {
     const { projects, project } = await seedProject();
     const session = sessionDouble(supervisorResourceId(project.id));
 
@@ -221,6 +221,7 @@ describe('hydrateSupervisorSession', () => {
     expect(session.readState()).toMatchObject({
       factoryProjectId: project.id,
       factoryOrgId: 'org-1',
+      factoryRunAsUserId: project.createdBy,
     });
     expect(session.model.switch).toHaveBeenCalledWith({ modelId: 'anthropic/claude-sonnet-4' });
   });

--- a/mastracode/factory/src/supervisor/session.ts
+++ b/mastracode/factory/src/supervisor/session.ts
@@ -34,25 +34,59 @@ export function parseSupervisorResourceId(resourceId: string | undefined | null)
   return factoryProjectId.length > 0 ? factoryProjectId : null;
 }
 
+/** How a supervisor scope was established — drives which tools register. */
+export interface ResolvedSupervisorScope extends SupervisorScope {
+  /**
+   * `auth`: a factory-authenticated caller whose org owns the project.
+   * `session-state`: a signal-driven turn (notification wake) with no factory
+   * auth, trusted from the hydration-stamped session state. Signal turns get
+   * the read tools plus the approval-free v1 tools only, with agent-actor
+   * attribution — never the human-gated write tools.
+   */
+  via: 'auth' | 'session-state';
+}
+
 /**
- * Scope a request to a supervisor session the caller is allowed to drive:
- * the resourceId must name a project, and the caller's org must own it.
+ * Scope a request to a supervisor session the caller is allowed to drive.
+ * Two paths:
+ *
+ * - Authenticated: the resourceId must name a project and the caller's auth
+ *   org must own it. An authenticated caller whose org does NOT own the
+ *   project gets null — never a fallback to session state.
+ * - Signal turn (no factory auth, e.g. a notification wake whose request
+ *   context carries only the controller context): trust the session state
+ *   that `hydrateSupervisorSession` stamped at (re)creation, but only when
+ *   ALL of: the resourceId is supervisor-prefixed; the state's project id
+ *   exactly equals the id parsed from the resourceId; and a fresh project
+ *   lookup confirms the stated org still owns that project.
+ *
  * Anything else yields null and the supervisor tools stay unregistered.
  */
 export async function resolveSupervisorScope(options: {
   requestContext: RequestContext | undefined;
-  projects: Pick<FactoryProjectsStorage, 'get'>;
-}): Promise<SupervisorScope | null> {
+  projects: Pick<FactoryProjectsStorage, 'get' | 'getById'>;
+}): Promise<ResolvedSupervisorScope | null> {
   const { requestContext } = options;
   if (!requestContext || typeof requestContext.get !== 'function') return null;
   const context = requestContext.get('controller') as AgentControllerRequestContext<MastraCodeState> | undefined;
   const factoryProjectId = parseSupervisorResourceId(context?.resourceId);
   if (!factoryProjectId) return null;
-  const orgId = getFactoryAuthOrgId(getFactoryAuthUserFromContext(requestContext));
-  if (!orgId) return null;
-  const project = await options.projects.get({ orgId, id: factoryProjectId });
-  if (!project) return null;
-  return { orgId, factoryProjectId };
+  const authOrgId = getFactoryAuthOrgId(getFactoryAuthUserFromContext(requestContext));
+  if (authOrgId) {
+    const project = await options.projects.get({ orgId: authOrgId, id: factoryProjectId });
+    if (!project) return null;
+    return { orgId: authOrgId, factoryProjectId, via: 'auth' };
+  }
+  // Signal turn: no factory auth anywhere in the request context. Trust the
+  // state stamped by hydrateSupervisorSession, verified against storage.
+  const state = context?.state as Partial<Pick<MastraCodeState, 'factoryProjectId' | 'factoryOrgId'>> | undefined;
+  const stateProjectId = typeof state?.factoryProjectId === 'string' ? state.factoryProjectId : null;
+  const stateOrgId = typeof state?.factoryOrgId === 'string' ? state.factoryOrgId : null;
+  if (!stateProjectId || !stateOrgId) return null;
+  if (stateProjectId !== factoryProjectId) return null;
+  const project = await options.projects.getById({ id: factoryProjectId });
+  if (!project || project.orgId !== stateOrgId) return null;
+  return { orgId: project.orgId, factoryProjectId, via: 'session-state' };
 }
 
 /**

--- a/mastracode/factory/src/supervisor/session.ts
+++ b/mastracode/factory/src/supervisor/session.ts
@@ -71,15 +71,23 @@ export async function resolveSupervisorScope(options: {
   const context = requestContext.get('controller') as AgentControllerRequestContext<MastraCodeState> | undefined;
   const factoryProjectId = parseSupervisorResourceId(context?.resourceId);
   if (!factoryProjectId) return null;
-  const authOrgId = getFactoryAuthOrgId(getFactoryAuthUserFromContext(requestContext));
-  if (authOrgId) {
+  const authUser = getFactoryAuthUserFromContext(requestContext);
+  if (authUser) {
+    // Any authenticated caller is judged on its own org, never on session
+    // state: a user without an org (personal account, partial context) fails
+    // closed rather than borrowing the signal path.
+    const authOrgId = getFactoryAuthOrgId(authUser);
+    if (!authOrgId) return null;
     const project = await options.projects.get({ orgId: authOrgId, id: factoryProjectId });
     if (!project) return null;
     return { orgId: authOrgId, factoryProjectId, via: 'auth' };
   }
   // Signal turn: no factory auth anywhere in the request context. Trust the
-  // state stamped by hydrateSupervisorSession, verified against storage.
-  const state = context?.state as Partial<Pick<MastraCodeState, 'factoryProjectId' | 'factoryOrgId'>> | undefined;
+  // state stamped by hydrateSupervisorSession, verified against storage. Read
+  // live state where the context offers it; the snapshot is the fallback.
+  const state = (context?.getState?.() ?? context?.state) as
+    | Partial<Pick<MastraCodeState, 'factoryProjectId' | 'factoryOrgId'>>
+    | undefined;
   const stateProjectId = typeof state?.factoryProjectId === 'string' ? state.factoryProjectId : null;
   const stateOrgId = typeof state?.factoryOrgId === 'string' ? state.factoryOrgId : null;
   if (!stateProjectId || !stateOrgId) return null;

--- a/mastracode/factory/src/supervisor/session.ts
+++ b/mastracode/factory/src/supervisor/session.ts
@@ -111,9 +111,12 @@ export async function hydrateSupervisorSession(
   if (!factoryProjectId) return;
   const project = await deps.projects.getById({ id: factoryProjectId });
   if (!project) return;
+  // A turn the server starts on this session (a notification wake) has no
+  // person on the request; it runs as the project's creator, org-first.
   await session.state.set({
     factoryProjectId,
     factoryOrgId: project.orgId,
+    factoryRunAsUserId: project.createdBy,
   });
   await hydrateFactorySession(session, {
     orgId: project.orgId,

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -905,6 +905,48 @@ describe('GitHub session workspace preparation', () => {
     );
   });
 
+  it('lets the server itself reach a supervisor session with no factory auth, if the project exists', async () => {
+    // The health sweep and the dispatcher ensure-create the supervisor
+    // session before ringing it, and notification delivery turns carry only
+    // the controller context: none of them has a factory auth user.
+    const projects = {
+      get: vi.fn().mockResolvedValue(null),
+      getById: vi.fn(async ({ id }: { id: string }) => (id === 'project-1' ? { id, orgId: 'org-1' } : null)),
+    };
+    const resolver = createWorkspaceFactory({ projects: projects as any });
+    const requestContext = createRequestContext('/unused');
+    requestContext.set('controller', {
+      resourceId: 'factory-supervisor:project-1',
+      threadId: 'factory-supervisor:project-1',
+    });
+
+    await expect(resolver({ requestContext } as any)).resolves.toBeUndefined();
+    expect(projects.getById).toHaveBeenCalledWith({ id: 'project-1' });
+    expect(projects.get).not.toHaveBeenCalled();
+
+    const missing = createRequestContext('/unused');
+    missing.set('controller', { resourceId: 'factory-supervisor:project-9', threadId: 'factory-supervisor:project-9' });
+    await expect(resolver({ requestContext: missing } as any)).rejects.toThrow(
+      'Factory supervisor project-9 is not available to the current user',
+    );
+  });
+
+  it('never lets an authenticated caller without an org borrow the unauthenticated path', async () => {
+    const projects = {
+      get: vi.fn().mockResolvedValue(null),
+      getById: vi.fn().mockResolvedValue({ id: 'project-1', orgId: 'org-1' }),
+    };
+    const resolver = createWorkspaceFactory({ projects: projects as any });
+    const requestContext = createGithubRequestContext('project-1', 'factory-supervisor:project-1', {
+      workosId: 'user-1',
+    });
+
+    await expect(resolver({ requestContext } as any)).rejects.toThrow(
+      'Factory supervisor project-1 is not available to the current user',
+    );
+    expect(projects.getById).not.toHaveBeenCalled();
+  });
+
   it('opens the session for a session-shaped auth user, whose org lives on the session half', async () => {
     const { root, workspace } = await createLocalFactory();
     addProject();

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -239,7 +239,7 @@ export interface CreateWorkspaceFactoryOptions {
    * without it every session uses the default (worker) PAT. */
   workItems?: Pick<WorkItemsStorage, 'findRunBindingBySession'>;
   /** Projects storage used to authorize workspace-free supervisor sessions. */
-  projects?: Pick<FactoryProjectsStorage, 'get'>;
+  projects?: Pick<FactoryProjectsStorage, 'get' | 'getById'>;
   /** Runtime workspace/token registrations invalidated when a session retires. */
   workspaceRegistry?: FactoryWorkspaceRegistry;
 }
@@ -310,8 +310,23 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
     const ctx = requestContext.get('controller') as AgentControllerRequestContext<MastraCodeState> | undefined;
     const supervisorProjectId = parseSupervisorResourceId(ctx?.resourceId);
     if (supervisorProjectId) {
-      const orgId = getFactoryAuthOrgId(getFactoryAuthUserFromContext(requestContext));
-      const project = orgId && projects ? await projects.get({ orgId, id: supervisorProjectId }) : null;
+      // The supervisor never gets a workspace. An authenticated caller is
+      // still judged here, before the controller session opens: its org must
+      // own the project. A caller with no factory auth at all is the server
+      // itself (the health sweep or dispatcher ensure-creating the session
+      // before it rings, or a notification delivery turn), not a person
+      // reaching for another org's supervisor; the project only has to
+      // exist. Tool registration enforces scope on every turn regardless
+      // (resolveSupervisorScope fails closed).
+      const authUser = getFactoryAuthUserFromContext(requestContext);
+      const orgId = getFactoryAuthOrgId(authUser);
+      const project = authUser
+        ? orgId && projects
+          ? await projects.get({ orgId, id: supervisorProjectId })
+          : null
+        : projects
+          ? await projects.getById({ id: supervisorProjectId })
+          : null;
       if (!project) throw new Error(`Factory supervisor ${supervisorProjectId} is not available to the current user`);
       return undefined;
     }

--- a/mastracode/sdk/src/agents/credential-resolver.test.ts
+++ b/mastracode/sdk/src/agents/credential-resolver.test.ts
@@ -90,6 +90,47 @@ describe('credential store provider registry', () => {
     warn.mockRestore();
   });
 
+  it("resolves a server-started factory session turn as the session's own tenant, org first", () => {
+    // A notification wake carries only the controller context: the factory
+    // stamped the org onto the session and chose its owner at creation.
+    const ctx = new RequestContext();
+    ctx.set('controller', {
+      state: { factoryProjectId: 'project_1', factoryOrgId: 'org_1' },
+      session: { id: 's1', ownerId: 'user_owner' },
+    });
+    expect(resolveTenantFromRequestContext(ctx)).toEqual({ orgId: 'org_1', userId: 'user_owner', orgFirst: true });
+  });
+
+  it('stays unresolved for a session missing any of project, org, or owner, and for a non-factory session', () => {
+    for (const controller of [
+      { state: { factoryProjectId: 'project_1' }, session: { ownerId: 'user_owner' } },
+      { state: { factoryProjectId: 'project_1', factoryOrgId: 'org_1' }, session: { ownerId: '' } },
+      { state: { factoryProjectId: 'project_1', factoryOrgId: 'org_1' } },
+      { state: { factoryOrgId: 'org_1' }, session: { ownerId: 'user_owner' } },
+    ]) {
+      const ctx = new RequestContext();
+      ctx.set('controller', controller);
+      expect(resolveTenantFromRequestContext(ctx)).toBeUndefined();
+    }
+  });
+
+  it('never lets session state override a person who is on the request', () => {
+    const ctx = new RequestContext();
+    ctx.set('controller', {
+      state: { factoryProjectId: 'project_1', factoryOrgId: 'org_other' },
+      session: { ownerId: 'user_owner' },
+    });
+    ctx.set('user', { workosId: 'user_1', organizationId: 'org_1' });
+    expect(resolveTenantFromRequestContext(ctx)).toEqual({ orgId: 'org_1', userId: 'user_1', orgFirst: true });
+    const bad = new RequestContext();
+    bad.set('controller', {
+      state: { factoryProjectId: 'project_1', factoryOrgId: 'org_1' },
+      session: { ownerId: 'u' },
+    });
+    bad.set('user', 'not-a-user');
+    expect(resolveTenantFromRequestContext(bad)).toBeUndefined();
+  });
+
   it('falls back to the provider id when workosId is absent', () => {
     const ctx = new RequestContext();
     ctx.set('user', { id: 'prov_2' });

--- a/mastracode/sdk/src/agents/credential-resolver.test.ts
+++ b/mastracode/sdk/src/agents/credential-resolver.test.ts
@@ -101,6 +101,17 @@ describe('credential store provider registry', () => {
     expect(resolveTenantFromRequestContext(ctx)).toEqual({ orgId: 'org_1', userId: 'user_owner', orgFirst: true });
   });
 
+  it('runs as the user the factory seeded over the session owner', () => {
+    // A session first opened over HTTP is owned by the controller itself; the
+    // factory names who it runs as (the supervisor: its project's creator).
+    const ctx = new RequestContext();
+    ctx.set('controller', {
+      state: { factoryProjectId: 'project_1', factoryOrgId: 'org_1', factoryRunAsUserId: 'user_creator' },
+      session: { id: 's1', ownerId: 'controller-id' },
+    });
+    expect(resolveTenantFromRequestContext(ctx)).toEqual({ orgId: 'org_1', userId: 'user_creator', orgFirst: true });
+  });
+
   it('stays unresolved for a session missing any of project, org, or owner, and for a non-factory session', () => {
     for (const controller of [
       { state: { factoryProjectId: 'project_1' }, session: { ownerId: 'user_owner' } },

--- a/mastracode/sdk/src/agents/credential-resolver.ts
+++ b/mastracode/sdk/src/agents/credential-resolver.ts
@@ -106,21 +106,26 @@ function isFactorySessionContext(requestContext?: RequestContext): boolean {
  * The tenant a factory-owned session carries on its own state, for turns the
  * server starts with no person attached (a notification wake, a scheduled
  * sweep). Trusted factory server code stamps `factoryOrgId` beside
- * `factoryProjectId` when it creates the session, and the session's owner is
- * the user the factory chose to run it as (the person who kicked off the run,
- * or the project's creator for the supervisor). Such a run is org work, so it
- * resolves org > user, exactly as an interactive turn on the same session
- * would. Anything short of all three fields stays unresolved (fail closed).
+ * `factoryProjectId` when it seeds the session, and names the user the
+ * factory runs it as: `factoryRunAsUserId` when seeded (the supervisor runs
+ * as its project's creator), else the session's owner (a board run is owned
+ * by the person who kicked it off). Such a run is org work, so it resolves
+ * org > user, exactly as an interactive turn on the same session would.
+ * Anything short of project, org, and a user stays unresolved (fail closed).
  */
 function resolveFactorySessionTenant(requestContext?: RequestContext): CredentialTenant | undefined {
   const controller = requestContext?.get('controller') as
-    | { state?: { factoryProjectId?: unknown; factoryOrgId?: unknown }; session?: { ownerId?: unknown } }
+    | {
+        state?: { factoryProjectId?: unknown; factoryOrgId?: unknown; factoryRunAsUserId?: unknown };
+        session?: { ownerId?: unknown };
+      }
     | undefined;
   if (!isFactorySessionContext(requestContext)) return undefined;
   const orgId = controller?.state?.factoryOrgId;
-  const ownerId = controller?.session?.ownerId;
-  if (typeof orgId !== 'string' || !orgId || typeof ownerId !== 'string' || !ownerId) return undefined;
-  return { orgId, userId: ownerId, orgFirst: true };
+  const runAs = controller?.state?.factoryRunAsUserId;
+  const userId = typeof runAs === 'string' && runAs ? runAs : controller?.session?.ownerId;
+  if (typeof orgId !== 'string' || !orgId || typeof userId !== 'string' || !userId) return undefined;
+  return { orgId, userId, orgFirst: true };
 }
 
 /**

--- a/mastracode/sdk/src/agents/credential-resolver.ts
+++ b/mastracode/sdk/src/agents/credential-resolver.ts
@@ -103,6 +103,27 @@ function isFactorySessionContext(requestContext?: RequestContext): boolean {
 }
 
 /**
+ * The tenant a factory-owned session carries on its own state, for turns the
+ * server starts with no person attached (a notification wake, a scheduled
+ * sweep). Trusted factory server code stamps `factoryOrgId` beside
+ * `factoryProjectId` when it creates the session, and the session's owner is
+ * the user the factory chose to run it as (the person who kicked off the run,
+ * or the project's creator for the supervisor). Such a run is org work, so it
+ * resolves org > user, exactly as an interactive turn on the same session
+ * would. Anything short of all three fields stays unresolved (fail closed).
+ */
+function resolveFactorySessionTenant(requestContext?: RequestContext): CredentialTenant | undefined {
+  const controller = requestContext?.get('controller') as
+    | { state?: { factoryProjectId?: unknown; factoryOrgId?: unknown }; session?: { ownerId?: unknown } }
+    | undefined;
+  if (!isFactorySessionContext(requestContext)) return undefined;
+  const orgId = controller?.state?.factoryOrgId;
+  const ownerId = controller?.session?.ownerId;
+  if (typeof orgId !== 'string' || !orgId || typeof ownerId !== 'string' || !ownerId) return undefined;
+  return { orgId, userId: ownerId, orgFirst: true };
+}
+
+/**
  * Derive the calling tenant from a request context, if an authenticated web
  * user was stashed on it. Mirrors the web layer's stable-id resolution
  * (`workosId` falling back to the provider `id`).
@@ -115,6 +136,9 @@ function isFactorySessionContext(requestContext?: RequestContext): boolean {
  */
 export function resolveTenantFromRequestContext(requestContext?: RequestContext): CredentialTenant | undefined {
   const raw = requestContext?.get('user') as (RequestContextUser & RequestContextSession) | undefined;
+  // No person on the request at all: a server-started turn on a factory
+  // session resolves as the session's own tenant; anything else is unresolved.
+  if (raw === undefined) return resolveFactorySessionTenant(requestContext);
   if (!raw || typeof raw !== 'object') return undefined;
 
   // Precedence matches `toFactoryAuthUser` in `@mastra/factory`: a wrapper's org

--- a/mastracode/sdk/src/schema.ts
+++ b/mastracode/sdk/src/schema.ts
@@ -23,6 +23,13 @@ export interface MastraCodeState {
   /** Authoritative organization id seeded by factory at session construction. */
   factoryOrgId?: string;
   /**
+   * The user the factory runs this session as when no person is on the
+   * request (a notification wake, a scheduled sweep): model credentials
+   * resolve org-first, then this user's own. Seeded by factory; the
+   * supervisor runs as its project's creator.
+   */
+  factoryRunAsUserId?: string;
+  /**
    * Factory owns this session but could not resolve its organization. Knowledge
    * capture refuses rather than filing under a substituted identity; without the
    * marker a projectless factory session is indistinguishable from a local one.
@@ -116,6 +123,7 @@ export const stateSchema = z.object({
   projectName: z.string().optional(),
   factoryProjectId: z.string().optional(),
   factoryOrgId: z.string().optional(),
+  factoryRunAsUserId: z.string().optional(),
   factoryOrgUnresolved: z.boolean().optional(),
   projectRepositoryId: z.string().optional(),
   branch: z.string().optional(),


### PR DESCRIPTION
## Summary

Part of COR-1183 (Improved Supervisor). Segment 1 of 5, base of the stack.

Today the Factory supervisor only learns about problems when its five-minute health sweep runs and a human happens to open the Attention rail. This PR gives the Factory a way to ring the supervisor's doorbell: when the sweep opens or reopens a finding, it sends a notification signal to that project's supervisor session so an idle supervisor wakes up and looks.

- `factory_supervisor_findings` gains a nullable `last_notified_at`, stamped occurrence-safely after a successful send and cleared when a finding reopens. One rule (open rows with a null stamp get emitted) covers newly opened, reopened, and crash-between-write-and-emit cases. The first sweep after deploy emits once for every pre-existing open finding (intended catch-up; core coalescing bounds it).
- `notifySupervisor` helper (`supervisor/notify.ts`): ensure-creates the supervisor session before sending (a never-created session would otherwise produce a model-less wake), `coalesceKey` = finding key, priority `high` for supervisor-actionable kinds (`decision-failed`, `decision-stuck`, `start-stalled`, `seat-orphaned`, `seat-missing`) and `low` for human-facing kinds.
- The health worker drains un-notified findings by keyset cursor after each reconciliation; a failing send is logged, left un-stamped for the next sweep, and never blocks the rows behind it.
- Signal-turn auth gap closed: a notification-woken turn carries no factory auth user, so previously it registered zero supervisor tools. `resolveSupervisorScope` now has a trusted session-state path requiring a supervisor-prefixed resourceId, a state project id equal to the resourceId's, a fresh project-ownership lookup, and no fallback for any authenticated caller (org-less or foreign-org auth fails closed). Signal turns register the supervisor read tools only; the seven approval-gated write tools and integration tools stay on authenticated human turns. A supervisor session that cannot prove its scope gets no tools.
- Fixes three `factory.test.ts` assertions left stale by #23001.

## Test plan

- [x] `pnpm vitest run src/supervisor src/storage/domains/work-items/base.test.ts src/factory.test.ts` in `mastracode/factory`: 8 files, 166 tests
- [x] `pnpm check` (factory) exit 0; root oxfmt check exit 0
- [x] Real-server harness (`mountAgentControllerOnMastra` + real libsql storage): sweep ensure-creates the supervisor session before sending, one `high` record delivered with `coalesceKey` = finding key, second sweep silent, resolve + re-detect re-rings; controller-only context resolves scope from session state and registers exactly the five read tools, forged org resolves no scope
- [ ] Rig finale (segment 5) covers a woken supervisor turn actually calling a tool

## Found on a real server (added after the rig finale)

Running the whole stack on a deployed `~/shipyard` rig exposed four gaps this PR owns, all fixed here:

- The workspace resolver refused every server-started supervisor session (no person on the request), so every ring failed. The server may reach a supervisor session whose project exists; an authenticated caller is still judged on its own org.
- A woken supervisor turn had no model credentials: deployed credential resolution derives the tenant from the person on the request and a wake has none. When there is no person and the session is a factory session, the tenant is the project org plus the user recorded on the session (`factoryRunAsUserId`, the project creator, stamped at hydration), org-first as a board run already does (`@mastra/code-sdk`, own changeset).
- Wakes never pass through HTTP, so the per-request credential snapshot was never primed; the ring now primes the project creator's credentials before sending.
