### PR TITLE
fix(convex): preserve snapshot creation time in atomic upsert

### DIFF
--- a/.changeset/cozy-dodos-win.md
+++ b/.changeset/cozy-dodos-win.md
@@ -1,0 +1,5 @@
+---
+'@mastra/convex': patch
+---
+
+Fixed workflow snapshot saves to preserve their original creation time atomically, removing a redundant read before each save. Redeploy the Convex server functions before upgrading the application runtime so both sides use the updated snapshot upsert behavior.

--- a/stores/convex/src/server/storage.test.ts
+++ b/stores/convex/src/server/storage.test.ts
@@ -143,6 +143,61 @@ describe('mastraStorage typed load', () => {
   });
 });
 
+describe('mastraStorage workflow snapshot upsert', () => {
+  it.each([
+    ['mastra_workflow_snapshots', TABLE_WORKFLOW_SNAPSHOT, '2026-05-15T00:00:00.000Z', '2026-05-15T00:00:00.000Z'],
+    ['mastra_workflow_snapshots', TABLE_WORKFLOW_SNAPSHOT, undefined, '2026-05-16T00:00:00.000Z'],
+    ['mastra_threads', TABLE_THREADS, '2026-05-15T00:00:00.000Z', '2026-05-16T00:00:00.000Z'],
+  ] as const)('upserts %s with existing createdAt %s', async (table, tableName, createdAt, expectedCreatedAt) => {
+    const existing = { _id: asConvexId('existing-doc'), id: 'record-1', createdAt };
+    const unique = vi.fn(async () => existing);
+    const withIndex = vi.fn(() => ({ unique }));
+    const patch = vi.fn();
+    const ctx = { db: { query: vi.fn(() => ({ withIndex })), patch } } as unknown as TypedOperationCtx;
+    const record = {
+      id: 'record-1',
+      snapshot: JSON.stringify({ status: 'suspended', value: { checkpoint: 2 } }),
+      createdAt: '2026-05-16T00:00:00.000Z',
+      updatedAt: '2026-05-17T00:00:00.000Z',
+    };
+
+    await handleTypedOperation(ctx, table, { op: 'insert', tableName, record });
+
+    expect(withIndex).toHaveBeenCalledWith('by_record_id', expect.any(Function));
+    expect(patch).toHaveBeenCalledExactlyOnceWith(existing._id, {
+      snapshot: record.snapshot,
+      createdAt: expectedCreatedAt,
+      updatedAt: record.updatedAt,
+    });
+  });
+
+  it('retains the supplied creation time on the first snapshot insert', async () => {
+    const insert = vi.fn();
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({ withIndex: vi.fn(() => ({ unique: vi.fn(async () => null) })) })),
+        insert,
+      },
+    } as unknown as TypedOperationCtx;
+    const record = {
+      id: 'workflow-a-run-1',
+      workflow_name: 'workflow-a',
+      run_id: 'run-1',
+      snapshot: '{}',
+      createdAt: '2026-05-15T00:00:00.000Z',
+      updatedAt: '2026-05-16T00:00:00.000Z',
+    };
+
+    await handleTypedOperation(ctx, 'mastra_workflow_snapshots', {
+      op: 'insert',
+      tableName: TABLE_WORKFLOW_SNAPSHOT,
+      record,
+    });
+
+    expect(insert).toHaveBeenCalledExactlyOnceWith('mastra_workflow_snapshots', record);
+  });
+});
+
 describe('mastraStorage workflow snapshot merge operations', () => {
   function createWorkflowSnapshotCtx(snapshot: unknown, { missing = false }: { missing?: boolean } = {}) {
     const patches: Array<{ id: GenericId<string>; data: Record<string, unknown> }> = [];

--- a/stores/convex/src/server/storage.ts
+++ b/stores/convex/src/server/storage.ts
@@ -505,6 +505,9 @@ export async function handleTypedOperation(
       if (existing) {
         // Update existing - don't include id in patch (it's already set)
         const { id: _, ...updateData } = record;
+        if (convexTable === CONVEX_TABLE_WORKFLOW_SNAPSHOTS) {
+          updateData.createdAt = existing.createdAt ?? updateData.createdAt;
+        }
         await ctx.db.patch(existing._id, updateData);
       } else {
         // Insert new - include id as a regular field

--- a/stores/convex/src/storage/domains/workflows/index.ts
+++ b/stores/convex/src/storage/domains/workflows/index.ts
@@ -71,12 +71,6 @@ export class WorkflowsConvex extends WorkflowsStorage {
     updatedAt?: Date;
   }): Promise<void> {
     const now = new Date();
-    // Check if a record already exists to preserve createdAt
-    const existing = await this.#db.load<{ createdAt?: string } | null>({
-      tableName: TABLE_WORKFLOW_SNAPSHOT,
-      keys: { workflow_name: workflowName, run_id: runId },
-    });
-
     await this.#db.insert({
       tableName: TABLE_WORKFLOW_SNAPSHOT,
       record: {
@@ -88,7 +82,7 @@ export class WorkflowsConvex extends WorkflowsStorage {
         // contain $schema/$ref/$defs/$id keys, so we serialize the snapshot here.
         // loadWorkflowSnapshot / ensureSnapshot already handle the string case.
         snapshot: JSON.stringify(snapshot),
-        createdAt: existing?.createdAt ?? (createdAt ? new Date(createdAt).toISOString() : now.toISOString()),
+        createdAt: createdAt ? new Date(createdAt).toISOString() : now.toISOString(),
         updatedAt: updatedAt ? new Date(updatedAt).toISOString() : now.toISOString(),
       },
     });

--- a/stores/convex/src/storage/domains/workflows/workflows.test.ts
+++ b/stores/convex/src/storage/domains/workflows/workflows.test.ts
@@ -24,8 +24,7 @@ type CapturedRequest = Extract<StorageRequest, { op: 'insert' }>;
 
 function createFakeClient() {
   const requests: StorageRequest[] = [];
-  // We mock callStorage directly. Pretend load returns null (no existing row),
-  // so persist takes the "insert new" branch.
+  // Capture storage requests without making network calls.
   const callStorage = vi.fn(async (request: StorageRequest) => {
     requests.push(request);
     if (request.op === 'load') return null;

--- a/stores/convex/src/storage/domains/workflows/workflows.test.ts
+++ b/stores/convex/src/storage/domains/workflows/workflows.test.ts
@@ -128,6 +128,38 @@ describe('WorkflowsConvex.persistWorkflowSnapshot — $-prefixed keys', () => {
   });
 });
 
+describe('WorkflowsConvex snapshot persistence', () => {
+  it('persists each checkpoint in one request without a client-side read', async () => {
+    const { client, requests } = createFakeClient();
+    const workflows = new WorkflowsConvex({ client });
+    const createdAt = new Date('2026-05-15T00:00:00.000Z');
+    const updatedAt = new Date('2026-05-16T00:00:00.000Z');
+    const snapshot = snapshotWithDollarKeys();
+
+    for (let checkpoint = 0; checkpoint < 2; checkpoint++) {
+      await workflows.persistWorkflowSnapshot({
+        workflowName: 'agentic-loop',
+        runId: 'run-1',
+        snapshot,
+        createdAt,
+        updatedAt,
+      });
+    }
+
+    expect(requests).toHaveLength(2);
+    for (const request of requests) {
+      expect(request).toMatchObject({
+        op: 'insert',
+        record: {
+          snapshot: JSON.stringify(snapshot),
+          createdAt: createdAt.toISOString(),
+          updatedAt: updatedAt.toISOString(),
+        },
+      });
+    }
+  });
+});
+
 describe('WorkflowsConvex atomic workflow updates', () => {
   it('advertises concurrent update support', () => {
     const { client } = createFakeClient();


### PR DESCRIPTION
Superseded by #23137. Addresses #23118.

This original PR preserves workflow snapshot creation time in single-record Convex upserts and removes the client's redundant pre-save read. It was automatically closed while the linked issue awaited triage. GitHub rejected reopening it after the blocking label was removed.

The replacement PR includes the additional `batchInsert` fix identified during issue triage, updated regression coverage, and the server-before-runtime deployment note. Please review #23137 for the current implementation and validation results.
