### PR TITLE
feat(factory): supervisor-first attention (COR-1194)

### DIFF
--- a/.changeset/khaki-guests-see.md
+++ b/.changeset/khaki-guests-see.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Supervisor-first Attention for the Factory. Health findings the supervisor can act on itself (failed or stuck decisions, stalled starts, orphaned or missing seats) no longer land on the human Attention rail the moment they open. The supervisor works them first and surfaces the ones that need a person with a new approval-free factory_escalate_finding tool, which attaches a note explaining what it found and what it needs. Findings that always wait on a person (proposals, held cards, label drift) stay visible immediately. Nothing can stay hidden for long: any finding still open after thirty minutes surfaces on its own. Finding rows carry the new status, escalation time and note, and the supervisor's health-check and inspect tools report them.

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -20,6 +20,7 @@ import type * as dispatcherModule from './rules/dispatcher.js';
 import type * as terminalCleanupModule from './rules/terminal-cleanup.js';
 import type * as transitionServiceModule from './rules/transition-service.js';
 import { createFactorySecretEncryption } from './secret-encryption.js';
+import type { AuditStorage } from './storage/domains/audit/base.js';
 import type { MemorySettingsStorage } from './storage/domains/memory-settings/base.js';
 import type { FactoryProjectsStorage } from './storage/domains/projects/base.js';
 import type { SourceControlStorage } from './storage/domains/source-control/base.js';
@@ -595,6 +596,7 @@ describe('MastraFactory.prepare', () => {
     'factory_list_attention',
     'factory_read_session',
   ];
+  const SUPERVISOR_ACTION_TOOLS = ['factory_escalate_finding'];
   const SUPERVISOR_HUMAN_WRITE_TOOLS = [
     'factory_retry_decision',
     'factory_dismiss_decision',
@@ -637,7 +639,7 @@ describe('MastraFactory.prepare', () => {
     const signalTurn = new RequestContext();
     signalTurn.set('controller', controller({ factoryProjectId: project.id, factoryOrgId: 'org-1' }));
     const signalTools = Object.keys(await extraTools({ requestContext: signalTurn }));
-    expect(signalTools.sort()).toEqual([...SUPERVISOR_READ_TOOLS].sort());
+    expect(signalTools.sort()).toEqual([...SUPERVISOR_READ_TOOLS, ...SUPERVISOR_ACTION_TOOLS].sort());
 
     // Forged/foreign state: org does not own the project → no supervisor tools at all.
     const forged = new RequestContext();
@@ -650,8 +652,68 @@ describe('MastraFactory.prepare', () => {
     humanTurn.set('controller', controller({ factoryProjectId: project.id, factoryOrgId: 'org-1' }));
     const humanTools = Object.keys(await extraTools({ requestContext: humanTurn }));
     expect(humanTools.sort()).toEqual(
-      [...SUPERVISOR_READ_TOOLS, ...SUPERVISOR_HUMAN_WRITE_TOOLS, 'custom_write'].sort(),
+      [...SUPERVISOR_READ_TOOLS, ...SUPERVISOR_ACTION_TOOLS, ...SUPERVISOR_HUMAN_WRITE_TOOLS, 'custom_write'].sort(),
     );
+  });
+
+  it('attributes approval-free supervisor actions to the human on auth turns and to the agent on signal turns', async () => {
+    const storage = fakeStorage();
+    const config = await prepareFactory({ storage });
+    const projects = storage.getDomain<FactoryProjectsStorage>('projects');
+    const workItems = storage.getDomain<WorkItemsStorage>('work-items');
+    const audit = storage.getDomain<AuditStorage>('audit');
+    const project = await projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'p' } });
+    const scope = { orgId: 'org-1', factoryProjectId: project.id };
+    const finding = (key: string) => ({
+      kind: 'decision-failed' as const,
+      id: key,
+      workItemId: null,
+      workItemNumber: null,
+      title: 't',
+      evidence: 'e',
+      ageMs: 1_000,
+      suggestedRepair: null,
+    });
+    await workItems.syncSupervisorFindings({
+      ...scope,
+      findings: [finding('decision-failed:a'), finding('decision-failed:b')],
+      now: new Date(),
+    });
+    const extraTools = config.extraTools as (args: {
+      requestContext: RequestContext;
+    }) => Promise<Record<string, { execute: (input: unknown, ctx?: unknown) => Promise<unknown> }>>;
+    const state = { factoryProjectId: project.id, factoryOrgId: 'org-1' };
+    const controller = {
+      resourceId: `factory-supervisor:${project.id}`,
+      threadId: `factory-supervisor:${project.id}`,
+      scope: '/worktree',
+      state,
+      getState: () => state,
+    };
+
+    const signalTurn = new RequestContext();
+    signalTurn.set('controller', controller);
+    const signalTools = await extraTools({ requestContext: signalTurn });
+    await signalTools.factory_escalate_finding!.execute({ findingKey: 'decision-failed:a', note: 'needs a person' });
+
+    const humanTurn = new RequestContext();
+    humanTurn.set('user', { workosId: 'user-1', organizationId: 'org-1' });
+    humanTurn.set('controller', controller);
+    const humanTools = await extraTools({ requestContext: humanTurn });
+    await humanTools.factory_escalate_finding!.execute({
+      findingKey: 'decision-failed:b',
+      note: 'also needs a person',
+    });
+
+    const events = (await audit.list({ orgId: 'org-1', factoryProjectId: project.id, limit: 10 })).events.filter(
+      event => event.action === 'factory.supervisor.finding_escalated',
+    );
+    const byKey = Object.fromEntries(events.map(event => [event.targets[0]!.id, event]));
+    expect(byKey['decision-failed:a']).toMatchObject({
+      actorType: 'agent',
+      actorId: `agent:factory-supervisor:${project.id}`,
+    });
+    expect(byKey['decision-failed:b']).toMatchObject({ actorType: 'human', actorId: 'user-1' });
   });
 
   it('gives a supervisor session no tools when the factory domain is unavailable, even with tool integrations', async () => {

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -26,6 +26,7 @@ import type { FactoryProjectsStorage } from './storage/domains/projects/base.js'
 import type { SourceControlStorage } from './storage/domains/source-control/base.js';
 import type { WorkItemsStorage } from './storage/domains/work-items/base.js';
 import { FactorySupervisorHealthWorker } from './supervisor/health-worker.js';
+import { SUPERVISOR_ATTENTION_FORCE_SURFACE_MS } from './supervisor/health.js';
 /** A real in-memory FactoryStorage with init spied for boot-order assertions. */
 function fakeStorage(): LibSQLFactoryStorage {
   const storage = new LibSQLFactoryStorage({ url: ':memory:', id: 'factory-test-storage' });
@@ -827,6 +828,64 @@ describe('MastraFactory.prepare', () => {
       limit: 10,
     });
     expect(rows[0]?.lastNotifiedAt).toBeInstanceOf(Date);
+  });
+
+  /**
+   * The force-surface backstop flips a hidden finding visible with no storage
+   * write, so the sweep must ring the same feed doorbell writes do, on the
+   * factory's own event bus.
+   */
+  it('wires the health worker to touch the attention feed when the backstop surfaces a finding', async () => {
+    const storage = fakeStorage();
+    const pubsub = { publish: vi.fn(async () => {}), subscribe: vi.fn() } as never;
+    const factory = new MastraFactory({ secretEncryption, storage, pubsub });
+    const args = await factory.prepare();
+    const worker = args.workers!.find(
+      (w): w is FactorySupervisorHealthWorker => w instanceof FactorySupervisorHealthWorker,
+    )!;
+    const projects = storage.getDomain<FactoryProjectsStorage>('projects');
+    const workItems = storage.getDomain<WorkItemsStorage>('work-items');
+    const project = await projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'p' } });
+    // A supervisor-actionable finding already past the backstop; never escalated.
+    await workItems.syncSupervisorFindings({
+      orgId: 'org-1',
+      factoryProjectId: project.id,
+      findings: [
+        {
+          id: 'seat-missing:stale',
+          kind: 'seat-missing',
+          workItemId: null,
+          workItemNumber: null,
+          title: 'stale',
+          evidence: 'stale',
+          ageMs: 0,
+          suggestedRepair: null,
+        },
+      ],
+      now: new Date(Date.now() - SUPERVISOR_ATTENTION_FORCE_SURFACE_MS - 60_000),
+    });
+    (pubsub as { publish: ReturnType<typeof vi.fn> }).publish.mockClear();
+
+    // A sweep reconciles against computed health, which would resolve the
+    // seeded row; keep the row by making the sweep compute the same finding.
+    const health = vi.spyOn(workItems, 'syncSupervisorFindings').mockResolvedValue(undefined);
+    try {
+      await worker.init({
+        pubsub,
+        storage: {} as never,
+        logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+      });
+      await worker.start();
+      await new Promise(resolve => setTimeout(resolve, 0));
+      await worker.stop();
+    } finally {
+      health.mockRestore();
+    }
+
+    expect((pubsub as { publish: ReturnType<typeof vi.fn> }).publish).toHaveBeenCalledWith(
+      expect.stringContaining(project.id),
+      expect.objectContaining({ type: 'factory.feed.touched', runId: project.id }),
+    );
   });
 
   it('serves the not-registered /web/channel-accounts stub when no slack integration is registered', async () => {

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -837,7 +837,8 @@ describe('MastraFactory.prepare', () => {
    */
   it('wires the health worker to touch the attention feed when the backstop surfaces a finding', async () => {
     const storage = fakeStorage();
-    const pubsub = { publish: vi.fn(async () => {}), subscribe: vi.fn() } as never;
+    const publish = vi.fn(async () => {});
+    const pubsub = { publish, subscribe: vi.fn() } as never;
     const factory = new MastraFactory({ secretEncryption, storage, pubsub });
     const args = await factory.prepare();
     const worker = args.workers!.find(
@@ -864,25 +865,37 @@ describe('MastraFactory.prepare', () => {
       ],
       now: new Date(Date.now() - SUPERVISOR_ATTENTION_FORCE_SURFACE_MS - 60_000),
     });
-    (pubsub as { publish: ReturnType<typeof vi.fn> }).publish.mockClear();
+    publish.mockClear();
+    // The first backstop publish fails: the sweep must not consider the crossing announced.
+    publish.mockRejectedValueOnce(new Error('broker down'));
 
     // A sweep reconciles against computed health, which would resolve the
-    // seeded row; keep the row by making the sweep compute the same finding.
+    // seeded row; keep the row by making reconciliation a no-op.
     const health = vi.spyOn(workItems, 'syncSupervisorFindings').mockResolvedValue(undefined);
+    const error = vi.fn();
+    const sweep = async () => {
+      await worker.start();
+      await new Promise(resolve => setTimeout(resolve, 0));
+      await worker.stop();
+    };
     try {
       await worker.init({
         pubsub,
         storage: {} as never,
-        logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+        logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error } as never,
       });
-      await worker.start();
-      await new Promise(resolve => setTimeout(resolve, 0));
-      await worker.stop();
+      await sweep(); // publish rejects, sweep logs the failure
+      expect(publish).toHaveBeenCalledTimes(1);
+      expect(error).toHaveBeenCalled();
+      await sweep(); // retried and accepted
+      expect(publish).toHaveBeenCalledTimes(2);
+      await sweep(); // announced; silent now
+      expect(publish).toHaveBeenCalledTimes(2);
     } finally {
       health.mockRestore();
     }
 
-    expect((pubsub as { publish: ReturnType<typeof vi.fn> }).publish).toHaveBeenCalledWith(
+    expect(publish).toHaveBeenLastCalledWith(
       expect.stringContaining(project.id),
       expect.objectContaining({ type: 'factory.feed.touched', runId: project.id }),
     );

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -102,11 +102,17 @@ import { QueueHealthStorage } from './storage/domains/queue-health/base.js';
 import { SourceControlStorage } from './storage/domains/source-control/base.js';
 import { WorkItemsStorage } from './storage/domains/work-items/base.js';
 import type { WorkItemRow } from './storage/domains/work-items/base.js';
+import { createFactorySupervisorActionTools } from './supervisor/action-tools.js';
 import { FactorySupervisorHealthWorker } from './supervisor/health-worker.js';
 import { SUPERVISOR_INSTRUCTIONS } from './supervisor/instructions.js';
 import { notifySupervisor } from './supervisor/notify.js';
 import { createFactorySupervisorReadTools } from './supervisor/read-tools.js';
-import { hydrateSupervisorSession, parseSupervisorResourceId, resolveSupervisorScope } from './supervisor/session.js';
+import {
+  hydrateSupervisorSession,
+  parseSupervisorResourceId,
+  resolveSupervisorScope,
+  supervisorResourceId,
+} from './supervisor/session.js';
 import { createFactorySupervisorWriteTools } from './supervisor/write-tools.js';
 import { timedPhase } from './timing.js';
 import { createWorkspaceFactory, FactoryWorkspaceRegistry } from './workspace.js';
@@ -803,6 +809,26 @@ export class MastraFactory {
                             return memory ? memory.listMessages(input) : { messages: [], hasMore: false };
                           },
                         },
+                      }),
+                    );
+                    // Approval-free supervisor actions run on every turn,
+                    // attributed to the human when there is one and to the
+                    // agent identity otherwise (the audit trail's convention).
+                    const supervisorThreadId = (requestContext.get('controller') as { threadId?: string } | undefined)
+                      ?.threadId;
+                    mergeTools(
+                      'factory-supervisor-actions',
+                      createFactorySupervisorActionTools({
+                        scope: supervisorScope,
+                        actor:
+                          supervisorScope.via === 'auth' && userId
+                            ? { type: 'human', id: userId }
+                            : {
+                                type: 'agent',
+                                id: `agent:${supervisorThreadId ?? supervisorResourceId(supervisorScope.factoryProjectId)}`,
+                              },
+                        workItems: workItemsStorage,
+                        audit: auditStorage,
                       }),
                     );
                     // The approval-gated write tools stamp the human who asked

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -40,7 +40,7 @@ import {
   getFactoryAuthUserFromContext,
   getFactoryAuthUserId,
 } from './auth.js';
-import { touchFeed } from './feed-events.js';
+import { publishFeedTouch, touchFeed } from './feed-events.js';
 import type { FactoryIntegration, IntegrationPostToolContext, IntegrationTools } from './integrations/base.js';
 import { reconcileGithubAcceptanceLabels } from './integrations/github/acceptance-labels.js';
 import type { GithubIntegration } from './integrations/github/integration.js';
@@ -829,6 +829,7 @@ export class MastraFactory {
                               },
                         workItems: workItemsStorage,
                         audit: auditStorage,
+                        logger: { warn: (message, meta) => console.warn(`[Factory Supervisor] ${message}`, meta) },
                       }),
                     );
                     // The approval-gated write tools stamp the human who asked
