### PR TITLE
fix(memory): preserve manually renamed thread titles

### DIFF
--- a/.changeset/petite-needles-act.md
+++ b/.changeset/petite-needles-act.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed manual thread renames being overwritten by Observational Memory. Renames now pin the title by default; pass pin: false for initial titles or regenerate the title to resume automatic naming.

--- a/.changeset/petite-needles-act.md
+++ b/.changeset/petite-needles-act.md
@@ -2,4 +2,12 @@
 '@mastra/core': patch
 ---
 
-Fixed manual thread renames being overwritten by Observational Memory. Renames now pin the title by default; pass pin: false for initial titles or regenerate the title to resume automatic naming.
+Fixed manual thread renames being overwritten by Observational Memory. Renames now pin the title by default; pass `pin: false` for initial titles or regenerate the title to resume automatic naming.
+
+```typescript
+// Allow Observational Memory to refine a programmatic initial title.
+await session.thread.rename({ title: 'Initial task title', pin: false });
+
+// Pin a manually chosen title (the default).
+await session.thread.rename({ title: 'My chosen title' });
+```

--- a/.changeset/solid-rivers-jog.md
+++ b/.changeset/solid-rivers-jog.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed Observational Memory overwriting pinned thread titles during synchronous observation, background buffering, resource-scoped updates, and buffered activation, while preserving automatic titles for unpinned threads.

--- a/.changeset/thin-plums-itch.md
+++ b/.changeset/thin-plums-itch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Kept Factory startup titles eligible for automatic updates after manual thread renames began pinning titles by default.

--- a/mastracode/factory/src/rules/start-coordinator.test.ts
+++ b/mastracode/factory/src/rules/start-coordinator.test.ts
@@ -148,6 +148,7 @@ describe('FactoryStartCoordinator', () => {
     });
     expect((await storage.listPendingStarts('org-1', PROJECT_ID))[0]?.status).toBe('sent');
     const session = await vi.mocked(controller.createSession).mock.results[0]?.value;
