### PR TITLE
feat(playground-ui): add settings layout

### DIFF
--- a/.changeset/tender-forks-sleep.md
+++ b/.changeset/tender-forks-sleep.md
@@ -1,0 +1,11 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added `SettingsLayout` for settings page titles, actions, constrained width, and section spacing. Section headings now align with the card edge by default. Pass `inset` to `SettingsLayout` and `Section.Header` to align headings with row content.
+
+```tsx
+<SettingsLayout title="Project Settings">
+  <Section variant="factory">...</Section>
+</SettingsLayout>
+```

--- a/packages/playground-ui/src/ds/components/Section/section-header.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section-header.tsx
@@ -1,16 +1,19 @@
 import type { ComponentProps } from 'react';
 import { cn } from '@/lib/utils';
 
-export type SectionHeaderProps = ComponentProps<'header'>;
+export type SectionHeaderProps = ComponentProps<'header'> & {
+  inset?: boolean;
+};
 
-export function SectionHeader({ children, className, ...props }: SectionHeaderProps) {
+export function SectionHeader({ children, className, inset = false, ...props }: SectionHeaderProps) {
   return (
     <header
       data-slot="section-header"
       className={cn(
         'group-data-[variant=default]/section:grid group-data-[variant=default]/section:grid-cols-[1fr_auto] group-data-[variant=default]/section:items-center',
-        'group-data-[variant=flat]/section:flex group-data-[variant=flat]/section:min-w-0 group-data-[variant=flat]/section:flex-col group-data-[variant=flat]/section:gap-4 group-data-[variant=flat]/section:px-4 group-data-[variant=flat]/section:pb-4 sm:group-data-[variant=flat]/section:flex-row sm:group-data-[variant=flat]/section:items-start sm:group-data-[variant=flat]/section:justify-between sm:group-data-[variant=flat]/section:gap-6',
-        'group-data-[variant=factory]/section:flex group-data-[variant=factory]/section:min-w-0 group-data-[variant=factory]/section:flex-col group-data-[variant=factory]/section:gap-2 group-data-[variant=factory]/section:px-4 sm:group-data-[variant=factory]/section:flex-row sm:group-data-[variant=factory]/section:items-start sm:group-data-[variant=factory]/section:justify-between sm:group-data-[variant=factory]/section:gap-4',
+        'group-data-[variant=flat]/section:flex group-data-[variant=flat]/section:min-w-0 group-data-[variant=flat]/section:flex-col group-data-[variant=flat]/section:gap-4 group-data-[variant=flat]/section:pb-4 sm:group-data-[variant=flat]/section:flex-row sm:group-data-[variant=flat]/section:items-start sm:group-data-[variant=flat]/section:justify-between sm:group-data-[variant=flat]/section:gap-6',
+        'group-data-[variant=factory]/section:flex group-data-[variant=factory]/section:min-w-0 group-data-[variant=factory]/section:flex-col group-data-[variant=factory]/section:gap-2 sm:group-data-[variant=factory]/section:flex-row sm:group-data-[variant=factory]/section:items-start sm:group-data-[variant=factory]/section:justify-between sm:group-data-[variant=factory]/section:gap-4',
+        inset && 'px-4',
         className,
       )}
       {...props}

--- a/packages/playground-ui/src/ds/components/Section/section.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section.stories.tsx
@@ -4,22 +4,67 @@ import { Button } from '../Button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../Select';
 import { Switch } from '../Switch';
 import { Section } from './section';
+import type { SectionVariant } from './section';
 
-const meta: Meta<typeof Section> = {
+type SectionPlaygroundProps = {
+  variant: SectionVariant;
+  inset: boolean;
+};
+
+function SectionPlayground({ variant, inset }: SectionPlaygroundProps) {
+  return (
+    <Section variant={variant} className="w-full max-w-150">
+      <Section.Header inset={inset}>
+        <Section.HeaderText>
+          <Section.Heading>General</Section.Heading>
+          <Section.Description>Choose how this section aligns with its content.</Section.Description>
+        </Section.HeaderText>
+      </Section.Header>
+      <Section.Content>
+        <Section.Row label="Auto-approve tools" description="Run tool calls without asking.">
+          <Switch aria-label="Auto-approve tools" />
+        </Section.Row>
+        <Section.Divider />
+        <Section.Row label="Smart editing" description="Use AST-aware edits when available.">
+          <Switch aria-label="Smart editing" defaultChecked />
+        </Section.Row>
+      </Section.Content>
+    </Section>
+  );
+}
+
+const meta = {
   title: 'Layout/Section',
-  component: Section,
+  component: SectionPlayground,
   parameters: {
     layout: 'centered',
   },
-};
+  args: {
+    variant: 'factory',
+    inset: false,
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'flat', 'factory'],
+    },
+    inset: { control: 'boolean' },
+  },
+} satisfies Meta<typeof SectionPlayground>;
 
 export default meta;
-type Story = StoryObj<typeof Section>;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
 
 export const Default: Story = {
-  render: () => (
-    <Section className="w-125">
-      <Section.Header>
+  args: {
+    variant: 'default',
+    inset: false,
+  },
+  render: ({ variant, inset }) => (
+    <Section variant={variant} className="w-125">
+      <Section.Header inset={inset}>
         <Section.Heading>Section Title</Section.Heading>
       </Section.Header>
       <div className="border-border1 bg-surface2 rounded-md border p-4">
@@ -30,9 +75,13 @@ export const Default: Story = {
 };
 
 export const WithAction: Story = {
-  render: () => (
-    <Section className="w-125">
-      <Section.Header>
+  args: {
+    variant: 'default',
+    inset: false,
+  },
+  render: ({ variant, inset }) => (
+    <Section variant={variant} className="w-125">
+      <Section.Header inset={inset}>
         <Section.Heading>Agents</Section.Heading>
         <Button size="md">
           <Plus className="size-4" />
@@ -47,9 +96,13 @@ export const WithAction: Story = {
 };
 
 export const ConfigurationSection: Story = {
-  render: () => (
-    <Section className="w-125">
-      <Section.Header>
+  args: {
+    variant: 'default',
+    inset: false,
+  },
+  render: ({ variant, inset }) => (
+    <Section variant={variant} className="w-125">
+      <Section.Header inset={inset}>
         <Section.Heading>Configuration</Section.Heading>
         <Button variant="outline" size="md">
           Edit
@@ -74,9 +127,13 @@ export const ConfigurationSection: Story = {
 };
 
 export const Flat: Story = {
-  render: () => (
-    <Section variant="flat" className="w-full max-w-150">
-      <Section.Header>
+  args: {
+    variant: 'flat',
+    inset: false,
+  },
+  render: ({ variant, inset }) => (
+    <Section variant={variant} className="w-full max-w-150">
+      <Section.Header inset={inset}>
         <Section.HeaderText>
           <Section.Heading>Security</Section.Heading>
           <Section.Description>Manage sign-in requirements for your account.</Section.Description>
@@ -110,9 +167,13 @@ export const Flat: Story = {
 };
 
 export const Factory: Story = {
-  render: () => (
-    <Section variant="factory" className="w-full max-w-150">
-      <Section.Header>
+  args: {
+    variant: 'factory',
+    inset: false,
+  },
+  render: ({ variant, inset }) => (
+    <Section variant={variant} className="w-full max-w-150">
+      <Section.Header inset={inset}>
         <Section.HeaderText>
           <Section.Heading>Behavior</Section.Heading>
           <Section.Description>Choose how agents handle tools and completion alerts.</Section.Description>
@@ -150,9 +211,13 @@ export const Factory: Story = {
 };
 
 export const PermissionAndDestructiveRows: Story = {
-  render: () => (
-    <Section variant="factory" className="w-full max-w-150">
-      <Section.Header>
+  args: {
+    variant: 'factory',
+    inset: false,
+  },
+  render: ({ variant, inset }) => (
+    <Section variant={variant} className="w-full max-w-150">
+      <Section.Header inset={inset}>
         <Section.HeaderText>
           <Section.Heading>Organization access</Section.Heading>
           <Section.Description>Review inherited permissions and organization actions.</Section.Description>
@@ -178,10 +243,13 @@ export const PermissionAndDestructiveRows: Story = {
 };
 
 export const MultipleSections: Story = {
-  render: () => (
+  argTypes: {
+    variant: { table: { disable: true } },
+  },
+  render: ({ inset }) => (
     <div className="w-[calc(100vw-2rem)] max-w-150 space-y-8">
       <Section variant="factory">
-        <Section.Header>
+        <Section.Header inset={inset}>
           <Section.HeaderText>
             <Section.Heading>Behavior</Section.Heading>
             <Section.Description>Choose how agents handle tools and completion alerts.</Section.Description>
@@ -216,7 +284,7 @@ export const MultipleSections: Story = {
       </Section>
 
       <Section variant="flat">
-        <Section.Header>
+        <Section.Header inset={inset}>
           <Section.HeaderText>
             <Section.Heading>Security</Section.Heading>
             <Section.Description>Manage sign-in requirements for your account.</Section.Description>

--- a/packages/playground-ui/src/ds/components/Section/section.test.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section.test.tsx
@@ -17,9 +17,12 @@ describe('Section', () => {
       </Section>,
     );
 
-    expect(screen.getByRole('heading', { name: 'Overview' }).className).toContain(
-      'group-data-[variant=default]/section:font-bold',
-    );
+    const heading = screen.getByRole('heading', { name: 'Overview' });
+    const headerClasses = heading.closest('[data-slot="section-header"]')?.className.split(' ');
+
+    expect(heading.className).toContain('group-data-[variant=default]/section:font-bold');
+    expect(headerClasses).toContain('group-data-[variant=default]/section:grid');
+    expect(headerClasses).not.toContain('px-4');
     expect(screen.getByText('Section content').closest('[data-slot="section"]')?.dataset.variant).toBe('default');
   });
 
@@ -59,7 +62,7 @@ describe('Section', () => {
     expect(screen.getByText('Leave organization').className).toContain('text-accent2');
   });
 
-  it('aligns flat and factory content to the same horizontal inset', () => {
+  it('keeps flat and factory headings on the card edge while rows retain their inset', () => {
     render(
       <div>
         <Section variant="factory">
@@ -90,18 +93,49 @@ describe('Section', () => {
     expect(flatHeading.className).toContain('group-data-[variant=flat]/section:font-medium');
     expect(factory?.className).toContain('w-full');
     expect(flat?.className).toContain('w-full');
-    expect(factory?.querySelector('[data-slot="section-header"]')?.className).toContain(
-      'group-data-[variant=factory]/section:px-4',
-    );
-    expect(flat?.querySelector('[data-slot="section-header"]')?.className).toContain(
-      'group-data-[variant=flat]/section:px-4',
-    );
+    const factoryHeaderClasses = factory?.querySelector('[data-slot="section-header"]')?.className.split(' ');
+
+    expect(factoryHeaderClasses).toContain('group-data-[variant=factory]/section:flex');
+    expect(factoryHeaderClasses).not.toContain('px-4');
+    const flatHeaderClasses = flat?.querySelector('[data-slot="section-header"]')?.className.split(' ');
+
+    expect(flatHeaderClasses).toContain('group-data-[variant=flat]/section:flex');
+    expect(flatHeaderClasses).not.toContain('px-4');
     expect(screen.getByText('Factory row').closest('[data-slot="section-row"]')?.className).toContain(
       'group-data-[variant=factory]/section:px-4',
     );
     expect(screen.getByText('Flat row').closest('[data-slot="section-row"]')?.className).toContain(
       'group-data-[variant=flat]/section:p-4',
     );
+  });
+
+  it('supports inset flat and factory headings', () => {
+    render(
+      <div>
+        <Section variant="factory">
+          <Section.Header inset>
+            <Section.Heading>Project</Section.Heading>
+          </Section.Header>
+          <Section.Content>
+            <Section.Row label="Project row" />
+          </Section.Content>
+        </Section>
+        <Section variant="flat">
+          <Section.Header inset>
+            <Section.Heading>Account</Section.Heading>
+          </Section.Header>
+          <Section.Content>
+            <Section.Row label="Account row" />
+          </Section.Content>
+        </Section>
+      </div>,
+    );
+
+    for (const name of ['Project', 'Account']) {
+      expect(
+        screen.getByRole('heading', { name }).closest('[data-slot="section-header"]')?.className.split(' '),
+      ).toContain('px-4');
+    }
   });
 
   it('renders factory rows with explicit dividers', () => {

--- a/packages/playground-ui/src/ds/components/SettingsLayout/index.ts
+++ b/packages/playground-ui/src/ds/components/SettingsLayout/index.ts
@@ -1,0 +1,1 @@
+export { SettingsLayout, type SettingsLayoutProps } from './settings-layout';

--- a/packages/playground-ui/src/ds/components/SettingsLayout/settings-layout.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SettingsLayout/settings-layout.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from '../Button';
+import { Section } from '../Section';
+import type { SectionVariant } from '../Section';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../Select';
+import { Switch } from '../Switch';
+import { SettingsLayout } from './settings-layout';
+
+type SettingsLayoutStoryProps = {
+  title: string;
+  inset: boolean;
+  sectionVariant: SectionVariant;
+  showAction: boolean;
+};
+
+function SettingsLayoutStory({ title, inset, sectionVariant, showAction }: SettingsLayoutStoryProps) {
+  return (
+    <SettingsLayout
+      title={title}
+      inset={inset}
+      action={showAction ? <Button size="sm">Save changes</Button> : undefined}
+    >
+      <Section variant={sectionVariant}>
+        <Section.Header inset={inset}>
+          <Section.HeaderText>
+            <Section.Heading>General</Section.Heading>
+            <Section.Description>Stored in this browser.</Section.Description>
+          </Section.HeaderText>
+        </Section.Header>
+        <Section.Content>
+          <Section.Row label="Theme" description="Color scheme for the interface" htmlFor="settings-theme">
+            <Select defaultValue="system">
+              <SelectTrigger id="settings-theme" className="w-full sm:w-40">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="system">System</SelectItem>
+                <SelectItem value="light">Light</SelectItem>
+                <SelectItem value="dark">Dark</SelectItem>
+              </SelectContent>
+            </Select>
+          </Section.Row>
+          <Section.Divider />
+          <Section.Row label="Completion sound" description="Played when an agent run finishes in a workspace">
+            <Switch aria-label="Play completion sound" defaultChecked />
+          </Section.Row>
+        </Section.Content>
+      </Section>
+    </SettingsLayout>
+  );
+}
+
+const meta = {
+  title: 'Layout/SettingsLayout',
+  component: SettingsLayoutStory,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    title: 'Preferences',
+    inset: false,
+    sectionVariant: 'factory',
+    showAction: false,
+  },
+  argTypes: {
+    title: { control: 'text' },
+    inset: { control: 'boolean' },
+    sectionVariant: {
+      control: 'select',
+      options: ['default', 'flat', 'factory'],
+    },
+    showAction: { control: 'boolean' },
+  },
+} satisfies Meta<typeof SettingsLayoutStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const InsetWithAction: Story = {
+  args: {
+    title: 'Project Settings',
+    inset: true,
+    showAction: true,
+  },
+};

--- a/packages/playground-ui/src/ds/components/SettingsLayout/settings-layout.test.tsx
+++ b/packages/playground-ui/src/ds/components/SettingsLayout/settings-layout.test.tsx
@@ -32,9 +32,9 @@ describe('SettingsLayout', () => {
     expect(output).toContain('pl-4');
   });
 
-  it('supports content with its own page header', () => {
+  it.each([undefined, null])('supports content with its own page header when title is %s', title => {
     const output = renderToStaticMarkup(
-      <SettingsLayout>
+      <SettingsLayout title={title}>
         <h1>Usage</h1>
         <section>Usage settings</section>
       </SettingsLayout>,

--- a/packages/playground-ui/src/ds/components/SettingsLayout/settings-layout.test.tsx
+++ b/packages/playground-ui/src/ds/components/SettingsLayout/settings-layout.test.tsx
@@ -1,0 +1,48 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { SettingsLayout } from './settings-layout';
+
+describe('SettingsLayout', () => {
+  it('renders the page title, action, and settings content', () => {
+    const output = renderToStaticMarkup(
+      <SettingsLayout title="Project Settings" action={<button type="button">Save</button>}>
+        <section>General settings</section>
+      </SettingsLayout>,
+    );
+
+    expect(output).toContain('<h1');
+    expect(output).toContain('Project Settings');
+    expect(output).toContain('data-slot="settings-page-header"');
+    expect(output).toContain('flex min-w-0 flex-wrap items-center justify-between gap-4');
+    expect(output).not.toContain('pl-4');
+    expect(output).toContain('min-w-0 truncate');
+    expect(output).toContain('font-sans font-medium tracking-normal text-neutral4');
+    expect(output).toContain('<button type="button">Save</button>');
+    expect(output).toContain('data-slot="settings-layout-content"');
+    expect(output).toContain('General settings');
+  });
+
+  it('insets the page title when requested', () => {
+    const output = renderToStaticMarkup(
+      <SettingsLayout title="Project Settings" inset>
+        <section>General settings</section>
+      </SettingsLayout>,
+    );
+
+    expect(output).toContain('pl-4');
+  });
+
+  it('supports content with its own page header', () => {
+    const output = renderToStaticMarkup(
+      <SettingsLayout>
+        <h1>Usage</h1>
+        <section>Usage settings</section>
+      </SettingsLayout>,
+    );
+
+    expect(output).not.toContain('data-slot="settings-page-header"');
+    expect(output).toContain('<h1>Usage</h1>');
+    expect(output).toContain('data-slot="settings-layout-content"');
+    expect(output).toContain('Usage settings');
+  });
+});

--- a/packages/playground-ui/src/ds/components/SettingsLayout/settings-layout.tsx
+++ b/packages/playground-ui/src/ds/components/SettingsLayout/settings-layout.tsx
@@ -10,7 +10,7 @@ export interface SettingsLayoutProps {
 }
 
 export function SettingsLayout({ title, action, inset = false, children }: SettingsLayoutProps) {
-  if (title === undefined) {
+  if (title === undefined || title === null) {
     return (
       <div
         data-slot="settings-layout-content"

--- a/packages/playground-ui/src/ds/components/SettingsLayout/settings-layout.tsx
+++ b/packages/playground-ui/src/ds/components/SettingsLayout/settings-layout.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react';
+import { Txt } from '../Txt';
+import { cn } from '@/lib/utils';
+
+export interface SettingsLayoutProps {
+  title?: ReactNode;
+  action?: ReactNode;
+  inset?: boolean;
+  children: ReactNode;
+}
+
+export function SettingsLayout({ title, action, inset = false, children }: SettingsLayoutProps) {
+  if (title === undefined) {
+    return (
+      <div
+        data-slot="settings-layout-content"
+        className="mx-auto w-full max-w-5xl min-w-0 overflow-x-hidden px-4 py-6 sm:px-6 sm:py-8"
+      >
+        <div className="min-w-0 space-y-14">{children}</div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div
+        data-slot="settings-page-header"
+        className="mx-auto w-full max-w-5xl min-w-0 overflow-x-clip px-4 pt-6 pb-0 sm:px-6 sm:pt-12"
+      >
+        <div className={cn('flex min-w-0 flex-wrap items-center justify-between gap-4', inset && 'pl-4')}>
+          <Txt
+            as="h1"
+            variant="header-md"
+            className={cn('min-w-0 truncate', 'font-sans font-medium tracking-normal text-neutral4')}
+          >
+            {title}
+          </Txt>
+          {action ? <div className="shrink-0">{action}</div> : null}
+        </div>
+      </div>
+      <div
+        data-slot="settings-layout-content"
+        className="mx-auto w-full max-w-5xl min-w-0 overflow-x-hidden px-4 py-6 sm:px-6 sm:py-8"
+      >
+        <div className="min-w-0 space-y-8">{children}</div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Adds a shared `SettingsLayout` for page titles, actions, constrained width, and section spacing. `Section.Header` now aligns headings with the card edge by default, while the `inset` prop preserves content-aligned layouts for Platform.

| Section heading alignment | Light | Dark |
| --- | --- | --- |
| Before | ![Section heading inset with row content in light mode](https://github.com/user-attachments/assets/c5a3e86e-e157-4ca2-9b96-39877fd00dfd) | ![Section heading inset with row content in dark mode](https://github.com/user-attachments/assets/75646dbe-9ca4-45bd-93e9-cc95fbf752bf) |
| After | ![Section heading aligned to the card edge in light mode](https://github.com/user-attachments/assets/f66aa072-4331-4a29-b203-a1c835803650) | ![Section heading aligned to the card edge in dark mode](https://github.com/user-attachments/assets/7ce2b8f7-388a-4511-9088-95aa04d0f6c6) |

| New SettingsLayout | Light | Dark |
| --- | --- | --- |
| After | ![SettingsLayout preferences shell in light mode](https://github.com/user-attachments/assets/1aac903e-1a65-4a61-aef9-02da659a32c0) | ![SettingsLayout preferences shell in dark mode](https://github.com/user-attachments/assets/ed5dcdf8-7861-4931-ad2f-8c229f453ee7) |

Verified with focused tests, typecheck, lint, package and Storybook builds, accessibility checks, desktop and mobile browser assertions, and mutation testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a shared layout for settings pages. It also lets section headings align with either the card edge or the row content.

## Changes

- Added the reusable `SettingsLayout` component.
- Added support for:
  - Page titles
  - Optional actions
  - Responsive constrained width
  - Configurable inset spacing
  - Shared section spacing and styling
- Added the `inset` prop to `Section.Header`.
- Updated section stories and tests for default and inset alignment.
- Added `SettingsLayout` stories and tests.
- Handled null and undefined titles with a content-only layout.
- Added a changeset for `@mastra/playground-ui`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->