### PR TITLE
test: repair the two unit shards red on main

### DIFF
--- a/packages/core/src/agent/__tests__/workspace-tool-context.test.ts
+++ b/packages/core/src/agent/__tests__/workspace-tool-context.test.ts
@@ -738,6 +738,7 @@ describe('Workspace tools receive workspace via ToolOptions fallback (GH-14203)'
     // workspace baked into ToolOptions at build time (the fix).
     const coreTools = await (agent as any).listWorkspaceTools({
       requestContext: new RequestContext(),
+      getModel: () => agent.getModel(),
     });
 
     const listFilesCoreTool = coreTools[WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES];

--- a/packages/playground/src/domains/experiments/__tests__/experiment-item-route.msw.test.tsx
+++ b/packages/playground/src/domains/experiments/__tests__/experiment-item-route.msw.test.tsx
@@ -248,7 +248,7 @@ describe('experiment item sub-route', () => {
       expect(dialog.parentElement?.className).toContain('grid-cols-[1fr_1fr]');
 
       fireEvent.click(await screen.findByText('Experiment tool call'));
-      const spanHeading = await screen.findByText(/# experiment-span-child/);
+      const spanHeading = await screen.findByText(/# span-child/);
       const spanSection = spanHeading.closest('section');
       if (!spanSection) throw new Error('Expected span detail section');
 
@@ -272,7 +272,7 @@ describe('experiment item sub-route', () => {
       fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
       fireEvent.click(await screen.findByText('Experiment tool call'));
 
-      expect(await screen.findByText(/# experiment-span-child/)).toBeDefined();
+      expect(await screen.findByText(/# span-child/)).toBeDefined();
       const traceSection = screen.getByText('Experiment agent run').closest('section');
       const panelGrid = traceSection?.parentElement;
       const topLevelPanels = Array.from(panelGrid?.children ?? []).filter(child => child.tagName === 'SECTION');
@@ -287,13 +287,13 @@ describe('experiment item sub-route', () => {
       await screen.findByRole('dialog');
       fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
       fireEvent.click(await screen.findByText('Experiment tool call'));
-      expect(await screen.findByText(/# experiment-span-child/)).toBeDefined();
+      expect(await screen.findByText(/# span-child/)).toBeDefined();
 
       fireEvent.click(screen.getByLabelText('Previous span'));
-      expect(await screen.findByText(/# experiment-span-root/)).toBeDefined();
+      expect(await screen.findByText(/# span-root/)).toBeDefined();
 
       fireEvent.click(screen.getByLabelText('Next span'));
-      expect(await screen.findByText(/# experiment-span-child/)).toBeDefined();
+      expect(await screen.findByText(/# span-child/)).toBeDefined();
     });
 
     it('closes span details without closing the trace card', async () => {
@@ -302,13 +302,13 @@ describe('experiment item sub-route', () => {
       const dialog = await screen.findByRole('dialog');
       fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
       fireEvent.click(await screen.findByText('Experiment tool call'));
-      expect(await screen.findByText(/# experiment-span-child/)).toBeDefined();
+      expect(await screen.findByText(/# span-child/)).toBeDefined();
 
-      const spanSection = screen.getByText(/# experiment-span-child/).closest('section');
+      const spanSection = screen.getByText(/# span-child/).closest('section');
       if (!spanSection) throw new Error('Expected span detail section');
       fireEvent.click(within(spanSection).getByLabelText('Close Panel'));
 
-      await waitFor(() => expect(screen.queryByText(/# experiment-span-child/)).toBeNull());
+      await waitFor(() => expect(screen.queryByText(/# span-child/)).toBeNull());
       expect(screen.getByText('Experiment agent run')).toBeDefined();
       expect(dialog.isConnected).toBe(true);
     });

--- a/packages/playground/src/domains/experiments/__tests__/fixtures/experiment-item-route.ts
+++ b/packages/playground/src/domains/experiments/__tests__/fixtures/experiment-item-route.ts
@@ -28,13 +28,13 @@ const baseSpan = {
 
 export const experimentTraceRootSpan = {
   ...baseSpan,
-  spanId: 'experiment-span-root',
+  spanId: 'span-root',
   name: 'Experiment agent run',
   parentSpanId: null,
 };
 export const experimentTraceChildSpan = {
   ...baseSpan,
-  spanId: 'experiment-span-child',
+  spanId: 'span-child',
   name: 'Experiment tool call',
   spanType: SpanType.TOOL_CALL,
   parentSpanId: experimentTraceRootSpan.spanId,


### PR DESCRIPTION
**─────── TLDR ───────**
> `UNIT Test (Shard 1)` and `UNIT Test (Shard 3)` fail on every PR that runs them since 2026-09-04; both are stale tests, no product code moves.

Two merges changed a signature and a rendering rule without updating the tests that assert them. The unit workflow does not run on pushes to main, so main looked green while every PR touching `packages/core` went red on the same two files.

`listWorkspaceTools` in `workspace-tool-context.test.ts`, shard 3
&nbsp;&nbsp;├─ **was** — omits `getModel`, required since #23080
&nbsp;&nbsp;└─ **now** — passes `getModel: () => agent.getModel()`

span heading in `experiment-item-route.msw.test.tsx`, shard 1, four tests
&nbsp;&nbsp;├─ **was** — asserts the full span id; #23009 truncates it to 12 characters
&nbsp;&nbsp;└─ **now** — fixture ids fit in 12 characters: `span-root`, `span-child`

### Decisions

- **shortened the fixture ids instead of matching the ellipsis** — `experiment-span-root` and `experiment-span-child` both truncate to `experiment-s…`, so the prev/next navigation test could not tell its two spans apart; matching the ellipsis is one edit away if you prefer the long ids

---

> ██████████████████ **tests** `+11 −10`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes two test failures. It gives one test the model information it needs and shortens test span IDs so the UI can display them clearly.

## Changes

- Pass `getModel: () => agent.getModel()` to `listWorkspaceTools`.
- Update experiment span fixtures and assertions to use `span-root` and `span-child`.
- No product code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->