### PR TITLE
fix: resolve immer prototype pollution

### DIFF
--- a/.changeset/salty-rocks-win.md
+++ b/.changeset/salty-rocks-win.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed an Immer prototype pollution vulnerability in Playground UI dependencies.

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -157,7 +157,7 @@
     "react-day-picker": "^8.10.1",
     "react-markdown": "^9.1.0",
     "react-resizable-panels": "^4.7.3",
-    "recharts": "^3.8.0",
+    "recharts": "^3.10.1",
     "remark-gfm": "^4.0.1",
     "remend": "^1.3.0",
     "shiki": "^1.29.2",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -85,7 +85,7 @@
     "react-resizable-panels": "^4.7.3",
     "react-router": "^8.0.0",
     "react-syntax-highlighter": "^15.6.6",
-    "recharts": "^3.8.0",
+    "recharts": "^3.10.1",
     "remark-gfm": "^4.0.1",
     "semver": "^7.7.4",
     "sonner": "^2.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ overrides:
   brace-expansion@<1.1.13: 5.0.9
   brace-expansion@>=2.0.0 <2.1.4: 2.1.4
   brace-expansion@>=4.0.0 <5.0.9: 5.0.9
-  immer@>=11.0.0 <11.1.9: 11.1.9
+  immer@>=4.0.0 <11.1.9: 11.1.9
   '@clerk/shared@>=3.0.0 <3.47.5': 3.47.8
   js-cookie@>=3.0.0 <3.0.7: 3.0.7
   path-to-regexp@<0.1.13: 0.1.13
@@ -26431,9 +26431,6 @@ packages:
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
-  immer@10.2.0:
-    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
-
   immer@11.1.9:
     resolution: {integrity: sha512-sc/z0Cyti70bZa0ZU4sWfAElfovFb9Ni8tArJZLuklYWxegPiK3pDOql1Rq5H0FIRAW9LSQRG6OX4KqBldbhBA==}
 
@@ -52194,8 +52191,6 @@ snapshots:
 
   immediate@3.0.6: {}
 
-  immer@10.2.0: {}
-
   immer@11.1.9: {}
 
   import-fresh@3.3.1:
@@ -56628,7 +56623,7 @@ snapshots:
       decimal.js-light: 2.5.1
       es-toolkit: 1.46.1
       eventemitter3: 5.0.4
-      immer: 10.2.0
+      immer: 11.1.9
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-is: 18.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ overrides:
   brace-expansion@<1.1.13: 5.0.9
   brace-expansion@>=2.0.0 <2.1.4: 2.1.4
   brace-expansion@>=4.0.0 <5.0.9: 5.0.9
-  immer@>=4.0.0 <11.1.9: 11.1.9
+  immer@>=11.0.0 <11.1.9: 11.1.9
   '@clerk/shared@>=3.0.0 <3.47.5': 3.47.8
   js-cookie@>=3.0.0 <3.0.7: 3.0.7
   path-to-regexp@<0.1.13: 0.1.13
@@ -5717,8 +5717,8 @@ importers:
         specifier: ^15.6.6
         version: 15.6.6(react@19.2.7)
       recharts:
-        specifier: ^3.8.0
-        version: 3.8.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)
+        specifier: ^3.10.1
+        version: 3.10.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1(supports-color@10.2.2)
@@ -5895,8 +5895,8 @@ importers:
         specifier: ^4.7.3
         version: 4.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       recharts:
-        specifier: ^3.8.0
-        version: 3.8.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)
+        specifier: ^3.10.1
+        version: 3.10.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1(supports-color@10.2.2)
@@ -30102,8 +30102,8 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
-  recharts@3.8.1:
-    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+  recharts@3.10.1:
+    resolution: {integrity: sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -30388,8 +30388,8 @@ packages:
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
-  reselect@5.1.1:
-    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   reselect@5.3.0:
     resolution: {integrity: sha512-XGoLeRAVzUTcJ1qkxPQhDJyIZ5d6zzZD9nT7AEZOaaU9UbWclhycElmhO+VD5bFeLuzhPBaOV2oXC8uG35ZSpg==}
@@ -43952,7 +43952,7 @@ snapshots:
       immer: 11.1.9
       redux: 5.0.1
       redux-thunk: 3.1.0(redux@5.0.1)
-      reselect: 5.1.1
+      reselect: 5.3.0
     optionalDependencies:
       react: 19.2.7
       react-redux: 9.2.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
@@ -56616,7 +56616,7 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
-  recharts@3.8.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1):
+  recharts@3.10.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)
       clsx: 2.1.1
@@ -56628,7 +56628,7 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       react-is: 18.3.1
       react-redux: 9.2.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
-      reselect: 5.1.1
+      reselect: 5.2.0
       tiny-invariant: 1.3.3
       use-sync-external-store: 1.6.0(react@19.2.7)
       victory-vendor: 37.3.6
@@ -57230,7 +57230,7 @@ snapshots:
 
   requires-port@1.0.0: {}
 
-  reselect@5.1.1: {}
+  reselect@5.2.0: {}
 
   reselect@5.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -267,7 +267,7 @@ overrides:
   brace-expansion@<1.1.13: 5.0.9
   brace-expansion@>=2.0.0 <2.1.4: 2.1.4
   brace-expansion@>=4.0.0 <5.0.9: 5.0.9
-  immer@>=11.0.0 <11.1.9: 11.1.9
+  immer@>=4.0.0 <11.1.9: 11.1.9
   '@clerk/shared@>=3.0.0 <3.47.5': 3.47.8
   js-cookie@>=3.0.0 <3.0.7: 3.0.7
   path-to-regexp@<0.1.13: 0.1.13

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -267,7 +267,7 @@ overrides:
   brace-expansion@<1.1.13: 5.0.9
   brace-expansion@>=2.0.0 <2.1.4: 2.1.4
   brace-expansion@>=4.0.0 <5.0.9: 5.0.9
-  immer@>=4.0.0 <11.1.9: 11.1.9
+  immer@>=11.0.0 <11.1.9: 11.1.9
   '@clerk/shared@>=3.0.0 <3.47.5': 3.47.8
   js-cookie@>=3.0.0 <3.0.7: 3.0.7
   path-to-regexp@<0.1.13: 0.1.13


### PR DESCRIPTION
Fixes AIKIDO-2026-445255 by upgrading both Playground consumers from Recharts 3.8 to Recharts 3.10.1, which declares compatibility with Immer 11. The existing scoped override then resolves the compatible ^11.1.8 request to patched 11.1.9 without forcing a dependency across a major-version boundary.

Before: Recharts 3.8.1 requested immer:^10.1.1, which could not be safely overridden to Immer 11.
After: Recharts 3.10.1 requests immer:^11.1.8 and resolves to 11.1.9.

The targeted Playground and Playground UI production build and typecheck passed, all 2,984 Playground UI tests passed, and a direct compatibility probe confirmed the vulnerable constructor.prototype access is blocked without polluting Object.prototype.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This update ensures Recharts uses a safe version of Immer. It also updates Recharts consumers and adds a patch changeset for the security fix.

## Changes

- Expanded the workspace Immer override to resolve vulnerable versions to patched version `11.1.9`.
- Upgraded Playground consumers from Recharts `^3.8.0` to `^3.10.1`.
- Added a patch changeset for `@mastra/playground-ui`.
- Addresses `AIKIDO-2026-445255`.

## Verification

- Completed a targeted Playground build and typecheck.
- Passed 2,984 Playground UI tests.
- Passed a direct prototype-pollution probe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->