### PR TITLE
fix(core): connect Browser Use stdin commands to managed browsers

### DIFF
--- a/.changeset/public-beans-exist.md
+++ b/.changeset/public-beans-exist.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Browser Use stdin commands connecting to Mastra-managed browsers. Older subcommands keep their existing CLI flags.

--- a/docs/src/content/en/integrations/browsers/browser-viewer.mdx
+++ b/docs/src/content/en/integrations/browsers/browser-viewer.mdx
@@ -65,7 +65,8 @@ const browserAgent = new Agent({
   model: '__GATEWAY_OPENAI_MODEL__',
   workspace,
   instructions: `You are a web automation assistant.
-Use browser-use commands to navigate and interact with websites.`,
+Run browser-use with Python on stdin to navigate and interact with websites.
+Read the installed Browser Use skill before writing a command.`,
   memory: new Memory(),
 })
 
@@ -78,7 +79,16 @@ export const mastra = new Mastra({
 })
 ```
 
-When the agent runs a CLI command like `browser-use open https://example.com`, Mastra automatically launches Chrome and injects the CDP connection, plus starts streaming the screencast to Studio.
+The current Browser Use CLI reads Python from stdin. For example, the agent can run this command through `workspace_execute_command`:
+
+```bash
+browser-use <<'PY'
+new_tab("https://example.com")
+print(page_info())
+PY
+```
+
+Mastra launches Chrome and passes its CDP endpoint and an isolated daemon name through `BU_CDP_WS` and `BU_NAME`. The output includes the Example Domain page title. Screencast frames stream to Studio.
 
 ## How it works
 
@@ -116,7 +126,7 @@ pip install browser-use
 npx skills add browser-use/browser-use --skill browser-use
 ```
 
-CDP flag: `--cdp-url`
+Stdin commands use `BU_CDP_WS` and `BU_NAME`, which Mastra injects automatically. CLI 3 removed the `open` subcommand, `--cdp-url`, and `--session`. Mastra still uses those flags for legacy subcommand invocations from older installed CLIs.
 
 ### `browse`
 

--- a/docs/src/content/en/reference/browser/browser-viewer.mdx
+++ b/docs/src/content/en/reference/browser/browser-viewer.mdx
@@ -271,7 +271,7 @@ await viewer.injectKeyboardEvent({
 
 ## Supported CLIs
 
-Each CLI must be installed separately. Each also publishes a [skill](/docs/sandbox/skills) that teaches the agent its commands and workflows. When a CLI command runs through `workspace_execute_command`, Mastra detects it and injects the CDP URL automatically using the correct flag.
+Each CLI must be installed separately. Each also publishes a [skill](/docs/sandbox/skills) that teaches the agent its commands and workflows. When a CLI command runs through `workspace_execute_command`, Mastra detects it and injects the CDP URL automatically using the provider's flag or environment variables.
 
 Unlike SDK providers, `BrowserViewer` doesn't provide agent tools. The agent uses CLI commands through `workspace_execute_command` instead.
 
@@ -286,7 +286,7 @@ npx skills add vercel-labs/agent-browser
 
 ### [`browser-use`](https://pypi.org/project/browser-use/)
 
-Config value: `'browser-use'` · CDP flag: `--cdp-url`
+Config value: `'browser-use'`. Current Python-on-stdin commands receive `BU_CDP_WS` and `BU_NAME`. Legacy subcommands retain `--cdp-url` and `--session` for older installed CLIs.
 
 ```bash
 pip install browser-use

--- a/packages/core/src/browser/__tests__/cli-handler.test.ts
+++ b/packages/core/src/browser/__tests__/cli-handler.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import type { MastraBrowser } from '../browser';
 import { BrowserCliHandler } from '../cli-handler';
+import { shellQuote } from '../../workspace/sandbox/utils';
 
 describe('BrowserCliHandler', () => {
   let handler: BrowserCliHandler;
@@ -183,6 +184,47 @@ describe('BrowserCliHandler', () => {
     });
 
     describe('browser-use', () => {
+      it('uses environment variables for current stdin commands', () => {
+        const command = "browser-use <<'PY'\nprint(page_info())\nPY\n";
+        const result = handler.injectCdpUrl(command, cdpUrl, threadId);
+        expect(result).toMatch(/^BU_CDP_WS=\S+ BU_NAME=mastra-[a-f0-9]{16} sh -c /);
+        expect(result.endsWith(shellQuote(command))).toBe(true);
+        expect(result).not.toContain('--cdp-url');
+        expect(result).not.toContain('--session');
+      });
+
+      it('preserves Python heredoc operators and text that looks like an external CLI', () => {
+        const command = 'browser-use <<\'PY\'\nx = 1; y = 2\nprint("browser --cdp-url wss://example.com")\nPY\n';
+        expect(handler.injectCdpUrl(command, cdpUrl, threadId).endsWith(shellQuote(command))).toBe(true);
+        const analysis = handler.analyzeCommand(command);
+        expect(analysis.parts).toEqual([command]);
+        expect(analysis.usingExternalCdp).toBe(false);
+        expect(analysis.browserClis.map(cli => cli.name)).toEqual(['browser-use']);
+      });
+
+      it('supports redirected files and bare stdin without changing legacy subcommands', () => {
+        for (const alias of ['browser-use', 'browseruse', 'browser', 'bu']) {
+          expect(handler.injectCdpUrl(`${alias} < task.py`, cdpUrl, threadId)).toMatch(/^BU_CDP_WS=/);
+          expect(handler.injectCdpUrl(alias, cdpUrl, threadId)).toMatch(/^BU_CDP_WS=/);
+          expect(handler.injectCdpUrl(`${alias} open google.com`, cdpUrl, threadId)).toContain('--cdp-url');
+        }
+      });
+
+      it('isolates daemon names by thread and browser endpoint', () => {
+        const name = (url: string, thread?: string) =>
+          handler.injectCdpUrl('browser-use', url, thread).match(/BU_NAME=(\S+)/)![1];
+        expect(name(cdpUrl, threadId)).toBe(name(cdpUrl, threadId));
+        expect(name(cdpUrl, threadId)).not.toBe(name(cdpUrl, 'thread-002'));
+        expect(name(cdpUrl, threadId)).not.toBe(name('ws://localhost:9333/devtools/browser/new', threadId));
+        expect(name(cdpUrl)).toMatch(/^mastra-[a-f0-9]{16}$/);
+      });
+
+      it('quotes endpoint values and never puts raw thread IDs into shell commands', () => {
+        const result = handler.injectCdpUrl('browser-use', "ws://localhost:9222/?q=';echo bad", 'thread; echo bad');
+        expect(result).toContain("BU_CDP_WS='ws://localhost:9222/?q='\\'';echo bad'");
+        expect(result).not.toContain('thread; echo bad');
+      });
+
       it('injects CDP URL and session flag', () => {
         const result = handler.injectCdpUrl('browser open google.com', cdpUrl, threadId);
         expect(result).toContain('--cdp-url');

--- a/packages/core/src/browser/cli-handler.ts
+++ b/packages/core/src/browser/cli-handler.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { shellQuote, splitShellCommand, reassembleShellCommand } from '../workspace/sandbox/utils';
 import type { MastraBrowser } from './browser';
 
@@ -87,6 +89,11 @@ export interface BrowserCliProcessResult {
  * Centralizes all browser CLI-specific logic that was previously in execute-command.ts.
  */
 export class BrowserCliHandler {
+  /** CLI 3 reads Python from stdin; older subcommands still use flags. */
+  private isBrowserUseStdinCommand(command: string): boolean {
+    return /^(?:browser-use|browseruse|browser|bu)[ \t]*(?:<|$)/.test(command.trim());
+  }
+
   /**
    * Track which CLI providers have been warmed up per browser instance and thread.
    * Key format: `${browserId}:${cliName}:${threadId}`
@@ -198,6 +205,16 @@ export class BrowserCliHandler {
    * chained command string (commands joined by &&, ||, or ;).
    */
   injectCdpUrl(command: string, cdpUrl: string, threadId?: string): string {
+    if (this.isBrowserUseStdinCommand(command)) {
+      // Keep the Python input verbatim. Shell splitting can corrupt heredoc bodies.
+      // Include the endpoint so a restarted browser cannot reuse a stale daemon.
+      const name = `mastra-${createHash('sha256')
+        .update(JSON.stringify([threadId ?? 'default', cdpUrl]))
+        .digest('hex')
+        .slice(0, 16)}`;
+      return `BU_CDP_WS=${shellQuote(cdpUrl)} BU_NAME=${shellQuote(name)} sh -c ${shellQuote(command)}`;
+    }
+
     const { parts, operators } = splitShellCommand(command);
 
     const modifiedParts = parts.map((part: string) => {
@@ -285,6 +302,15 @@ export class BrowserCliHandler {
     /** External CDP URL if detected */
     externalCdpUrl: string | null;
   } {
+    if (this.isBrowserUseStdinCommand(command)) {
+      return {
+        browserClis: [{ name: 'browser-use', config: CLI_CDP_PATTERNS['browser-use']! }],
+        parts: [command],
+        usingExternalCdp: false,
+        externalCdpUrl: null,
+      };
+    }
+
     const { parts } = splitShellCommand(command);
 
     const browserClis = parts


### PR DESCRIPTION
Browser Use's stdin CLI rejects the `--cdp-url` and `--session` flags that Mastra adds. The command exits before opening a page.

Fixes #23132.

Pass `BU_CDP_WS` and an endpoint-and-thread-scoped `BU_NAME` for direct stdin commands. Keep the Python input intact and leave legacy subcommands, agent-browser and browse on their existing paths. Update the guide and reference with a stdin example.

Tested with Browser Use 0.13.10, BrowserViewer 0.2.3 and real headless Chrome on macOS: unchanged handler exits 2; patched identical task returns Example Domain. Two browser threads remain isolated across repeated calls, including heredocs containing Python semicolons. The focused 55-test suite, changed-file formatting, remark checks and available frontmatter checks pass.

This verifies the browser connection, not a complete LLM-driven Agent run, Studio rendering, Windows, remote sandboxes or the full monorepo/docs build. No customer prevalence is claimed. Direct stdin invocations are in scope; new shell-wrapper support is not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Browser Use changed how it connects to browsers. This PR updates BrowserViewer to use the new connection method while keeping older commands working.

## Changes

- Use `BU_CDP_WS` for Browser Use stdin commands.
- Use an endpoint- and thread-scoped `BU_NAME` for daemon isolation.
- Preserve `--cdp-url` and `--session` for legacy subcommands.
- Preserve Python stdin input and shell quoting.
- Add tests for heredocs, redirected files, bare stdin, quoting, and browser-thread isolation.
- Update BrowserViewer documentation and add a patch changeset.

## Validation

Testing covered Browser Use 0.13.10, BrowserViewer 0.2.3, headless Chrome, isolated browser threads, focused tests, formatting, remark checks, and frontmatter checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->