### PR TITLE
fix(core): keep one durable thread broadcast across approval

### DIFF
--- a/.changeset/wise-brooms-see.md
+++ b/.changeset/wise-brooms-see.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed duplicate live answers after a durable agent resumes from tool approval. Preserve the continuous thread stream while later approvals, stop commands, and request context continue to work.

--- a/packages/core/src/agent-controller/__tests__/durable-approval-message-identity.test.ts
+++ b/packages/core/src/agent-controller/__tests__/durable-approval-message-identity.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../../agent/durable';
+import { InMemoryServerCache } from '../../cache';
+import { EventEmitterPubSub } from '../../events';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage';
+import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
+import { createTool } from '../../tools';
+import { AgentController } from '../agent-controller';
+import { createMockWorkspace } from '../test-utils';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+describe('public approval completion keeps one answer identity', () => {
+  it.each([
+    { yolo: false, durable: false, rounds: 1, siblings: 1, chunkDelay: 0 },
+    { yolo: true, durable: false, rounds: 1, siblings: 1, chunkDelay: 0 },
+    { yolo: false, durable: true, rounds: 1, siblings: 1, chunkDelay: 0 },
+    { yolo: true, durable: true, rounds: 1, siblings: 1, chunkDelay: 0 },
+    { yolo: false, durable: true, rounds: 2, siblings: 1, chunkDelay: 0 },
+    { yolo: false, durable: true, rounds: 1, siblings: 2, chunkDelay: 0 },
+    { yolo: false, durable: true, rounds: 2, siblings: 2, chunkDelay: 5 },
+  ])(
+    'keeps one answer: yolo=$yolo durable=$durable rounds=$rounds siblings=$siblings chunkDelay=$chunkDelay',
+    async ({ yolo, durable, rounds, siblings, chunkDelay }) => {
+      let modelCalls = 0;
+      let toolCalls = 0;
+      const model = new MastraLanguageModelV2Mock({
+        doStream: async () => {
+          const call = ++modelCalls;
+          return {
+            stream: new ReadableStream({
+              start(stream) {
+                stream.enqueue({ type: 'stream-start', warnings: [] });
+                stream.enqueue({
+                  type: 'response-metadata',
+                  id: `provider-${call}`,
+                  modelId: 'mock',
+                  timestamp: new Date(0),
+                });
+                if (call <= rounds) {
+                  for (let sibling = 0; sibling < siblings; sibling++)
+                    stream.enqueue({
+                      type: 'tool-call',
+                      toolCallId: `page-read-${call}-${sibling}`,
+                      toolName: 'read_page',
+                      input: '{}',
+                      providerExecuted: false,
+                    });
+                } else {
+                  stream.enqueue({ type: 'text-start', id: 'answer' });
+                  stream.enqueue({ type: 'text-delta', id: 'answer', delta: 'Example Domain' });
+                  stream.enqueue({ type: 'text-end', id: 'answer' });
+                }
+                stream.enqueue({
+                  type: 'finish',
+                  finishReason: call <= rounds ? 'tool-calls' : 'stop',
+                  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                });
+                stream.close();
+              },
+            }),
+          };
+        },
+      });
+      const storage = new InMemoryStore();
+      const baseAgent = new Agent({
+        id: 'identity-agent',
+        name: 'Identity agent',
+        instructions: 'Read one page.',
+        model,
+        outputProcessors: [
+          {
+            id: 'usage-metadata',
+            processOutputStep: async ({ messageList }) => messageList,
+            processOutputStream: async ({ part }) => {
+              if (chunkDelay) await new Promise(resolve => setTimeout(resolve, chunkDelay));
+              return part;
+            },
+            processOutputResult: async ({ messages }) => {
+              await new Promise(resolve => setTimeout(resolve, 30));
+              return messages.map(message => ({
+                ...message,
+                content: { ...message.content, metadata: { ...message.content.metadata, fixtureUsage: true } },
+              }));
+            },
+          },
+        ],
+        tools: {
+          read_page: createTool({
+            id: 'read_page',
+            description: 'Read a fixture page.',
+            inputSchema: z.object({}),
+            execute: async () => {
+              toolCalls++;
+              return { title: 'Example Domain' };
+            },
+          }),
+        },
+      });
+      const cache = new InMemoryServerCache();
+      const pubsub = new EventEmitterPubSub();
+      const agent = durable ? createDurableAgent({ agent: baseAgent, cache, pubsub }) : baseAgent;
+      const mastra = new Mastra({ agents: { agent: agent as any }, storage, cache, pubsub, logger: false });
+      const controller = new AgentController({
+        id: 'identity-controller',
+        agent: mastra.getAgent('agent'),
+        pubsub,
+        workspace: createMockWorkspace(),
+        storage,
+        initialState: { yolo } as any,
+        modes: [{ id: 'default', default: true }],
+      });
+      await controller.init();
+      const session = await controller.createSession({
+        resourceId: 'identity-user',
+        scope: 'thread:identity-thread',
+        threadId: 'identity-thread',
+      });
+      const rows = new Map<string, any>();
+      const approved = new Set<string>();
+      session.subscribe(event => {
+        if (event.type === 'message_start' || event.type === 'message_update' || event.type === 'message_end')
+          rows.set(event.message.id, structuredClone(event.message));
+        if (event.type === 'tool_approval_required' && !approved.has(event.toolCallId)) {
+          approved.add(event.toolCallId);
+          queueMicrotask(() => {
+            session.respondToToolApproval({ decision: 'approve', toolCallId: event.toolCallId });
+          });
+        }
+      });
+      await session.sendMessage({ content: 'Read the fixture page.' });
+      await vi.waitFor(
+        () => {
+          expect(modelCalls).toBe(rounds + 1);
+          expect(session.run.isRunning()).toBe(false);
+        },
+        { timeout: 20000 },
+      );
+      await new Promise(resolve => setTimeout(resolve, 300));
+      const answers = [...rows.values()].filter(
+        row =>
+          row.role === 'assistant' &&
+          row.content.parts.some((part: any) => part.type === 'text' && part.text === 'Example Domain'),
+      );
+      expect(modelCalls).toBe(rounds + 1);
+      expect(toolCalls).toBe(rounds * siblings);
+      expect(answers).toHaveLength(1);
+    },
+  );
+});