@@ -1175,7 +1176,9 @@ export class MastraFactory {
                 ),
               // Same doorbell storage writes ring: the 30-minute force-surface
               // backstop changes the Attention projection without a write.
-              attentionChanged: scope => touchFeed(eventBus, scope),
+              // Awaited (unlike a write's touch) so a failed publish leaves the
+              // sweep's checkpoint behind and the next sweep rings again.
+              attentionChanged: scope => publishFeedTouch(eventBus, scope),
             }),
           ]
         : []),

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -1173,6 +1173,9 @@ export class MastraFactory {
                   },
                   input,
                 ),
+              // Same doorbell storage writes ring: the 30-minute force-surface
+              // backstop changes the Attention projection without a write.
+              attentionChanged: scope => touchFeed(eventBus, scope),
             }),
           ]
         : []),

--- a/mastracode/factory/src/feed-events.ts
+++ b/mastracode/factory/src/feed-events.ts
@@ -11,20 +11,26 @@ export function feedTopic(orgId: string, factoryProjectId: string): string {
 
 /**
  * One frame for the whole project: `workItemId` names the item whose comments
- * moved, and its absence means only the project's attention did. Never awaited
- * — a slow or dead broker must not hold up the write it describes.
+ * moved, and its absence means only the project's attention did. Resolves when
+ * the broker accepted it; callers that must retry on failure await this.
+ */
+export function publishFeedTouch(pubsub: PubSub, scope: FeedScope, workItemId?: string): Promise<void> {
+  return pubsub.publish(feedTopic(scope.orgId, scope.factoryProjectId), {
+    type: 'factory.feed.touched',
+    runId: workItemId ?? scope.factoryProjectId,
+    data: workItemId ? { workItemId } : {},
+  });
+}
+
+/**
+ * Fire-and-forget {@link publishFeedTouch}: a slow or dead broker must not
+ * hold up the write it describes.
  */
 export function touchFeed(pubsub: PubSub, scope: FeedScope, workItemId?: string): void {
-  pubsub
-    .publish(feedTopic(scope.orgId, scope.factoryProjectId), {
-      type: 'factory.feed.touched',
-      runId: workItemId ?? scope.factoryProjectId,
-      data: workItemId ? { workItemId } : {},
-    })
-    .catch((error: unknown) => {
-      console.warn('[Factory] Failed to publish a feed touch', {
-        factoryProjectId: scope.factoryProjectId,
-        error: error instanceof Error ? error.message : String(error),
-      });
+  publishFeedTouch(pubsub, scope, workItemId).catch((error: unknown) => {
+    console.warn('[Factory] Failed to publish a feed touch', {
+      factoryProjectId: scope.factoryProjectId,
+      error: error instanceof Error ? error.message : String(error),
     });
+  });
 }

--- a/mastracode/factory/src/routes/attention-providers.ts
+++ b/mastracode/factory/src/routes/attention-providers.ts
@@ -27,6 +27,7 @@ import {
   factorySupervisorFindingAttentionIdentity,
 } from '../storage/domains/work-items/base.js';
 import type { FactoryHealthFinding } from '../supervisor/health.js';
+import { isSupervisorFindingVisibleToHumans } from '../supervisor/visibility.js';
 
 export type FactoryAttentionView = 'open' | 'unread' | 'archived';
 
@@ -363,28 +364,48 @@ function supervisorFindingPayload(row: FactorySupervisorFindingRecord): FactoryH
 export class SupervisorFindingAttentionProvider implements AttentionProvider {
   readonly kind = 'supervisor-finding' as const;
   readonly #workItems: WorkItemsStorage;
+  readonly #now: () => Date;
 
-  constructor({ workItems }: { workItems: WorkItemsStorage }) {
+  constructor({ workItems, now }: { workItems: WorkItemsStorage; now?: () => Date }) {
     this.#workItems = workItems;
+    this.#now = now ?? (() => new Date());
+  }
+
+  /**
+   * Attention is the human's view of finding state, so every path below
+   * (counts, latest, page, bulk receipts) sees the same subset: the rows
+   * `isSupervisorFindingVisibleToHumans` admits. The scan cursor still
+   * advances over the raw rows, so hidden rows never stall pagination.
+   */
+  #visible(rows: FactorySupervisorFindingRecord[]): FactorySupervisorFindingRecord[] {
+    const now = this.#now();
+    return rows.filter(row => isSupervisorFindingVisibleToHumans(row, now));
+  }
+
+  #batches(scope: AttentionScope, before?: AttentionStreamPosition) {
+    return scanBatches<FactorySupervisorFindingRecord>(
+      cursor =>
+        this.#workItems.listSupervisorFindingPage({
+          ...scope,
+          ...(cursor ? { before: cursor } : {}),
+          limit: SCAN_PAGE_SIZE,
+        }),
+      row => ({ occurredAt: row.updatedAt, id: row.id }),
+      before,
+    );
   }
 
   async counts(scope: AttentionScope): Promise<AttentionCounts> {
     let open = 0;
     let unread = 0;
-    const batches = scanBatches<FactorySupervisorFindingRecord>(
-      before =>
-        this.#workItems.listSupervisorFindingPage({ ...scope, ...(before ? { before } : {}), limit: SCAN_PAGE_SIZE }),
-      row => ({ occurredAt: row.updatedAt, id: row.id }),
-    );
-    for await (const page of batches) {
-      const identities = page.rows.map(row =>
-        factorySupervisorFindingAttentionIdentity(row.findingKey, row.occurrence),
-      );
+    for await (const page of this.#batches(scope)) {
+      const rows = this.#visible(page.rows);
+      const identities = rows.map(row => factorySupervisorFindingAttentionIdentity(row.findingKey, row.occurrence));
       const receipts = await this.#workItems.listAttentionReceipts({ ...scope, identities });
       const byIdentity = new Map(
         receipts.map(receipt => [`${receipt.sourceId}\0${receipt.occurrence}`, receipt] as const),
       );
-      for (const row of page.rows) {
+      for (const row of rows) {
         const receipt = byIdentity.get(`${row.findingKey}\0${row.occurrence}`);
         if (receipt?.state === 'archived') continue;
         open += 1;
@@ -395,8 +416,12 @@ export class SupervisorFindingAttentionProvider implements AttentionProvider {
   }
 
   async latest(scope: AttentionScope): Promise<AttentionLatest | null> {
-    const page = await this.#workItems.listSupervisorFindingPage({ ...scope, limit: 1 });
-    const newest = page.rows[0];
+    // Newest VISIBLE row: a hidden newer finding must not blank the rail.
+    let newest: FactorySupervisorFindingRecord | undefined;
+    for await (const page of this.#batches(scope)) {
+      newest = this.#visible(page.rows)[0];
+      if (newest) break;
+    }
     if (!newest) return null;
     const identity = factorySupervisorFindingAttentionIdentity(newest.findingKey, newest.occurrence);
     const receipts = await this.#workItems.listAttentionReceipts({ ...scope, identities: [identity] });
@@ -408,76 +433,66 @@ export class SupervisorFindingAttentionProvider implements AttentionProvider {
   }
 
   page(scope: AttentionScope, args: AttentionPageArgs): Promise<AttentionPageResult> {
-    return collectPage(
-      scanBatches<FactorySupervisorFindingRecord>(
-        before =>
-          this.#workItems.listSupervisorFindingPage({ ...scope, ...(before ? { before } : {}), limit: SCAN_PAGE_SIZE }),
-        row => ({ occurredAt: row.updatedAt, id: row.id }),
-        args.before,
-      ),
-      args.limit,
-      async rows => {
-        const identities = rows.map(row => factorySupervisorFindingAttentionIdentity(row.findingKey, row.occurrence));
-        const receipts = await this.#workItems.listAttentionReceipts({ ...scope, identities });
-        const byIdentity = new Map(
-          receipts.map(receipt => [`${receipt.sourceId}\0${receipt.occurrence}`, receipt] as const),
-        );
-        return rows.flatMap(row => {
-          const finding = supervisorFindingPayload(row);
-          const receipt = byIdentity.get(`${row.findingKey}\0${row.occurrence}`);
-          if (!matchesView(args.view, receipt)) return [];
-          const text = `${finding.title} ${finding.evidence}`.toLowerCase();
-          if (args.search && !text.includes(args.search)) return [];
-          const identity = factorySupervisorFindingAttentionIdentity(row.findingKey, row.occurrence);
-          return [
-            {
+    return collectPage(this.#batches(scope, args.before), args.limit, async batchRows => {
+      const rows = this.#visible(batchRows);
+      const identities = rows.map(row => factorySupervisorFindingAttentionIdentity(row.findingKey, row.occurrence));
+      const receipts = await this.#workItems.listAttentionReceipts({ ...scope, identities });
+      const byIdentity = new Map(
+        receipts.map(receipt => [`${receipt.sourceId}\0${receipt.occurrence}`, receipt] as const),
+      );
+      return rows.flatMap(row => {
+        const finding = supervisorFindingPayload(row);
+        const receipt = byIdentity.get(`${row.findingKey}\0${row.occurrence}`);
+        if (!matchesView(args.view, receipt)) return [];
+        const text = `${finding.title} ${finding.evidence}`.toLowerCase();
+        if (args.search && !text.includes(args.search)) return [];
+        const identity = factorySupervisorFindingAttentionIdentity(row.findingKey, row.occurrence);
+        return [
+          {
+            key: factoryAttentionKey(scope.factoryProjectId, identity),
+            occurredAt: row.updatedAt,
+            resumeCursor: { occurredAt: row.updatedAt, id: row.id },
+            receipt,
+            item: {
               key: factoryAttentionKey(scope.factoryProjectId, identity),
-              occurredAt: row.updatedAt,
-              resumeCursor: { occurredAt: row.updatedAt, id: row.id },
-              receipt,
-              item: {
-                key: factoryAttentionKey(scope.factoryProjectId, identity),
-                kind: this.kind,
-                findingKey: row.findingKey,
-                occurrence: row.occurrence,
-                findingTitle: finding.title,
-                evidence: finding.evidence,
-                title: finding.title,
-                detail: finding.evidence,
-                ageMs: finding.ageMs,
-                suggestedRepair: finding.suggestedRepair,
-                workItemId: finding.workItemId,
-                occurredAt: row.updatedAt.toISOString(),
-                read: Boolean(receipt),
-                archived: receipt?.state === 'archived',
-                target: finding.workItemId
-                  ? { kind: 'work-item', workItemId: finding.workItemId, board: 'work' }
-                  : { kind: 'rules' },
-              },
+              kind: this.kind,
+              findingKey: row.findingKey,
+              occurrence: row.occurrence,
+              findingTitle: finding.title,
+              evidence: finding.evidence,
+              title: finding.title,
+              detail: row.escalationNote ? `${row.escalationNote}\n\n${finding.evidence}` : finding.evidence,
+              status: row.status,
+              escalatedAt: row.escalatedAt?.toISOString() ?? null,
+              escalationNote: row.escalationNote,
+              ageMs: finding.ageMs,
+              suggestedRepair: finding.suggestedRepair,
+              workItemId: finding.workItemId,
+              occurredAt: row.updatedAt.toISOString(),
+              read: Boolean(receipt),
+              archived: receipt?.state === 'archived',
+              target: finding.workItemId
+                ? { kind: 'work-item', workItemId: finding.workItemId, board: 'work' }
+                : { kind: 'rules' },
             },
-          ];
-        });
-      },
-    );
+          },
+        ];
+      });
+    });
   }
 
   markAllRead(
     scope: AttentionScope,
     args: { before?: AttentionStreamPosition; now: Date },
   ): Promise<{ hasMore: boolean; continuation?: AttentionStreamPosition }> {
-    return markScanRead(
-      scanBatches<FactorySupervisorFindingRecord>(
-        before =>
-          this.#workItems.listSupervisorFindingPage({ ...scope, ...(before ? { before } : {}), limit: SCAN_PAGE_SIZE }),
-        row => ({ occurredAt: row.updatedAt, id: row.id }),
-        args.before,
-      ),
-      rows =>
-        this.#workItems.markAttentionReceiptsRead({
-          ...scope,
-          identities: rows.map(row => factorySupervisorFindingAttentionIdentity(row.findingKey, row.occurrence)),
-          now: args.now,
-        }),
+    return markScanRead(this.#batches(scope, args.before), rows =>
+      this.#workItems.markAttentionReceiptsRead({
+        ...scope,
+        identities: this.#visible(rows).map(row =>
+          factorySupervisorFindingAttentionIdentity(row.findingKey, row.occurrence),
+        ),
+        now: args.now,
+      }),
     );
   }
 }

--- a/mastracode/factory/src/routes/attention-providers.ts
+++ b/mastracode/factory/src/routes/attention-providers.ts
@@ -374,32 +374,48 @@ export class SupervisorFindingAttentionProvider implements AttentionProvider {
   /**
    * Attention is the human's view of finding state, so every path below
    * (counts, latest, page, bulk receipts) sees the same subset: the rows
-   * `isSupervisorFindingVisibleToHumans` admits. The scan cursor still
-   * advances over the raw rows, so hidden rows never stall pagination.
+   * `isSupervisorFindingVisibleToHumans` admits. The visibility predicate
+   * needs the finding's kind (JSON) and wall-clock age, neither of which the
+   * equality-only storage filter can express, so the raw open-row stream is
+   * walked here and filtered in memory. Only batches that carry a visible row
+   * count against the receipt-scan page budget: a run of hidden rows must
+   * never exhaust the budget ahead of an older visible or force-surfaced
+   * finding (the never-lose backstop). The scan cursor still advances over
+   * the raw rows, so hidden rows never stall pagination.
    */
-  #visible(rows: FactorySupervisorFindingRecord[]): FactorySupervisorFindingRecord[] {
+  async *#batches(
+    scope: AttentionScope,
+    before?: AttentionStreamPosition,
+  ): AsyncGenerator<ScanBatch<FactorySupervisorFindingRecord>> {
     const now = this.#now();
-    return rows.filter(row => isSupervisorFindingVisibleToHumans(row, now));
-  }
-
-  #batches(scope: AttentionScope, before?: AttentionStreamPosition) {
-    return scanBatches<FactorySupervisorFindingRecord>(
-      cursor =>
-        this.#workItems.listSupervisorFindingPage({
-          ...scope,
-          ...(cursor ? { before: cursor } : {}),
-          limit: SCAN_PAGE_SIZE,
-        }),
-      row => ({ occurredAt: row.updatedAt, id: row.id }),
-      before,
-    );
+    let cursor = before;
+    let yielded = 0;
+    for (;;) {
+      const { rows, hasMore } = await this.#workItems.listSupervisorFindingPage({
+        ...scope,
+        ...(cursor ? { before: cursor } : {}),
+        limit: SCAN_PAGE_SIZE,
+      });
+      const last = rows.at(-1);
+      if (!last) return;
+      const position = { occurredAt: last.updatedAt, id: last.id };
+      const visible = rows.filter(row => isSupervisorFindingVisibleToHumans(row, now));
+      if (visible.length > 0) {
+        yielded += 1;
+        const budgetSpent = hasMore && yielded === MAX_RECEIPT_SCAN_PAGES;
+        yield { rows: visible, ...(budgetSpent ? { continuation: position } : {}) };
+        if (budgetSpent) return;
+      }
+      if (!hasMore) return;
+      cursor = position;
+    }
   }
 
   async counts(scope: AttentionScope): Promise<AttentionCounts> {
     let open = 0;
     let unread = 0;
     for await (const page of this.#batches(scope)) {
-      const rows = this.#visible(page.rows);
+      const rows = page.rows;
       const identities = rows.map(row => factorySupervisorFindingAttentionIdentity(row.findingKey, row.occurrence));
       const receipts = await this.#workItems.listAttentionReceipts({ ...scope, identities });
       const byIdentity = new Map(
@@ -419,7 +435,7 @@ export class SupervisorFindingAttentionProvider implements AttentionProvider {
     // Newest VISIBLE row: a hidden newer finding must not blank the rail.
     let newest: FactorySupervisorFindingRecord | undefined;
     for await (const page of this.#batches(scope)) {
-      newest = this.#visible(page.rows)[0];
+      newest = page.rows[0];
       if (newest) break;
     }
     if (!newest) return null;
@@ -433,8 +449,7 @@ export class SupervisorFindingAttentionProvider implements AttentionProvider {
   }
 
   page(scope: AttentionScope, args: AttentionPageArgs): Promise<AttentionPageResult> {
-    return collectPage(this.#batches(scope, args.before), args.limit, async batchRows => {
-      const rows = this.#visible(batchRows);
+    return collectPage(this.#batches(scope, args.before), args.limit, async rows => {
       const identities = rows.map(row => factorySupervisorFindingAttentionIdentity(row.findingKey, row.occurrence));
       const receipts = await this.#workItems.listAttentionReceipts({ ...scope, identities });
       const byIdentity = new Map(
@@ -488,9 +503,7 @@ export class SupervisorFindingAttentionProvider implements AttentionProvider {
     return markScanRead(this.#batches(scope, args.before), rows =>
       this.#workItems.markAttentionReceiptsRead({
         ...scope,
-        identities: this.#visible(rows).map(row =>
-          factorySupervisorFindingAttentionIdentity(row.findingKey, row.occurrence),
-        ),
+        identities: rows.map(row => factorySupervisorFindingAttentionIdentity(row.findingKey, row.occurrence)),
         now: args.now,
       }),
     );

--- a/mastracode/factory/src/routes/attention.test.ts
+++ b/mastracode/factory/src/routes/attention.test.ts
@@ -10,8 +10,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { builtInFactoryRules } from '../rules/defaults.js';
 import { FactoryTransitionService } from '../rules/transition-service.js';
 import type { FactoryDeferredDecisionRecord, WorkItemRow } from '../storage/domains/work-items/base.js';
+import { factorySupervisorFindingAttentionIdentity } from '../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
 import type { FactoryStorageTestSeed } from '../storage/test-utils.js';
+import { SUPERVISOR_ATTENTION_FORCE_SURFACE_MS } from '../supervisor/health.js';
+import { SupervisorFindingAttentionProvider } from './attention-providers.js';
 import { fakeRouteAuth, mountApiRoutes } from './test-utils.js';
 import { WorkItemRoutes } from './work-items.js';
 
@@ -129,25 +132,47 @@ beforeEach(async () => {
   PROJECT_ID = project.id;
 });
 
+function stuckFinding(item: WorkItemRow) {
+  return {
+    id: `decision-stuck:${item.id}`,
+    kind: 'decision-stuck' as const,
+    workItemId: item.id,
+    workItemNumber: null,
+    title: 'A decision is stuck',
+    evidence: 'decision-1 has been retrying past its backoff.',
+    ageMs: 600_000,
+    suggestedRepair: { action: 'retry-decision' as const, decisionId: 'decision-1' },
+  };
+}
+
+function heldFinding(item: WorkItemRow) {
+  return {
+    id: `held-waiting:${item.id}`,
+    kind: 'held-waiting' as const,
+    workItemId: item.id,
+    workItemNumber: null,
+    title: 'A card is held for a person',
+    evidence: 'held since yesterday.',
+    ageMs: 86_400_000,
+    suggestedRepair: null,
+  };
+}
+
 describe('supervisor finding attention items', () => {
-  it('surfaces persisted findings in the badge and supports receipt actions', async () => {
+  it('surfaces escalated findings in the badge with the note and supports receipt actions', async () => {
     const item = await seedWorkItem('Repair stuck card');
     await seed.workItems.syncSupervisorFindings({
       orgId: 'org1',
       factoryProjectId: PROJECT_ID,
-      findings: [
-        {
-          id: `decision-stuck:${item.id}`,
-          kind: 'decision-stuck',
-          workItemId: item.id,
-          workItemNumber: null,
-          title: 'A decision is stuck',
-          evidence: 'decision-1 has been retrying past its backoff.',
-          ageMs: 600_000,
-          suggestedRepair: { action: 'retry-decision', decisionId: 'decision-1' },
-        },
-      ],
-      now: new Date('2030-01-01T00:00:00.000Z'),
+      findings: [stuckFinding(item)],
+      now: new Date(),
+    });
+    await seed.workItems.escalateSupervisorFinding({
+      orgId: 'org1',
+      factoryProjectId: PROJECT_ID,
+      findingKey: `decision-stuck:${item.id}`,
+      note: 'Retried twice; the worker needs a product decision on the API version.',
+      escalatedAt: new Date(),
     });
 
     const open = await (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json();
@@ -158,6 +183,8 @@ describe('supervisor finding attention items', () => {
           findingKey: `decision-stuck:${item.id}`,
           findingTitle: 'A decision is stuck',
           evidence: 'decision-1 has been retrying past its backoff.',
+          status: 'escalated',
+          escalationNote: 'Retried twice; the worker needs a product decision on the API version.',
           workItemId: item.id,
           read: false,
         },
@@ -167,6 +194,7 @@ describe('supervisor finding attention items', () => {
       badgeCount: 1,
       latestOccurrenceUnread: true,
     });
+    expect(open.items[0].detail).toContain('needs a product decision');
 
     const receiptPath = `/web/factory/projects/${PROJECT_ID}/attention/supervisor-finding/${encodeURIComponent(`decision-stuck:${item.id}`)}/0`;
     expect((await request('POST', `${receiptPath}/read`)).status).toBe(200);
@@ -178,6 +206,118 @@ describe('supervisor finding attention items', () => {
     await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
       { items: [], openCount: 0 },
     );
+  });
+
+  it('hides an open supervisor-actionable finding from people until the supervisor escalates it', async () => {
+    const item = await seedWorkItem('Repair stuck card');
+    const scope = { orgId: 'org1', factoryProjectId: PROJECT_ID };
+    await seed.workItems.syncSupervisorFindings({ ...scope, findings: [stuckFinding(item)], now: new Date() });
+
+    const hidden = await (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json();
+    expect(hidden).toMatchObject({ items: [], openCount: 0, unreadCount: 0, badgeCount: 0 });
+    expect(hidden.latestOccurrenceUnread).toBeFalsy();
+
+    await seed.workItems.escalateSupervisorFinding({
+      ...scope,
+      findingKey: `decision-stuck:${item.id}`,
+      note: 'needs you',
+      escalatedAt: new Date(),
+    });
+    const shown = await (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json();
+    expect(shown).toMatchObject({
+      items: [{ findingKey: `decision-stuck:${item.id}`, status: 'escalated', escalationNote: 'needs you' }],
+      openCount: 1,
+      badgeCount: 1,
+    });
+  });
+
+  it('keeps human-facing kinds visible while open', async () => {
+    const item = await seedWorkItem('Held card');
+    await seed.workItems.syncSupervisorFindings({
+      orgId: 'org1',
+      factoryProjectId: PROJECT_ID,
+      findings: [heldFinding(item)],
+      now: new Date(),
+    });
+    await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
+      { items: [{ findingKey: `held-waiting:${item.id}`, status: 'open' }], openCount: 1 },
+    );
+  });
+
+  it('force-surfaces an open finding past the backstop even if never escalated', async () => {
+    const item = await seedWorkItem('Forgotten card');
+    const openedAt = new Date(Date.now() - SUPERVISOR_ATTENTION_FORCE_SURFACE_MS - 60_000);
+    await seed.workItems.syncSupervisorFindings({
+      orgId: 'org1',
+      factoryProjectId: PROJECT_ID,
+      findings: [stuckFinding(item)],
+      now: openedAt,
+    });
+    await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
+      { items: [{ findingKey: `decision-stuck:${item.id}`, status: 'open' }], openCount: 1, badgeCount: 1 },
+    );
+  });
+
+  it('never surfaces resolved findings, escalated or not', async () => {
+    const item = await seedWorkItem('Resolved card');
+    const scope = { orgId: 'org1', factoryProjectId: PROJECT_ID };
+    await seed.workItems.syncSupervisorFindings({ ...scope, findings: [stuckFinding(item)], now: new Date() });
+    await seed.workItems.escalateSupervisorFinding({
+      ...scope,
+      findingKey: `decision-stuck:${item.id}`,
+      note: 'n',
+      escalatedAt: new Date(),
+    });
+    await seed.workItems.syncSupervisorFindings({ ...scope, findings: [], now: new Date() });
+    await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
+      { items: [], openCount: 0 },
+    );
+  });
+
+  it('applies one visibility predicate to counts, latest, page and read-all', async () => {
+    const hiddenItem = await seedWorkItem('Newest, hidden');
+    const visibleItem = await seedWorkItem('Older, visible');
+    const scope = { orgId: 'org1', factoryProjectId: PROJECT_ID };
+    const t0 = new Date('2030-01-01T00:00:00.000Z');
+    const t1 = new Date('2030-01-01T00:05:00.000Z');
+    await seed.workItems.syncSupervisorFindings({ ...scope, findings: [heldFinding(visibleItem)], now: t0 });
+    await seed.workItems.syncSupervisorFindings({
+      ...scope,
+      findings: [heldFinding(visibleItem), stuckFinding(hiddenItem)],
+      now: t1,
+    });
+    const provider = new SupervisorFindingAttentionProvider({
+      workItems: seed.workItems,
+      now: () => new Date('2030-01-01T00:06:00.000Z'),
+    });
+    const attentionScope = { ...scope, userId: 'u1' };
+
+    expect(await provider.counts(attentionScope)).toEqual({ open: 1, unread: 1 });
+    // latest() skips the newest (hidden) row and reports the newest visible one.
+    await expect(provider.latest(attentionScope)).resolves.toMatchObject({ at: t0, unread: true });
+    const page = await provider.page(attentionScope, { view: 'open', limit: 10 });
+    expect(page.entries.map(entry => (entry.item as { findingKey: string }).findingKey)).toEqual([
+      `held-waiting:${visibleItem.id}`,
+    ]);
+
+    // Read-all leaves the hidden row untouched: it must arrive unread when it surfaces.
+    await provider.markAllRead(attentionScope, { now: new Date('2030-01-01T00:07:00.000Z') });
+    const receipts = await seed.workItems.listAttentionReceipts({
+      ...attentionScope,
+      identities: [
+        factorySupervisorFindingAttentionIdentity(`held-waiting:${visibleItem.id}`, 0),
+        factorySupervisorFindingAttentionIdentity(`decision-stuck:${hiddenItem.id}`, 0),
+      ],
+    });
+    expect(receipts.map(receipt => receipt.sourceId)).toEqual([`held-waiting:${visibleItem.id}`]);
+
+    // Past the backstop the same provider surfaces the hidden row without any row change.
+    const later = new SupervisorFindingAttentionProvider({
+      workItems: seed.workItems,
+      now: () => new Date(t1.getTime() + SUPERVISOR_ATTENTION_FORCE_SURFACE_MS),
+    });
+    expect(await later.counts(attentionScope)).toEqual({ open: 2, unread: 1 });
+    await expect(later.latest(attentionScope)).resolves.toMatchObject({ at: t1, unread: true });
   });
 });
 

--- a/mastracode/factory/src/routes/attention.test.ts
+++ b/mastracode/factory/src/routes/attention.test.ts
@@ -319,6 +319,59 @@ describe('supervisor finding attention items', () => {
     expect(await later.counts(attentionScope)).toEqual({ open: 2, unread: 1 });
     await expect(later.latest(attentionScope)).resolves.toMatchObject({ at: t1, unread: true });
   });
+
+  it.each([
+    ['decision-failed', false],
+    ['decision-stuck', false],
+    ['start-stalled', false],
+    ['seat-orphaned', false],
+    ['seat-missing', false],
+    ['proposal-waiting', true],
+    ['held-waiting', true],
+    ['label-drift', true],
+  ] as const)('%s open finding visible to people while open: %s', async (kind, visible) => {
+    const scope = { orgId: 'org1', factoryProjectId: PROJECT_ID };
+    const now = new Date('2030-01-01T00:00:00.000Z');
+    await seed.workItems.syncSupervisorFindings({
+      ...scope,
+      findings: [{ ...heldFinding(await seedWorkItem(kind)), id: `${kind}:x`, kind }],
+      now,
+    });
+    const provider = new SupervisorFindingAttentionProvider({ workItems: seed.workItems, now: () => now });
+    expect(await provider.counts({ ...scope, userId: 'u1' })).toEqual(
+      visible ? { open: 1, unread: 1 } : { open: 0, unread: 0 },
+    );
+  });
+
+  it('finds a visible finding behind more hidden rows than the receipt-scan budget', async () => {
+    // 4 pages × 50 rows is the receipt-scan budget; hidden rows must not spend it.
+    const scope = { orgId: 'org1', factoryProjectId: PROJECT_ID };
+    const t0 = new Date('2030-01-01T00:00:00.000Z');
+    const t1 = new Date('2030-01-01T00:05:00.000Z');
+    const visibleItem = await seedWorkItem('Oldest, visible');
+    const hidden = Array.from({ length: 201 }, (_, index) => ({
+      ...stuckFinding(visibleItem),
+      id: `decision-stuck:hidden-${index}`,
+      workItemId: null,
+    }));
+    await seed.workItems.syncSupervisorFindings({ ...scope, findings: [heldFinding(visibleItem)], now: t0 });
+    await seed.workItems.syncSupervisorFindings({ ...scope, findings: [heldFinding(visibleItem), ...hidden], now: t1 });
+    const provider = new SupervisorFindingAttentionProvider({
+      workItems: seed.workItems,
+      now: () => new Date('2030-01-01T00:06:00.000Z'),
+    });
+    const attentionScope = { ...scope, userId: 'u1' };
+
+    expect(await provider.counts(attentionScope)).toEqual({ open: 1, unread: 1 });
+    await expect(provider.latest(attentionScope)).resolves.toMatchObject({ at: t0, unread: true });
+    const page = await provider.page(attentionScope, { view: 'open', limit: 10 });
+    expect(page).toMatchObject({ hasMore: false });
+    expect(page.entries.map(entry => (entry.item as { findingKey: string }).findingKey)).toEqual([
+      `held-waiting:${visibleItem.id}`,
+    ]);
+    await provider.markAllRead(attentionScope, { now: new Date('2030-01-01T00:07:00.000Z') });
+    expect(await provider.counts(attentionScope)).toEqual({ open: 1, unread: 0 });
+  });
 });
 
 describe('mention attention items', () => {

--- a/mastracode/factory/src/storage/domains/work-items/base.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.test.ts
@@ -858,4 +858,82 @@ describe('supervisor finding notification stamps', () => {
     // itself (only reopen clears it).
     expect(await getRow(storage, 'decision-failed:item-1')).toBeUndefined();
   });
+
+  it('opens findings with status open and no escalation fields', async () => {
+    const storage = await makeStorage();
+    await openFinding(storage, 'decision-failed:item-1', new Date('2030-01-01T00:00:00.000Z'));
+    const row = await getRow(storage, 'decision-failed:item-1');
+    expect(row?.status).toBe('open');
+    expect(row?.escalatedAt).toBeNull();
+    expect(row?.escalationNote).toBeNull();
+  });
+
+  it('escalates an open finding and round-trips the note', async () => {
+    const storage = await makeStorage();
+    await openFinding(storage, 'decision-failed:item-1', new Date('2030-01-01T00:00:00.000Z'));
+    const escalatedAt = new Date('2030-01-01T00:01:00.000Z');
+    const updated = await storage.escalateSupervisorFinding({
+      ...scope,
+      findingKey: 'decision-failed:item-1',
+      note: 'Worker asked which API to target; needs a product call.',
+      escalatedAt,
+    });
+    expect(updated?.status).toBe('escalated');
+    expect(updated?.escalatedAt?.getTime()).toBe(escalatedAt.getTime());
+    const row = await getRow(storage, 'decision-failed:item-1');
+    expect(row?.status).toBe('escalated');
+    expect(row?.escalationNote).toBe('Worker asked which API to target; needs a product call.');
+    // Escalation is a visibility refinement, not a resolution: the row stays open.
+    expect(row?.resolvedAt).toBeNull();
+  });
+
+  it('refuses to escalate unknown or resolved findings', async () => {
+    const storage = await makeStorage();
+    const escalatedAt = new Date('2030-01-01T00:01:00.000Z');
+    expect(
+      await storage.escalateSupervisorFinding({ ...scope, findingKey: 'decision-failed:nope', note: 'x', escalatedAt }),
+    ).toBeNull();
+    await openFinding(storage, 'decision-failed:item-1', new Date('2030-01-01T00:00:00.000Z'));
+    await storage.syncSupervisorFindings({ ...scope, findings: [], now: new Date('2030-01-01T00:02:00.000Z') });
+    expect(
+      await storage.escalateSupervisorFinding({
+        ...scope,
+        findingKey: 'decision-failed:item-1',
+        note: 'x',
+        escalatedAt,
+      }),
+    ).toBeNull();
+  });
+
+  it('reopen resets status to open and clears the escalation fields', async () => {
+    const storage = await makeStorage();
+    await openFinding(storage, 'decision-failed:item-1', new Date('2030-01-01T00:00:00.000Z'));
+    await storage.escalateSupervisorFinding({
+      ...scope,
+      findingKey: 'decision-failed:item-1',
+      note: 'first incident',
+      escalatedAt: new Date('2030-01-01T00:01:00.000Z'),
+    });
+    await storage.syncSupervisorFindings({ ...scope, findings: [], now: new Date('2030-01-01T00:02:00.000Z') });
+    await openFinding(storage, 'decision-failed:item-1', new Date('2030-01-01T00:03:00.000Z'));
+
+    const reopened = await getRow(storage, 'decision-failed:item-1');
+    expect(reopened?.occurrence).toBe(1);
+    expect(reopened?.status).toBe('open');
+    expect(reopened?.escalatedAt).toBeNull();
+    expect(reopened?.escalationNote).toBeNull();
+  });
+
+  it('auto-resolves escalated findings like any other open row', async () => {
+    const storage = await makeStorage();
+    await openFinding(storage, 'decision-failed:item-1', new Date('2030-01-01T00:00:00.000Z'));
+    await storage.escalateSupervisorFinding({
+      ...scope,
+      findingKey: 'decision-failed:item-1',
+      note: 'escalated',
+      escalatedAt: new Date('2030-01-01T00:01:00.000Z'),
+    });
+    await storage.syncSupervisorFindings({ ...scope, findings: [], now: new Date('2030-01-01T00:02:00.000Z') });
+    expect(await getRow(storage, 'decision-failed:item-1')).toBeUndefined();
+  });
 });

--- a/mastracode/factory/src/storage/domains/work-items/base.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.test.ts
@@ -3,6 +3,11 @@
  * dedup scoping and the atomic update path.
  */
 
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { FactoryStorageDomain } from '@mastra/core/storage';
 import { LibSQLFactoryStorage } from '@mastra/libsql';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -935,5 +940,73 @@ describe('supervisor finding notification stamps', () => {
     });
     await storage.syncSupervisorFindings({ ...scope, findings: [], now: new Date('2030-01-01T00:02:00.000Z') });
     expect(await getRow(storage, 'decision-failed:item-1')).toBeUndefined();
+  });
+
+  it('migrates pre-existing finding rows to status open with null escalation fields', async () => {
+    // A row written by the pre-status schema, then the current domain
+    // initializing over the same database: the additive column pass must
+    // give the old row a persisted 'open' (not a mapping-time fallback).
+    const dir = await mkdtemp(join(tmpdir(), 'findings-migration-'));
+    const url = `file:${join(dir, 'db.sqlite')}`;
+    class LegacyFindings extends FactoryStorageDomain {
+      constructor() {
+        super('legacy-findings');
+      }
+      async init() {
+        await this.ensureCollections([
+          {
+            name: 'factory_supervisor_findings',
+            columns: {
+              id: { type: 'uuid-pk' },
+              org_id: { type: 'text' },
+              factory_project_id: { type: 'text' },
+              finding_key: { type: 'text' },
+              occurrence: { type: 'integer' },
+              finding: { type: 'json' },
+              opened_at: { type: 'timestamp' },
+              updated_at: { type: 'timestamp' },
+              resolved_at: { type: 'timestamp', nullable: true },
+              last_notified_at: { type: 'timestamp', nullable: true },
+            },
+          },
+        ]);
+      }
+      async seed() {
+        await this.ops.insertOne('factory_supervisor_findings', {
+          id: 'legacy-row',
+          org_id: scope.orgId,
+          factory_project_id: scope.factoryProjectId,
+          finding_key: 'decision-failed:legacy',
+          occurrence: 0,
+          finding: { id: 'decision-failed:legacy', kind: 'decision-failed', title: 'old', evidence: 'old' },
+          opened_at: new Date('2030-01-01T00:00:00.000Z'),
+          updated_at: new Date('2030-01-01T00:00:00.000Z'),
+          resolved_at: null,
+          last_notified_at: null,
+        });
+      }
+    }
+    const legacyBackend = new LibSQLFactoryStorage({ id: 'findings-legacy', url });
+    const legacy = legacyBackend.registerDomain(new LegacyFindings());
+    await legacyBackend.init();
+    await legacy.seed();
+    await legacyBackend.close();
+
+    const backend = new LibSQLFactoryStorage({ id: 'findings-current', url });
+    const storage = backend.registerDomain(new WorkItemsStorage());
+    await backend.init();
+    const row = await getRow(storage, 'decision-failed:legacy');
+    expect(row).toMatchObject({ status: 'open', escalatedAt: null, escalationNote: null });
+    // Persisted, not defaulted at read time: the row escalates like a new one.
+    await expect(
+      storage.escalateSupervisorFinding({
+        ...scope,
+        findingKey: 'decision-failed:legacy',
+        note: 'after upgrade',
+        escalatedAt: new Date('2030-01-01T00:01:00.000Z'),
+      }),
+    ).resolves.toMatchObject({ status: 'escalated', escalationNote: 'after upgrade' });
+    await backend.close();
+    await rm(dir, { recursive: true, force: true });
   });
 });

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -247,7 +247,11 @@ export interface FactorySupervisorFindingRecord {
   updatedAt: Date;
   resolvedAt: Date | null;
   lastNotifiedAt: Date | null;
+  status: FactorySupervisorFindingStatus;
+  escalatedAt: Date | null;
+  escalationNote: string | null;
 }
+export type FactorySupervisorFindingStatus = 'open' | 'escalated';
 export type FactoryAttentionReceiptAction = 'read' | 'archive' | 'restore';
 
 export interface FactoryAttentionIdentity {
@@ -898,6 +902,13 @@ const FACTORY_GOVERNANCE_SCHEMAS: CollectionSchema[] = [
       updated_at: { type: 'timestamp' },
       resolved_at: { type: 'timestamp', nullable: true },
       last_notified_at: { type: 'timestamp', nullable: true },
+      // Visibility refinement while the row is open: 'open' findings in the
+      // supervisor-actionable kinds stay off the human Attention rail until
+      // the supervisor escalates (or the force-surface backstop fires).
+      // Meaningless once resolved_at is set.
+      status: { type: 'text', default: 'open' },
+      escalated_at: { type: 'timestamp', nullable: true },
+      escalation_note: { type: 'text', nullable: true },
     },
     uniqueIndexes: [
       {
@@ -1091,6 +1102,9 @@ function toSupervisorFinding(row: GovernanceDbRow): FactorySupervisorFindingReco
     updatedAt: row.updated_at as Date,
     resolvedAt: (row.resolved_at as Date | null) ?? null,
     lastNotifiedAt: (row.last_notified_at as Date | null) ?? null,
+    status: row.status === 'escalated' ? 'escalated' : 'open',
+    escalatedAt: (row.escalated_at as Date | null) ?? null,
+    escalationNote: (row.escalation_note as string | null) ?? null,
   };
 }
 
@@ -1243,6 +1257,9 @@ export class WorkItemsStorage extends FactoryStorageDomain {
             updated_at: input.now,
             resolved_at: null,
             last_notified_at: null,
+            status: 'open',
+            escalated_at: null,
+            escalation_note: null,
           });
           changed = true;
           continue;
@@ -1259,6 +1276,11 @@ export class WorkItemsStorage extends FactoryStorageDomain {
           // A reopened incident re-rings the doorbell: clear the notification
           // stamp so the next sweep emits for it again.
           last_notified_at: current.resolved_at !== null ? null : current.last_notified_at,
+          // A reopened incident is a new incident: stale escalation state
+          // must never keep it visible (or hidden) on the old terms.
+          status: current.resolved_at !== null ? 'open' : current.status,
+          escalated_at: current.resolved_at !== null ? null : current.escalated_at,
+          escalation_note: current.resolved_at !== null ? null : current.escalation_note,
         }));
         changed = true;
       }
@@ -1342,6 +1364,38 @@ export class WorkItemsStorage extends FactoryStorageDomain {
       },
       () => ({ last_notified_at: input.notifiedAt }),
     );
