### PR TITLE
fix(core): keep _background injection builder-local to avoid cross-agent leaks

### DIFF
--- a/.changeset/quiet-tools-share-schema.md
+++ b/.changeset/quiet-tools-share-schema.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Stop `_background` from leaking between agents that share one tool instance. `CoreToolBuilder` no longer writes the spliced input schema (with `_background` / `suspendedToolRunId` / `resumeData`) back onto the shared tool object — the schema now lives on the builder, so each agent's model-facing parameters only advertise the injected keys when that agent actually opted in. This also stops repeated conversions from re-wrapping Zod v3 / JSON schemas with nested override validators.

--- a/.changeset/quiet-tools-share-schema.md
+++ b/.changeset/quiet-tools-share-schema.md
@@ -2,4 +2,6 @@
 '@mastra/core': patch
 ---
 
-Stop `_background` from leaking between agents that share one tool instance. `CoreToolBuilder` no longer writes the spliced input schema (with `_background` / `suspendedToolRunId` / `resumeData`) back onto the shared tool object — the schema now lives on the builder, so each agent's model-facing parameters only advertise the injected keys when that agent actually opted in. This also stops repeated conversions from re-wrapping Zod v3 / JSON schemas with nested override validators.
+Fixed shared tools exposing `_background` to agents that do not support background execution.
+
+Agents now advertise `_background` only for eligible tools. `suspendedToolRunId` and `resumeData` remain scoped to resumable tools. Repeated schema conversions no longer add nested validators.

--- a/packages/core/src/tools/tool-builder/background-override-injection.test.ts
+++ b/packages/core/src/tools/tool-builder/background-override-injection.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { z as z3 } from 'zod/v3';
 import { z as z4 } from 'zod/v4';
 import { RequestContext } from '../../request-context';
-import { isStandardSchemaWithJSON, standardSchemaToJSONSchema, toStandardSchema } from '../../schema';
+import { toStandardSchema } from '../../schema';
 import { createTool } from '../../tools';
 import { CoreToolBuilder } from './builder';
 
@@ -32,13 +32,15 @@ function baseOptions() {
   };
 }
 
-function extractJsonProperties(tool: { inputSchema?: unknown }) {
-  const schema = tool.inputSchema;
-  expect(schema).toBeDefined();
-  expect(isStandardSchemaWithJSON(schema)).toBe(true);
-  const json = standardSchemaToJSONSchema(schema as any, { io: 'input' });
-  expect(json && typeof json === 'object' && (json as any).type === 'object').toBe(true);
-  return (json as any).properties as Record<string, any>;
+// The spliced schema now lives on the builder (not on the user's shared tool
+// object), so assertions read the built tool's model-facing `parameters`.
+function extractJsonProperties(builder: CoreToolBuilder) {
+  const built = builder.build();
+  const parameters = built.parameters as { jsonSchema?: { type?: string; properties?: Record<string, any> } };
+  expect(parameters?.jsonSchema).toBeDefined();
+  const json = parameters.jsonSchema!;
+  expect(json && typeof json === 'object' && json.type === 'object').toBe(true);
+  return json.properties!;
 }
 
 describe('CoreToolBuilder background override injection', () => {
@@ -79,13 +81,13 @@ describe('CoreToolBuilder background override injection', () => {
         execute: vi.fn(),
       });
 
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: baseOptions(),
         backgroundTaskEnabled: true,
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('query');
       expect(properties).toHaveProperty('_background');
     });
@@ -141,17 +143,17 @@ describe('CoreToolBuilder background override injection', () => {
         execute,
       });
 
-      new CoreToolBuilder({
+      const built = new CoreToolBuilder({
         originalTool: tool,
         options: baseOptions(),
         backgroundTaskEnabled: true,
-      });
+      }).build();
 
-      const schema = tool.inputSchema as any;
-      const result = schema['~standard'].validate({ query: 'ok', _background: { enabled: 'yes' } });
-      const resolved = result && typeof result.then === 'function' ? await result : result;
-      expect(resolved).toHaveProperty('issues');
-      expect((resolved as { issues: readonly unknown[] }).issues.length).toBeGreaterThan(0);
+      const parameters = built.parameters as { validate?: (value: unknown) => unknown };
+      expect(typeof parameters.validate).toBe('function');
+      const result = parameters.validate!({ query: 'ok', _background: { enabled: 'yes' } });
+      const resolved = result && typeof (result as Promise<unknown>).then === 'function' ? await result : result;
+      expect(resolved).toHaveProperty('success', false);
     });
   });
 
