### PR TITLE
fix(core): handle empty reasoning in v6 message conversion

### DIFF
--- a/.changeset/jolly-mangos-rescue.md
+++ b/.changeset/jolly-mangos-rescue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed AI SDK v6 message conversion crashing on empty opening reasoning parts while preserving surrounding content and tool approvals.

--- a/packages/core/src/agent/message-list/adapters/AIV6Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV6Adapter.ts
@@ -362,7 +362,8 @@ export class AIV6Adapter {
     const hasTextParts = dbParts.some(part => part.type === 'text');
 
     for (const part of dbParts) {
-      parts.push(AIV6Adapter.toUIPart(part));
+      const uiPart = AIV6Adapter.toUIPart(part);
+      if (uiPart) parts.push(uiPart);
     }
 
     if (!hasToolInvocationParts || !hasReasoningParts || !hasFileParts || !hasTextParts) {
@@ -564,7 +565,7 @@ export class AIV6Adapter {
     };
   }
 
-  private static toUIPart(part: MastraMessagePart): AIV6Type.UIMessage['parts'][number] {
+  private static toUIPart(part: MastraMessagePart): AIV6Type.UIMessage['parts'][number] | undefined {
     if (part.type === 'tool-invocation') {
       const base = withOptionalFields(
         {
@@ -697,17 +698,18 @@ export class AIV6Adapter {
       ) as AIV6Type.UIMessage['parts'][number];
     }
 
-    return AIV6Adapter.toUIPartFromV5(
-      AIV5Adapter.toUIMessage({
-        id: 'tmp',
-        role: 'assistant',
-        createdAt: new Date(),
-        content: {
-          format: 2,
-          parts: [part],
-        },
-      }).parts[0]!,
-    );
+    const v5Part = AIV5Adapter.toUIMessage({
+      id: 'tmp',
+      role: 'assistant',
+      createdAt: new Date(),
+      content: {
+        format: 2,
+        parts: [part],
+      },
+    }).parts[0];
+
+    // The v5 bridge omits empty reasoning parts before the first text delta.
+    return v5Part ? AIV6Adapter.toUIPartFromV5(v5Part) : undefined;
   }
 
   private static toUIPartFromV5(part: AIV5Type.UIMessage['parts'][number]): AIV6Type.UIMessage['parts'][number] {

--- a/packages/core/src/agent/message-list/tests/message-list-v6.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-v6.test.ts
@@ -7,6 +7,69 @@ import type { MastraDBMessage } from '../../index';
 import { MessageList } from '../../index';
 
 describe('MessageList AI SDK v6 support', () => {
+  it('projects an opening empty reasoning part without throwing', () => {
+    const message: MastraDBMessage = {
+      id: 'opening-reasoning',
+      role: 'assistant',
+      createdAt: new Date(),
+      content: { format: 2, parts: [{ type: 'reasoning', reasoning: '', details: [] }] },
+    };
+
+    const result = new MessageList().add(message, 'memory').get.all.aiV6.ui();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: message.id, role: 'assistant', parts: [] });
+    expect(message.content.parts).toEqual([{ type: 'reasoning', reasoning: '', details: [] }]);
+  });
+
+  it('keeps surrounding text, reasoning metadata and approvals when empty reasoning is omitted', () => {
+    const result = new MessageList()
+      .add(
+        {
+          id: 'mixed-reasoning',
+          role: 'assistant',
+          createdAt: new Date(),
+          content: {
+            format: 2,
+            parts: [
+              { type: 'text', text: 'Before' },
+              { type: 'reasoning', reasoning: '', details: [] },
+              {
+                type: 'reasoning',
+                reasoning: '',
+                details: [{ type: 'text', text: 'Preparing the requested task.' }],
+                providerMetadata: { test: { signature: 'test-signature' } },
+              },
+              {
+                type: 'tool-invocation',
+                toolInvocation: {
+                  toolCallId: 'read-page',
+                  toolName: 'readPage',
+                  args: { url: 'https://example.com' },
+                  state: 'approval-requested',
+                  approval: { id: 'approve-page' },
+                },
+              },
+              { type: 'text', text: 'After' },
+            ],
+          },
+        } satisfies MastraDBMessage,
+        'memory',
+      )
+      .get.all.aiV6.ui();
+
+    expect(result[0]?.parts).toMatchObject([
+      { type: 'text', text: 'Before' },
+      {
+        type: 'reasoning',
+        text: 'Preparing the requested task.',
+        providerMetadata: { test: { signature: 'test-signature' } },
+      },
+      { type: 'tool-readPage', toolCallId: 'read-page', state: 'approval-requested', approval: { id: 'approve-page' } },
+      { type: 'text', text: 'After' },
+    ]);
+  });
+
   it('projects MastraDBMessage records to AI SDK v6 UI messages', () => {
     const messages: MastraDBMessage[] = [
       {


### PR DESCRIPTION
An opening empty reasoning part makes the v6 message converter throw `Cannot read properties of undefined (reading 'type')` before the first text delta. The v5 bridge omits that part, but the v6 adapter assumes its first converted part exists.

This lets the v6 adapter retain that omission without dereferencing `undefined`. It preserves surrounding text, reasoning metadata, and native tool approval IDs. It does not change the input messages or the session lifecycle.

The two new regression tests fail with the original exception before the fix. With the fix, all 62 tests across the v6 message suite and adapter suites pass, and `@mastra/core` typecheck passes. The same opening-frame crash was also reproduced with published core 1.63.2 and 1.64.0 before preparing this change.

```ts
new MessageList().add({
  id: 'opening-reasoning', role: 'assistant', createdAt: new Date(),
  content: { format: 2, parts: [{ type: 'reasoning', reasoning: '', details: [] }] },
}, 'memory').get.all.aiV6.ui(); // Now returns the message with an empty parts array.
```


Fixes #23114.