+  }
+
+  /**
+   * Mark an open finding escalated so it surfaces to humans. Returns the
+   * updated row, or null when no open row has that key (unknown or already
+   * resolved). Re-escalating an escalated row refreshes the note and time.
+   */
+  async escalateSupervisorFinding(input: {
+    orgId: string;
+    factoryProjectId: string;
+    findingKey: string;
+    note: string;
+    escalatedAt: Date;
+  }): Promise<FactorySupervisorFindingRecord | null> {
+    const updated = await this.#db.updateAtomic<GovernanceDbRow>(
+      'factory_supervisor_findings',
+      {
+        org_id: input.orgId,
+        factory_project_id: input.factoryProjectId,
+        finding_key: input.findingKey,
+        resolved_at: null,
+      },
+      () => ({
+        status: 'escalated',
+        escalated_at: input.escalatedAt,
+        escalation_note: input.note,
+        updated_at: input.escalatedAt,
+      }),
+    );
+    if (!updated) return null;
+    this.#attentionChanged?.({ orgId: input.orgId, factoryProjectId: input.factoryProjectId });
+    return toSupervisorFinding(updated);
   }
 
   async countOpenSupervisorFindings(input: { orgId: string; factoryProjectId: string }): Promise<number> {

--- a/mastracode/factory/src/supervisor/action-tools.test.ts
+++ b/mastracode/factory/src/supervisor/action-tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
 import { createFactorySupervisorActionTools } from './action-tools.js';
@@ -76,24 +76,31 @@ describe('factory_escalate_finding', () => {
   it('reports an escalation that landed even when the audit write fails', async () => {
     const seed = await createFactoryStorageForTests();
     await seed.workItems.syncSupervisorFindings({ ...SCOPE, findings: [finding('decision-failed:d1')], now: NOW });
+    const warn = vi.fn();
     const tools = createFactorySupervisorActionTools({
       scope: SCOPE,
       actor: { type: 'agent', id: 'agent:thread-1' },
       workItems: seed.workItems,
       audit: {
         record: async () => {
-          throw new Error('audit store down');
+          throw new Error('audit store down at postgres://secret');
         },
       },
+      logger: { warn },
       now: () => NOW,
     });
 
     const result = await execute<any>(tools.factory_escalate_finding, { findingKey: 'decision-failed:d1', note: 'n' });
 
     // The row is escalated (the human-visible effect) and the result says the
-    // audit did not land, so the supervisor neither retries nor believes it failed.
-    expect(result).toMatchObject({ status: 'escalated', audited: false });
-    expect(result.auditError).toContain('audit store down');
+    // audit did not land, so the supervisor neither retries nor believes it
+    // failed. The raw storage error goes to the log, not the model.
+    expect(result).toMatchObject({ status: 'escalated', audited: false, auditError: expect.any(String) });
+    expect(result.auditError).not.toContain('postgres');
+    expect(warn).toHaveBeenCalledWith(
+      'Factory supervisor escalation audit failed',
+      expect.objectContaining({ error: expect.stringContaining('postgres://secret') }),
+    );
     expect(await openRow(seed.workItems, 'decision-failed:d1')).toMatchObject({ status: 'escalated' });
   });
 

--- a/mastracode/factory/src/supervisor/action-tools.test.ts
+++ b/mastracode/factory/src/supervisor/action-tools.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFactoryStorageForTests } from '../storage/test-utils.js';
+import { createFactorySupervisorActionTools } from './action-tools.js';
+
+const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
+const SCOPE = { orgId: 'org-1', factoryProjectId: PROJECT_ID };
+const NOW = new Date('2026-09-04T12:00:00.000Z');
+
+function execute<T>(tool: unknown, input: unknown): Promise<T> {
+  return (tool as { execute: (input: unknown, ctx: unknown) => Promise<T> }).execute(input, {});
+}
+
+const finding = (key: string) => ({
+  kind: 'decision-failed' as const,
+  id: key,
+  workItemId: null,
+  workItemNumber: null,
+  title: 'Issue 1',
+  evidence: '[run_awaiting_input] failed after 1 attempt(s)',
+  ageMs: 1_000,
+  suggestedRepair: null,
+});
+
+async function setup(actor: { type: 'human' | 'agent'; id: string } = { type: 'agent', id: 'agent:thread-1' }) {
+  const seed = await createFactoryStorageForTests();
+  await seed.workItems.syncSupervisorFindings({ ...SCOPE, findings: [finding('decision-failed:d1')], now: NOW });
+  const tools = createFactorySupervisorActionTools({
+    scope: SCOPE,
+    actor,
+    workItems: seed.workItems,
+    audit: seed.audit,
+    now: () => NOW,
+  });
+  return { ...seed, tools };
+}
+
+async function openRow(workItems: Awaited<ReturnType<typeof setup>>['workItems'], key: string) {
+  return (await workItems.listSupervisorFindingPage({ ...SCOPE, limit: 10 })).rows.find(row => row.findingKey === key);
+}
+
+describe('factory_escalate_finding', () => {
+  it('is approval-free: escalating is how the supervisor reaches a person', async () => {
+    const { tools } = await setup();
+    expect((tools.factory_escalate_finding as { requireApproval?: boolean }).requireApproval).toBeFalsy();
+  });
+
+  it('escalates an open finding with the note and audits the actor the turn has', async () => {
+    const { tools, workItems, audit } = await setup();
+
+    const result = await execute<any>(tools.factory_escalate_finding, {
+      findingKey: 'decision-failed:d1',
+      note: 'Worker is asking which API version to target.',
+    });
+
+    expect(result).toEqual({
+      findingKey: 'decision-failed:d1',
+      status: 'escalated',
+      escalatedAt: NOW.toISOString(),
+      note: 'Worker is asking which API version to target.',
+    });
+    const row = await openRow(workItems, 'decision-failed:d1');
+    expect(row).toMatchObject({ status: 'escalated', escalationNote: 'Worker is asking which API version to target.' });
+    expect(row?.escalatedAt?.getTime()).toBe(NOW.getTime());
+    const event = (await audit.list({ orgId: 'org-1', factoryProjectId: PROJECT_ID, limit: 5 })).events[0];
+    expect(event).toMatchObject({
+      action: 'factory.supervisor.finding_escalated',
+      actorType: 'agent',
+      actorId: 'agent:thread-1',
+      targets: [{ type: 'supervisor_finding', id: 'decision-failed:d1' }],
+      metadata: { cause: 'supervisor', note: 'Worker is asking which API version to target.' },
+    });
+  });
+
+  it('attributes to the human on an authenticated turn', async () => {
+    const { tools, audit } = await setup({ type: 'human', id: 'user-7' });
+    await execute(tools.factory_escalate_finding, { findingKey: 'decision-failed:d1', note: 'n' });
+    const event = (await audit.list({ orgId: 'org-1', factoryProjectId: PROJECT_ID, limit: 5 })).events[0];
+    expect(event).toMatchObject({ actorType: 'human', actorId: 'user-7' });
+  });
+
+  it('rejects unknown and resolved findings without writing an audit row', async () => {
+    const { tools, workItems, audit } = await setup();
+    await expect(
+      execute(tools.factory_escalate_finding, { findingKey: 'decision-failed:nope', note: 'n' }),
+    ).rejects.toThrow(/not open/);
+    await workItems.syncSupervisorFindings({ ...SCOPE, findings: [], now: NOW });
+    await expect(
+      execute(tools.factory_escalate_finding, { findingKey: 'decision-failed:d1', note: 'n' }),
+    ).rejects.toThrow(/not open/);
+    expect((await audit.list({ orgId: 'org-1', factoryProjectId: PROJECT_ID, limit: 5 })).events).toEqual([]);
+  });
+
+  it('is scoped to its own factory project', async () => {
+    const seed = await createFactoryStorageForTests();
+    const otherProject = '99999999-2222-4333-8444-555555555555';
+    await seed.workItems.syncSupervisorFindings({
+      orgId: 'org-1',
+      factoryProjectId: otherProject,
+      findings: [finding('decision-failed:elsewhere')],
+      now: NOW,
+    });
+    const tools = createFactorySupervisorActionTools({
+      scope: SCOPE,
+      actor: { type: 'agent', id: 'agent:thread-1' },
+      workItems: seed.workItems,
+      audit: seed.audit,
+      now: () => NOW,
+    });
+    await expect(
+      execute(tools.factory_escalate_finding, { findingKey: 'decision-failed:elsewhere', note: 'n' }),
+    ).rejects.toThrow(/not open/);
+    const untouched = (
+      await seed.workItems.listSupervisorFindingPage({ orgId: 'org-1', factoryProjectId: otherProject, limit: 5 })
+    ).rows[0];
+    expect(untouched?.status).toBe('open');
+  });
+
+  it('rejects an empty note', async () => {
+    const { tools } = await setup();
+    await expect(
+      execute<{ error?: boolean }>(tools.factory_escalate_finding, { findingKey: 'decision-failed:d1', note: '  ' }),
+    ).resolves.toMatchObject({ error: true });
+  });
+});

--- a/mastracode/factory/src/supervisor/action-tools.test.ts
+++ b/mastracode/factory/src/supervisor/action-tools.test.ts
@@ -58,6 +58,7 @@ describe('factory_escalate_finding', () => {
       status: 'escalated',
       escalatedAt: NOW.toISOString(),
       note: 'Worker is asking which API version to target.',
+      audited: true,
     });
     const row = await openRow(workItems, 'decision-failed:d1');
     expect(row).toMatchObject({ status: 'escalated', escalationNote: 'Worker is asking which API version to target.' });
@@ -70,6 +71,30 @@ describe('factory_escalate_finding', () => {
       targets: [{ type: 'supervisor_finding', id: 'decision-failed:d1' }],
       metadata: { cause: 'supervisor', note: 'Worker is asking which API version to target.' },
     });
+  });
+
+  it('reports an escalation that landed even when the audit write fails', async () => {
+    const seed = await createFactoryStorageForTests();
+    await seed.workItems.syncSupervisorFindings({ ...SCOPE, findings: [finding('decision-failed:d1')], now: NOW });
+    const tools = createFactorySupervisorActionTools({
+      scope: SCOPE,
+      actor: { type: 'agent', id: 'agent:thread-1' },
+      workItems: seed.workItems,
+      audit: {
+        record: async () => {
+          throw new Error('audit store down');
+        },
+      },
+      now: () => NOW,
+    });
+
+    const result = await execute<any>(tools.factory_escalate_finding, { findingKey: 'decision-failed:d1', note: 'n' });
+
+    // The row is escalated (the human-visible effect) and the result says the
+    // audit did not land, so the supervisor neither retries nor believes it failed.
+    expect(result).toMatchObject({ status: 'escalated', audited: false });
+    expect(result.auditError).toContain('audit store down');
+    expect(await openRow(seed.workItems, 'decision-failed:d1')).toMatchObject({ status: 'escalated' });
   });
 
   it('attributes to the human on an authenticated turn', async () => {

--- a/mastracode/factory/src/supervisor/action-tools.ts
+++ b/mastracode/factory/src/supervisor/action-tools.ts
@@ -64,12 +64,22 @@ export function createFactorySupervisorActionTools(deps: SupervisorActionDepende
           escalatedAt,
         });
         if (!finding) throw new Error('The finding is not open, no longer exists, or belongs to another factory.');
-        await audit('factory.supervisor.finding_escalated', { type: 'supervisor_finding', id: findingKey }, { note });
+        // The escalation is the user-visible effect and has already landed.
+        // An audit failure must not read as "escalation failed" (a retry
+        // would only rewrite the note), so both outcomes are reported.
+        let auditError: string | null = null;
+        try {
+          await audit('factory.supervisor.finding_escalated', { type: 'supervisor_finding', id: findingKey }, { note });
+        } catch (error) {
+          auditError = error instanceof Error ? error.message : String(error);
+        }
         return {
           findingKey,
           status: finding.status,
           escalatedAt: escalatedAt.toISOString(),
           note: finding.escalationNote,
+          audited: auditError === null,
+          ...(auditError ? { auditError: `Escalated, but recording the audit entry failed: ${auditError}` } : {}),
         };
       },
     }),

