### PR TITLE
fix(rag): preserve trailing and consecutive start separators

### DIFF
--- a/.changeset/curvy-pots-shine.md
+++ b/.changeset/curvy-pots-shine.md
@@ -1,0 +1,5 @@
+---
+'@mastra/rag': patch
+---
+
+Fixed trailing and consecutive separators being dropped when chunking text with separatorPosition set to start.

--- a/packages/rag/src/document/transformers/character.test.ts
+++ b/packages/rag/src/document/transformers/character.test.ts
@@ -1,10 +1,43 @@
 import { describe, expect, it } from 'vitest';
 
-import { CharacterTransformer } from './character';
+import { CharacterTransformer, RecursiveCharacterTransformer } from './character';
 
 const utf8Length = (text: string) => new TextEncoder().encode(text).length;
 
+describe('RecursiveCharacterTransformer', () => {
+  it('preserves consecutive and trailing start separators when merging chunks', () => {
+    const transformer = new RecursiveCharacterTransformer({
+      separators: [','],
+      separatorPosition: 'start',
+      maxSize: 6,
+      overlap: 0,
+      stripWhitespace: false,
+    });
+
+    const chunks = transformer.splitText({ text: 'hello,,world,' });
+    expect(chunks.join('')).toBe('hello,,world,');
+    expect(chunks.every(chunk => chunk.length <= 6)).toBe(true);
+  });
+});
+
 describe('CharacterTransformer', () => {
+  it.each<[string, string[]]>([
+    ['hello,', ['hello', ',']],
+    ['hello,,world', ['hello', ',', ',world']],
+    [',,', [',', ',']],
+    ['', []],
+  ])('preserves start separators in %j', (text, expected) => {
+    const transformer = new CharacterTransformer({
+      separator: ',',
+      separatorPosition: 'start',
+      maxSize: 100,
+      overlap: 0,
+      stripWhitespace: false,
+    });
+
+    expect(transformer.splitText({ text })).toEqual(expected);
+  });
+
   it('preserves character-based overlap with the default length function', () => {
     const transformer = new CharacterTransformer({
       maxSize: 3,

--- a/packages/rag/src/document/transformers/character.ts
+++ b/packages/rag/src/document/transformers/character.ts
@@ -39,7 +39,7 @@ function splitTextWithRegex(text: string, separator: string, separatorPosition?:
     for (let i = 1; i < splits.length - 1; i += 2) {
       const separator = splits[i];
       const text = splits[i + 1];
-      if (separator && text) {
+      if (separator) {
         result.push(separator + text);
       }
     }


### PR DESCRIPTION
Fixes #23122.

With `separatorPosition: 'start'`, the splitter drops a separator whenever the following text is empty. For example, `hello,,world,` becomes `['hello', ',world']`, losing two commas. Keep separator-only pieces so character and recursive chunking preserve consecutive and trailing separators.

Added regression tests for trailing separators, consecutive separators, separator-only input, empty input, and recursive chunk merging. The initial character regressions failed before the fix; all 40 transformer tests now pass. Oxlint, ESLint, formatting, and the scoped `@mastra/rag` build with declaration generation pass. I also checked the built `MDocument.chunk()` API with the reproduction inputs, without external services or credentials.

Includes a patch changeset generated with the repository changeset CLI. Prepared with AI assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When text contains separators such as commas, chunking now keeps every comma, including repeated and trailing commas. Empty input still produces no chunks.

## Changes

- Fixed `separatorPosition: 'start'` in character and recursive chunking.
- Preserved separator-only pieces when the following text is empty.
- Added regression tests for trailing, consecutive, separator-only, empty, and recursive chunk merging cases.
- Added a patch changeset for `@mastra/rag`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->