### PR TITLE
fix(workflows): claim outer starts and preserve nested callback identity

### DIFF
--- a/.changeset/four-bikes-occur.md
+++ b/.changeset/four-bikes-occur.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed repeated workflow start errors to return HTTP 409 and forwarded the outer workflow identity to remote step workers.

--- a/.changeset/free-crabs-watch.md
+++ b/.changeset/free-crabs-watch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed PostgreSQL workflow creation so a delayed create request cannot overwrite a running or completed run, and enabled atomic outer workflow start claims.

--- a/.changeset/large-spoons-return.md
+++ b/.changeset/large-spoons-return.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed duplicate outer workflow starts and retained the outer run identity for nested callbacks.
+
+Tools running inside nested default or evented workflows can read `context.workflow.rootRun` to find the outer `workflowId` and `runId`, then resume that run by its suspension label. Older snapshots may omit this field. Repeated outer starts reject with `WORKFLOW_START_ALREADY_CLAIMED` when the storage adapter supports atomic starts.

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -240,7 +240,8 @@ The first `execute` parameter is the validated value from `inputSchema`. Destruc
                     name: 'workflow',
                     type: 'WorkflowToolExecutionContext',
                     isOptional: true,
-                    description: 'Workflow-specific context (state, setState, suspend, etc.)',
+                    description:
+                      'Workflow-specific context (state, setState, suspend, etc.). The optional rootRun contains the outermost workflowId and runId, including inside nested workflows. Use this identity to resume an outer workflow by a suspension label. It is preserved in snapshots by the default and evented engines; older snapshots and other engines may omit it. The immediate workflowId and runId still identify the workflow directly executing the tool.',
                   },
                   {
                     name: 'mcp',

--- a/docs/src/content/en/reference/workflows/run-methods/start.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/start.mdx
@@ -21,6 +21,16 @@ const result = await run.start({
 })
 ```
 
+## Repeated starts
+
+With the default and evented execution engines, PostgreSQL and in-memory storage atomically claim a pending outer run before executing its steps. If two callers start the same outer run, only one enters execution. Later calls reject with `WORKFLOW_START_ALREADY_CLAIMED`, including after the run finishes. Create a new run to execute the workflow again. The admitted outer engine still controls nested runs, including repeated loop iterations and retries.
+
+This protection requires storage that reports both `supportsAtomicWorkflowStarts()` and `supportsConcurrentUpdates()`. The default engine also requires a snapshot policy that persists pending and running states. The evented engine always stores the initial run record for execution. Other storage adapters and execution engines retain their existing behavior. Custom storage adapters must support both create-only snapshot inserts and conditional `updateWorkflowState()` updates before enabling this capability.
+
+Input validation and `onStart` run before the claim. A rejected input or `onStart` callback leaves the run pending. Keep `onStart` safe to repeat, since competing callers can both reach that callback.
+
+The claim saves the initial input, state, and request context. If the process exits before the first step, use [`.restart()`](/reference/workflows/run-methods/restart) to recover the run after stopping the original executor. Recovery can replay an interrupted step, so external operations still need their own idempotency guarantees.
+
 ## Parameters
 
 <PropertiesTable

--- a/packages/core/src/storage/domains/workflows/base.ts
+++ b/packages/core/src/storage/domains/workflows/base.ts
@@ -12,6 +12,11 @@ export abstract class WorkflowsStorage extends StorageDomain {
 
   abstract supportsConcurrentUpdates(): boolean;
 
+  /** Whether create-only snapshots and expectedStatus updates are both atomic. */
+  supportsAtomicWorkflowStarts(): boolean {
+    return false;
+  }
+
   abstract updateWorkflowResults({
     workflowName,
     runId,
@@ -43,6 +48,8 @@ export abstract class WorkflowsStorage extends StorageDomain {
     snapshot: WorkflowRunState;
     createdAt?: Date;
     updatedAt?: Date;
+    /** Insert only: an existing run must remain unchanged. Requires supportsAtomicWorkflowStarts(). */
+    createOnly?: boolean;
   }): Promise<void>;
 
   abstract loadWorkflowSnapshot({

--- a/packages/core/src/storage/domains/workflows/inmemory.ts
+++ b/packages/core/src/storage/domains/workflows/inmemory.ts
@@ -280,6 +280,10 @@ export class WorkflowsInMemory extends WorkflowsStorage {
     return snapshot;
   }
 
+  override supportsAtomicWorkflowStarts(): boolean {
+    return true;
+  }
+
   async persistWorkflowSnapshot({
     workflowName,
     runId,
@@ -287,6 +291,7 @@ export class WorkflowsInMemory extends WorkflowsStorage {
     snapshot,
     createdAt,
     updatedAt,
+    createOnly,
   }: {
     workflowName: string;
     runId: string;
@@ -294,10 +299,12 @@ export class WorkflowsInMemory extends WorkflowsStorage {
     snapshot: WorkflowRunState;
     createdAt?: Date;
     updatedAt?: Date;
+    createOnly?: boolean;
   }): Promise<void> {
     const key = this.getWorkflowKey(workflowName, runId);
     const now = new Date();
     const existing = this.db.workflows.get(key);
+    if (createOnly && existing) return;
     const data: StorageWorkflowRun = {
       workflow_name: workflowName,
       run_id: runId,

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -2221,6 +2221,11 @@ export type StorageWorkspaceRef =
 
 export interface UpdateWorkflowStateOptions {
   status: WorkflowRunStatus;
+  /** Initial execution data persisted atomically with a start claim. */
+  context?: WorkflowRunState['context'];
+  value?: WorkflowRunState['value'];
+  requestContext?: WorkflowRunState['requestContext'];
+  timestamp?: number;
   result?: StepResult<any, any, any, any>;
   error?: SerializedError;
   suspendedPaths?: Record<string, number[]>;

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -526,12 +526,13 @@ export class Tool<
             };
           } else if (isWorkflowExecution && !baseContext.workflow) {
             // Reorganize workflow context - nest workflow-specific properties under 'workflow' key
-            const { workflowId, runId, state, setState, suspend, resumeData, ...rest } = baseContext;
+            const { workflowId, runId, rootRun, state, setState, suspend, resumeData, ...rest } = baseContext;
             organizedContext = {
               ...rest,
               workflow: {
                 workflowId,
                 runId,
+                rootRun,
                 state,
                 setState,
                 suspend,

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -233,6 +233,8 @@ export interface WorkflowToolExecutionContext<TSuspend, TResume> {
   // Always present when called from workflow context
   runId: string;
   workflowId: string;
+  /** Outermost workflow run. Absent for older snapshots or engines without root identity. */
+  rootRun?: { workflowId: string; runId: string };
   state: any;
   setState: (state: any) => void;
   suspend: (suspendPayload: TSuspend, suspendOptions?: SuspendOptions) => Promise<void>;

--- a/packages/core/src/worker/strategies/in-process-strategy.ts
+++ b/packages/core/src/worker/strategies/in-process-strategy.ts
@@ -58,6 +58,7 @@ export class InProcessStrategy implements StepExecutionStrategy {
 
     return executor.execute({
       workflowId: params.workflowId,
+      rootRun: params.rootRun,
       entry,
       runId: params.runId,
       stepResults: params.stepResults as Record<string, StepResult<any, any, any, any>>,

--- a/packages/core/src/worker/types.ts
+++ b/packages/core/src/worker/types.ts
@@ -9,6 +9,7 @@ export interface StepExecutionStrategy {
 export interface StepExecutionParams {
   workflowId: string;
   runId: string;
+  rootRun?: import('../workflows/types').WorkflowRunIdentity;
   stepId: string;
   executionPath: number[];
   stepResults: Record<string, unknown>;

--- a/packages/core/src/workflows/concurrent-start.test.ts
+++ b/packages/core/src/workflows/concurrent-start.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { Mastra } from '../mastra';
+import { RequestContext } from '../request-context';
+import { InMemoryStore } from '../storage/mock';
+import { createWorkflow, createEventedWorkflow } from './create';
+import { createStep } from './workflow';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+const instances: Mastra[] = [];
+afterEach(async () => {
+  await Promise.all(instances.splice(0).map(mastra => mastra.stopWorkers()));
+});
+
+function fixture(evented = false) {
+  const storage = new InMemoryStore();
+  const entered = deferred();
+  const release = deferred();
+  const execute = vi.fn(
+    async ({
+      inputData,
+      state,
+      requestContext,
+    }: {
+      inputData: { item: string };
+      state: any;
+      requestContext: RequestContext;
+    }) => {
+      entered.resolve();
+      await release.promise;
+      return { ...inputData, total: state.total, tenant: requestContext.get('tenant') };
+    },
+  );
+  const onStart = vi.fn();
+  const ready: Promise<void>[] = [];
+  const replica = () => {
+    const step = createStep({
+      id: 'work',
+      inputSchema: z.object({ item: z.string() }),
+      outputSchema: z.object({ item: z.string(), total: z.number(), tenant: z.string() }),
+      execute,
+    });
+    const workflow = (evented ? createEventedWorkflow : createWorkflow)({
+      id: 'concurrent-start',
+      inputSchema: step.inputSchema,
+      outputSchema: step.outputSchema,
+      stateSchema: z.object({ total: z.number() }),
+      options: { onStart },
+    })
+      .then(step)
+      .commit();
+    const mastra = new Mastra({ storage, workflows: { [workflow.id]: workflow }, logger: false });
+    instances.push(mastra);
+    if (evented) ready.push(mastra.startWorkers());
+    return workflow;
+  };
+  const args = {
+    inputData: { item: 'widget' },
+    initialState: { total: 7 },
+    requestContext: new RequestContext([['tenant', 'one']]),
+  };
+  return { storage, entered, release, execute, onStart, replica, args, ready };
+}
+
+describe('concurrent workflow starts', () => {
+  it('claims evented starts across instances and rejects repeated terminal starts', async () => {
+    const f = fixture(true);
+    const runs = await Promise.all([
+      f.replica().createRun({ runId: 'evented-shared' }),
+      f.replica().createRun({ runId: 'evented-shared' }),
+    ]);
+    await Promise.all(f.ready);
+    const resultsPromise = Promise.allSettled(runs.map(run => run.start(f.args)));
+    try {
+      await f.entered.promise;
+    } finally {
+      f.release.resolve();
+    }
+    const results = await resultsPromise;
+    expect(f.execute).toHaveBeenCalledTimes(1);
+    expect(results.find(result => result.status === 'fulfilled')).toMatchObject({ value: { status: 'success' } });
+    expect(results.find(result => result.status === 'rejected')).toMatchObject({
+      reason: { id: 'WORKFLOW_START_ALREADY_CLAIMED' },
+    });
+    await expect(runs[0]!.start(f.args)).rejects.toMatchObject({ id: 'WORKFLOW_START_ALREADY_CLAIMED' });
+  }, 15000);
+
+  it('recovers an evented run claimed before its first event was published', async () => {
+    const f = fixture(true);
+    const workflow = f.replica();
+    const run = await workflow.createRun({ runId: 'evented-crash' });
+    await Promise.all(f.ready);
+    vi.spyOn(workflow.executionEngine, 'execute').mockRejectedValueOnce(new Error('process stopped'));
+    await expect(run.start(f.args)).rejects.toThrow('process stopped');
+    expect(f.execute).not.toHaveBeenCalled();
+    f.release.resolve();
+    const recovered = await f.replica().createRun({ runId: 'evented-crash' });
+    await Promise.all(f.ready);
+    expect(await recovered.restart()).toMatchObject({
+      status: 'success',
+      result: { item: 'widget', total: 7, tenant: 'one' },
+    });
+    expect(f.execute).toHaveBeenCalledTimes(1);
+  }, 15000);
+
+  it('allows only one start across separate workflow instances sharing storage', async () => {
+    const f = fixture();
+    const runs = await Promise.all([
+      f.replica().createRun({ runId: 'shared' }),
+      f.replica().createRun({ runId: 'shared' }),
+    ]);
+    const resultsPromise = Promise.allSettled(runs.map(run => run.start(f.args)));
+    try {
+      await f.entered.promise;
+    } finally {
+      f.release.resolve();
+    }
+    const results = await resultsPromise;
+    expect(f.execute).toHaveBeenCalledTimes(1);
+    expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.find(result => result.status === 'rejected')).toMatchObject({
+      reason: { id: 'WORKFLOW_START_ALREADY_CLAIMED' },
+    });
+  });
+
+  it('rejects redelivery after completion without replacing the saved result', async () => {
+    const f = fixture();
+    f.release.resolve();
+    const first = await f.replica().createRun({ runId: 'completed' });
+    expect(await first.start(f.args)).toMatchObject({ status: 'success' });
+    const next = await f.replica().createRun({ runId: 'completed' });
+    await expect(next.start(f.args)).rejects.toMatchObject({ id: 'WORKFLOW_START_ALREADY_CLAIMED' });
+    expect(f.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a run available after input validation or onStart rejects', async () => {
+    const f = fixture();
+    f.release.resolve();
+    const run = await f.replica().createRun({ runId: 'retry-gate' });
+    await expect(run.start({ ...f.args, inputData: { item: 3 as unknown as string } })).rejects.toThrow();
+    f.onStart.mockRejectedValueOnce(new Error('quota denied'));
+    await expect(run.start(f.args)).rejects.toThrow('quota denied');
+    expect(await run.start(f.args)).toMatchObject({
+      status: 'success',
+      result: { item: 'widget', total: 7, tenant: 'one' },
+    });
+    expect(f.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let a delayed initial snapshot overwrite an already running replica', async () => {
+    const f = fixture();
+    const store = (await f.storage.getStore('workflows'))!;
+    const persist = store.persistWorkflowSnapshot.bind(store);
+    const createEntered = deferred();
+    const releaseCreate = deferred();
+    vi.spyOn(store, 'persistWorkflowSnapshot').mockImplementationOnce(async args => {
+      createEntered.resolve();
+      await releaseCreate.promise;
+      await persist(args);
+    });
+    const slow = f.replica().createRun({ runId: 'late-create' });
+    await createEntered.promise;
+    const fast = await f.replica().createRun({ runId: 'late-create' });
+    const executing = fast.start(f.args);
+    try {
+      await f.entered.promise;
+      releaseCreate.resolve();
+      const delayed = await slow;
+      const snapshot = await store.loadWorkflowSnapshot({ workflowName: 'concurrent-start', runId: 'late-create' });
+      expect(snapshot?.status).toBe('running');
+      await expect(delayed.start(f.args)).rejects.toMatchObject({ id: 'WORKFLOW_START_ALREADY_CLAIMED' });
+    } finally {
+      releaseCreate.resolve();
+      f.release.resolve();
+      await executing;
+    }
+    expect(f.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers original input, state and context after a crash immediately following the claim', async () => {
+    const f = fixture();
+    const workflow = f.replica();
+    const run = await workflow.createRun({ runId: 'crash-before-first-step' });
+    vi.spyOn(workflow.executionEngine, 'execute').mockRejectedValueOnce(new Error('process stopped'));
+    await expect(run.start(f.args)).rejects.toThrow('process stopped');
+    expect(f.execute).not.toHaveBeenCalled();
+    f.release.resolve();
+    const recovered = await f.replica().createRun({ runId: 'crash-before-first-step' });
+    expect(await recovered.restart()).toMatchObject({
+      status: 'success',
+      result: { item: 'widget', total: 7, tenant: 'one' },
+    });
+    expect(f.execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -7,7 +7,6 @@ import { getErrorFromUnknown } from '../error/utils.js';
 import type { PubSub } from '../events/pubsub';
 import type { ObservabilityContext, Span, SpanType, TracingPolicy } from '../observability';
 import { createObservabilityContext, resolveExportedSpanId } from '../observability';
-import { MASTRA_AUTH_TOKEN_KEY } from '../request-context';
 import { deepEqual } from '../utils/deep-equal';
 import type { ExecutionGraph } from './execution-engine';
 import { ExecutionEngine } from './execution-engine';
@@ -673,26 +672,6 @@ export class DefaultExecutionEngine extends ExecutionEngine {
   // =============================================================================
 
   /**
-   * Serialize a RequestContext Map to a plain object for JSON serialization.
-   * Used by durable execution engines to persist context across step replays.
-   */
-  serializeRequestContext(requestContext: RequestContext): Record<string, any> {
-    let obj: Record<string, any>;
-    if (typeof requestContext.toJSON === 'function') {
-      obj = requestContext.toJSON();
-    } else {
-      obj = {};
-      requestContext.forEach((value, key) => {
-        obj[key] = value;
-      });
-    }
-    // Never persist the framework-managed bearer token in durable snapshots.
-    // A resumed authenticated request supplies its own fresh live token.
-    delete obj[MASTRA_AUTH_TOKEN_KEY];
-    return obj;
-  }
-
-  /**
    * Deserialize a plain object back to a RequestContext instance.
    * Used to restore context after durable execution replay.
    */
@@ -743,6 +722,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
   async execute<TState, TInput, TOutput>(params: {
     workflowId: string;
     runId: string;
+    rootRun?: import('./types').WorkflowRunIdentity;
     resourceId?: string;
     disableScorers?: boolean;
     graph: ExecutionGraph;
@@ -847,6 +827,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
           executionContext: lastExecutionContext || {
             workflowId,
             runId,
+            rootRun: params.rootRun,
             executionPath: [i],
             stepExecutionPath,
             activeStepsPath: {},
@@ -903,6 +884,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
       const executionContext: ExecutionContext = {
         workflowId,
         runId,
+        rootRun: params.rootRun,
         executionPath: [i],
         stepExecutionPath,
         activeStepsPath: {},

--- a/packages/core/src/workflows/entry-executors/run-tool-entry.ts
+++ b/packages/core/src/workflows/entry-executors/run-tool-entry.ts
@@ -26,6 +26,7 @@ export async function runToolEntry(entry: ToolStepEntry, ctx: EntryExecuteContex
     resumeData,
     runId,
     workflowId,
+    rootRun,
     state,
     setState,
     abortSignal,
@@ -42,6 +43,7 @@ export async function runToolEntry(entry: ToolStepEntry, ctx: EntryExecuteContex
     resumeData,
     workflow: {
       runId,
+      rootRun,
       suspend,
       resumeData,
       workflowId,

--- a/packages/core/src/workflows/evented/execution-engine.ts
+++ b/packages/core/src/workflows/evented/execution-engine.ts
@@ -184,6 +184,10 @@ export class EventedExecutionEngine extends ExecutionEngine {
       } else if (params.restart) {
         const prevStepId = getStepId(this.resolveWorkflow(params.workflowId, params.runId), params.restart.activePaths);
         const prevResult = params.restart.stepResults[prevStepId ?? 'input'];
+        const beforeFirstStep =
+          params.restart.activePaths.length === 1 &&
+          params.restart.activePaths[0] === 0 &&
+          Object.keys(params.restart.stepResults).every(key => key === 'input');
         await pubsub.publish('workflows', {
           type: 'workflow.start',
           runId: params.runId,
@@ -193,7 +197,10 @@ export class EventedExecutionEngine extends ExecutionEngine {
             executionPath: params.restart.activePaths,
             stepResults: params.restart.stepResults,
             restart: params.restart,
-            prevResult: { status: 'success', output: prevResult?.payload },
+            prevResult: {
+              status: 'success',
+              output: beforeFirstStep ? params.restart.stepResults.input : prevResult?.payload,
+            },
             requestContext: params.requestContext.toJSON(),
             format: params.format,
             perStep: params.perStep,

--- a/packages/core/src/workflows/evented/step-executor.ts
+++ b/packages/core/src/workflows/evented/step-executor.ts
@@ -64,6 +64,7 @@ export class StepExecutor extends MastraBase {
 
   async execute(params: {
     workflowId: string;
+    rootRun?: import('../types').WorkflowRunIdentity;
     entry: SingleStepEntry;
     runId: string;
     input?: any;
@@ -182,6 +183,7 @@ export class StepExecutor extends MastraBase {
             {
               workflowId: params.workflowId,
               runId,
+              rootRun: params.rootRun,
               mastra: this.mastra!,
               requestContext,
               inputData,

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -555,6 +555,15 @@ export class WorkflowEventProcessor extends EventProcessor {
     const workflowsStore = await this.mastra.getStorage()?.getStore('workflows');
     const existingRun = await workflowsStore?.getWorkflowRunById({ runId, workflowName: workflow.id });
     const resourceId = existingRun?.resourceId;
+    const existingSnapshot =
+      typeof existingRun?.snapshot === 'string' ? JSON.parse(existingRun.snapshot) : existingRun?.snapshot;
+    let rootRun = existingSnapshot?.rootRun as WorkflowRunState['rootRun'];
+    if (!rootRun && (parentWorkflow || (!restart && !timeTravel && !resumeSteps?.length))) {
+      rootRun = { workflowId, runId };
+      for (let parent = parentWorkflow; parent; parent = parent.parentWorkflow) {
+        rootRun = { workflowId: parent.workflowId, runId: parent.runId };
+      }
+    }
 
     // Check shouldPersistSnapshot option - default to true if not specified
     // This is particularly important for resume: if shouldPersist returns false for 'running',
@@ -567,6 +576,7 @@ export class WorkflowEventProcessor extends EventProcessor {
 
     if (shouldPersist) {
       const runningSnapshot: WorkflowRunState = {
+        rootRun,
         activePaths: [],
         suspendedPaths: {},
         resumeLabels: {},
@@ -1338,9 +1348,16 @@ export class WorkflowEventProcessor extends EventProcessor {
     const nestedWorkflowStep = getEntryWorkflow(leaf);
     if (nestedWorkflowStep) {
       const nestedWorkflow = nestedWorkflowStep;
+      const parentStepResult = stepResults[leafId];
+      const nestedStepResult =
+        step.type === 'foreach' && executionPath[1] !== undefined
+          ? (parentStepResult && 'output' in parentStepResult
+              ? (parentStepResult.output as ForeachIterationResult[])
+              : undefined)?.[executionPath[1]]
+          : parentStepResult;
       // Handle resume with only nested workflow ID specified (auto-detect suspended inner step)
       if (resumeSteps?.length === 1 && resumeSteps[0] === leafId) {
-        const stepData = stepResults[leafId];
+        const stepData = nestedStepResult;
         const nestedRunId = stepData?.suspendPayload?.__workflow_meta?.runId;
         if (!nestedRunId) {
           return this.errorWorkflow(
@@ -1438,7 +1455,7 @@ export class WorkflowEventProcessor extends EventProcessor {
           },
         });
       } else if (resumeSteps?.length > 1 && resumeSteps[0] === leafId) {
-        const stepData = stepResults[leafId];
+        const stepData = nestedStepResult;
         const nestedRunId = stepData?.suspendPayload?.__workflow_meta?.runId;
         if (!nestedRunId) {
           return this.errorWorkflow(
@@ -1729,12 +1746,17 @@ export class WorkflowEventProcessor extends EventProcessor {
     // Get the abort controller for this workflow run
     const abortController = this.getOrCreateAbortController(runId);
 
+    // Read the immutable identity saved when this invocation started. Unlike a request
+    // context key, this also survives detached workers and direct nested-run resume.
+    const rootRun = (await workflowsStore?.loadWorkflowSnapshot({ workflowName: workflowId, runId }))?.rootRun;
+
     let stepResult: StepResult<any, any, any, any>;
 
     if (this.stepExecutionStrategy) {
       stepResult = await this.stepExecutionStrategy.executeStep({
         workflowId,
         runId,
+        rootRun,
         stepId: leafId,
         executionPath,
         stepResults,
@@ -1754,6 +1776,7 @@ export class WorkflowEventProcessor extends EventProcessor {
         workflowId,
         entry: leaf,
         runId,
+        rootRun,
         stepResults,
         state: currentState,
         requestContext: rc,
@@ -2450,7 +2473,11 @@ export class WorkflowEventProcessor extends EventProcessor {
             if (iterResult && typeof iterResult === 'object' && iterResult.status === 'suspended') {
               // Collect resume labels
               if (iterResult.suspendPayload?.__workflow_meta?.resumeLabels) {
-                Object.assign(collectedResumeLabels, iterResult.suspendPayload.__workflow_meta.resumeLabels);
+                for (const [label, target] of Object.entries(iterResult.suspendPayload.__workflow_meta.resumeLabels)) {
+                  // The outer foreach owns this index. A nested workflow's label refers to
+                  // its own step context and does not know which outer item invoked it.
+                  collectedResumeLabels[label] = { ...(target as { stepId: string }), foreachIndex: i };
+                }
               }
               if (firstSuspendedIterationPayload === undefined) {
                 firstSuspendedIterationPayload = iterResult.suspendPayload;

--- a/packages/core/src/workflows/evented/workflow-event-processor/loop.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/loop.ts
@@ -248,7 +248,9 @@ export async function processWorkflowForEach(
         const iterResult = currentResult.output[i];
         if (iterResult?.status === 'suspended') {
           if (iterResult.suspendPayload?.__workflow_meta?.resumeLabels) {
-            Object.assign(collectedResumeLabels, iterResult.suspendPayload.__workflow_meta.resumeLabels);
+            for (const [label, target] of Object.entries(iterResult.suspendPayload.__workflow_meta.resumeLabels)) {
+              collectedResumeLabels[label] = { ...(target as { stepId: string }), foreachIndex: i };
+            }
           }
           if (firstSuspendedIterationPayload === undefined) {
             firstSuspendedIterationPayload = iterResult.suspendPayload;

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -65,6 +65,7 @@ import type {
   WorkflowEngineType,
   WorkflowRunStatus,
   WorkflowRunState,
+  WorkflowRunIdentity,
   StepParams,
   ToolStep,
   DefaultEngineType,
@@ -1740,6 +1741,7 @@ export class EventedWorkflow<
 
   async createRun(options?: {
     runId?: string;
+    rootRun?: WorkflowRunIdentity | null;
     resourceId?: string;
     disableScorers?: boolean;
   }): Promise<Run<TEngineType, TSteps, TState, TInput, TOutput>> {
@@ -1775,6 +1777,7 @@ export class EventedWorkflow<
       this.runs.get(runIdToUse) ??
       new EventedRun({
         workflowId: this.id,
+        rootRun: options?.rootRun,
         runId: runIdToUse,
         resourceId: options?.resourceId,
         isInternalWorkflow: this.isInternal,
@@ -1818,6 +1821,7 @@ export class EventedWorkflow<
     if (!existsInStorage && shouldPersistSnapshot) {
       const initialSnapshot: WorkflowRunState = {
         runId: runIdToUse,
+        rootRun: run.rootRun,
         status: 'pending',
         value: {},
         context: {} as WorkflowRunState['context'],
@@ -1834,6 +1838,7 @@ export class EventedWorkflow<
       await workflowsStore?.persistWorkflowSnapshot({
         workflowName: this.id,
         runId: runIdToUse,
+        createOnly: workflowsStore.supportsAtomicWorkflowStarts(),
         resourceId: options?.resourceId,
         snapshot: this.options?.pruneSnapshot
           ? this.options.pruneSnapshot({ snapshot: initialSnapshot, workflowStatus: 'pending' })
@@ -1855,6 +1860,7 @@ export class EventedRun<
   constructor(params: {
     workflowId: string;
     runId: string;
+    rootRun?: WorkflowRunIdentity | null;
     resourceId?: string;
     isInternalWorkflow?: boolean;
     executionEngine: ExecutionEngine;
@@ -1944,31 +1950,35 @@ export class EventedRun<
     });
 
     const workflowsStore = await this.mastra?.getStorage()?.getStore('workflows');
-    // Always persist the initial run record regardless of shouldPersistSnapshot.
-    // The evented engine relies on this record for parallel branch result
-    // aggregation (aggregateBranchResults reads stepResults via storage).
-    const initialRunSnapshot: WorkflowRunState = {
-      runId: this.runId,
-      serializedStepGraph: this.serializedStepGraph,
-      status: 'running',
-      value: {},
-      context: inputDataToUse != null ? ({ input: inputDataToUse } as any) : ({} as any),
-      requestContext: requestContext.toJSON(),
-      activePaths: [],
-      activeStepsPath: {},
-      suspendedPaths: {},
-      resumeLabels: {},
-      waitingPaths: {},
-      timestamp: Date.now(),
-    };
-    await workflowsStore?.persistWorkflowSnapshot({
-      workflowName: this.workflowId,
-      runId: this.runId,
-      resourceId: this.resourceId,
-      snapshot: this.executionEngine.options?.pruneSnapshot
-        ? this.executionEngine.options.pruneSnapshot({ snapshot: initialRunSnapshot, workflowStatus: 'running' })
-        : initialRunSnapshot,
-    });
+    const claimed = await this._claimStart(inputDataToUse, initialStateToUse, requestContext);
+    if (!claimed) {
+      // Always persist the initial run record regardless of shouldPersistSnapshot.
+      // The evented engine relies on this record for parallel branch result
+      // aggregation (aggregateBranchResults reads stepResults via storage).
+      const initialRunSnapshot: WorkflowRunState = {
+        rootRun: this.rootRun,
+        runId: this.runId,
+        serializedStepGraph: this.serializedStepGraph,
+        status: 'running',
+        value: {},
+        context: inputDataToUse != null ? ({ input: inputDataToUse } as any) : ({} as any),
+        requestContext: requestContext.toJSON(),
+        activePaths: [],
+        activeStepsPath: {},
+        suspendedPaths: {},
+        resumeLabels: {},
+        waitingPaths: {},
+        timestamp: Date.now(),
+      };
+      await workflowsStore?.persistWorkflowSnapshot({
+        workflowName: this.workflowId,
+        runId: this.runId,
+        resourceId: this.resourceId,
+        snapshot: this.executionEngine.options?.pruneSnapshot
+          ? this.executionEngine.options.pruneSnapshot({ snapshot: initialRunSnapshot, workflowStatus: 'running' })
+          : initialRunSnapshot,
+      });
+    }
 
     if (!this.mastra?.pubsub) {
       throw new Error('Mastra instance with pubsub is required for workflow execution');
@@ -2078,31 +2088,35 @@ export class EventedRun<
     });
 
     const workflowsStore = await this.mastra?.getStorage()?.getStore('workflows');
-    // Always persist the initial run record regardless of shouldPersistSnapshot.
-    // The evented engine relies on this record for parallel branch result
-    // aggregation (aggregateBranchResults reads stepResults via storage).
-    const initialRunSnapshot: WorkflowRunState = {
-      runId: this.runId,
-      serializedStepGraph: this.serializedStepGraph,
-      status: 'running',
-      value: {},
-      context: inputDataToUse != null ? ({ input: inputDataToUse } as any) : ({} as any),
-      requestContext: requestContext.toJSON(),
-      activePaths: [],
-      activeStepsPath: {},
-      suspendedPaths: {},
-      resumeLabels: {},
-      waitingPaths: {},
-      timestamp: Date.now(),
-    };
-    await workflowsStore?.persistWorkflowSnapshot({
-      workflowName: this.workflowId,
-      runId: this.runId,
-      resourceId: this.resourceId,
-      snapshot: this.executionEngine.options?.pruneSnapshot
-        ? this.executionEngine.options.pruneSnapshot({ snapshot: initialRunSnapshot, workflowStatus: 'running' })
-        : initialRunSnapshot,
-    });
+    const claimed = await this._claimStart(inputDataToUse, initialStateToUse, requestContext);
+    if (!claimed) {
+      // Always persist the initial run record regardless of shouldPersistSnapshot.
+      // The evented engine relies on this record for parallel branch result
+      // aggregation (aggregateBranchResults reads stepResults via storage).
+      const initialRunSnapshot: WorkflowRunState = {
+        rootRun: this.rootRun,
+        runId: this.runId,
+        serializedStepGraph: this.serializedStepGraph,
+        status: 'running',
+        value: {},
+        context: inputDataToUse != null ? ({ input: inputDataToUse } as any) : ({} as any),
+        requestContext: requestContext.toJSON(),
+        activePaths: [],
+        activeStepsPath: {},
+        suspendedPaths: {},
+        resumeLabels: {},
+        waitingPaths: {},
+        timestamp: Date.now(),
+      };
+      await workflowsStore?.persistWorkflowSnapshot({
+        workflowName: this.workflowId,
+        runId: this.runId,
+        resourceId: this.resourceId,
+        snapshot: this.executionEngine.options?.pruneSnapshot
+          ? this.executionEngine.options.pruneSnapshot({ snapshot: initialRunSnapshot, workflowStatus: 'running' })
+          : initialRunSnapshot,
+      });
+    }
 
     if (!this.mastra?.pubsub) {
       throw new Error('Mastra instance with pubsub is required for workflow execution');

--- a/packages/core/src/workflows/execution-engine.ts
+++ b/packages/core/src/workflows/execution-engine.ts
@@ -6,6 +6,7 @@ import { RegisteredLogger } from '../logger';
 import type { IMastraLogger } from '../logger';
 import type { Mastra } from '../mastra';
 import type { Span, SpanType, TracingPolicy } from '../observability';
+import { MASTRA_AUTH_TOKEN_KEY } from '../request-context';
 import type {
   OutputWriter,
   SerializedStepFlowEntry,
@@ -121,6 +122,16 @@ export abstract class ExecutionEngine extends MastraBase {
     return this.logger;
   }
 
+  /** Serialize durable context without persisting the live request's bearer token. */
+  serializeRequestContext(requestContext: RequestContext): Record<string, any> {
+    const result =
+      typeof requestContext.toJSON === 'function'
+        ? requestContext.toJSON()
+        : Object.fromEntries(requestContext.entries());
+    delete result[MASTRA_AUTH_TOKEN_KEY];
+    return result;
+  }
+
   /**
    * Invokes the onStart lifecycle callback if it is defined, before any step runs.
    * Errors are intentionally propagated so the hook can gate the run (for example a
@@ -214,6 +225,7 @@ export abstract class ExecutionEngine extends MastraBase {
   abstract execute<TState, TInput, TOutput>(params: {
     workflowId: string;
     runId: string;
+    rootRun?: WorkflowRunState['rootRun'];
     resourceId?: string;
     disableScorers?: boolean;
     graph: ExecutionGraph;

--- a/packages/core/src/workflows/handlers/control-flow.ts
+++ b/packages/core/src/workflows/handlers/control-flow.ts
@@ -198,6 +198,7 @@ export async function executeParallel(
         timeTravel,
         resume,
         executionContext: {
+          rootRun: executionContext.rootRun,
           activeStepsPath: executionContext.activeStepsPath,
           workflowId,
           runId,
@@ -520,6 +521,7 @@ export async function executeConditional(
         restart,
         timeTravel,
         executionContext: {
+          rootRun: executionContext.rootRun,
           workflowId,
           runId,
           executionPath: [...executionContext.executionPath, steps.indexOf(step)],

--- a/packages/core/src/workflows/handlers/entry.ts
+++ b/packages/core/src/workflows/handlers/entry.ts
@@ -208,6 +208,7 @@ export async function persistStepUpdate(
 
     const snapshot: WorkflowRunState = {
       runId,
+      rootRun: executionContext.rootRun,
       status: workflowStatus,
       value: executionContext.state,
       context: stepResults as any,
@@ -359,6 +360,7 @@ export async function executeEntry(
       stepResults,
       resume,
       executionContext: {
+        rootRun: executionContext.rootRun,
         workflowId,
         runId,
         executionPath: [...executionContext.executionPath, idx!],
@@ -433,6 +435,7 @@ export async function executeEntry(
         stepResults,
         resume,
         executionContext: {
+          rootRun: executionContext.rootRun,
           workflowId,
           runId,
           executionPath: [...executionContext.executionPath, idx!],
@@ -472,6 +475,7 @@ export async function executeEntry(
         restart,
         timeTravel,
         executionContext: {
+          rootRun: executionContext.rootRun,
           workflowId,
           runId,
           executionPath: [...executionContext.executionPath, idx!],

--- a/packages/core/src/workflows/handlers/step.ts
+++ b/packages/core/src/workflows/handlers/step.ts
@@ -347,6 +347,7 @@ export async function executeStep(
         runId: nestedRunId ?? runId,
         resourceId,
         workflowId,
+        rootRun: executionContext.rootRun,
         mastra: mastraForStep,
         requestContext,
         actor,

--- a/packages/core/src/workflows/nested-resume-label.test.ts
+++ b/packages/core/src/workflows/nested-resume-label.test.ts
@@ -65,7 +65,9 @@ describe('resume-label propagation', () => {
       const storage = new MockStore();
       new Mastra({ logger: false, storage, workflows: { 'single-label-wf': workflow } });
 
-      const run = await workflow.createRun();
+      // The workflow fixture is shared, but storage is fresh per test. Use a distinct ID
+      // instead of returning the previous test's cached suspended Run (UUID mocks reset).
+      const run = await workflow.createRun({ runId: 'single-label-resume' });
       await run.start({ inputData: { item: 'widget' } });
 
       // Resume by auto-detecting suspended step (the label-based lookup maps
@@ -192,7 +194,7 @@ describe('resume-label propagation', () => {
         workflows: { 'outer-wf': outerWorkflow, 'inner-wf': innerWorkflow },
       });
 
-      const run = await outerWorkflow.createRun();
+      const run = await outerWorkflow.createRun({ runId: 'nested-label-payload' });
       await run.start({ inputData: { item: 'gadget' } });
 
       const store = await storage.getStore('workflows');

--- a/packages/core/src/workflows/root-run-identity.test.ts
+++ b/packages/core/src/workflows/root-run-identity.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { Mastra } from '../mastra';
+import { RequestContext } from '../request-context';
+import { InMemoryStore } from '../storage/mock';
+import { createTool } from '../tools';
+import { createWorkflow, createEventedWorkflow } from './create';
+import type { WorkflowRunIdentity } from './types';
+import { createStep } from './workflow';
+
+const instances: Mastra[] = [];
+afterEach(async () => {
+  await Promise.all(instances.splice(0).map(mastra => mastra.stopWorkers()));
+});
+
+async function graph(
+  storage: InMemoryStore,
+  seen: Array<{ rootRun?: WorkflowRunIdentity; runId: string; workflowId: string }>,
+  evented = false,
+) {
+  const build = evented ? createEventedWorkflow : createWorkflow;
+  const inputSchema = z.object({ item: z.string() });
+  const outputSchema = z.object({ item: z.string(), approved: z.boolean() });
+  const tool = createTool({
+    id: 'approval-tool',
+    inputSchema,
+    outputSchema,
+    suspendSchema: inputSchema,
+    resumeSchema: z.object({ approved: z.boolean() }),
+    execute: async (input, context) => {
+      const workflow = context.workflow!;
+      seen.push({ rootRun: workflow.rootRun, runId: workflow.runId, workflowId: workflow.workflowId });
+      if (!workflow.resumeData) {
+        await workflow.suspend(input, { resumeLabel: `callback:${input.item}` });
+        return { ...input, approved: false };
+      }
+      return { ...input, approved: workflow.resumeData.approved };
+    },
+  });
+  const helper = build({ id: 'helper', inputSchema, outputSchema }).then(createStep(tool)).commit();
+  const middle = build({ id: 'middle', inputSchema, outputSchema }).then(helper).commit();
+  const finish = createStep({
+    id: 'finish',
+    inputSchema: outputSchema,
+    outputSchema,
+    execute: async ({ inputData }) => inputData,
+  });
+  const root = build({ id: 'root', inputSchema, outputSchema }).then(middle).then(finish).commit();
+  const mastra = new Mastra({ storage, workflows: { root, middle, helper }, logger: false });
+  instances.push(mastra);
+  if (evented) await mastra.startWorkers();
+  return { root, helper, mastra };
+}
+
+describe.each(['default', 'evented'])('native root workflow identity (%s)', engine => {
+  it('lets a nested tool identify and resume the outer run after a fresh Mastra instance', async () => {
+    const storage = new InMemoryStore();
+    const seen: Array<{ rootRun?: WorkflowRunIdentity; runId: string; workflowId: string }> = [];
+    const first = await graph(storage, seen, engine === 'evented');
+    const run = await first.root.createRun({ runId: 'outer-run', resourceId: 'tenant-one' });
+    expect(await run.start({ inputData: { item: 'document' } })).toMatchObject({ status: 'suspended' });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ workflowId: 'helper', rootRun: { workflowId: 'root', runId: 'outer-run' } });
+    expect(seen[0]!.workflowId).not.toBe(seen[0]!.rootRun!.workflowId);
+
+    await first.mastra.stopWorkers();
+    const fresh = await graph(storage, seen, engine === 'evented');
+    const identity = seen[0]!.rootRun!;
+    const restored = await fresh.mastra.getWorkflow(identity.workflowId).createRun({ runId: identity.runId });
+    expect(await restored.resume({ label: 'callback:document', resumeData: { approved: true } })).toMatchObject({
+      status: 'success',
+      result: { item: 'document', approved: true },
+    });
+    expect(seen).toHaveLength(2);
+    expect(seen[1]!.rootRun).toEqual(identity);
+    const snapshot = await (await storage.getStore('workflows'))!.loadWorkflowSnapshot({
+      workflowName: 'root',
+      runId: 'outer-run',
+    });
+    expect(snapshot).toMatchObject({ status: 'success', rootRun: identity });
+  });
+
+  it('keeps concurrent roots separate even when they share the same request context and helper', async () => {
+    const storage = new InMemoryStore();
+    const seen: Array<{ rootRun?: WorkflowRunIdentity; runId: string; workflowId: string }> = [];
+    const { root } = await graph(storage, seen, engine === 'evented');
+    const forgedRoot = { workflowId: 'other-tenant', runId: 'forged-run' };
+    const context = new RequestContext([['rootRun', forgedRoot]]);
+    const runs = await Promise.all(['outer-a', 'outer-b'].map(runId => root.createRun({ runId })));
+    const results = await Promise.all(
+      runs.map((run, index) => run.start({ inputData: { item: String(index) }, requestContext: context })),
+    );
+    expect(results.map(result => result.status)).toEqual(['suspended', 'suspended']);
+    expect(seen.map(item => item.rootRun?.runId).sort()).toEqual(['outer-a', 'outer-b']);
+    expect([...context.entries()]).toEqual([['rootRun', forgedRoot]]);
+  });
+
+  it('retains the outer identity for each suspended foreach invocation and its continuation', async () => {
+    const storage = new InMemoryStore();
+    const seen: Array<{ rootRun?: WorkflowRunIdentity; runId: string; workflowId: string }> = [];
+    const { helper, mastra: unused } = await graph(storage, seen, engine === 'evented');
+    await unused.stopWorkers();
+    const build = engine === 'evented' ? createEventedWorkflow : createWorkflow;
+    const batch = build({
+      id: 'batch',
+      inputSchema: z.array(z.object({ item: z.string() })),
+      outputSchema: z.array(z.object({ item: z.string(), approved: z.boolean() })),
+    })
+      .foreach(helper, { concurrency: 2 })
+      .commit();
+    const mastra = new Mastra({ storage, workflows: { batch, helper }, logger: false });
+    instances.push(mastra);
+    if (engine === 'evented') await mastra.startWorkers();
+    const run = await batch.createRun({ runId: 'batch-run' });
+    expect(await run.start({ inputData: [{ item: 'a' }, { item: 'b' }] })).toMatchObject({ status: 'suspended' });
+    expect(seen).toHaveLength(2);
+    expect(new Set(seen.map(item => item.runId)).size).toBe(2);
+    expect(seen.every(item => item.rootRun?.workflowId === 'batch' && item.rootRun.runId === 'batch-run')).toBe(true);
+    const snapshot = await (await storage.getStore('workflows'))!.loadWorkflowSnapshot({
+      workflowName: 'batch',
+      runId: 'batch-run',
+    });
+    expect(snapshot?.resumeLabels).toMatchObject({
+      'callback:a': { stepId: 'helper', foreachIndex: 0 },
+      'callback:b': { stepId: 'helper', foreachIndex: 1 },
+    });
+    const firstResume = await run.resume({ label: 'callback:a', resumeData: { approved: true } });
+    expect(firstResume, JSON.stringify(firstResume)).toMatchObject({ status: 'suspended' });
+    expect(await run.resume({ label: 'callback:b', resumeData: { approved: true } })).toMatchObject({
+      status: 'success',
+      result: [
+        { item: 'a', approved: true },
+        { item: 'b', approved: true },
+      ],
+    });
+    expect(seen).toHaveLength(4);
+    expect(seen.every(item => item.rootRun?.workflowId === 'batch' && item.rootRun.runId === 'batch-run')).toBe(true);
+  });
+});

--- a/packages/core/src/workflows/step.ts
+++ b/packages/core/src/workflows/step.ts
@@ -8,7 +8,7 @@ import type { InferStandardSchemaOutput, StandardSchemaWithJSON } from '../schem
 import type { ToolStream } from '../tools/stream';
 import type { DynamicArgument } from '../types';
 import type { PUBSUB_SYMBOL, STREAM_FORMAT_SYMBOL } from './constants';
-import type { OutputWriter, StepResult, StepMetadata } from './types';
+import type { OutputWriter, StepResult, StepMetadata, WorkflowRunIdentity } from './types';
 import type { Workflow } from './workflow';
 
 export type SuspendOptions = {
@@ -33,6 +33,8 @@ export type ExecuteFunctionParams<
   runId: string;
   resourceId?: string;
   workflowId: string;
+  /** Outermost run, if the execution engine has retained its identity. */
+  rootRun?: WorkflowRunIdentity;
   mastra: Mastra;
   requestContext: RequestContext<TRequestContext>;
   actor?: ActorSignal;

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -380,9 +380,16 @@ export type WorkflowStateField =
   | 'requestContext'
   | 'tracingContext';
 
+/** The outermost workflow invocation, retained across nested workflow runs. */
+export interface WorkflowRunIdentity {
+  workflowId: string;
+  runId: string;
+}
+
 export interface WorkflowRunState {
   // Core state info
   runId: string;
+  rootRun?: WorkflowRunIdentity;
   status: WorkflowRunStatus;
   result?: Record<string, any>;
   error?: SerializedError;
@@ -1175,6 +1182,7 @@ export type SubsetOf<TStepState, TState> =
 export type ExecutionContext = {
   workflowId: string;
   runId: string;
+  rootRun?: WorkflowRunIdentity;
   executionPath: number[];
   stepExecutionPath?: string[];
   activeStepsPath: Record<string, number[]>;

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -95,6 +95,7 @@ import type {
   WorkflowResult,
   WorkflowType,
   WorkflowRunState,
+  WorkflowRunIdentity,
   WorkflowRunStatus,
   WorkflowState,
   WorkflowStateField,
@@ -2562,6 +2563,8 @@ export class Workflow<
    */
   async createRun(options?: {
     runId?: string;
+    /** @internal Outermost invocation supplied by native nested execution; null means unknown. */
+    rootRun?: WorkflowRunIdentity | null;
     resourceId?: string;
     disableScorers?: boolean;
     /** Optional pubsub instance for streaming events. If not provided, a new EventEmitterPubSub is created. */
@@ -2598,6 +2601,7 @@ export class Workflow<
       this.#runs.get(runIdToUse) ??
       new Run({
         workflowId: this.id,
+        rootRun: options?.rootRun,
         stateSchema: this.stateSchema,
         inputSchema: this.inputSchema,
         requestContextSchema: this.requestContextSchema,
@@ -2654,6 +2658,7 @@ export class Workflow<
       const workflowsStore = await this.mastra?.getStorage()?.getStore('workflows');
       const initialSnapshot: WorkflowRunState = {
         runId: runIdToUse,
+        rootRun: run.rootRun,
         status: 'pending',
         value: {},
         // @ts-expect-error - context type mismatch
@@ -2672,6 +2677,7 @@ export class Workflow<
         workflowName: this.id,
         runId: runIdToUse,
         resourceId: options?.resourceId,
+        createOnly: workflowsStore.supportsAtomicWorkflowStarts(),
         snapshot: this.#options.pruneSnapshot
           ? this.#options.pruneSnapshot({ snapshot: initialSnapshot, workflowStatus: 'pending' })
           : initialSnapshot,
@@ -2713,6 +2719,7 @@ export class Workflow<
   // To run a workflow use `.createRun` and then `.start` or `.resume`
   async execute({
     runId,
+    rootRun,
     resourceId,
     inputData,
     resumeData,
@@ -2737,6 +2744,7 @@ export class Workflow<
     ...rest
   }: {
     runId?: string;
+    rootRun?: WorkflowRunIdentity;
     resourceId?: string;
     inputData: TInput;
     resumeData?: unknown;
@@ -2829,8 +2837,8 @@ export class Workflow<
     const useSharedPubsub = !!this.#options?.sharePubsub;
     const nestedPubsub = useSharedPubsub ? pubsub : undefined;
     const run = isResume
-      ? await this.createRun({ runId: resume.runId, resourceId, pubsub: nestedPubsub })
-      : await this.createRun({ runId, resourceId, pubsub: nestedPubsub });
+      ? await this.createRun({ runId: resume.runId, rootRun: rootRun ?? null, resourceId, pubsub: nestedPubsub })
+      : await this.createRun({ runId, rootRun: rootRun ?? null, resourceId, pubsub: nestedPubsub });
     const nestedAbortCb = () => {
       abort();
     };
@@ -3367,6 +3375,8 @@ export class Run<
 
   readonly workflowEngineType: WorkflowEngineType;
 
+  readonly rootRun?: WorkflowRunIdentity;
+
   /**
    * The storage for this run
    */
@@ -3395,6 +3405,7 @@ export class Run<
   constructor(params: {
     workflowId: string;
     runId: string;
+    rootRun?: WorkflowRunIdentity | null;
     resourceId?: string;
     isInternalWorkflow?: boolean;
     stateSchema?: StandardSchemaWithJSON<TState>;
@@ -3419,6 +3430,8 @@ export class Run<
   }) {
     this.workflowId = params.workflowId;
     this.runId = params.runId;
+    this.rootRun =
+      params.rootRun === null ? undefined : (params.rootRun ?? { workflowId: params.workflowId, runId: params.runId });
     this.resourceId = params.resourceId;
     this.isInternalWorkflow = params.isInternalWorkflow ?? false;
     this.serializedStepGraph = params.serializedStepGraph;
@@ -3553,6 +3566,100 @@ export class Run<
     return this.#validateSchema(step.inputSchema, inputData, 'inputData');
   }
 
+  /** Claim the pending snapshot before any step executes on a persistent native engine. */
+  protected async _claimStart(
+    input: TInput | undefined,
+    state: TState | undefined,
+    requestContext: RequestContext,
+  ): Promise<boolean> {
+    // The outer run owns admission. Its engine may start the same nested run again for a
+    // loop iteration or retry, so nested starts must retain that native execution behavior.
+    if (!this.rootRun || this.rootRun.workflowId !== this.workflowId || this.rootRun.runId !== this.runId) return false;
+    // Other execution engines own their own durable dispatch protocol.
+    if (this.workflowEngineType !== 'default' && this.workflowEngineType !== 'evented') return false;
+    const store = await this.#mastra?.getStorage()?.getStore('workflows');
+    if (!store) return false;
+    const persist =
+      this.executionEngine.getRunPersistenceOverride(this.runId) ?? this.executionEngine.options.shouldPersistSnapshot;
+    if (
+      this.workflowEngineType === 'default' &&
+      (!persist({ workflowStatus: 'pending', stepResults: {} }) ||
+        !persist({ workflowStatus: 'running', stepResults: { input } as any }))
+    )
+      return false;
+    if (!store.supportsAtomicWorkflowStarts() || !store.supportsConcurrentUpdates()) {
+      this.#mastra
+        ?.getLogger()
+        ?.warn(
+          `[Workflow ${this.workflowId}] Storage does not support atomic workflow starts; concurrent starts for run ${this.runId} may execute steps more than once.`,
+        );
+      return false;
+    }
+
+    // Save enough data in the claim itself to restart if the process exits before the first
+    // engine checkpoint. Reuse the native first-entry recovery path for nested pending runs.
+    const initial: WorkflowRunState = {
+      runId: this.runId,
+      status: 'pending',
+      value: state as Record<string, any>,
+      rootRun: this.rootRun,
+      context: { input } as WorkflowRunState['context'],
+      activePaths: [],
+      activeStepsPath: {},
+      serializedStepGraph: this.serializedStepGraph,
+      suspendedPaths: {},
+      resumeLabels: {},
+      waitingPaths: {},
+      result: undefined,
+      error: undefined,
+      requestContext: this.executionEngine.serializeRequestContext(requestContext),
+      timestamp: Date.now(),
+    };
+    if (this.executionGraph.steps.length === 0) throw new Error('Cannot start a workflow with an empty graph');
+    // Evented execution always needs a run record for branch aggregation, even when its
+    // snapshot predicate excludes pending. This insert must not overwrite another start.
+    if (this.workflowEngineType === 'evented') {
+      await store.persistWorkflowSnapshot({
+        workflowName: this.workflowId,
+        runId: this.runId,
+        resourceId: this.resourceId,
+        snapshot: initial,
+        createOnly: true,
+      });
+    }
+    const recovery = createRestartExecutionParams({ snapshot: initial, graph: this.executionGraph });
+    const running: WorkflowRunState = {
+      ...initial,
+      status: 'running',
+      activePaths: recovery.activePaths,
+      activeStepsPath: recovery.activeStepsPath,
+    };
+    const snapshot =
+      this.executionEngine.options.pruneSnapshot?.({ snapshot: running, workflowStatus: 'running' }) ?? running;
+    const claimed = await store.updateWorkflowState({
+      workflowName: this.workflowId,
+      runId: this.runId,
+      opts: {
+        status: 'running',
+        expectedStatus: 'pending',
+        context: snapshot.context,
+        value: snapshot.value,
+        requestContext: snapshot.requestContext,
+        timestamp: snapshot.timestamp,
+        activePaths: snapshot.activePaths,
+        activeStepsPath: snapshot.activeStepsPath,
+      },
+    });
+    if (claimed) return true;
+    throw new MastraError({
+      id: 'WORKFLOW_START_ALREADY_CLAIMED',
+      domain: ErrorDomain.MASTRA_WORKFLOW,
+      category: ErrorCategory.USER,
+      text: `Workflow "${this.workflowId}" run "${this.runId}" is no longer pending. Only one start() may execute a run; read its current state before continuing.`,
+      details: { workflowId: this.workflowId, runId: this.runId, expectedStatus: 'pending' },
+    });
+  }
+
   protected async _start({
     inputData,
     initialState,
@@ -3631,6 +3738,12 @@ export class Run<
         state: validatedState as Record<string, any>,
       });
 
+      await this._claimStart(
+        validatedInput,
+        validatedState,
+        (requestContext ?? new RequestContext()) as RequestContext,
+      );
+
       return { inputDataToUse: validatedInput, initialStateToUse: validatedState };
     })().catch(error => {
       workflowSpan?.error({ error: error as Error });
@@ -3640,6 +3753,7 @@ export class Run<
     const result = await this.executionEngine.execute<TState, TInput, WorkflowResult<TState, TInput, TOutput, TSteps>>({
       workflowId: this.workflowId,
       runId: this.runId,
+      rootRun: this.rootRun,
       resourceId: this.resourceId,
       disableScorers: this.disableScorers,
       graph: this.executionGraph,
@@ -4668,6 +4782,7 @@ export class Run<
       .execute<TState, TInput, WorkflowResult<TState, TInput, TOutput, TSteps>>({
         workflowId: this.workflowId,
         runId: this.runId,
+        rootRun: snapshot.rootRun,
         resourceId: this.resourceId,
         graph: this.executionGraph,
         serializedStepGraph: this.serializedStepGraph,
@@ -4831,6 +4946,7 @@ export class Run<
       graph: this.executionGraph,
       serializedStepGraph: this.serializedStepGraph,
       restart: restartData,
+      rootRun: snapshot.rootRun,
       pubsub: this.pubsub,
       retryConfig: this.retryConfig,
       requestContext: requestContextToUse as RequestContext,
@@ -4969,6 +5085,7 @@ export class Run<
       disableScorers: this.disableScorers,
       graph: this.executionGraph,
       timeTravel: timeTravelData,
+      rootRun: snapshot ? snapshot.rootRun : this.rootRun,
       serializedStepGraph: this.serializedStepGraph,
       pubsub: this.pubsub,
       retryConfig: this.retryConfig,

--- a/packages/server/src/server/handlers/error.test.ts
+++ b/packages/server/src/server/handlers/error.test.ts
@@ -124,8 +124,8 @@ describe('handleError', () => {
   });
 
   describe('WORKFLOW_RESUME_ALREADY_CLAIMED', () => {
-    it('maps a losing concurrent resume to 409', () => {
-      const err = Object.assign(new Error('already resumed'), { id: 'WORKFLOW_RESUME_ALREADY_CLAIMED' });
+    it.each(['WORKFLOW_RESUME_ALREADY_CLAIMED', 'WORKFLOW_START_ALREADY_CLAIMED'])('maps %s to 409', id => {
+      const err = Object.assign(new Error('already resumed'), { id });
       let caught: HTTPException | undefined;
       try {
         handleError(err, 'default');

--- a/packages/server/src/server/handlers/error.ts
+++ b/packages/server/src/server/handlers/error.ts
@@ -46,8 +46,13 @@ function isWorkflowSchemaValidationError(error: unknown): error is Error {
 
 const WORKFLOW_RESUME_ALREADY_CLAIMED_CODE = 'WORKFLOW_RESUME_ALREADY_CLAIMED';
 
-function isWorkflowResumeAlreadyClaimedError(error: unknown): error is Error {
-  return error instanceof Error && (error as { id?: unknown }).id === WORKFLOW_RESUME_ALREADY_CLAIMED_CODE;
+function isWorkflowRunAlreadyClaimedError(error: unknown): error is Error {
+  return (
+    error instanceof Error &&
+    [WORKFLOW_RESUME_ALREADY_CLAIMED_CODE, 'WORKFLOW_START_ALREADY_CLAIMED'].includes(
+      (error as { id?: string }).id ?? '',
+    )
+  );
 }
 
 /**
@@ -111,9 +116,9 @@ export function handleError(error: unknown, defaultMessage: string): never {
     });
   }
 
-  // A losing concurrent resume is a conflict on run state, not a malformed request, so it maps
+  // A losing concurrent start or resume is a conflict on run state, not a malformed request, so it maps
   // to 409 and clients can distinguish it from a 400/500 and re-read the run.
-  if (isWorkflowResumeAlreadyClaimedError(error)) {
+  if (isWorkflowRunAlreadyClaimedError(error)) {
     throw new HTTPException(409, {
       message: error.message,
       stack: error.stack,

--- a/packages/server/src/server/handlers/workflows.root-run.test.ts
+++ b/packages/server/src/server/handlers/workflows.root-run.test.ts
@@ -1,0 +1,49 @@
+import { Mastra } from '@mastra/core/mastra';
+import { createTool } from '@mastra/core/tools';
+import { createStep, createWorkflow } from '@mastra/core/workflows';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { EXECUTE_WORKFLOW_STEP_ROUTE } from './workflows';
+
+describe('remote workflow step root identity', () => {
+  it.each([true, false])('preserves the public tool contract when root identity is present: %s', async present => {
+    const rootRun = { workflowId: 'outer', runId: 'outer-run' };
+    const seen: unknown[] = [];
+    const schema = z.object({ item: z.string() });
+    const tool = createTool({
+      id: 'remote-tool',
+      inputSchema: schema,
+      outputSchema: schema,
+      execute: async (input, context) => {
+        seen.push(context.workflow);
+        return input;
+      },
+    });
+    const helper = createWorkflow({ id: 'helper', inputSchema: schema, outputSchema: schema })
+      .then(createStep(tool))
+      .commit();
+    const mastra = new Mastra({ workflows: { helper }, logger: false });
+    const body = EXECUTE_WORKFLOW_STEP_ROUTE.bodySchema!.parse(
+      JSON.parse(
+        JSON.stringify({
+          ...(present ? { rootRun } : {}),
+          stepId: 'remote-tool',
+          executionPath: [0],
+          stepResults: {},
+          state: {},
+          requestContext: { rootRun: { workflowId: 'forged', runId: 'forged' } },
+          input: { item: 'document' },
+        }),
+      ),
+    );
+    const result = await EXECUTE_WORKFLOW_STEP_ROUTE.handler({
+      mastra,
+      workflowId: 'helper',
+      runId: 'child-run',
+      ...body,
+    });
+    expect(result).toMatchObject({ status: 'success', output: { item: 'document' } });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ workflowId: 'helper', runId: 'child-run', rootRun: present ? rootRun : undefined });
+  });
+});

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -1454,6 +1454,7 @@ export const OBSERVE_STREAM_LEGACY_WORKFLOW_ROUTE = createRoute({
 // `workflowId` and `runId` are taken from path params (single source of
 // truth); they are intentionally omitted from the request body schema.
 const stepExecutionBodySchema = z.object({
+  rootRun: z.object({ workflowId: z.string().min(1), runId: z.string().min(1) }).optional(),
   stepId: z.string(),
   executionPath: z.array(z.number().int().nonnegative()),
   stepResults: z.record(z.string(), z.unknown()),
@@ -1525,6 +1526,7 @@ export const EXECUTE_WORKFLOW_STEP_ROUTE = createRoute({
       const result = await strategy.executeStep({
         workflowId,
         runId,
+        rootRun: body.rootRun,
         stepId: body.stepId,
         executionPath: body.executionPath,
         stepResults: body.stepResults,

--- a/stores/pg/src/storage/__fixtures__/workflow-start-process.mjs
+++ b/stores/pg/src/storage/__fixtures__/workflow-start-process.mjs
@@ -1,0 +1,96 @@
+import { Mastra } from '@mastra/core/mastra';
+import { RequestContext } from '@mastra/core/request-context';
+import { createTool } from '@mastra/core/tools';
+import { createStep, createWorkflow, createEventedWorkflow } from '@mastra/core/workflows';
+import { z } from 'zod/v4';
+import { PostgresStore } from '@mastra/pg';
+
+const [runId, mode, engine = 'default'] = process.argv.slice(2);
+const buildWorkflow = engine === 'evented' ? createEventedWorkflow : createWorkflow;
+const storage = new PostgresStore({
+  id: `process-${process.pid}`,
+  connectionString: process.env.WORKFLOW_START_TEST_DATABASE_URL,
+  schemaName: process.env.WORKFLOW_START_TEST_SCHEMA,
+  disableInit: true,
+});
+let release;
+const released = new Promise(resolve => {
+  release = resolve;
+});
+const step = createStep({
+  id: 'work',
+  inputSchema: z.object({ item: z.string() }),
+  outputSchema: z.object({ item: z.string(), total: z.number(), tenant: z.string() }),
+  execute: async ({ inputData, state, requestContext }) => {
+    process.send({ type: 'entered', pid: process.pid });
+    if (mode !== 'restart') await released;
+    return { ...inputData, total: state.total, tenant: requestContext.get('tenant') };
+  },
+});
+let workflow = buildWorkflow({
+  id: 'process-start',
+  inputSchema: step.inputSchema,
+  outputSchema: step.outputSchema,
+  stateSchema: z.object({ total: z.number() }),
+})
+  .then(step)
+  .commit();
+let workflows = { [workflow.id]: workflow };
+if (mode.startsWith('callback-')) {
+  const schema = z.object({ item: z.string() });
+  const tool = createTool({
+    id: 'callback-tool',
+    description: 'Wait for an external callback',
+    inputSchema: schema,
+    outputSchema: schema,
+    resumeSchema: z.object({ approved: z.boolean() }),
+    suspendSchema: schema,
+    execute: async (input, context) => {
+      process.send({ type: 'root', rootRun: context.workflow.rootRun });
+      if (!context.workflow.resumeData?.approved) {
+        await context.workflow.suspend(input, { resumeLabel: 'callback' });
+        return input;
+      }
+      return { item: `${input.item}:approved` };
+    },
+  });
+  const helper = buildWorkflow({ id: 'callback-helper', inputSchema: schema, outputSchema: schema })
+    .then(createStep(tool))
+    .commit();
+  const middle = buildWorkflow({ id: 'callback-middle', inputSchema: schema, outputSchema: schema })
+    .then(helper)
+    .commit();
+  workflow = buildWorkflow({ id: 'callback-root', inputSchema: schema, outputSchema: schema }).then(middle).commit();
+  workflows = { [workflow.id]: workflow, [helper.id]: helper, [middle.id]: middle };
+}
+const mastra = new Mastra({ storage, workflows, logger: false });
+if (engine === 'evented') await mastra.startWorkers();
+if (mode === 'crash') workflow.executionEngine.execute = async () => process.exit(23);
+process.on('message', async message => {
+  if (message === 'release') {
+    release();
+    return;
+  }
+  if (message !== 'start') return;
+  try {
+    const run = await workflow.createRun({ runId, resourceId: 'test-owner' });
+    const result =
+      mode === 'callback-resume'
+        ? await run.resume({ label: 'callback', resumeData: { approved: true } })
+        : mode === 'restart'
+          ? await run.restart()
+          : await run.start({
+              inputData: { item: 'widget' },
+              initialState: { total: 7 },
+              requestContext: new RequestContext([['tenant', 'one']]),
+            });
+    process.send({ type: 'result', result });
+  } catch (error) {
+    process.send({ type: 'error', id: error.id, message: error.message });
+  } finally {
+    await mastra.stopWorkers();
+    await storage.close();
+    process.disconnect();
+  }
+});
+process.send({ type: 'ready', pid: process.pid });

--- a/stores/pg/src/storage/concurrent-start.test.ts
+++ b/stores/pg/src/storage/concurrent-start.test.ts
@@ -1,0 +1,189 @@
+import { fork } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { PostgresStore } from '.';
+
+const connectionString = process.env.WORKFLOW_START_TEST_DATABASE_URL;
+const schemaName = `start_${randomUUID().replaceAll('-', '')}`;
+const fixturePath = fileURLToPath(new URL('./__fixtures__/workflow-start-process.mjs', import.meta.url));
+
+// Run against a dedicated PostgreSQL test database. Child processes consume the built public
+// packages, so build @mastra/core and @mastra/pg before this integration test.
+describe.skipIf(!connectionString).each(['default', 'evented'])(
+  'workflow reliability across PostgreSQL processes (%s)',
+  engine => {
+    let storage: PostgresStore;
+    beforeAll(async () => {
+      storage = new PostgresStore({ id: 'start-proof', connectionString: connectionString!, schemaName });
+      await storage.init();
+    }, 60000);
+    afterAll(async () => {
+      await storage?.close();
+    });
+
+    function replica(runId: string, mode = 'start') {
+      const child = fork(fixturePath, [runId, mode, engine], {
+        stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+        env: {
+          ...process.env,
+          WORKFLOW_START_TEST_DATABASE_URL: connectionString,
+          WORKFLOW_START_TEST_SCHEMA: schemaName,
+        },
+      });
+      const messages: any[] = [];
+      let stderr = '';
+      child.stderr?.on('data', chunk => {
+        stderr += chunk;
+      });
+      const waiters = new Set<() => void>();
+      child.on('message', message => {
+        messages.push(message);
+        for (const wake of waiters) wake();
+      });
+      const exit = new Promise<number | null>((resolve, reject) => {
+        child.on('error', reject);
+        child.on('exit', code => {
+          resolve(code);
+          for (const wake of waiters) wake();
+        });
+      });
+      function waitFor(predicate: (message: any) => boolean): Promise<any> {
+        return new Promise((resolve, reject) => {
+          const timer = setTimeout(() => {
+            waiters.delete(check);
+            reject(new Error(`Child timed out: ${stderr}`));
+          }, 20000);
+          const check = () => {
+            const match = messages.find(predicate);
+            if (match) {
+              clearTimeout(timer);
+              waiters.delete(check);
+              resolve(match);
+            } else if (child.exitCode !== null) {
+              clearTimeout(timer);
+              waiters.delete(check);
+              reject(new Error(`Child exited ${child.exitCode}: ${stderr}`));
+            }
+          };
+          waiters.add(check);
+          check();
+        });
+      }
+      return { child, messages, waitFor, exit };
+    }
+
+    it('executes once when two processes create and start the same run simultaneously', async () => {
+      const runId = randomUUID();
+      const replicas = [replica(runId), replica(runId)];
+      try {
+        await Promise.all(replicas.map(p => p.waitFor(m => m.type === 'ready')));
+        replicas.forEach(p => p.child.send('start'));
+        const decisions = await Promise.all(
+          replicas.map(p => p.waitFor(m => m.type === 'entered' || m.type === 'error')),
+        );
+        replicas.filter(p => p.child.connected).forEach(p => p.child.send('release'));
+        const terminal = await Promise.all(
+          replicas.map(p => p.waitFor(m => m.type === 'result' || m.type === 'error')),
+        );
+        expect(decisions.filter(m => m.type === 'entered')).toHaveLength(1);
+        expect(terminal.find(m => m.type === 'error')).toMatchObject({ id: 'WORKFLOW_START_ALREADY_CLAIMED' });
+        expect(terminal.find(m => m.type === 'result')).toMatchObject({
+          result: { status: 'success', result: { item: 'widget', total: 7, tenant: 'one' } },
+        });
+        const snapshot = await (await storage.getStore('workflows'))!.loadWorkflowSnapshot({
+          workflowName: 'process-start',
+          runId,
+        });
+        expect(snapshot?.status).toBe('success');
+        await Promise.all(replicas.map(p => p.exit));
+      } finally {
+        replicas.forEach(p => p.child.kill());
+      }
+    }, 60000);
+
+    it('restarts in a fresh process after the claiming process exits before executing a step', async () => {
+      const runId = randomUUID();
+      const crashing = replica(runId, 'crash');
+      let recovering: ReturnType<typeof replica> | undefined;
+      try {
+        await crashing.waitFor(m => m.type === 'ready');
+        crashing.child.send('start');
+        expect(await crashing.exit).toBe(23);
+        expect(crashing.messages.some(m => m.type === 'entered')).toBe(false);
+        const snapshot = await (await storage.getStore('workflows'))!.loadWorkflowSnapshot({
+          workflowName: 'process-start',
+          runId,
+        });
+        expect(snapshot).toMatchObject({
+          status: 'running',
+          context: { input: { item: 'widget' } },
+          value: { total: 7 },
+          requestContext: { tenant: 'one' },
+        });
+        // A create request that read before the claim may arrive late. Its conditional insert
+        // must preserve the running checkpoint, including the original tenant and input.
+        const workflowsStore = (await storage.getStore('workflows'))!;
+        await workflowsStore.persistWorkflowSnapshot({
+          workflowName: 'process-start',
+          runId,
+          resourceId: 'late-creator',
+          snapshot: { ...snapshot!, status: 'pending', context: {} as any },
+          createOnly: true,
+        });
+        expect(await workflowsStore.loadWorkflowSnapshot({ workflowName: 'process-start', runId })).toEqual(snapshot);
+        recovering = replica(runId, 'restart');
+        await recovering.waitFor(m => m.type === 'ready');
+        recovering.child.send('start');
+        expect(await recovering.waitFor(m => m.type === 'result' || m.type === 'error')).toMatchObject({
+          type: 'result',
+          result: { status: 'success', result: { item: 'widget', total: 7, tenant: 'one' } },
+        });
+        expect(recovering.messages.filter(m => m.type === 'entered')).toHaveLength(1);
+        await recovering.exit;
+      } finally {
+        crashing.child.kill();
+        recovering?.child.kill();
+      }
+    }, 60000);
+
+    it('resumes the outer workflow from a nested tool callback after the first process exits', async () => {
+      const runId = randomUUID();
+      const starting = replica(runId, 'callback-start');
+      let resuming: ReturnType<typeof replica> | undefined;
+      try {
+        await starting.waitFor(m => m.type === 'ready');
+        starting.child.send('start');
+        expect(await starting.waitFor(m => m.type === 'result' || m.type === 'error')).toMatchObject({
+          type: 'result',
+          result: { status: 'suspended' },
+        });
+        const root = await starting.waitFor(m => m.type === 'root');
+        expect(root.rootRun).toEqual({ workflowId: 'callback-root', runId });
+        expect(await starting.exit).toBe(0);
+        const workflowsStore = (await storage.getStore('workflows'))!;
+        expect(
+          await workflowsStore.loadWorkflowSnapshot({
+            workflowName: root.rootRun.workflowId,
+            runId: root.rootRun.runId,
+          }),
+        ).toMatchObject({ status: 'suspended', rootRun: root.rootRun });
+        resuming = replica(root.rootRun.runId, 'callback-resume');
+        await resuming.waitFor(m => m.type === 'ready');
+        resuming.child.send('start');
+        expect(await resuming.waitFor(m => m.type === 'result' || m.type === 'error')).toMatchObject({
+          type: 'result',
+          result: { status: 'success', result: { item: 'widget:approved' } },
+        });
+        expect(await resuming.waitFor(m => m.type === 'root')).toMatchObject({ rootRun: root.rootRun });
+        expect(await resuming.exit).toBe(0);
+        expect(
+          await workflowsStore.loadWorkflowSnapshot({ workflowName: root.rootRun.workflowId, runId }),
+        ).toMatchObject({ status: 'success', rootRun: root.rootRun });
+      } finally {
+        starting.child.kill();
+        resuming?.child.kill();
+      }
+    }, 60000);
+  },
+);

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -409,6 +409,10 @@ export class WorkflowsPG extends WorkflowsStorage {
     }
   }
 
+  override supportsAtomicWorkflowStarts(): boolean {
+    return true;
+  }
+
   async persistWorkflowSnapshot({
     workflowName,
     runId,
@@ -416,6 +420,7 @@ export class WorkflowsPG extends WorkflowsStorage {
     snapshot,
     createdAt,
     updatedAt,
+    createOnly,
   }: {
     workflowName: string;
     runId: string;
@@ -423,6 +428,7 @@ export class WorkflowsPG extends WorkflowsStorage {
     snapshot: WorkflowRunState;
     createdAt?: Date;
     updatedAt?: Date;
+    createOnly?: boolean;
   }): Promise<void> {
     try {
       const now = new Date();
@@ -434,8 +440,11 @@ export class WorkflowsPG extends WorkflowsStorage {
         `INSERT INTO ${getTableName({ indexName: TABLE_WORKFLOW_SNAPSHOT, schemaName: getSchemaName(this.#schema) })} AS t
                  (workflow_name, run_id, "resourceId", snapshot, "createdAt", "updatedAt", "createdAtZ", "updatedAtZ")
                  VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-                 ON CONFLICT (workflow_name, run_id) DO UPDATE
-                 SET "resourceId" = COALESCE($3, t."resourceId"), snapshot = $4, "updatedAt" = $6, "updatedAtZ" = $8`,
+                 ON CONFLICT (workflow_name, run_id) ${
+                   createOnly
+                     ? 'DO NOTHING'
+                     : 'DO UPDATE SET "resourceId" = COALESCE($3, t."resourceId"), snapshot = $4, "updatedAt" = $6, "updatedAtZ" = $8'
+                 }`,
         [
           workflowName,
           runId,


### PR DESCRIPTION
Two servers can currently start the same stored workflow run and both execute its steps. A nested tool also lacks a durable reference to the outer workflow, so an external callback can finish its helper while the outer run stays suspended.

This adds an atomic outer-run start claim for PostgreSQL and in-memory storage, preserving input, state, and request context for restart after a crash. It exposes the native outer workflow identity as context.workflow.rootRun through nested execution, saved snapshots, and remote step workers. It also fixes nested foreach callback labels and child-run selection in the evented engine. The outer engine keeps control of nested loops and retries; other storage adapters keep their existing behavior until they opt into the atomic storage contract.

Validated against the Core 1.64.0 source tag: 71 focused Core tests, 13 server tests, and 6 PostgreSQL tests passed. The PostgreSQL tests use separate Node processes, including a physical exit before the first step and a fresh-process nested callback. Typed Core/Server/PostgreSQL builds, scoped lint, and focused documentation checks passed. These checks use no external model or media provider. Deployment and real-provider acceptance remain outside this contribution proof.