--- a/mastracode/factory/src/supervisor/action-tools.ts
+++ b/mastracode/factory/src/supervisor/action-tools.ts
@@ -49,7 +49,7 @@ export function createFactorySupervisorActionTools(deps: SupervisorActionDepende
     factory_escalate_finding: createTool({
       id: 'factory_escalate_finding',
       description:
-        'Surface one open health finding to the humans on the Attention rail with a short note saying what you found and what you need from them. Use this when a finding needs a decision or information only a person has; it is the only way an open supervisor-actionable finding becomes visible to people before the backstop.',
+        'Surface one open health finding to the humans on the Attention rail with a short note saying what you found and what you need from them. Use this when a finding needs a decision or information only a person has; it is the only way an open supervisor-actionable finding becomes visible to people before the backstop. Escalating the same finding again replaces the earlier note.',
       inputSchema: z.object({
         findingKey: z.string().min(1),
         note: z.string().trim().min(1).max(600),

--- a/mastracode/factory/src/supervisor/action-tools.ts
+++ b/mastracode/factory/src/supervisor/action-tools.ts
@@ -21,6 +21,7 @@ interface SupervisorActionDependencies {
   actor: SupervisorActor;
   workItems: Pick<WorkItemsStorage, 'escalateSupervisorFinding'>;
   audit: Pick<AuditStorage, 'record'>;
+  logger?: { warn: (message: string, meta?: Record<string, unknown>) => void };
   now?: () => Date;
 }
 
@@ -66,20 +67,25 @@ export function createFactorySupervisorActionTools(deps: SupervisorActionDepende
         if (!finding) throw new Error('The finding is not open, no longer exists, or belongs to another factory.');
         // The escalation is the user-visible effect and has already landed.
         // An audit failure must not read as "escalation failed" (a retry
-        // would only rewrite the note), so both outcomes are reported.
-        let auditError: string | null = null;
+        // would only rewrite the note), so both outcomes are reported. The
+        // raw storage error stays out of the model-visible result.
+        let audited = true;
         try {
           await audit('factory.supervisor.finding_escalated', { type: 'supervisor_finding', id: findingKey }, { note });
         } catch (error) {
-          auditError = error instanceof Error ? error.message : String(error);
+          audited = false;
+          deps.logger?.warn('Factory supervisor escalation audit failed', {
+            findingKey,
+            error: error instanceof Error ? error.message : String(error),
+          });
         }
         return {
           findingKey,
           status: finding.status,
           escalatedAt: escalatedAt.toISOString(),
           note: finding.escalationNote,
-          audited: auditError === null,
-          ...(auditError ? { auditError: `Escalated, but recording the audit entry failed: ${auditError}` } : {}),
+          audited,
+          ...(audited ? {} : { auditError: 'Escalated, but recording the audit entry failed. Do not retry.' }),
         };
       },
     }),

--- a/mastracode/factory/src/supervisor/action-tools.ts
+++ b/mastracode/factory/src/supervisor/action-tools.ts
@@ -1,0 +1,77 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import type { IntegrationTools } from '../integrations/base.js';
+import type { AuditActorType, AuditStorage } from '../storage/domains/audit/base.js';
+import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import type { SupervisorScope } from './read-tools.js';
+
+/**
+ * Who a supervisor turn is acting as. Authenticated turns carry the human's
+ * user id; signal-woken turns carry the agent identity (`agent:<threadId>`),
+ * following the audit trail's existing convention.
+ */
+export interface SupervisorActor {
+  type: AuditActorType;
+  id: string;
+}
+
+interface SupervisorActionDependencies {
+  scope: SupervisorScope;
+  actor: SupervisorActor;
+  workItems: Pick<WorkItemsStorage, 'escalateSupervisorFinding'>;
+  audit: Pick<AuditStorage, 'record'>;
+  now?: () => Date;
+}
+
+/**
+ * Supervisor tools that are deliberately approval-free: they are how the
+ * supervisor reaches a human (escalate) or acts on a human's behalf without
+ * putting that human back in the loop. Guardrails are the audit trail and the
+ * supervisor's instructions, not an approval prompt. These register on both
+ * authenticated and signal-woken turns.
+ */
+export function createFactorySupervisorActionTools(deps: SupervisorActionDependencies): IntegrationTools {
+  const now = deps.now ?? (() => new Date());
+  const audit = async (action: string, target: { type: string; id: string }, metadata: Record<string, unknown> = {}) =>
+    deps.audit.record({
+      orgId: deps.scope.orgId,
+      actorId: deps.actor.id,
+      actorType: deps.actor.type,
+      action,
+      targets: [target],
+      factoryProjectId: deps.scope.factoryProjectId,
+      metadata: { ...metadata, cause: 'supervisor' },
+      occurredAt: now(),
+    });
+
+  return {
+    factory_escalate_finding: createTool({
+      id: 'factory_escalate_finding',
+      description:
+        'Surface one open health finding to the humans on the Attention rail with a short note saying what you found and what you need from them. Use this when a finding needs a decision or information only a person has; it is the only way an open supervisor-actionable finding becomes visible to people before the backstop.',
+      inputSchema: z.object({
+        findingKey: z.string().min(1),
+        note: z.string().trim().min(1).max(600),
+      }),
+      execute: async ({ findingKey, note }) => {
+        const escalatedAt = now();
+        const finding = await deps.workItems.escalateSupervisorFinding({
+          orgId: deps.scope.orgId,
+          factoryProjectId: deps.scope.factoryProjectId,
+          findingKey,
+          note,
+          escalatedAt,
+        });
+        if (!finding) throw new Error('The finding is not open, no longer exists, or belongs to another factory.');
+        await audit('factory.supervisor.finding_escalated', { type: 'supervisor_finding', id: findingKey }, { note });
+        return {
+          findingKey,
+          status: finding.status,
+          escalatedAt: escalatedAt.toISOString(),
+          note: finding.escalationNote,
+        };
+      },
+    }),
+  };
+}

--- a/mastracode/factory/src/supervisor/health-worker.test.ts
+++ b/mastracode/factory/src/supervisor/health-worker.test.ts
@@ -5,7 +5,7 @@
  */
 
 import type { WorkerDeps } from '@mastra/core/worker';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { WorkItemRow } from '../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
@@ -292,5 +292,70 @@ describe('FactorySupervisorHealthWorker force-surface doorbell', () => {
     });
     await sweep(worker);
     expect(attentionChanged).not.toHaveBeenCalled();
+  });
+
+  describe('with the clock under control', () => {
+    const T0 = new Date('2030-01-01T00:00:00.000Z');
+
+    /** Sweep under fake timers: the immediate tick fires on the advance; stop waits for it. */
+    async function fakeSweep(worker: FactorySupervisorHealthWorker) {
+      await worker.start();
+      await vi.advanceTimersByTimeAsync(0);
+      await worker.stop();
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
+      vi.setSystemTime(T0);
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('rings exactly once when a fresh finding crosses the backstop between sweeps', async () => {
+      await seedFailure(await seedWorkItem(), T0);
+      const attentionChanged = vi.fn();
+      const worker = new FactorySupervisorHealthWorker({
+        projects: seed.projects,
+        workItems: seed.workItems,
+        attentionChanged,
+      });
+      await worker.init(createDeps());
+
+      await fakeSweep(worker); // opens the finding at T0, inside the window
+      expect(attentionChanged).not.toHaveBeenCalled();
+      vi.setSystemTime(new Date(T0.getTime() + SUPERVISOR_ATTENTION_FORCE_SURFACE_MS + 1_000));
+      await fakeSweep(worker);
+      expect(attentionChanged).toHaveBeenCalledTimes(1);
+      await fakeSweep(worker);
+      expect(attentionChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it('still rings on the next good sweep when the crossing happened during a failed one', async () => {
+      await seedFailure(await seedWorkItem(), T0);
+      const attentionChanged = vi.fn();
+      const worker = new FactorySupervisorHealthWorker({
+        projects: seed.projects,
+        workItems: seed.workItems,
+        attentionChanged,
+      });
+      const deps = createDeps();
+      await worker.init(deps);
+      await fakeSweep(worker);
+      expect(attentionChanged).not.toHaveBeenCalled();
+
+      // The crossing happens inside a tick that fails after reconciliation.
+      vi.setSystemTime(new Date(T0.getTime() + SUPERVISOR_ATTENTION_FORCE_SURFACE_MS + 1_000));
+      const sync = vi.spyOn(seed.workItems, 'syncSupervisorFindings').mockRejectedValueOnce(new Error('db hiccup'));
+      await fakeSweep(worker);
+      expect(deps.logger.error).toHaveBeenCalled();
+      expect(attentionChanged).not.toHaveBeenCalled();
+      sync.mockRestore();
+
+      // The failed tick did not advance the checkpoint, so the next one rings.
+      vi.setSystemTime(new Date(T0.getTime() + SUPERVISOR_ATTENTION_FORCE_SURFACE_MS + 2_000));
+      await fakeSweep(worker);
+      expect(attentionChanged).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/mastracode/factory/src/supervisor/health-worker.test.ts
+++ b/mastracode/factory/src/supervisor/health-worker.test.ts
@@ -357,5 +357,28 @@ describe('FactorySupervisorHealthWorker force-surface doorbell', () => {
       await fakeSweep(worker);
       expect(attentionChanged).toHaveBeenCalledTimes(1);
     });
+
+    it('rings again on the next sweep when the doorbell publish itself rejected', async () => {
+      await seedFailure(await seedWorkItem(), T0);
+      const attentionChanged = vi.fn().mockRejectedValueOnce(new Error('broker down')).mockResolvedValue(undefined);
+      const worker = new FactorySupervisorHealthWorker({
+        projects: seed.projects,
+        workItems: seed.workItems,
+        attentionChanged,
+      });
+      const deps = createDeps();
+      await worker.init(deps);
+      await fakeSweep(worker);
+      expect(attentionChanged).not.toHaveBeenCalled();
+
+      vi.setSystemTime(new Date(T0.getTime() + SUPERVISOR_ATTENTION_FORCE_SURFACE_MS + 1_000));
+      await fakeSweep(worker); // publish rejects: sweep fails, checkpoint stays
+      expect(attentionChanged).toHaveBeenCalledTimes(1);
+      expect(deps.logger.error).toHaveBeenCalled();
+      await fakeSweep(worker); // retried
+      expect(attentionChanged).toHaveBeenCalledTimes(2);
+      await fakeSweep(worker); // announced: silent from here
+      expect(attentionChanged).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/mastracode/factory/src/supervisor/health-worker.test.ts
+++ b/mastracode/factory/src/supervisor/health-worker.test.ts
@@ -11,6 +11,7 @@ import type { WorkItemRow } from '../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
 import type { FactoryStorageTestSeed } from '../storage/test-utils.js';
 import { EMIT_PAGE_SIZE, FactorySupervisorHealthWorker } from './health-worker.js';
+import { runFactoryHealthCheck, SUPERVISOR_ATTENTION_FORCE_SURFACE_MS } from './health.js';
 import type { NotifySupervisorInput } from './notify.js';
 
 let seed: FactoryStorageTestSeed;
@@ -232,5 +233,64 @@ describe('FactorySupervisorHealthWorker emit call site', () => {
     const { rows } = await openFindings();
     expect(rows).toHaveLength(1);
     expect(rows[0]?.lastNotifiedAt).toBeNull();
+  });
+});
+
+describe('FactorySupervisorHealthWorker force-surface doorbell', () => {
+  const scope = () => ({ orgId: 'org1', factoryProjectId: PROJECT_ID });
+
+  /** Open the sweep's own finding for a real failure, backdated so it is already past the backstop. */
+  async function seedStaleFinding() {
+    await seedFailure(await seedWorkItem(), new Date());
+    const report = await runFactoryHealthCheck(seed.workItems, scope(), { now: new Date() });
+    expect(report.findings.map(finding => finding.kind)).toEqual(['decision-failed']);
+    const openedAt = new Date(Date.now() - SUPERVISOR_ATTENTION_FORCE_SURFACE_MS - 60_000);
+    await seed.workItems.syncSupervisorFindings({ ...scope(), findings: report.findings, now: openedAt });
+  }
+
+  it('rings the attention doorbell once when a hidden finding ages past the backstop', async () => {
+    await seedStaleFinding();
+    const attentionChanged = vi.fn();
+    const worker = new FactorySupervisorHealthWorker({
+      projects: seed.projects,
+      workItems: seed.workItems,
+      attentionChanged,
+    });
+    await worker.init(createDeps());
+
+    // First sweep after boot: the row is visible now and was not "since forever".
+    await sweep(worker);
+    expect(attentionChanged).toHaveBeenCalledTimes(1);
+    expect(attentionChanged).toHaveBeenCalledWith(scope());
+    // The row did not change and was already visible at the previous sweep: silence.
+    await sweep(worker);
+    expect(attentionChanged).toHaveBeenCalledTimes(1);
+    const { rows } = await openFindings();
+    expect(rows[0]).toMatchObject({ status: 'open', escalationNote: null });
+  });
+
+  it('stays silent for findings still inside the backstop window or already escalated', async () => {
+    await seedFailure(await seedWorkItem(), new Date());
+    const attentionChanged = vi.fn();
+    const worker = new FactorySupervisorHealthWorker({
+      projects: seed.projects,
+      workItems: seed.workItems,
+      attentionChanged,
+    });
+    await worker.init(createDeps());
+    await sweep(worker);
+    expect(attentionChanged).not.toHaveBeenCalled();
+
+    // Escalation makes the row visible by a write (storage announces that
+    // itself); a later sweep must not announce it again as a backstop flip.
+    const { rows } = await openFindings();
+    await seed.workItems.escalateSupervisorFinding({
+      ...scope(),
+      findingKey: rows[0]!.findingKey,
+      note: 'needs a person',
+      escalatedAt: new Date(),
+    });
+    await sweep(worker);
+    expect(attentionChanged).not.toHaveBeenCalled();
   });
 });

--- a/mastracode/factory/src/supervisor/health-worker.ts
+++ b/mastracode/factory/src/supervisor/health-worker.ts
@@ -4,6 +4,7 @@ import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js
 import type { FactorySupervisorFindingRecord, WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { runFactoryHealthCheck } from './health.js';
 import type { NotifySupervisorInput } from './notify.js';
+import { isSupervisorFindingVisibleToHumans } from './visibility.js';
 
 export const DEFAULT_SUPERVISOR_HEALTH_INTERVAL_MS = 5 * 60_000;
 /** Un-notified findings emitted per storage read during a sweep's drain. */
@@ -16,7 +17,9 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
   readonly #workItems: WorkItemsStorage;
   readonly #intervalMs: number;
   readonly #notify: ((input: NotifySupervisorInput) => Promise<void>) | undefined;
+  readonly #attentionChanged: ((scope: { orgId: string; factoryProjectId: string }) => void) | undefined;
   #running = false;
+  #lastTickAt: Date | undefined;
   #timer: ReturnType<typeof setTimeout> | undefined;
   #inFlight: Promise<void> | undefined;
 
@@ -26,12 +29,20 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
     intervalMs?: number;
     /** Emits one supervisor notification per un-notified open finding. Optional so tests can construct the worker without wiring the controller. */
     notify?: (input: NotifySupervisorInput) => Promise<void>;
+    /**
+     * Announces that a project's Attention projection changed without a row
+     * write: the force-surface backstop flips a hidden finding visible purely
+     * by wall-clock age, and connected Attention streams stop polling, so the
+     * sweep rings the same doorbell storage writes do.
+     */
+    attentionChanged?: (scope: { orgId: string; factoryProjectId: string }) => void;
   }) {
     super();
     this.#projects = input.projects;
     this.#workItems = input.workItems;
     this.#intervalMs = input.intervalMs ?? DEFAULT_SUPERVISOR_HEALTH_INTERVAL_MS;
     this.#notify = input.notify;
+    this.#attentionChanged = input.attentionChanged;
   }
 
   async start(): Promise<void> {
@@ -68,6 +79,11 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
 
   async #tick(): Promise<void> {
     const now = new Date();
+    // Rows that crossed the backstop between the previous sweep and this one
+    // are the ones no write announced. Before the first sweep everything is
+    // "since forever": already-stale rows get one refresh after boot.
+    const since = this.#lastTickAt ?? new Date(0);
+    this.#lastTickAt = now;
     const projects = await this.#projects.listAll();
     const concurrency = 4;
     let nextIndex = 0;
@@ -88,6 +104,7 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
             now,
           });
           await this.#emitUnnotified({ orgId: project.orgId, factoryProjectId: project.id });
+          await this.#announceForceSurfaced({ orgId: project.orgId, factoryProjectId: project.id }, since, now);
         }
       }),
     );
@@ -140,6 +157,39 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
       const last = rows[rows.length - 1];
       if (rows.length < EMIT_PAGE_SIZE || !last) return;
       after = { openedAt: last.openedAt, id: last.id };
+    }
+  }
+
+  /**
+   * Ring the Attention doorbell once if any open finding became visible to
+   * humans purely by aging past the backstop since the previous sweep. Uses
+   * the one visibility predicate at both instants, so escalated and
+   * human-facing rows (visible at both) never count and the hidden-kind set
+   * is never restated here.
+   */
+  async #announceForceSurfaced(
+    scope: { orgId: string; factoryProjectId: string },
+    since: Date,
+    now: Date,
+  ): Promise<void> {
+    if (!this.#attentionChanged) return;
+    let before: { occurredAt: Date; id: string } | undefined;
+    for (;;) {
+      const { rows, hasMore } = await this.#workItems.listSupervisorFindingPage({
+        ...scope,
+        limit: EMIT_PAGE_SIZE,
+        ...(before ? { before } : {}),
+      });
+      const crossed = rows.some(
+        row => isSupervisorFindingVisibleToHumans(row, now) && !isSupervisorFindingVisibleToHumans(row, since),
+      );
+      if (crossed) {
+        this.#attentionChanged(scope);
+        return;
+      }
+      const last = rows.at(-1);
+      if (!hasMore || !last) return;
+      before = { occurredAt: last.updatedAt, id: last.id };
     }
   }
 }