+    expect(session.thread.rename).toHaveBeenCalledWith({ title: 'Investigate issue 1', pin: false });
     expect(session.permissions.setForTool).toHaveBeenCalledWith({
       toolName: 'factory_transition_work_item',
       policy: 'allow',

--- a/mastracode/factory/src/rules/start-coordinator.ts
+++ b/mastracode/factory/src/rules/start-coordinator.ts
@@ -74,7 +74,7 @@ async function resolveSourceSession(
 
 async function configureThread(session: FactorySession, request: FactoryStartRequest): Promise<string> {
   const threadId = session.thread.requireId();
-  await session.thread.rename({ title: request.threadTitle });
+  await session.thread.rename({ title: request.threadTitle, pin: false });
   await session.thread.setSetting({ key: 'factorySessionId', value: request.sessionId });
   return threadId;
 }

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -13,6 +13,7 @@ import { defaultGateways } from '../llm/model/gateways/defaults';
 import type { MastraModelConfig } from '../llm/model/shared.types';
 import { Mastra } from '../mastra';
 import type { MastraMemory } from '../memory/memory';
+import { setThreadTitlePinned } from '../memory/types';
 import type { StorageThreadType } from '../memory/types';
 import type { TracingContext, TracingOptions } from '../observability';
 import { RequestContext } from '../request-context';
@@ -1306,7 +1307,12 @@ export class AgentController<TState = {}> {
     )?.trim();
     if (!title) return undefined;
 
-    await this.persistThreadRow({ ...thread, title, updatedAt: new Date() });
+    await this.persistThreadRow({
+      ...thread,
+      title,
+      metadata: setThreadTitlePinned(thread.metadata, false),
+      updatedAt: new Date(),
+    });
     session?.emit({ type: 'thread_title_updated', threadId, title });
     return title;
   }

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -21,6 +21,7 @@ import { ModelRouterLanguageModel } from '../llm/model/router';
 import type { MastraModelConfig } from '../llm/model/shared.types';
 import { createRunScopeKey } from '../mastra/run-scope';
 import type { RunScope } from '../mastra/run-scope';
+import { setThreadTitlePinned } from '../memory/types';
 import type { SendNotificationSignalInput } from '../notifications';
 import type { TracingContext, TracingOptions } from '../observability';
 import type { RequestContext } from '../request-context';
@@ -675,8 +676,12 @@ export class SessionThread {
     return thread;
   }
 
-  /** Rename the session's active thread. No-op when unbound or storageless. */
-  async rename({ title }: { title: string }): Promise<void> {
+  /**
+   * Rename and pin the session's active thread so Observational Memory preserves the title.
+   * Pass `pin: false` for programmatic initial titles that the observer may still update.
+   * No-op when unbound or storageless.
+   */
+  async rename({ title, pin = true }: { title: string; pin?: boolean }): Promise<void> {
     const store = this.#store;
     const threadId = this.#threadId;
     if (!threadId || !store?.hasStorage()) return;
@@ -684,7 +689,7 @@ export class SessionThread {
     const thread = await store.getById({ threadId });
     if (thread) {
       await store.saveThread({
-        thread: { ...thread, title, updatedAt: new Date() },
+        thread: { ...thread, title, metadata: setThreadTitlePinned(thread.metadata, pin), updatedAt: new Date() },
       });
       this.#owner.emit({ type: 'thread_title_updated', threadId, title });
     }

--- a/packages/core/src/agent-controller/thread-title.test.ts
+++ b/packages/core/src/agent-controller/thread-title.test.ts
@@ -100,6 +100,9 @@ describe('AgentController thread titles', () => {
     const { controller, session, memory } = await startNamedThread();
     const threadId = session.thread.getId()!;
     await session.thread.rename({ title: 'Wrong name' });
+    expect((await memory.getThreadById({ threadId }))?.metadata).toMatchObject({
+      mastra: { titlePinned: true },
+    });
 
     const events: AgentControllerEvent[] = [];
     session.subscribe(event => events.push(event));
@@ -111,6 +114,9 @@ describe('AgentController thread titles', () => {
 
     expect(title).toBe('Log parser rewrite');
     expect((await memory.getThreadById({ threadId }))?.title).toBe('Log parser rewrite');
+    expect((await memory.getThreadById({ threadId }))?.metadata).toMatchObject({
+      mastra: { titlePinned: false },
+    });
     expect(events).toContainEqual({ type: 'thread_title_updated', threadId, title: 'Log parser rewrite' });
   });
 
@@ -122,6 +128,45 @@ describe('AgentController thread titles', () => {
 
     expect(await controller.generateThreadTitle({ threadId })).toBe('Log parser rewrite');
     expect((await memory.getThreadById({ threadId }))?.title).toBe('Log parser rewrite');
+    expect((await memory.getThreadById({ threadId }))?.metadata).toMatchObject({
+      mastra: { titlePinned: false },
+    });
+  });
+
+  it('lets programmatic renames opt out of pinning without losing other metadata', async () => {
+    const { session, memory } = await startNamedThread();
+    const threadId = session.thread.getId()!;
+    const thread = (await memory.getThreadById({ threadId }))!;
+    await memory.saveThread({
+      thread: { ...thread, metadata: { custom: 'keep', mastra: { om: { currentTask: 'Keep working' } } } },
+    });
+
+    await session.thread.rename({ title: 'My title' });
+    await session.thread.rename({ title: 'Initial task title', pin: false });
+
+    expect(await memory.getThreadById({ threadId })).toMatchObject({
+      title: 'Initial task title',
+      metadata: { custom: 'keep', mastra: { titlePinned: false, om: { currentTask: 'Keep working' } } },
+    });
+  });
+
+  it.each(['empty', 'failed'])('keeps a manual title pinned when regeneration is %s', async outcome => {
+    const { controller, session, memory, agent } = await startNamedThread();
+    const threadId = session.thread.getId()!;
+    await session.thread.rename({ title: 'My title' });
+    const namer = vi.spyOn(agent, 'generateTitleFromUserMessage');
+    if (outcome === 'failed') {
+      namer.mockRejectedValueOnce(new Error('Title generation failed'));
+      await expect(controller.generateThreadTitle({ threadId })).rejects.toThrow('Title generation failed');
+    } else {
+      namer.mockResolvedValueOnce('   ');
+      expect(await controller.generateThreadTitle({ threadId })).toBeUndefined();
+    }
+
+    expect(await memory.getThreadById({ threadId })).toMatchObject({
+      title: 'My title',
+      metadata: { mastra: { titlePinned: true } },
+    });
   });
 
   it('names a thread under the identity the caller supplies', async () => {

--- a/packages/core/src/memory/thread-title.test.ts
+++ b/packages/core/src/memory/thread-title.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { isThreadTitlePinned, setThreadOMMetadata, setThreadTitlePinned } from './types';
+
+describe('thread title pin metadata', () => {
+  it.each([undefined, {}, { mastra: null }, { mastra: [] }, { mastra: 'invalid' }, { mastra: {} }])(
+    'treats missing or malformed metadata %j as unpinned',
+    metadata => {
+      expect(isThreadTitlePinned(metadata)).toBe(false);
+      expect(isThreadTitlePinned(setThreadTitlePinned(metadata, true))).toBe(true);
+    },
+  );
+
+  it.each([undefined, false, 'true', 1])('does not treat titlePinned=%j as an explicit pin', titlePinned => {
+    expect(isThreadTitlePinned({ mastra: { titlePinned } })).toBe(false);
+  });
+
+  it('preserves other metadata and does not mutate the original when pinning or unpinning', () => {
+    const metadata = { custom: 'keep', mastra: { om: { currentTask: 'Keep working' }, other: 'keep' } };
+    const pinned = setThreadTitlePinned(metadata, true);
+    const unpinned = setThreadTitlePinned(pinned, false);
+
+    expect(pinned).toEqual({ ...metadata, mastra: { ...metadata.mastra, titlePinned: true } });
+    expect(unpinned).toEqual({ ...metadata, mastra: { ...metadata.mastra, titlePinned: false } });
+    expect(isThreadTitlePinned(pinned)).toBe(true);
+    expect(isThreadTitlePinned(metadata)).toBe(false);
+    expect(metadata.mastra).not.toHaveProperty('titlePinned');
+    expect(pinned.mastra).not.toBe(metadata.mastra);
+  });
+
+  it('retains the pin when observational memory updates its own metadata', () => {
+    const pinned = setThreadTitlePinned(undefined, true);
+    const updated = setThreadOMMetadata(pinned, { threadTitle: 'Observer title' });
+    expect(isThreadTitlePinned(updated)).toBe(true);
+    expect(updated).toMatchObject({ mastra: { om: { threadTitle: 'Observer title' } } });
+  });
+});

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -72,11 +72,29 @@ export type ThreadOMMetadata = {
  * Stored on thread.metadata.mastra
  */
 export type ThreadMastraMetadata = {
+  /** Preserve a manually chosen title instead of replacing it with an observer-generated title. */
+  titlePinned?: boolean;
   om?: ThreadOMMetadata;
 };
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Whether the thread title has been explicitly pinned. Older threads default to unpinned. */
+export function isThreadTitlePinned(threadMetadata?: Record<string, unknown>): boolean {
+  const mastra = threadMetadata?.mastra;
+  return isPlainObject(mastra) && mastra.titlePinned === true;
+}
+
+/** Set the title pin without mutating or discarding other thread metadata. */
+export function setThreadTitlePinned(
+  threadMetadata: Record<string, unknown> | undefined,
+  pinned: boolean,
+): Record<string, unknown> {
+  const existing = threadMetadata ?? {};
+  const existingMastra = isPlainObject(existing.mastra) ? existing.mastra : {};
+  return { ...existing, mastra: { ...existingMastra, titlePinned: pinned } };
 }
 
 /**

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -16781,7 +16781,7 @@ describe('Async reflection failure should not permanently block future reflectio
 });
 
 describe('Observer output threadTitle propagation', () => {
-  it('should persist threadTitle from observer output to thread metadata', async () => {
+  it.each([false, true])('preserves observer hints with titlePinned=%s', async titlePinned => {
     // This tests the fix: threadTitle extracted by parseObserverOutput must
     // propagate through ObserverRunner.call() → sync strategy process() →
     // persist() → setThreadOMMetadata.
@@ -16849,7 +16849,7 @@ describe('Observer output threadTitle propagation', () => {
         title: 'Test Thread',
         createdAt: new Date('2025-01-01T08:00:00Z'),
         updatedAt: new Date('2025-01-01T08:00:00Z'),
-        metadata: {},
+        metadata: { mastra: { titlePinned } },
       },
     });
     await storage.initializeObservationalMemory({
@@ -16886,22 +16886,27 @@ describe('Observer output threadTitle propagation', () => {
 
     // Check that threadTitle was persisted to thread metadata
     const thread = await storage.getThreadById({ threadId });
+    expect(thread?.title).toBe(titlePinned ? 'Test Thread' : 'React Dashboard Project');
     const omMetadata = ((thread?.metadata as any)?.mastra?.om ?? {}) as any;
     expect(omMetadata.threadTitle).toBe('React Dashboard Project');
     expect(omMetadata.currentTask).toBe('Building the dashboard');
     expect(omMetadata.suggestedResponse).toBe('Let me help with that.');
 
     const threadUpdatePart = capturedParts.find(part => part?.type === 'data-om-thread-update');
-    expect(threadUpdatePart).toMatchObject({
-      type: 'data-om-thread-update',
-      data: {
-        threadId,
-        oldTitle: 'Test Thread',
-        newTitle: 'React Dashboard Project',
-      },
-    });
-    expect(threadUpdatePart?.data.cycleId).toEqual(expect.any(String));
-    expect(threadUpdatePart?.data.timestamp).toEqual(expect.any(String));
+    if (titlePinned) {
+      expect(threadUpdatePart).toBeUndefined();
+    } else {
+      expect(threadUpdatePart).toMatchObject({
+        type: 'data-om-thread-update',
+        data: {
+          threadId,
+          oldTitle: 'Test Thread',
+          newTitle: 'React Dashboard Project',
+        },
+      });
+      expect(threadUpdatePart?.data.cycleId).toEqual(expect.any(String));
+      expect(threadUpdatePart?.data.timestamp).toEqual(expect.any(String));
+    }
     expect(capturedParts.every(part => part.transient === true)).toBe(true);
 
     const after = await storage.listMessages({
@@ -16922,10 +16927,10 @@ describe('Observer output threadTitle propagation', () => {
           part => part.type === 'data-om-thread-update' && (part.data as any)?.newTitle === 'React Dashboard Project',
         ),
       ),
-    ).toBe(true);
+    ).toBe(!titlePinned);
   });
 
-  it('should persist threadTitle from activated buffered chunks to thread record', async () => {
+  it.each([false, true])('respects titlePinned=%s when activating buffered chunks', async titlePinned => {
     const storage = createInMemoryStorage();
     const threadId = 'buf-title-thread';
     const resourceId = 'buf-title-resource';
@@ -16977,12 +16982,15 @@ describe('Observer output threadTitle propagation', () => {
       },
     });
 
+    // A manual rename can happen after the observer has already buffered its title.
+    await storage.patchThread({ id: threadId, metadata: { mastra: { titlePinned } } });
+
     const result = await om.activate({ threadId, resourceId });
     expect(result.activated).toBe(true);
 
     // Verify threadTitle was persisted to the thread record
     const thread = await storage.getThreadById({ threadId });
-    expect(thread?.title).toBe('React Dashboard Project');
+    expect(thread?.title).toBe(titlePinned ? 'New Thread' : 'React Dashboard Project');
 
     // Verify OM metadata includes the threadTitle
     const omMetadata = ((thread?.metadata as any)?.mastra?.om ?? {}) as any;

--- a/packages/memory/src/processors/observational-memory/__tests__/pinned-thread-titles.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/pinned-thread-titles.test.ts
@@ -1,0 +1,76 @@
+import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { InMemoryDB, InMemoryMemory } from '@mastra/core/storage';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ObservationStrategy } from '../observation-strategies';
+import { ObservationalMemory } from '../observational-memory';
+
+describe.each(['sync', 'async-buffer', 'resource-scoped'] as const)('%s title persistence', mode => {
+  it.each([undefined, false, true])('respects titlePinned=%s without dropping observer metadata', async titlePinned => {
+    const storage = new InMemoryMemory({ db: new InMemoryDB() });
+    const threadId = 'title-thread';
+    const resourceId = 'title-resource';
+    const scope = mode === 'resource-scoped' ? 'resource' : 'thread';
+    const createdAt = new Date('2025-01-01T08:00:00Z');
+    const lastObservedAt = new Date('2025-01-01T09:00:00Z');
+    const threadTitle = '  Generated title  ';
+    for (const id of [threadId, 'other-thread']) {
+      await storage.saveThread({
+        thread: { id, resourceId, title: 'Initial title', createdAt, updatedAt: createdAt },
+      });
+    }
+    const record = await storage.initializeObservationalMemory({ threadId, resourceId, scope, config: {} });
+    const om = new ObservationalMemory({
+      storage,
+      scope,
+      model: new MockLanguageModelV2(),
+      observation: { threadTitle: true },
+    });
+    const custom = vi.fn().mockResolvedValue(undefined);
+    const strategy = ObservationStrategy.create(om, {
+      record,
+      threadId,
+      resourceId,
+      messages: [],
+      ...(mode === 'async-buffer' ? { cycleId: 'title-cycle' } : {}),
+      writer: { custom },
+    });
+
+    // Rename after creating the strategy, as a user can do while the observer is running.
+    await storage.patchThread({
+      id: threadId,
+      title: 'My chosen title',
+      metadata: {
+        custom: 'keep',
+        mastra: { ...(titlePinned === undefined ? {} : { titlePinned }), om: { extracted: { prior: 'keep' } } },
+      },
+    });
+    await strategy.persist({
+      observations: '- User is building a dashboard',
+      observationTokens: 10,
+      cycleObservationTokens: 10,
+      observedMessageIds: [],
+      lastObservedAt,
+      threadTitle,
+      threadMetadataUpdates: [threadId, 'other-thread'].map(id => ({
+        threadId: id,
+        threadTitle,
+        lastObservedAt: lastObservedAt.toISOString(),
+      })),
+    });
+
+    expect(await storage.getThreadById({ threadId })).toMatchObject({
+      title: titlePinned ? 'My chosen title' : 'Generated title',
+      metadata: { custom: 'keep', mastra: { om: { threadTitle, extracted: { prior: 'keep' } } } },
+    });
+    const titleUpdates = custom.mock.calls
+      .map(([part]) => part)
+      .filter(part => part.type === 'data-om-thread-update' && part.data.threadId === threadId);
+    expect(titleUpdates).toHaveLength(titlePinned ? 0 : 1);
+
+    if (mode === 'resource-scoped') {
+      // Pinning one thread must not disable automatic titles for another thread in the resource.
+      expect((await storage.getThreadById({ threadId: 'other-thread' }))?.title).toBe('Generated title');
+    }
+  });
+});

--- a/packages/memory/src/processors/observational-memory/observation-strategies/async-buffer.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/async-buffer.ts
@@ -14,6 +14,7 @@ import { wrapInObservationGroup } from '../observation-groups';
 import { buildMessageRange } from '../observational-memory';
 import { formatMessagesForObserver } from '../observer-agent';
 import { withRetry } from '../retry';
+import { resolveThreadTitleUpdate } from '../thread-title';
 import { ObservationStrategy } from './base';
 import type { StrategyDeps } from './base';
 import type { ObservationRunOpts, ObserverOutput, ProcessedObservation } from './types';
@@ -168,13 +169,12 @@ export class AsyncBufferObservationStrategy extends ObservationStrategy {
     await this.indexObservationGroups(processed.observations, threadId, resourceId, processed.lastObservedAt);
 
     // Persist extracted values immediately; buffered observation activation is unrelated to extractor state.
-    const newTitle = processed.threadTitle?.trim();
-    const hasValidThreadTitle = !!newTitle && newTitle.length >= 3;
+    const hasValidThreadTitle = (processed.threadTitle?.trim().length ?? 0) >= 3;
     if (hasValidThreadTitle || processed.extractedValues) {
       const thread = await this.storage.getThreadById({ threadId });
       if (thread) {
         const oldTitle = thread.title?.trim();
-        const shouldUpdateThreadTitle = hasValidThreadTitle && newTitle !== oldTitle;
+        const newTitle = resolveThreadTitleUpdate(thread, processed.threadTitle);
         const previousOmMetadata = getThreadOMMetadata(thread.metadata);
         const metadataUpdate = buildThreadMetadataFromExtractedValues(
           processed.extractors ?? this.observationConfig.extractors,
@@ -191,11 +191,11 @@ export class AsyncBufferObservationStrategy extends ObservationStrategy {
         });
         await this.storage.patchThread({
           id: threadId,
-          ...(shouldUpdateThreadTitle ? { title: newTitle } : {}),
+          ...(newTitle ? { title: newTitle } : {}),
           metadata: newMetadata,
         });
 
-        if (shouldUpdateThreadTitle) {
+        if (newTitle) {
           const marker = createThreadUpdateMarker({
             cycleId: this.cycleId,
             threadId,

--- a/packages/memory/src/processors/observational-memory/observation-strategies/resource-scoped.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/resource-scoped.ts
@@ -19,6 +19,7 @@ import {
 import { getLastObservedMessageCursor, sortThreadsByOldestMessage } from '../message-utils';
 import { buildMessageRange } from '../observational-memory';
 import { formatMessagesForObserver } from '../observer-agent';
+import { resolveThreadTitleUpdate } from '../thread-title';
 import { getMaxThreshold } from '../thresholds';
 
 import { ObservationStrategy } from './base';
@@ -417,8 +418,7 @@ export class ResourceScopedObservationStrategy extends ObservationStrategy {
         const thread = await this.storage.getThreadById({ threadId: update.threadId });
         if (thread) {
           const oldTitle = thread.title?.trim();
-          const newTitle = update.threadTitle?.trim();
-          const shouldUpdateThreadTitle = !!newTitle && newTitle.length >= 3 && newTitle !== oldTitle;
+          const newTitle = resolveThreadTitleUpdate(thread, update.threadTitle);
           const previousOmMetadata = getThreadOMMetadata(thread.metadata);
           const metadataUpdate = buildThreadMetadataFromExtractedValues(
             update.extractors ?? this.observationConfig.extractors,
@@ -437,11 +437,11 @@ export class ResourceScopedObservationStrategy extends ObservationStrategy {
           });
           await this.storage.patchThread({
             id: update.threadId,
-            ...(shouldUpdateThreadTitle ? { title: newTitle } : {}),
+            ...(newTitle ? { title: newTitle } : {}),
             metadata: newMetadata,
           });
 
-          if (shouldUpdateThreadTitle) {
+          if (newTitle) {
             threadUpdateMarkers.push(
               createThreadUpdateMarker({
                 cycleId: this.cycleId ?? crypto.randomUUID(),

--- a/packages/memory/src/processors/observational-memory/observation-strategies/sync.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/sync.ts
@@ -17,6 +17,7 @@ import { getLastObservedMessageCursor } from '../message-utils';
 
 import { buildMessageRange } from '../observational-memory';
 import { formatMessagesForObserver } from '../observer-agent';
+import { resolveThreadTitleUpdate } from '../thread-title';
 import { ObservationStrategy } from './base';
 import type { StrategyDeps } from './base';
 import type { ObservationRunOpts, ObserverOutput, ProcessedObservation } from './types';
@@ -201,8 +202,7 @@ export class SyncObservationStrategy extends ObservationStrategy {
 
     if (thread) {
       const oldTitle = thread.title?.trim();
-      const newTitle = processed.threadTitle?.trim();
-      const shouldUpdateThreadTitle = !!newTitle && newTitle.length >= 3 && newTitle !== oldTitle;
+      const newTitle = resolveThreadTitleUpdate(thread, processed.threadTitle);
       const previousOmMetadata = getThreadOMMetadata(thread.metadata);
       const metadataUpdate = buildThreadMetadataFromExtractedValues(
         processed.extractors ?? this.observationConfig.extractors,
@@ -220,11 +220,11 @@ export class SyncObservationStrategy extends ObservationStrategy {
       });
       await this.storage.patchThread({
         id: threadId,
-        ...(shouldUpdateThreadTitle ? { title: newTitle } : {}),
+        ...(newTitle ? { title: newTitle } : {}),
         metadata: newMetadata,
       });
 
-      if (shouldUpdateThreadTitle) {
+      if (newTitle) {
         threadUpdateMarker = createThreadUpdateMarker({
           cycleId: this.cycleId ?? crypto.randomUUID(),
           threadId,

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -245,6 +245,7 @@ import { registerOp, unregisterOp, isOpActiveInProcess } from './operation-regis
 import type { CompressionLevel } from './reflector-agent';
 import { ReflectorRunner } from './reflector-runner';
 import { isOmReproCaptureEnabled, writeObserverExchangeReproCapture } from './repro-capture';
+import { resolveThreadTitleUpdate } from './thread-title';
 import {
   calculateDynamicThreshold,
   calculateProjectedMessageRemoval,
@@ -3558,12 +3559,10 @@ ${formattedMessages}
           currentTask: lastActivated.currentTask,
           threadTitle: chunkThreadTitle,
         });
-        const oldTitle = thread.title?.trim();
-        const newTitle = chunkThreadTitle?.trim();
-        const shouldUpdateThreadTitle = !!newTitle && newTitle.length >= 3 && newTitle !== oldTitle;
+        const newTitle = resolveThreadTitleUpdate(thread, chunkThreadTitle);
         await this.storage.patchThread({
           id: threadId,
-          ...(shouldUpdateThreadTitle ? { title: newTitle } : {}),
+          ...(newTitle ? { title: newTitle } : {}),
           metadata: newMetadata,
         });
       }

--- a/packages/memory/src/processors/observational-memory/thread-title.ts
+++ b/packages/memory/src/processors/observational-memory/thread-title.ts
@@ -1,0 +1,9 @@
+import { isThreadTitlePinned } from '@mastra/core/memory';
+import type { StorageThreadType } from '@mastra/core/memory';
+
+/** Resolve an automatic title update against the latest stored thread, respecting manual renames. */
+export function resolveThreadTitleUpdate(thread: StorageThreadType, proposedTitle?: string): string | undefined {
+  if (isThreadTitlePinned(thread.metadata)) return undefined;
+  const title = proposedTitle?.trim();
+  return title && title.length >= 3 && title !== thread.title?.trim() ? title : undefined;
+}


### PR DESCRIPTION
Fixes #22421.

> **Draft — atomic storage dependency unresolved.** The published head (`19999622`) still contains the two confirmed concurrency bugs discussed in [the review thread](https://github.com/mastra-ai/mastra/pull/23112#discussion_r3944315019). Snapshot-only pin checks do not protect a manual rename across storage clients. A broader conditional-storage implementation and additional writer-path regressions are being validated on an unpublished local branch; they are not part of this PR head. Maintainer direction is still needed on the storage contract and adapter compatibility policy before that implementation is proposed. The validation below describes the published implementation, not proof that these races are fixed.

Pin titles set through Session.thread.rename() by default and respect that pin across sync, async-buffer, resource-scoped, and buffered-activation title updates. Observer metadata still updates normally. Factory startup passes pin: false, and successful explicit title regeneration clears the pin. Existing threads remain unpinned; no storage migration is needed.

Added regressions for pin persistence, regeneration, all four overwrite paths, and unpinned controls. Controller tests (499), OM tests (1,230 with two workers), metadata helpers (12), and Factory startup tests (18) pass, as do core/memory builds and core/memory/factory typechecks. A local LibSQL close/reopen smoke also passes. One reminder test failed in the first parallel OM run, then passed alone and in the full rerun. The full integration harness was not run because its frozen install reports an overrides/lockfile mismatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Manually renamed thread titles now stay unchanged when automatic naming runs. Threads that were not manually renamed can still receive automatic titles, and users can regenerate a title when needed.

## Changes

- Added `titlePinned` metadata with helpers to read and update pin state.
- Made `Session.thread.rename()` pin titles by default.
- Added `pin: false` for callers that need automatic naming, including Factory startup.
- Cleared the pin after successful explicit title regeneration.
- Applied pinned-title checks across synchronous, buffered, resource-scoped, and activation-based Observational Memory updates.
- Preserved observer metadata and update events.
- Kept existing threads unpinned by default without a storage migration.

## Tests

- Covered manual rename and regeneration behavior.
- Covered unpinned programmatic renames.
- Covered malformed or missing metadata.
- Covered all Observational Memory persistence strategies.
- Verified that pinned titles remain unchanged and unpinned titles continue to update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