@@ -175,14 +177,13 @@ describe('CoreToolBuilder background override injection', () => {
         backgroundTaskEnabled: true,
       });
 
-      expect(isStandardSchemaWithJSON(tool.inputSchema)).toBe(true);
-      const json = standardSchemaToJSONSchema(tool.inputSchema as any, { io: 'input' });
-      expect(json.properties).toMatchObject({
+      const built = builder.build();
+      const json = (built.parameters as { jsonSchema?: { properties?: Record<string, unknown> } }).jsonSchema;
+      expect(json?.properties).toMatchObject({
         query: expect.anything(),
         _background: expect.anything(),
       });
 
-      const built = builder.build();
       const result = await built.execute!(
         { query: 'docs', _background: { enabled: 'yes' } },
         { toolCallId: 'call-1', messages: [] },
@@ -214,7 +215,7 @@ describe('CoreToolBuilder background override injection', () => {
         ok: true,
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('query');
       expect(properties).toHaveProperty('_background');
     });
@@ -245,7 +246,7 @@ describe('CoreToolBuilder background override injection', () => {
         ok: true,
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('query');
       expect(properties).toHaveProperty('_background');
     });
@@ -260,12 +261,12 @@ describe('CoreToolBuilder background override injection', () => {
         execute: vi.fn(),
       });
 
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: baseOptions(),
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('message');
       expect(properties).toHaveProperty('suspendedToolRunId');
       expect(properties).toHaveProperty('resumeData');
@@ -289,12 +290,12 @@ describe('CoreToolBuilder background override injection', () => {
         execute: vi.fn(),
       });
 
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: baseOptions(),
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('suspendedToolRunId');
       expect(properties).toHaveProperty('resumeData');
     });
@@ -310,13 +311,13 @@ describe('CoreToolBuilder background override injection', () => {
         execute: vi.fn(),
       });
 
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: baseOptions(),
         backgroundTaskEnabled: true,
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('message');
       expect(properties).toHaveProperty('_background');
       expect(properties).toHaveProperty('suspendedToolRunId');
@@ -340,19 +341,19 @@ describe('CoreToolBuilder background override injection', () => {
 
     it('does NOT inject _background when the manager is enabled but the tool has no opt-in', () => {
       const tool = makeTool();
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: { ...baseOptions(), backgroundConfig: undefined },
         backgroundTaskEnabled: true,
       });
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('query');
       expect(properties).not.toHaveProperty('_background');
     });
 
     it('injects _background when the agent config whitelists the tool', () => {
       const tool = makeTool();
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: {
           ...baseOptions(),
@@ -361,13 +362,13 @@ describe('CoreToolBuilder background override injection', () => {
         },
         backgroundTaskEnabled: true,
       });
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('_background');
     });
 
     it('resolves agent whitelist entries for agent- prefixed tool names', () => {
       const tool = makeTool('agent-biExecutor');
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: {
           ...baseOptions(),
@@ -377,13 +378,13 @@ describe('CoreToolBuilder background override injection', () => {
         },
         backgroundTaskEnabled: true,
       });
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('_background');
     });
 
     it('does NOT inject _background when the agent whitelists other tools only', () => {
       const tool = makeTool();
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: {
           ...baseOptions(),
@@ -392,7 +393,7 @@ describe('CoreToolBuilder background override injection', () => {
         },
         backgroundTaskEnabled: true,
       });
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).not.toHaveProperty('_background');
     });
 