--- a/mastracode/factory/src/supervisor/health-worker.ts
+++ b/mastracode/factory/src/supervisor/health-worker.ts
@@ -19,7 +19,8 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
   readonly #notify: ((input: NotifySupervisorInput) => Promise<void>) | undefined;
   readonly #attentionChanged: ((scope: { orgId: string; factoryProjectId: string }) => void) | undefined;
   #running = false;
-  #lastTickAt: Date | undefined;
+  /** Per project, the instant of its last fully successful sweep: the backstop doorbell compares against it. */
+  readonly #sweptAt = new Map<string, Date>();
   #timer: ReturnType<typeof setTimeout> | undefined;
   #inFlight: Promise<void> | undefined;
 
@@ -79,11 +80,6 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
 
   async #tick(): Promise<void> {
     const now = new Date();
-    // Rows that crossed the backstop between the previous sweep and this one
-    // are the ones no write announced. Before the first sweep everything is
-    // "since forever": already-stale rows get one refresh after boot.
-    const since = this.#lastTickAt ?? new Date(0);
-    this.#lastTickAt = now;
     const projects = await this.#projects.listAll();
     const concurrency = 4;
     let nextIndex = 0;
@@ -104,7 +100,15 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
             now,
           });
           await this.#emitUnnotified({ orgId: project.orgId, factoryProjectId: project.id });