--- a/packages/core/src/agent-controller/__tests__/session-abort-approval-suspension.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-abort-approval-suspension.test.ts
@@ -12,6 +12,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import z from 'zod';
 import { Agent } from '../../agent';
+import { createDurableAgent } from '../../agent/durable';
+import { InMemoryServerCache } from '../../cache';
+import { EventEmitterPubSub } from '../../events';
 import { Mastra } from '../../mastra';
 import { InMemoryStore } from '../../storage';
 import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
@@ -62,7 +65,7 @@ function textStream() {
   });
 }
 
-async function createHarness(id: string) {
+async function createHarness(id: string, durable: boolean) {
   const findUser = createTool({
     id: 'find-user',
     description: 'Look up a user by name.',
@@ -76,7 +79,7 @@ async function createHarness(id: string) {
   });
 
   let callCount = 0;
-  const agent = new Agent({
+  const baseAgent = new Agent({
     id: `${id}-agent`,
     name: `${id} agent`,
     instructions: 'You look up users.',
@@ -90,10 +93,15 @@ async function createHarness(id: string) {
   });
 
   const storage = new InMemoryStore();
-  const mastra = new Mastra({ agents: { [`${id}-agent`]: agent }, logger: false, storage });
+  const cache = new InMemoryServerCache();
+  const pubsub = new EventEmitterPubSub();
+  const agent = durable ? createDurableAgent({ agent: baseAgent, cache, pubsub }) : baseAgent;
+  const mastra = new Mastra({ agents: { [`${id}-agent`]: agent as any }, logger: false, storage, cache, pubsub });
   const registeredAgent = mastra.getAgent(`${id}-agent`);
 
   const controller = new AgentController({
+    agent: registeredAgent,
+    pubsub,
     workspace: createMockWorkspace(),
     id: `${id}-controller`,
     storage,
@@ -103,7 +111,7 @@ async function createHarness(id: string) {
   const session = await controller.createSession({ id: `${id}-session`, ownerId: 'owner-1' });
   await session.thread.create();
 
-  return { session, events: [] as AgentControllerEvent[] };
+  return { session, agent: registeredAgent, events: [] as AgentControllerEvent[] };
 }
 
 function waitForAgentEnd(session: any, events: AgentControllerEvent[]) {
@@ -115,9 +123,9 @@ function waitForAgentEnd(session: any, events: AgentControllerEvent[]) {
   });
 }
 
-describe('session.abort() during approval / suspension (#20592)', () => {
+describe.each([false, true])('session.abort() during approval / suspension (#20592), durable=%s', durable => {
   it('Given a tool awaiting approval, When abort() is called synchronously from the subscriber, Then the run aborts without an error event', async () => {
-    const { session, events } = await createHarness('abort-approval');
+    const { session, events } = await createHarness('abort-approval', durable);
 
     const ended = waitForAgentEnd(session, events);
     session.subscribe((event: AgentControllerEvent) => {
@@ -132,7 +140,7 @@ describe('session.abort() during approval / suspension (#20592)', () => {
   });
 
   it('Given an aborted approval, When agent_end fires, Then the display state no longer shows the tool as pending', async () => {
-    const { session, events } = await createHarness('abort-approval-ds');
+    const { session, events } = await createHarness('abort-approval-ds', durable);
 
     const ended = waitForAgentEnd(session, events);
     session.subscribe((event: AgentControllerEvent) => {
@@ -157,7 +165,7 @@ describe('session.abort() during approval / suspension (#20592)', () => {
   });
 
   it('Given two subscribers that both abort a parked approval, When the run ends, Then it still aborts without an error event', async () => {
-    const { session, events } = await createHarness('abort-approval-twice');
+    const { session, events } = await createHarness('abort-approval-twice', durable);
 
     const ended = waitForAgentEnd(session, events);
     session.subscribe((event: AgentControllerEvent) => {
@@ -175,18 +183,33 @@ describe('session.abort() during approval / suspension (#20592)', () => {
   });
 
   it('Given an approved tool parked in suspend(), When abort() is called, Then the parked suspension is retracted from the display state', async () => {
-    const { session, events } = await createHarness('abort-suspension');
+    const { session, agent, events } = await createHarness('abort-suspension', durable);
 
     const ended = waitForAgentEnd(session, events);
     session.subscribe((event: AgentControllerEvent) => {
       if (event.type === 'tool_approval_required') {
         void session.respondToToolApproval({ decision: 'approve' });
       }
-      if (event.type === 'agent_end' && event.reason === 'suspended') session.abort();
+      if (!durable && event.type === 'agent_end' && event.reason === 'suspended') session.abort();
     });
 
-    await session.sendMessage({ content: 'find dero' });
-    await ended;
+    const sending = session.sendMessage({ content: 'find dero' });
+    if (durable) {
+      await vi.waitFor(
+        async () => {
+          const parked = await agent.listSuspendedRuns({});
+          expect(
+            parked.runs.some(run => run.toolCalls.some(tool => tool.toolCallId === 'call-1' && !tool.requiresApproval)),
+          ).toBe(true);
+        },
+        { timeout: 5000 },
+      );
+      session.abort();
+      await vi.waitFor(() => expect(session.displayState.get().pendingSuspensions.size).toBe(0));
+    } else {
+      await ended;
+    }
+    await sending;
 
     const ds = session.displayState.get();
     expect(ds.pendingSuspensions.size).toBe(0);

--- a/packages/core/src/agent/__tests__/thread-stream-durable-continuation.test.ts
+++ b/packages/core/src/agent/__tests__/thread-stream-durable-continuation.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { EventEmitterPubSub } from '../../events';
+import { RequestContext } from '../../request-context';
+import type { Agent } from '../agent';
+import { createDurableAgentStream, emitChunkEvent, emitFinishEvent } from '../durable/stream-adapter';
+import { AgentThreadStreamRuntime } from '../thread-stream-runtime';
+
+function setup() {
+  const runtime = new AgentThreadStreamRuntime();
+  const pubsub = new EventEmitterPubSub();
+  const publish = vi.spyOn(pubsub, 'publish');
+  const agent = { id: 'continuation-agent' } as Agent<any, any, any, any>;
+  const options = { memory: { thread: 'continuation-thread', resource: 'continuation-user' } };
+  const runId = crypto.randomUUID();
+  const makeStream = () =>
+    createDurableAgentStream({
+      pubsub,
+      runId,
+      messageId: crypto.randomUUID(),
+      model: { modelId: 'mock', provider: 'mock', version: 'v3' },
+    });
+  const chunk = (type: string, payload: Record<string, unknown>) =>
+    emitChunkEvent(pubsub, runId, { type, payload, runId, from: 'AGENT' } as any);
+  const finish = () =>
+    emitFinishEvent(pubsub, runId, {
+      output: { text: 'answer', steps: [] },
+      stepResult: { reason: 'stop' },
+    } as any);
+  const registrations = () => publish.mock.calls.filter(([, event]) => event.type === 'run-registered');
+  return { runtime, pubsub, agent, options, runId, makeStream, chunk, finish, registrations };
+}
+
+describe('durable thread continuation', () => {
+  it.each([false, true])('broadcasts one answer and keeps the prefix with delayed reader=%s', async delayed => {
+    const h = setup();
+    const initialContext = new RequestContext();
+    const resumedContext = new RequestContext();
+    const first = h.makeStream();
+    await first.ready;
+    await h.runtime.registerRun(h.agent, first.output, { ...h.options, requestContext: initialContext }, h.pubsub, {
+      canContinueAcrossSuspension: first.isOpen,
+    });
+    const subscription = await h.runtime.subscribeToThread(
+      h.agent,
+      {
+        threadId: h.options.memory.thread,
+        resourceId: h.options.memory.resource,
+      },
+      h.pubsub,
+    );
+    const parts: any[] = [];
+    const read = async () => {
+      for await (const part of subscription.stream) parts.push(part);
+    };
+    let reading = delayed ? undefined : read();
+    await h.chunk('text-delta', { text: 'prefix' });
+    await h.chunk('tool-call-approval', { toolCallId: 'call-1', toolName: 'read_page', args: {} });
+    await vi.waitFor(() => expect(first.output.status).toBe('suspended'));
+    if (!delayed) {
+      await vi.waitFor(() => expect(parts.some(part => part.type === 'tool-call-approval')).toBe(true));
+      expect(subscription.__getCurrentRunRequestContext()).toBe(initialContext);
+    }
+    const resumed = h.makeStream();
+    await resumed.ready;
+    await h.runtime.registerRun(
+      h.agent,
+      resumed.output,
+      {
+        ...h.options,
+        requestContext: resumedContext,
+        toolCallId: 'call-1',
+      } as any,
+      h.pubsub,
+      { canContinueAcrossSuspension: resumed.isOpen },
+    );
+    expect(h.registrations()).toHaveLength(1);
+    if (!delayed) expect(subscription.__getCurrentRunRequestContext()).toBe(resumedContext);
+
+    // A resumed segment is running even while the continuous output's last
+    // status remains suspended. Same-agent work must still wait its turn.
+    let contenderStarted = false;
+    const contender = h.runtime
+      .waitForCrossAgentThreadRun(h.agent, { ...h.options, runId: 'next-run' }, h.pubsub)
+      .then(() => {
+        contenderStarted = true;
+      });
+    await new Promise(resolve => setTimeout(resolve, 20));
+    expect(contenderStarted).toBe(false);
+    await h.chunk('text-delta', { text: 'answer' });
+    await h.finish();
+    // No caller reads resumed.fullStream; registration must drain it itself.
+    await resumed.output._waitUntilFinished();
+    reading ??= read();
+    await vi.waitFor(() => expect(parts.some(part => part.type === 'finish')).toBe(true));
+    expect(parts.filter(part => part.type === 'text-delta').map(part => part.payload.text)).toEqual([
+      'prefix',
+      'answer',
+    ]);
+    await contender;
+    subscription.unsubscribe();
+    await reading;
+    first.cleanup();
+    resumed.cleanup();
+    await h.pubsub.close();
+  });
+
+  it('registers a replacement after the original adapter was cleaned up', async () => {
+    const h = setup();
+    const first = h.makeStream();
+    await first.ready;
+    await h.runtime.registerRun(h.agent, first.output, h.options, h.pubsub, {
+      canContinueAcrossSuspension: first.isOpen,
+    });
+    await h.chunk('tool-call-approval', { toolCallId: 'call-1', toolName: 'read_page', args: {} });
+    await vi.waitFor(() => expect(first.output.status).toBe('suspended'));
+    first.cleanup();
+    expect(first.isOpen()).toBe(false);
+    const resumed = h.makeStream();
+    await resumed.ready;
+    await h.runtime.registerRun(h.agent, resumed.output, h.options, h.pubsub, {
+      canContinueAcrossSuspension: resumed.isOpen,
+    });
+    expect(h.registrations()).toHaveLength(2);
+    const subscription = await h.runtime.subscribeToThread(
+      h.agent,
+      {
+        threadId: h.options.memory.thread,
+        resourceId: h.options.memory.resource,
+      },
+      h.pubsub,
+    );
+    const parts: any[] = [];
+    const reading = (async () => {
+      for await (const part of subscription.stream) parts.push(part);
+    })();
+    await h.chunk('text-delta', { text: 'answer' });
+    await h.finish();
+    await vi.waitFor(() => expect(parts.some(part => part.type === 'finish')).toBe(true));
+    expect(parts.filter(part => part.type === 'text-delta')).toHaveLength(1);
+    subscription.unsubscribe();
+    await reading;
+    resumed.cleanup();
+    await h.pubsub.close();
+  });
+
+  it('keeps strict recovery ownership validation even for a live same-run stream', async () => {
+    const h = setup();
+    const first = h.makeStream();
+    await first.ready;
+    await h.runtime.registerRun(h.agent, first.output, h.options, h.pubsub, {
+      canContinueAcrossSuspension: first.isOpen,
+    });
+    const recovered = h.makeStream();
+    await recovered.ready;
+    await expect(
+      h.runtime.registerRun(h.agent, recovered.output, h.options, h.pubsub, {
+        strict: true,
+        canContinueAcrossSuspension: recovered.isOpen,
+        validate: () => {
+          throw new Error('Recovery ownership lost');
+        },
+      }),
+    ).rejects.toThrow('Recovery ownership lost');
+    expect(h.registrations()).toHaveLength(1);
+    await h.finish();
+    await first.output._waitUntilFinished();
+    first.cleanup();
+    recovered.cleanup();
+    await h.pubsub.close();
+  });
+});

--- a/packages/core/src/agent/durable/__tests__/recover-run.test.ts
+++ b/packages/core/src/agent/durable/__tests__/recover-run.test.ts
@@ -318,6 +318,57 @@ describe('DurableAgent.recover(runId)', () => {
     subscription.unsubscribe();
   });
 
+  it('keeps the recovered broadcast when the run suspends and resumes again', async () => {
+    const runId = 'recovered-continuation';
+    await seed(store, runId, 'running', 'agent-A');
+    const publish = vi.spyOn(agent.getPubSub(), 'publish');
+    const restart = vi.fn(async () => {
+      await emitChunkEvent(agent.pubsub, runId, {
+        type: 'tool-call-suspended',
+        runId,
+        from: 'AGENT',
+        payload: { toolCallId: 'call-1', toolName: 'read_page', args: {}, suspendPayload: {} },
+      } as any);
+      return { status: 'suspended' as const };
+    });
+    const resume = vi.fn(async () => {
+      await emitChunkEvent(agent.pubsub, runId, {
+        type: 'text-delta',
+        runId,
+        from: 'AGENT',
+        payload: { text: 'one recovered answer' },
+      } as any);
+      await emitFinishEvent(agent.pubsub, runId, {
+        output: { text: 'one recovered answer', steps: [] },
+        stepResult: { reason: 'stop' },
+      } as any);
+      return { status: 'success' as const };
+    });
+    vi.spyOn(agent, 'getWorkflow').mockReturnValue({
+      createRun: vi.fn(async () => ({ restart, resume, runId })),
+      deleteWorkflowRunById: vi.fn(async () => {}),
+    } as any);
+    const subscription = await agent.subscribeToThread({ threadId: 't', resourceId: 'r' });
+    const parts: any[] = [];
+    const reading = (async () => {
+      for await (const part of subscription.stream) parts.push(part);
+    })();
+    const recovered = await agent.recover(runId);
+    await globalRunRegistry.get(runId)?.workflowExecution;
+    await vi.waitFor(() => expect(parts.some(part => part.type === 'tool-call-suspended')).toBe(true));
+    const resumed = await agent.resume(runId, {}, { toolCallId: 'call-1' });
+    await vi.waitFor(() => expect(parts.some(part => part.type === 'finish')).toBe(true));
+    expect(publish.mock.calls.filter(([, event]) => event.type === 'run-registered')).toHaveLength(1);
+    expect(parts.filter(part => part.type === 'text-delta').map(part => part.payload.text)).toEqual([
+      'one recovered answer',
+    ]);
+    expect(resume).toHaveBeenCalledOnce();
+    subscription.unsubscribe();
+    await reading;
+    resumed.cleanup();
+    recovered.cleanup();
+  });
+
   it('allows only the recovery-lease holder to register and restart a run', async () => {
     const runId = 'run-concurrent-recovery';
     const sharedStore = new InMemoryStore();

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -911,6 +911,7 @@ export class DurableAgent<
         this.getPubSub(),
         {
           strict: true,
+          canContinueAcrossSuspension: stream.isOpen,
           validate: () => recoveryLease.assertOwned(),
         },
       );
@@ -1928,6 +1929,7 @@ export class DurableAgent<
       output,
       cleanup: streamCleanup,
       ready,
+      isOpen,
     } = createDurableAgentStream<TOutput>({
       pubsub: this.pubsub,
       runId,
@@ -2013,6 +2015,7 @@ export class DurableAgent<
       output,
       options as AgentExecutionOptions<TOutput>,
       this.getPubSub(),
+      { canContinueAcrossSuspension: () => (options as any)?.[CLOSE_ON_SUSPEND] !== true && isOpen() },
     );
 
     // 5. Create cleanup function (cancels auto-cleanup timer if called)
@@ -2251,6 +2254,13 @@ export class DurableAgent<
     const globalEntry = globalRunRegistry.get(runId);
     const resumeModel = globalEntry?.model as any;
 
+    // Settle the prior segment before taking its event offset. Otherwise a late
+    // suspension event can be replayed into the new segment and close it early.
+    const priorExecution = globalRunRegistry.get(runId)?.workflowExecution;
+    await priorExecution?.catch(() => {
+      /* errors already handled by the prior segment */
+    });
+
     // Skip events already broadcast by the original run (e.g. the SUSPENDED
     // chunk that paused it). Without this, a resume that closes on suspend
     // (resumeGenerate) would immediately close on the replayed SUSPENDED.
@@ -2313,6 +2323,7 @@ export class DurableAgent<
       output,
       cleanup: streamCleanup,
       ready,
+      isOpen,
     } = createDurableAgentStream<TOutput>({
       pubsub: this.pubsub,
       runId,
@@ -2351,26 +2362,9 @@ export class DurableAgent<
     const workflow = this.getWorkflow();
     const requestContext = resolvedOptions.requestContext;
 
-    // Capture the prior workflow execution BEFORE creating the new promise.
-    // If we read it inside the `.then()` callback, the global registry will
-    // already point to the NEW promise (assigned synchronously below),
-    // causing a self-referential deadlock.
-    const priorExecution = globalRunRegistry.get(runId)?.workflowExecution;
 
     const workflowExecution = ready
       .then(async () => {
-        // Wait for the prior workflow execution (stream / previous resume) to
-        // fully settle so the snapshot is persisted as 'suspended' before we
-        // attempt to resume it.  Without this, the pubsub tool-call-suspended
-        // event can arrive (and the consumer can call resumeStream) before the
-        // engine has finished writing the snapshot, leading to
-        // "This workflow run was not suspended".
-        if (priorExecution) {
-          await priorExecution.catch(() => {
-            /* errors already handled by the prior segment */
-          });
-        }
-
         const run = await workflow.createRun({ runId, resourceId: memoryInfo?.resourceId, pubsub: this.pubsub });
         if (this.__getGoalConfig()) {
           await beginGoalActivity({
@@ -2424,6 +2418,7 @@ export class DurableAgent<
       output,
       resumeStreamOptions,
       this.getPubSub(),
+      { canContinueAcrossSuspension: () => (resolvedOptions as any)[CLOSE_ON_SUSPEND] !== true && isOpen() },
     );
 
     const cleanup = () => {

--- a/packages/core/src/agent/durable/stream-adapter.ts
+++ b/packages/core/src/agent/durable/stream-adapter.ts
@@ -146,6 +146,8 @@ export interface DurableAgentStreamResult<OUTPUT = undefined> {
   cleanup: () => void;
   /** Promise that resolves when subscription is established */
   ready: Promise<void>;
+  /** Whether this adapter can still receive future workflow events. */
+  isOpen: () => boolean;
 }
 
 /**
@@ -647,6 +649,7 @@ export function createDurableAgentStream<OUTPUT = undefined>(
     output,
     cleanup,
     ready,
+    isOpen: () => !terminated && !cancelled,
   };
 }
 

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -155,6 +155,10 @@ type AgentThreadRunRecord<OUTPUT = unknown> = {
   createSubscriberStream?: () => ReadableStream<unknown>;
   /** Settles once every stream-part broadcast publish for this run completed. */
   broadcastFinished?: Promise<void>;
+  /** This output intentionally continues delivering chunks after suspension. */
+  canContinueAcrossSuspension?: () => boolean;
+  /** Latest segment status, while output remains the suspension-spanning source. */
+  activeOutput?: MastraModelOutput<OUTPUT>;
 };
 
 type PreparedThreadRun = {
@@ -217,12 +221,18 @@ export type ActiveThreadRun = { runId: string; resourceId?: string; threadId: st
 
 export type AgentThreadStrictRegistrationOptions = {
   strict: true;
+  canContinueAcrossSuspension?: () => boolean;
   /**
    * Revalidates ownership held outside this runtime (for example, a durable
    * recovery lease). A validation failure rolls back local registration but
    * deliberately leaves the same-run thread lease intact for the new owner.
    */
   validate?: () => void | Promise<void>;
+};
+
+type AgentThreadStreamRegistrationOptions = {
+  strict?: false;
+  canContinueAcrossSuspension?: () => boolean;
 };
 
 export type AgentThreadRunRegistration = {
@@ -507,7 +517,7 @@ export class AgentThreadStreamRuntime {
 
   #isActivelyRunning(state: AgentThreadRuntimeState, record: AgentThreadRunRecord<any>) {
     return (
-      record.output.status === 'running' &&
+      (record.activeOutput ?? record.output).status === 'running' &&
       record.lifecycle !== 'suspending' &&
       record.lifecycle !== 'suspended' &&
       !record.suspensions?.size &&
@@ -1215,13 +1225,14 @@ export class AgentThreadStreamRuntime {
     output: MastraModelOutput<OUTPUT>,
     streamOptions: AgentExecutionOptions<OUTPUT>,
     pubsub?: PubSub,
+    registrationOptions?: AgentThreadStreamRegistrationOptions,
   ): Promise<void> | undefined;
   registerRun<OUTPUT>(
     agent: Agent<any, any, any, any>,
     output: MastraModelOutput<OUTPUT>,
     streamOptions: AgentExecutionOptions<OUTPUT>,
     pubsub?: PubSub,
-    registrationOptions?: AgentThreadStrictRegistrationOptions,
+    registrationOptions?: AgentThreadStrictRegistrationOptions | AgentThreadStreamRegistrationOptions,
   ): Promise<void | AgentThreadRunRegistration> | undefined {
     const { threadId, resourceId } = this.#getThreadTarget(streamOptions);
     if (!threadId) return;
@@ -1233,6 +1244,30 @@ export class AgentThreadStreamRuntime {
     const state = this.#getState(pubsub);
     this.#sweepStaleSuspendedRecords(state, pubsub);
     const key = this.#threadKey(resourceId, threadId);
+    const existing = state.threadRunsById.get(output.runId);
+    if (
+      existing?.canContinueAcrossSuspension?.() &&
+      existing.agent === agent &&
+      existing.threadId === threadId &&
+      existing.resourceId === resourceId &&
+      state.activeThreadRunIds.get(key) === output.runId &&
+      state.activeThreadStreamIds.get(key) === existing.streamId &&
+      (existing.output.status === 'running' || existing.output.status === 'suspended')
+    ) {
+      // The original durable output already observes this resumed segment.
+      // Keep its buffered prefix, subscribers and completion watcher; a second
+      // broadcast would deliver the same tool results and answer again.
+      const resumedToolCallId = (streamOptions as AgentExecutionOptions<OUTPUT> & { toolCallId?: string }).toolCallId;
+      if (resumedToolCallId) this.#clearSuspendedToolCall(state, output.runId, resumedToolCallId);
+      else this.#clearSuspendedRun(state, output.runId);
+      existing.lifecycle = 'running';
+      existing.streamOptions = streamOptions;
+      existing.activeOutput = output;
+      // Resume callers may only send an approval and never read this segment.
+      // Drain its native output so completion and subsequent approvals advance.
+      void output.consumeStream();
+      return Promise.resolve();
+    }
     const { streamId, streamSeq } = this.#nextStreamIdentity(state, output.runId);
     const {
       output: outputForSubscribers,
@@ -1260,6 +1295,7 @@ export class AgentThreadStreamRuntime {
       createSubscriberStream,
       suspensions: state.suspensionMetadataByRunId.get(output.runId),
       broadcastFinished,
+      canContinueAcrossSuspension: registrationOptions?.canContinueAcrossSuspension,
     };
 
     state.threadRunsById.set(output.runId, record);
@@ -1360,6 +1396,7 @@ export class AgentThreadStreamRuntime {
       createSubscriberStream,
       suspensions: state.suspensionMetadataByRunId.get(output.runId),
       broadcastFinished,
+      canContinueAcrossSuspension: registrationOptions.canContinueAcrossSuspension,
     };
 
     let rolledBack = false;
@@ -2543,7 +2580,10 @@ export class AgentThreadStreamRuntime {
 
     return {
       activeRunId,
-      __getCurrentRunRequestContext: () => currentRunRequestContext,
+      __getCurrentRunRequestContext: () => {
+        const record = activeReaderStreamId ? state.threadRunsByStreamId.get(activeReaderStreamId) : undefined;
+        return record ? record.streamOptions.requestContext : currentRunRequestContext;
+      },
       abort: () => this.abortThread(options, resolvedPubSub),
       unsubscribe,
       stream: (async function* () {


### PR DESCRIPTION
Fixes #23116.

A durable approval resume currently creates a second thread broadcast while the original output still carries resumed chunks. One model answer can therefore arrive as two live assistant messages. This keeps the original open broadcast and consumes the resumed segment for completion without broadcasting it again.

The retained stream keeps its prefix, current run identity, and updated request context. Closed adapters use the existing registration path, and strict recovery still validates ownership. No new transport events or reader cancellation policy are added.

The exact 1.63.2 backport passes 113 focused tests and core type checking. Its packed public ESM and CommonJS APIs pass eight no-network approval cases. This current-main contribution builds and passes 47 focused continuation, message identity, stop, and recovery tests. Deployed-container acceptance is still pending.