@@ -424,6 +425,130 @@ describe('CoreToolBuilder background override injection', () => {
 
       // No injection => the builder should not have replaced inputSchema.
       expect(tool.inputSchema).toBe(originalSchema);
+    });
+  });
+
+  // Regression coverage for https://github.com/mastra-ai/mastra/issues/22843:
+  // `createTool()` results are typically module-level singletons registered on
+  // several agents, but `_background` eligibility is resolved per agent. The
+  // builder used to write the spliced schema back onto the shared tool object,
+  // so whichever agent converted first decided whether every other agent's
+  // model-facing parameters advertised `_background`.
+  describe('Shared tool instance across agents (issue #22843)', () => {
+    function makeSharedTool() {
+      return createTool({
+        id: 'search',
+        description: 'Search the web',
+        inputSchema: z4.object({ query: z4.string() }),
+        execute: vi.fn().mockResolvedValue({ ok: true }),
+      });
+    }
+
+    it('does not leak _background to an agent that did not opt in (eligible agent converts first)', () => {
+      const tool = makeSharedTool();
+      const before = tool.inputSchema;
+
+      const propertiesForA = extractJsonProperties(
+        new CoreToolBuilder({ originalTool: tool, options: baseOptions(), backgroundTaskEnabled: true }),
+      );
+      const propertiesForB = extractJsonProperties(
+        new CoreToolBuilder({
+          originalTool: tool,
+          options: { ...baseOptions(), backgroundConfig: undefined },
+          backgroundTaskEnabled: true,
+        }),
+      );
+
+      expect(propertiesForA).toHaveProperty('_background');
+      expect(propertiesForB).not.toHaveProperty('_background');
+      // The shared user object must not be mutated by the conversion.
+      expect(tool.inputSchema).toBe(before);
+    });
+
+    it('is order-independent when the opted-out agent converts first', () => {
+      const tool = makeSharedTool();
+
+      const propertiesForB = extractJsonProperties(
+        new CoreToolBuilder({
+          originalTool: tool,
+          options: { ...baseOptions(), backgroundConfig: undefined },
+          backgroundTaskEnabled: true,
+        }),
+      );
+      const propertiesForA = extractJsonProperties(
+        new CoreToolBuilder({ originalTool: tool, options: baseOptions(), backgroundTaskEnabled: true }),
+      );
+
+      expect(propertiesForB).not.toHaveProperty('_background');
+      expect(propertiesForA).toHaveProperty('_background');
+    });
+
+    it('does not re-wrap the schema on repeated conversions of the same tool (zod v3 fallback)', () => {
+      const tool = createTool({
+        id: 'v3-shared-tool',
+        description: 'Zod v3 tool shared across agents',
+        inputSchema: z3.object({ query: z3.string() }),
+        execute: vi.fn(),
+      });
+      const before = tool.inputSchema;
+
+      new CoreToolBuilder({ originalTool: tool, options: baseOptions(), backgroundTaskEnabled: true }).build();
+      new CoreToolBuilder({ originalTool: tool, options: baseOptions(), backgroundTaskEnabled: true }).build();
+
+      expect(tool.inputSchema).toBe(before);
+    });
+
+    // The injected `suspendedToolRunId` key must still survive through to the
+    // sub-agent tool's own execute() now that the spliced schema lives on the
+    // builder instead of being written back onto the tool.
+    it('still delivers suspendedToolRunId to agent- tool execute (zod v4)', async () => {
+      const execute = vi.fn().mockResolvedValue({ done: true });
+      const tool = createTool({
+        id: 'agent-child',
+        description: 'Sub-agent as a tool',
+        inputSchema: z4.object({ message: z4.string() }),
+        execute,
+      });
+
+      const built = new CoreToolBuilder({
+        originalTool: tool,
+        options: { ...baseOptions(), name: 'agent-child', backgroundConfig: undefined },
+      }).build();
+
+      await built.execute!({ message: 'hi', suspendedToolRunId: 'run_123' } as any, {
+        toolCallId: 'call-1',
+        messages: [],
+      });
+
+      expect(execute).toHaveBeenCalledWith(
+        expect.objectContaining({ suspendedToolRunId: 'run_123' }),
+        expect.anything(),
+      );
+    });
+
+    it('still delivers suspendedToolRunId to agent- tool execute (zod v3 fallback)', async () => {
+      const execute = vi.fn().mockResolvedValue({ done: true });
+      const tool = createTool({
+        id: 'agent-child-v3',
+        description: 'Sub-agent as a tool',
+        inputSchema: z3.object({ message: z3.string() }),
+        execute,
+      });
+
+      const built = new CoreToolBuilder({
+        originalTool: tool,
+        options: { ...baseOptions(), name: 'agent-child-v3', backgroundConfig: undefined },
+      }).build();
+
+      await built.execute!({ message: 'hi', suspendedToolRunId: 'run_123' } as any, {
+        toolCallId: 'call-1',
+        messages: [],
+      });
+
+      expect(execute).toHaveBeenCalledWith(
+        expect.objectContaining({ suspendedToolRunId: 'run_123' }),
+        expect.anything(),
+      );
     });
   });
 });

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -251,6 +251,17 @@ export class CoreToolBuilder extends MastraBase {
   private originalTool: ToolToConvert;
   private options: ToolOptions;
   private logType?: LogType;
+  /**
+   * Builder-local copy of the user's input schema with the framework-injected
+   * keys (`_background`, `suspendedToolRunId`, `resumeData`) spliced in.
+   *
+   * It must NOT be written back onto `originalTool.inputSchema`: `createTool()`
+   * results are commonly module-level singletons shared across several agents,
+   * while background eligibility is resolved per agent — a write-back would
+   * leak one agent's injected keys into every other agent's model-facing
+   * parameters (issue #22843).
+   */
+  private injectedInputSchema?: StandardSchemaWithJSON;
 
   constructor(input: {
     originalTool: ToolToConvert;
@@ -321,7 +332,7 @@ export class CoreToolBuilder extends MastraBase {
                 .optional(),
             });
           }
-          this.originalTool.inputSchema = toStandardSchema(nextSchema);
+          this.injectedInputSchema = toStandardSchema(nextSchema);
         } else {
           // Normalize to Standard Schema, extract JSON Schema, splice overrides.
           const standardSchema = isStandardSchemaWithJSON(schema) ? schema : toStandardSchema(schema);
@@ -352,11 +363,7 @@ export class CoreToolBuilder extends MastraBase {
             // `.transform()` / `.default()` / `.refine()` etc.) while exposing
             // the spliced JSON Schema for provider serialization. See
             // https://github.com/mastra-ai/mastra/pull/16915#discussion_r3282520408
-            this.originalTool.inputSchema = buildJsonOverrideSchema(
-              schema,
-              { ...jsonSchema, properties },
-              injectedKeys,
-            );
+            this.injectedInputSchema = buildJsonOverrideSchema(schema, { ...jsonSchema, properties }, injectedKeys);
           }
         }
       }