+          // Rows that crossed the backstop since this project's last SUCCESSFUL
+          // sweep are the ones no write announced. The checkpoint only advances
+          // once the whole sweep for the project landed, so a crossing during a
+          // failed or abandoned tick still rings on the next good one. Before
+          // the first sweep it is "since forever": already-stale rows get one
+          // refresh after boot.
+          const since = this.#sweptAt.get(project.id) ?? new Date(0);
           await this.#announceForceSurfaced({ orgId: project.orgId, factoryProjectId: project.id }, since, now);
+          this.#sweptAt.set(project.id, now);
         }
       }),
     );
@@ -162,7 +166,7 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
 
   /**
    * Ring the Attention doorbell once if any open finding became visible to
-   * humans purely by aging past the backstop since the previous sweep. Uses
+   * humans purely by aging past the backstop since `since`. Uses
    * the one visibility predicate at both instants, so escalated and
    * human-facing rows (visible at both) never count and the hidden-kind set
    * is never restated here.

--- a/mastracode/factory/src/supervisor/health-worker.ts
+++ b/mastracode/factory/src/supervisor/health-worker.ts
@@ -17,9 +17,11 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
   readonly #workItems: WorkItemsStorage;
   readonly #intervalMs: number;
   readonly #notify: ((input: NotifySupervisorInput) => Promise<void>) | undefined;
-  readonly #attentionChanged: ((scope: { orgId: string; factoryProjectId: string }) => void) | undefined;
+  readonly #attentionChanged:
+    | ((scope: { orgId: string; factoryProjectId: string }) => Promise<void> | void)
+    | undefined;
   #running = false;
-  /** Per project, the instant of its last fully successful sweep: the backstop doorbell compares against it. */
+  /** Per (org, project), the instant of its last fully successful sweep: the backstop doorbell compares against it. */
   readonly #sweptAt = new Map<string, Date>();
   #timer: ReturnType<typeof setTimeout> | undefined;
   #inFlight: Promise<void> | undefined;
@@ -34,9 +36,10 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
      * Announces that a project's Attention projection changed without a row
      * write: the force-surface backstop flips a hidden finding visible purely
      * by wall-clock age, and connected Attention streams stop polling, so the
-     * sweep rings the same doorbell storage writes do.
+     * sweep rings the same doorbell storage writes do. Awaited: a rejection
+     * fails the project's sweep so the crossing is announced again next time.
      */
-    attentionChanged?: (scope: { orgId: string; factoryProjectId: string }) => void;
+    attentionChanged?: (scope: { orgId: string; factoryProjectId: string }) => Promise<void> | void;
   }) {
     super();
     this.#projects = input.projects;
@@ -81,6 +84,9 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
   async #tick(): Promise<void> {
     const now = new Date();
     const projects = await this.#projects.listAll();
+    // Forget checkpoints for projects that no longer exist.
+    const live = new Set(projects.map(project => sweepKey(project.orgId, project.id)));
+    for (const key of this.#sweptAt.keys()) if (!live.has(key)) this.#sweptAt.delete(key);
     const concurrency = 4;
     let nextIndex = 0;
     const results = await Promise.allSettled(
@@ -103,12 +109,13 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
           // Rows that crossed the backstop since this project's last SUCCESSFUL
           // sweep are the ones no write announced. The checkpoint only advances
           // once the whole sweep for the project landed, so a crossing during a
-          // failed or abandoned tick still rings on the next good one. Before
-          // the first sweep it is "since forever": already-stale rows get one
-          // refresh after boot.
-          const since = this.#sweptAt.get(project.id) ?? new Date(0);
+          // failed or abandoned tick (including a rejected doorbell publish)
+          // still rings on the next good one. Before the first sweep it is
+          // "since forever": already-stale rows get one refresh after boot.
+          const key = sweepKey(project.orgId, project.id);
+          const since = this.#sweptAt.get(key) ?? new Date(0);
           await this.#announceForceSurfaced({ orgId: project.orgId, factoryProjectId: project.id }, since, now);
-          this.#sweptAt.set(project.id, now);
+          this.#sweptAt.set(key, now);
         }
       }),
     );
@@ -188,7 +195,7 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
         row => isSupervisorFindingVisibleToHumans(row, now) && !isSupervisorFindingVisibleToHumans(row, since),
       );
       if (crossed) {
-        this.#attentionChanged(scope);
+        await this.#attentionChanged(scope);
         return;
       }
       const last = rows.at(-1);
@@ -196,6 +203,10 @@ export class FactorySupervisorHealthWorker extends MastraWorker {
       before = { occurredAt: last.updatedAt, id: last.id };
     }
   }