@@ -381,8 +388,10 @@ export class CoreToolBuilder extends MastraBase {
       return schema;
     }
 
-    // For Mastra tools, inputSchema might also be a function
-    let schema = this.originalTool.inputSchema;
+    // For Mastra tools, inputSchema might also be a function. Prefer the
+    // builder-local injected schema (see `injectedInputSchema`) so per-agent
+    // injections never depend on mutation of the shared tool object.
+    let schema = this.injectedInputSchema ?? this.originalTool.inputSchema;
 
     if (isStandardSchemaWithJSON(schema)) {
       return schema;
@@ -760,7 +769,14 @@ export class CoreToolBuilder extends MastraBase {
           result = await executeWithContext({
             span: toolSpan,
             fn: async () => {
-              if (inputValidationSchema) {
+              if (inputValidationSchema || this.injectedInputSchema) {
+                // The injected keys are only declared on the builder-local
+                // schema. `Tool.execute` validates against the user's original
+                // schema, which would strip them (breaking sub-agent/workflow
+                // resume via `suspendedToolRunId`), so once this builder has
+                // validated the args itself — against the injected schema or a
+                // compat-processed version of it — mark the context to skip
+                // that second validation.
                 markBuilderValidatedInput(toolContext);
               }
               return tool?.execute?.(args, toolContext);


### PR DESCRIPTION
## What

`CoreToolBuilder` used to write the schema spliced with `_background` / `suspendedToolRunId` / `resumeData` back onto the caller's tool object (`originalTool.inputSchema`). `createTool()` results are commonly module-level singletons shared by several agents, and background eligibility is resolved per agent, so whichever agent converted first decided whether every other agent's model-facing `parameters` advertised `_background` — even for agents that never opted in. Repeated conversions also re-wrapped Zod v3 / JSON schemas with a nested `mastra-json-override` validator per call.

The spliced schema now lives on the builder (`injectedInputSchema`) and is used by `getParameters()`, so the shared tool object is never mutated. To keep sub-agent / workflow resume working, the builder now also marks the input as builder-validated whenever it injected keys, so `Tool.execute` skips re-validating against the user's original schema (which would strip `suspendedToolRunId` before it reaches the delegate tool).

Fixes #22843

## Verification

- New regression tests in `packages/core/src/tools/tool-builder/background-override-injection.test.ts`: shared-instance leak (eligible agent converts first), order-independence, no schema re-wrap on repeated conversions, and `suspendedToolRunId` still delivered to `agent-` tool execute on both the Zod v4 and Zod v3 fallback paths — the two leak tests fail on `main` and pass with this change.
- Existing injection assertions updated to read the built tool's `parameters` instead of the (no longer mutated) shared `inputSchema`.
- `vitest run` across tool-builder, tools, background-tasks, sub-agent resume and durable tool-call suites: 321 tests green; `tsc --noEmit`, `oxlint`, `eslint`, `oxfmt --check` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Each agent now gets its own tool schema. One agent can add background or resume fields without changing what other agents see.

## Changes

- Store injected `_background`, `suspendedToolRunId`, and `resumeData` fields on `CoreToolBuilder`.
- Use the builder-local schema for model-facing parameters.
- Preserve resume fields by marking builder-validated input before `Tool.execute`.
- Prevent repeated schema wrapping.
- Add regression tests for shared tools, conversion order, repeated conversions, suspended execution, and Zod v4 and Zod v3 fallback paths.
- Add a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->