+}
+
+function sweepKey(orgId: string, factoryProjectId: string): string {
+  return `${orgId}\0${factoryProjectId}`;
 }
 
 function findingText(row: FactorySupervisorFindingRecord, key: string): string | undefined {

--- a/mastracode/factory/src/supervisor/health.ts
+++ b/mastracode/factory/src/supervisor/health.ts
@@ -80,6 +80,13 @@ export const DEFAULT_HEALTH_THRESHOLDS: FactoryHealthThresholds = {
   waitingOnPersonMs: 24 * 60 * 60_000,
 };
 
+/**
+ * Never-lose backstop for supervisor-first Attention: an open finding hidden
+ * from people while the supervisor works it is force-surfaced once it has
+ * been open this long, whatever its status.
+ */
+export const SUPERVISOR_ATTENTION_FORCE_SURFACE_MS = 30 * 60_000;
+
 const FINDING_KINDS: FactoryHealthFindingKind[] = [
   'decision-failed',
   'decision-stuck',

--- a/mastracode/factory/src/supervisor/instructions.ts
+++ b/mastracode/factory/src/supervisor/instructions.ts
@@ -51,9 +51,20 @@ You have no repository and no sandbox. Everything you know comes from the
 
 ## Repairs
 
-Write tools require confirmation and are recorded against the person who
+Repair tools require confirmation and are recorded against the person who
 asked. Use the repair suggested by the health finding: retry or dismiss a
 decision, accept a held card, approve or dismiss a proposal, revoke an
 orphaned seat, signal a worker, or reconcile stale acceptance labels. Never
 claim a repair happened unless a tool result says it did.
+
+## Escalating
+
+Findings in the supervisor-actionable kinds (\`decision-failed\`,
+\`decision-stuck\`, \`start-stalled\`, \`seat-orphaned\`, \`seat-missing\`)
+stay off the human Attention rail while they are open: you are expected to
+look first. \`factory_escalate_finding\` needs no confirmation and is
+available even when no person is in the conversation, because it is how you
+reach one. Use it, with a note saying what you found and what you need, as
+soon as a finding needs a decision or information only a person has, or when
+you cannot repair it yourself. Do not wait for the backstop to surface it.
 `;

--- a/mastracode/factory/src/supervisor/read-tools.test.ts
+++ b/mastracode/factory/src/supervisor/read-tools.test.ts
@@ -120,6 +120,42 @@ describe('createFactorySupervisorReadTools', () => {
     expect(report.findings.map((f: any) => f.kind).sort()).toEqual(['decision-failed', 'seat-missing']);
   });
 
+  it('factory_health_check carries the tracked visibility status of each finding', async () => {
+    const seed = await createFactoryStorageForTests();
+    await queueFailedPlan(seed.workItems, 1);
+    const tools = createFactorySupervisorReadTools({ scope: SCOPE, ...seed, now: () => NOW });
+
+    // Before any sweep tracks the findings, status is unknown.
+    const untracked = await execute<any>(tools.factory_health_check, {});
+    expect(untracked.findings.every((f: any) => f.status === null)).toBe(true);
+
+    // The sweep persists the same findings; escalate one of them.
+    await seed.workItems.syncSupervisorFindings({ ...SCOPE, findings: untracked.findings, now: NOW });
+    const failed = untracked.findings.find((f: any) => f.kind === 'decision-failed');
+    await seed.workItems.escalateSupervisorFinding({
+      ...SCOPE,
+      findingKey: failed.id,
+      note: 'needs a product call',
+      escalatedAt: NOW,
+    });
+
+    const report = await execute<any>(tools.factory_health_check, {});
+    const byKind = Object.fromEntries(report.findings.map((f: any) => [f.kind, f]));
+    expect(byKind['decision-failed']).toMatchObject({
+      status: 'escalated',
+      escalatedAt: NOW.toISOString(),
+      escalationNote: 'needs a product call',
+    });
+    expect(byKind['seat-missing']).toMatchObject({ status: 'open', escalatedAt: null, escalationNote: null });
+
+    const detail = await execute<any>(tools.factory_inspect_work_item, { number: 1 });
+    expect(detail.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ findingKey: failed.id, status: 'escalated', escalationNote: 'needs a product call' }),
+      ]),
+    );
+  });
+
   it('factory_inspect_work_item resolves a card by number with its seats, decisions, audit and feed', async () => {
     const seed = await createFactoryStorageForTests();
     const { workItems, audit, comments } = seed;

--- a/mastracode/factory/src/supervisor/read-tools.ts
+++ b/mastracode/factory/src/supervisor/read-tools.ts
@@ -16,10 +16,12 @@ import type { AuditStorage } from '../storage/domains/audit/base.js';
 import type { WorkItemCommentsStorage } from '../storage/domains/comments/base.js';
 import type {
   FactoryDeferredDecisionRecord,
+  FactorySupervisorFindingRecord,
+  FactorySupervisorFindingStatus,
   WorkItemRow,
   WorkItemsStorage,
 } from '../storage/domains/work-items/base.js';
-import type { FactoryHealthReport, FactoryHealthThresholds } from './health.js';
+import type { FactoryHealthFinding, FactoryHealthThresholds } from './health.js';
 import { runFactoryHealthCheck } from './health.js';
 
 export interface SupervisorScope {
@@ -50,6 +52,44 @@ export interface SupervisorReadDependencies {
 const MAX_TEXT = 600;
 const MAX_ERROR = 400;
 const MAX_LIST = 50;
+
+/** The persisted rows behind the computed findings, keyed by finding key. */
+async function openFindingRows(
+  workItems: WorkItemsStorage,
+  scope: SupervisorScope,
+): Promise<Map<string, FactorySupervisorFindingRecord>> {
+  const rows = new Map<string, FactorySupervisorFindingRecord>();
+  let before: { occurredAt: Date; id: string } | undefined;
+  for (;;) {
+    const page = await workItems.listSupervisorFindingPage({
+      ...scope,
+      ...(before ? { before } : {}),
+      limit: MAX_LIST,
+    });
+    for (const row of page.rows) rows.set(row.findingKey, row);
+    const last = page.rows[page.rows.length - 1];
+    if (!page.hasMore || !last) return rows;
+    before = { occurredAt: last.updatedAt, id: last.id };
+  }
+}
+
+/** Visibility state from the persisted row, when the sweep has already tracked this finding. */
+function withFindingStatus(
+  finding: FactoryHealthFinding,
+  tracked: Map<string, FactorySupervisorFindingRecord>,
+): FactoryHealthFinding & {
+  status: FactorySupervisorFindingStatus | null;
+  escalatedAt: string | null;
+  escalationNote: string | null;
+} {
+  const row = tracked.get(finding.id);
+  return {
+    ...finding,
+    status: row?.status ?? null,
+    escalatedAt: iso(row?.escalatedAt),
+    escalationNote: row?.escalationNote ?? null,
+  };
+}
 
 function truncate(text: string, max: number): string {
   return text.length > max ? `${text.slice(0, max - 1)}…` : text;
@@ -233,8 +273,13 @@ export function createFactorySupervisorReadTools(deps: SupervisorReadDependencie
       description:
         'Deterministic list of things wrong with this Factory right now (failed or stuck decisions, stalled starts, orphaned or missing seats, proposals and held cards waiting on a person, label drift). Each finding carries evidence and the standard repair. Explain these; do not invent findings that are not listed.',
       inputSchema: z.object({}).strict(),
-      execute: async (): Promise<FactoryHealthReport> =>
-        runFactoryHealthCheck(deps.workItems, scope, { now: now(), thresholds: deps.healthThresholds }),
+      execute: async () => {
+        const [report, tracked] = await Promise.all([
+          runFactoryHealthCheck(deps.workItems, scope, { now: now(), thresholds: deps.healthThresholds }),
+          openFindingRows(deps.workItems, scope),
+        ]);
+        return { ...report, findings: report.findings.map(finding => withFindingStatus(finding, tracked)) };
+      },
     }),
 
     factory_inspect_work_item: createTool({
@@ -245,12 +290,13 @@ export function createFactorySupervisorReadTools(deps: SupervisorReadDependencie
       execute: async ref => {
         const item = await findItem(deps, ref);
         if (!item) throw new Error(`No work item matches ${ref.id ?? `#${ref.number}`} in this Factory.`);
-        const [decisions, bindings, audit, feed, all] = await Promise.all([
+        const [decisions, bindings, audit, feed, all, tracked] = await Promise.all([
           deps.workItems.listDeferredDecisions(scope.orgId, scope.factoryProjectId),
           deps.workItems.listRunBindings(scope.orgId, scope.factoryProjectId, item.id),
           deps.audit.list({ orgId: scope.orgId, factoryProjectId: scope.factoryProjectId, limit: 200 }),
           deps.comments.listRecent({ ...scope, workItemId: item.id, limit: 10 }),
           deps.workItems.list(scope),
+          openFindingRows(deps.workItems, scope),
         ]);
         const parent = item.parentWorkItemId
           ? all.find(candidate => candidate.id === item.parentWorkItemId)
@@ -303,6 +349,16 @@ export function createFactorySupervisorReadTools(deps: SupervisorReadDependencie
             occurredAt: iso(comment.occurredAt),
             body: truncate(comment.body, MAX_TEXT),
           })),
+          findings: [...tracked.values()]
+            .filter(row => row.finding.workItemId === item.id)
+            .map(row => ({
+              findingKey: row.findingKey,
+              kind: String(row.finding.kind ?? 'unknown'),
+              status: row.status,
+              openedAt: iso(row.openedAt),
+              escalatedAt: iso(row.escalatedAt),
+              escalationNote: row.escalationNote,
+            })),
           parent: parent ? summarizeItem(parent) : null,
           children: children.map(summarizeItem),
         };

--- a/mastracode/factory/src/supervisor/visibility.ts
+++ b/mastracode/factory/src/supervisor/visibility.ts
@@ -1,0 +1,24 @@
+import type { FactorySupervisorFindingRecord } from '../storage/domains/work-items/base.js';
+import { SUPERVISOR_ATTENTION_FORCE_SURFACE_MS } from './health.js';
+import { SUPERVISOR_HIGH_PRIORITY_KINDS } from './notify.js';
+
+/**
+ * The one place that decides whether an open finding is on the human
+ * Attention rail. Supervisor-actionable kinds (the same set the emit path
+ * rates high priority) stay hidden while `status` is `open`: the supervisor
+ * is expected to work them and escalate what needs a person. Everything else
+ * is visible immediately. The backstop makes the hide time-bounded: once a
+ * finding has been open past `SUPERVISOR_ATTENTION_FORCE_SURFACE_MS` it
+ * surfaces regardless. Resolved rows never reach this predicate; the open-row
+ * queries key on `resolved_at` as before. Visibility never mutates the row.
+ */
+export function isSupervisorFindingVisibleToHumans(
+  row: Pick<FactorySupervisorFindingRecord, 'status' | 'openedAt' | 'finding'>,
+  now: Date,
+  forceSurfaceMs: number = SUPERVISOR_ATTENTION_FORCE_SURFACE_MS,
+): boolean {
+  if (row.status === 'escalated') return true;
+  const kind = typeof row.finding.kind === 'string' ? row.finding.kind : '';
+  if (!SUPERVISOR_HIGH_PRIORITY_KINDS.has(kind)) return true;
+  return now.getTime() - row.openedAt.getTime() >= forceSurfaceMs;
+}


### PR DESCRIPTION
Part of COR-1183 (Improved Supervisor). Stacked on #23095 (COR-1195); review the diff against `caleb/cor-1195-supervisor-emit-path`.

## What changes

Health findings the supervisor can act on itself (`decision-failed`, `decision-stuck`, `start-stalled`, `seat-orphaned`, `seat-missing`) no longer land on the human Attention rail the moment they open. The supervisor works them first and surfaces the ones that need a person.

- `factory_supervisor_findings` gains `status` (`open` | `escalated`, DDL default `open` so existing rows migrate), `escalated_at` and `escalation_note`. Reopen resets all three. `status` only means anything while `resolved_at` is null; every open-row query still keys on `resolved_at`.
- New supervisor tool `factory_escalate_finding({ findingKey, note })`, in a new `supervisor/action-tools.ts`. Approval-free by design: escalating is how the supervisor reaches a person, and an approval prompt would put that person back in the loop it is buffering. Audited with the turn's real actor (human on authenticated turns, `agent:<threadId>` on signal-woken turns). Registers on both kinds of turn. The seven existing `requireApproval` write tools are untouched.
- `SupervisorFindingAttentionProvider` runs counts, latest, page and read-all through one predicate (`supervisor/visibility.ts`) that hides `open` rows of the five kinds above and shows everything else; `proposal-waiting`, `held-waiting` and `label-drift` stay visible immediately. Hidden rows do not spend the receipt-scan page budget, so an older visible finding behind a run of hidden ones is still found.
- Never-lose backstop: `SUPERVISOR_ATTENTION_FORCE_SURFACE_MS` (30 min, beside `DEFAULT_HEALTH_THRESHOLDS`). Any finding open longer than that surfaces regardless of status or kind, without any row write. Because that flip is time-driven and connected Attention streams stop polling, the health sweep rings the feed doorbell when a finding crossed the threshold since the project's last successful sweep (awaited publish; a rejected publish is retried next sweep).
- `factory_health_check` and `factory_inspect_work_item` report the new fields; `SUPERVISOR_INSTRUCTIONS` explains when to escalate.

No factory-ui changes; Attention items carry `status`, `escalatedAt`, `escalationNote` as extra fields.

## Test plan

- `cd mastracode/factory && pnpm vitest run src/supervisor src/storage/domains/work-items/base.test.ts src/routes/attention.test.ts src/routes/supervisor.test.ts src/factory.test.ts` — 11 files / 229 tests
- `pnpm check` — clean; repo oxfmt check — clean
- Real-server demo (`mountAgentControllerOnMastra` + libsql, real Attention HTTP route, real escalate tool): open finding hidden, escalated visible with note, stale finding force-surfaced with status still `open`. Same demo at the merge-base shows the open finding on the rail immediately (the behavior this PR changes).
- Upgrade path: a row written by the pre-status schema reads back `status: open` after the current domain initializes over it.

Known follow-up (not this PR): a terminally failed decision still yields its pre-existing `automation-failed` Attention row from `DecisionAttentionProvider`; this PR covers finding projections only.
