### PR TITLE
feat(factory): let GitHub integrations own event rules

### DIFF
--- a/.changeset/lovely-bikes-jump.md
+++ b/.changeset/lovely-bikes-jump.md
@@ -1,0 +1,13 @@
+---
+'@mastra/factory': minor
+---
+
+Added per-event rules to GithubIntegration and PlatformGithubIntegration so each installation owns its GitHub behavior. Functions replace defaults, null disables an event handler, and omitted or undefined values retain defaults. Removed global GitHub rule configuration; migrate rules.github[event].onEvent to the integration constructor rules[event].
+
+```typescript
+// Before: global Factory overrides
+const overrides = { github: { issueCommentCreated: { onEvent: null } } };
+
+// After: integration constructor
+const github = new PlatformGithubIntegration({ rules: { issueCommentCreated: null } });
+```

--- a/mastracode/factory/README.md
+++ b/mastracode/factory/README.md
@@ -60,7 +60,7 @@ const overrides = { github: { issueCommentCreated: { onEvent: null } } };
 const github = new PlatformGithubIntegration({ rules: { issueCommentCreated: null } });
 ```
 
-Global GitHub rule configuration now throws a migration error. Work, Review, tool, and Linear configuration remain unchanged. The global rule version remains shared audit metadata, including for GitHub evaluations; it is not a hash of custom handler code and does not change delivery replay semantics. Update the deployment-owned version when changing handler behavior.
+Work, Review, tool, and Linear configuration remain unchanged. The global rule version remains shared audit metadata, including for GitHub evaluations; it is not a hash of custom handler code and does not change delivery replay semantics. Update the deployment-owned version when changing handler behavior.
 
 Handlers receive the existing typed GitHub context and return one decision or `undefined`. External titles, bodies, and comments remain untrusted data after webhook authentication. Custom handlers must preserve any required actor-permission checks explicitly.
 

--- a/mastracode/factory/README.md
+++ b/mastracode/factory/README.md
@@ -29,6 +29,41 @@ A host application calls `MastraFactory.prepare()`, constructs its `Mastra` inst
 
 `prepare()` initializes the Factory-owned resources needed before Mastra is constructed. `finalize()` connects those resources to the completed host, including Factory routes, integrations, storage-backed behavior, and agent-controller features. Consumers should keep frontend concerns in `factory-ui` and host-specific environment or deployment wiring in `web` rather than adding them to this package.
 
+### GitHub event rules
+
+Both `GithubIntegration` and `PlatformGithubIntegration` own their GitHub event handlers. Existing installations retain the defaults without additional configuration.
+
+```typescript
+import { PlatformGithubIntegration } from '@mastra/factory/integrations/platform/github/integration';
+
+const github = new PlatformGithubIntegration({
+  rules: {
+    issueOpened: context => ({
+      type: 'reject',
+      code: 'manual_intake',
+      reason: 'This deployment manages issue intake manually.',
+    }),
+    issueCommentCreated: null,
+  },
+});
+```
+
+Pass the integration in `MastraFactory`'s `integrations` array. The direct `GithubIntegration` accepts the same `rules` option alongside its GitHub App credentials. A function replaces one default handler without composing with it. `null` disables that event's handler, not authentication, webhook ingestion, or reconciliation bookkeeping. Omitted events and `undefined` retain their defaults. Each instance copies and freezes its resolved handler map; unknown event names and invalid handler values are rejected during construction.
+
+**Migration:** Move each global `rules.github[event].onEvent` value to the integration constructor's `rules[event]` option:
+
+```typescript
+// Before: global Factory rule overrides
+const overrides = { github: { issueCommentCreated: { onEvent: null } } };
+
+// After: GitHub integration constructor options
+const github = new PlatformGithubIntegration({ rules: { issueCommentCreated: null } });
+```
+
+Global GitHub rule configuration now throws a migration error. Work, Review, tool, and Linear configuration remain unchanged. The global rule version remains shared audit metadata, including for GitHub evaluations; it is not a hash of custom handler code and does not change delivery replay semantics. Update the deployment-owned version when changing handler behavior.
+
+Handlers receive the existing typed GitHub context and return one decision or `undefined`. External titles, bodies, and comments remain untrusted data after webhook authentication. Custom handlers must preserve any required actor-permission checks explicitly.
+
 ### GitHub review commands
 
 A repository maintainer with write or admin access can start a Factory review from a pull-request comment by posting the exact first-line command:

--- a/mastracode/factory/factory-skills/configure-factory-rules/SKILL.md
+++ b/mastracode/factory/factory-skills/configure-factory-rules/SKILL.md
@@ -18,12 +18,20 @@ Do not guess a file path. Factory deployments can assemble `MastraFactory` from 
 
 ## Preserve the public shape
 
-Use one rules tree:
+Use the global rules tree for board, tool, and Linear handlers:
 
 - `work.<stage>.<source>.onEnter` or `onExit`
 - `review.<stage>.<source>.onEnter` or `onExit`
 - `tools.<toolName>.onResult`
-- `github.<event>.onEvent`
+- `linear.<event>.onEvent`
+
+Configure GitHub on the installed `GithubIntegration` or `PlatformGithubIntegration` constructor instead:
+
+```typescript
+new PlatformGithubIntegration({ rules: { issueCommentCreated: null } });
+```
+
+Migrate global `rules.github[event].onEvent` to constructor `rules[event]`. Global GitHub configuration is rejected. A function replaces the default, `null` disables that event's handler, and omitted or `undefined` values retain defaults. Constructors validate names and handler values, then copy and freeze the effective map per instance. Disabling a handler does not disable webhook authentication or reconciliation bookkeeping.
 
 Do not create an `actions` config or execute authoritative policy in React. Each handler returns one typed `FactoryRuleDecision` or `undefined`.
 
@@ -35,7 +43,7 @@ An override replaces the exact handler leaf. It does not compose with the built-
 
 Before replacing a built-in leaf:
 
-1. Read the built-in handler in `src/web/factory/rules/defaults.ts`.
+1. Find and read the built-in handler: GitHub handlers live in `src/integrations/github/default-rules.ts` within the Factory package; global defaults live in `src/rules/defaults.ts`.
 2. Decide whether the replacement must preserve part of that behavior explicitly.
 3. Use only fields exposed by the typed context. Do not reach into Factory storage or raw webhook payloads.
 4. Return `undefined` to allow the ingress with no decision, or return a typed rejection or bounded structured decision.

--- a/mastracode/factory/factory-skills/configure-factory-rules/SKILL.md
+++ b/mastracode/factory/factory-skills/configure-factory-rules/SKILL.md
@@ -12,7 +12,7 @@ Help the user change Factory policy in the typed deployment configuration. Facto
 1. Search for `new MastraFactory`, `defaultFactoryRules`, and the `rules` property.
 2. Read the existing rule configuration and its tests before editing.
 3. Import rule helpers and types from the same local Factory module used by the deployment.
-4. If the deployment doesn't configure `rules`, start with `defaultFactoryRules({ version, overrides })` and pass the result to `MastraFactory`.
+4. For board, tool, or Linear rules, start with `defaultFactoryRules({ version, overrides })` if needed and pass the result to `MastraFactory`. For GitHub rules, configure the installed GitHub integration constructor directly.
 
 Do not guess a file path. Factory deployments can assemble `MastraFactory` from different entry points.
 
@@ -31,7 +31,7 @@ Configure GitHub on the installed `GithubIntegration` or `PlatformGithubIntegrat
 new PlatformGithubIntegration({ rules: { issueCommentCreated: null } });
 ```
 
-Migrate global `rules.github[event].onEvent` to constructor `rules[event]`. Global GitHub configuration is rejected. A function replaces the default, `null` disables that event's handler, and omitted or `undefined` values retain defaults. Constructors validate names and handler values, then copy and freeze the effective map per instance. Disabling a handler does not disable webhook authentication or reconciliation bookkeeping.
+GitHub integrations exclusively own their event handlers; configure them through constructor `rules[event]`, not the global Factory rules tree. A function replaces the default, `null` disables that event's handler, and omitted or `undefined` values retain defaults. Constructors validate names and handler values, then copy and freeze the effective map per instance. Disabling a handler does not disable webhook authentication or reconciliation bookkeeping.
 
 Do not create an `actions` config or execute authoritative policy in React. Each handler returns one typed `FactoryRuleDecision` or `undefined`.
 

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -368,9 +368,8 @@ describe('MastraFactory.prepare', () => {
     expect(rules?.work.triage?.issue?.onEnter).toBeTypeOf('function');
     expect(rules?.review.review?.pullRequest?.onEnter).toBeTypeOf('function');
     expect(rules?.tools.submit_plan?.onResult).toBeTypeOf('function');
-    expect(rules?.github.issueOpened?.onEvent).toBeTypeOf('function');
-    expect(rules?.github.pullRequestOpened?.onEvent).toBeTypeOf('function');
-    expect(rules?.github.pullRequestMerged?.onEvent).toBeTypeOf('function');
+    expect(rules).not.toHaveProperty('github');
+    expect(rules?.linear.issueObserved?.onEvent).toBeTypeOf('function');
   });
 
   it('threads explicitly configured Factory rules without composing handler leaves', async () => {

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -203,7 +203,7 @@ export interface MastraFactoryConfig {
    */
   integrations?: FactoryIntegration[];
   /**
-   * Authoritative Factory board, tool-result, and GitHub-event rules. Construct
+   * Authoritative Factory board, tool-result, and Linear-event rules. Construct
    * with `defaultFactoryRules({ version, overrides })` so deployment policy has
    * an explicit version and exact handler leaves replace rather than compose.
    * Omitted → conservative built-in rules for the current deployment.

--- a/mastracode/factory/src/integrations/github/default-rules.test.ts
+++ b/mastracode/factory/src/integrations/github/default-rules.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import { defaultGithubRules, resolveGithubRules } from './default-rules.js';
+
+describe('GitHub rule resolution', () => {
+  it.each(Object.keys(defaultGithubRules))('preserves the default for %s', event => {
+    expect(resolveGithubRules()).toHaveProperty(event, Reflect.get(defaultGithubRules, event));
+  });
+
+  it('replaces only the specified event', () => {
+    const handler = vi.fn();
+    const rules = resolveGithubRules({ issueOpened: handler });
+    expect(rules.issueOpened).toBe(handler);
+    expect(rules.issueClosed).toBe(defaultGithubRules.issueClosed);
+  });
+
+  it('disables events with null and falls back for undefined', () => {
+    const rules = resolveGithubRules({ issueOpened: null, issueClosed: undefined });
+    expect(rules.issueOpened).toBeNull();
+    expect(rules.issueClosed).toBe(defaultGithubRules.issueClosed);
+  });
+
+  it('copies and freezes rules independently of caller mutation', () => {
+    const overrides = { issueOpened: vi.fn() };
+    const first = resolveGithubRules(overrides);
+    overrides.issueOpened = vi.fn();
+    const second = resolveGithubRules(overrides);
+    expect(first.issueOpened).not.toBe(second.issueOpened);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(resolveGithubRules().issueOpened).toBe(defaultGithubRules.issueOpened);
+  });
+
+  it.each([
+    null,
+    [],
+    'rules',
+    { unknown: null },
+    { toString: null },
+    { issueOpened: false },
+    { [Symbol('event')]: null },
+  ])('rejects invalid configuration %j', overrides => {
+    // @ts-expect-error Exercise JavaScript callers at the constructor boundary.
+    expect(() => resolveGithubRules(overrides)).toThrow();
+  });
+});

--- a/mastracode/factory/src/integrations/github/default-rules.ts
+++ b/mastracode/factory/src/integrations/github/default-rules.ts
@@ -1,0 +1,371 @@
+import type { FactoryGithubEventName, FactoryGithubRuleContext, FactoryRuleHandler } from '../../rules/types.js';
+
+export type GithubRuleOverrides = Partial<
+  Record<FactoryGithubEventName, FactoryRuleHandler<FactoryGithubRuleContext> | null | undefined>
+>;
+export type GithubEventRules = Readonly<
+  Record<FactoryGithubEventName, FactoryRuleHandler<FactoryGithubRuleContext> | null>
+>;
+
+function trustedGithubActor(context: Pick<FactoryGithubRuleContext, 'actor'>): boolean {
+  return context.actor.type === 'github' && context.actor.trusted;
+}
+
+function githubActorLogin(context: Pick<FactoryGithubRuleContext, 'actor'>): string | undefined {
+  return context.actor.type === 'github' ? context.actor.login : undefined;
+}
+
+function retriageGithubIssue(context: FactoryGithubRuleContext) {
+  if (!context.item || context.item.source !== 'github-issue' || !context.item.url) return;
+  if (context.actor.type === 'github' && context.actor.factoryAuthored) return;
+
+  const reason =
+    context.event === 'issueEdited'
+      ? context.issueChange?.title && context.issueChange.body
+        ? 'issue title and body edited'
+        : context.issueChange?.title
+          ? 'issue title edited'
+          : 'issue body edited'
+      : context.event === 'issueCommentDeleted'
+        ? 'comment deleted'
+        : context.event === 'issueCommentEdited'
+          ? 'comment edited'
+          : 'comment created';
+  return {
+    type: 'invokeSkill',
+    idempotencyKey: `${context.ingress.id}:factory-triage`,
+    role: 'triage',
+    skillName: 'factory-triage',
+    arguments: `Re-triage GitHub issue (${context.item.url}) after ${reason}.`,
+  } as const;
+}
+
+function createdAfterFactory(createdAt: string | undefined, factoryCreatedAt: string): boolean {
+  if (!createdAt) return false;
+  const sourceCreatedAt = Date.parse(createdAt);
+  const projectCreatedAt = Date.parse(factoryCreatedAt);
+  return Number.isFinite(sourceCreatedAt) && Number.isFinite(projectCreatedAt) && sourceCreatedAt > projectCreatedAt;
+}
+
+function issueOpened(context: FactoryGithubRuleContext) {
+  if (!context.issue) return;
+  // Everything arrives in Intake; arrival only stamps whether `onArrival` may
+  // suggest this card's run without a person.
+  return {
+    type: 'upsertLinkedWorkItem',
+    idempotencyKey: `${context.ingress.id}:issue-intake`,
+    board: 'work',
+    source: 'github-issue',
+    sourceKey: `github-issue:${context.issue.number}`,
+    title: context.issue.title,
+    url: context.issue.url,
+    stage: 'intake',
+    metadata: {
+      githubRepositoryId: context.repository.id,
+      githubIssueNumber: context.issue.number,
+      ...(context.issue.createdAt ? { sourceCreatedAt: context.issue.createdAt } : {}),
+      ...(githubActorLogin(context) ? { author: githubActorLogin(context) } : {}),
+      authorTrusted: trustedGithubActor(context),
+      autoStartCandidate:
+        trustedGithubActor(context) && createdAfterFactory(context.issue.createdAt, context.factory.createdAt),
+      assignees: context.issue.assignees ?? [],
+      labels: context.issue.labels ?? [],
+    },
+  } as const;
+}
+
+function issueClosed(context: FactoryGithubRuleContext) {
+  if (!context.item || context.item.source !== 'github-issue' || !context.issue) return;
+  if (context.board !== 'work') return;
+  // Already off the board: nothing to reconcile.
+  if (context.item.stages.some(stage => stage === 'done' || stage === 'canceled')) return;
+  // Issue closure is a repository fact, not third-party input — no actor trust
+  // gate. `not_planned` (and `duplicate`) means abandoned, everything else is
+  // completed work.
+  const canceled = context.issue.stateReason === 'not_planned' || context.issue.stateReason === 'duplicate';
+  return {
+    type: 'transition',
+    idempotencyKey: `${context.ingress.id}:issue-closed`,
+    board: 'work',
+    stage: canceled ? 'canceled' : 'done',
+    message: {
+      text:
+        `GitHub issue #${context.issue.number} was closed` +
+        `${context.issue.stateReason ? ` (${context.issue.stateReason})` : ''}; ` +
+        `this Work card was moved to ${canceled ? 'Canceled' : 'Done'}.`,
+    },
+  } as const;
+}
+
+function materializePullRequestIntake(
+  context: FactoryGithubRuleContext,
+  { idempotencyKey, autoStartCandidate }: { idempotencyKey: string; autoStartCandidate: boolean },
+) {
+  if (!context.pullRequest) return;
+  return {
+    type: 'upsertLinkedWorkItem',
+    idempotencyKey,
+    board: 'review',
+    source: 'github-pr',
+    sourceKey: `github-pr:${context.pullRequest.number}`,
+    title: context.pullRequest.title,
+    url: context.pullRequest.url,
+    stage: 'intake',
+    metadata: {
+      githubRepositoryId: context.repository.id,
+      githubPullRequestNumber: context.pullRequest.number,
+      ...(context.pullRequest.createdAt ? { sourceCreatedAt: context.pullRequest.createdAt } : {}),
+      factoryAuthored: context.pullRequest.factoryAuthored,
+      authorTrusted: trustedGithubActor(context),
+      autoStartCandidate,
+      state: context.pullRequest.state,
+      draft: context.pullRequest.draft,
+      merged: context.pullRequest.merged,
+      assignees: context.pullRequest.assignees ?? [],
+      requestedReviewers: context.pullRequest.requestedReviewers ?? [],
+      labels: context.pullRequest.labels ?? [],
+      headBranch: context.pullRequest.headBranch,
+      baseBranch: context.pullRequest.baseBranch,
+      ...(context.pullRequest.author ? { author: context.pullRequest.author } : {}),
+    },
+  } as const;
+}
+
+function pullRequestOpened(context: FactoryGithubRuleContext) {
+  if (!context.pullRequest) return;
+  // A GitHub App bot is never a collaborator, so Factory's own PRs score
+  // untrusted; their authorship is the trust signal.
+  const autoStartCandidate =
+    (trustedGithubActor(context) || context.pullRequest.factoryAuthored) &&
+    createdAfterFactory(context.pullRequest.createdAt, context.factory.createdAt);
+  return materializePullRequestIntake(context, {
+    idempotencyKey: `${context.ingress.id}:pull-request-intake`,
+    autoStartCandidate,
+  });
+}
+
+function pullRequestMerged(context: FactoryGithubRuleContext) {
+  if (!context.item || !context.pullRequest?.merged) return;
+  if (context.board === 'review') {
+    // The event is bound to the PR's own Review card: a merged PR is finished
+    // review work, so always move the card to Done. The message only reaches
+    // an active session (if any) — cards without one just move, instead of
+    // failing retries against a binding that never existed.
+    return {
+      type: 'transition',
+      idempotencyKey: `${context.ingress.id}:pull-request-merged`,
+      board: 'review',
+      stage: 'done',
+      message: {
+        text:
+          `Pull request #${context.pullRequest.number} merged; this Review card was moved to Done. ` +
+          'No further review is needed unless follow-up work was requested.',
+      },
+    } as const;
+  }
+  // Provenance bound the event to the originating Work item instead: remind
+  // its agent to assess completion — never auto-complete the Work item.
+  return {
+    type: 'sendMessage',
+    idempotencyKey: `${context.ingress.id}:assess-work-completion`,
+    role: 'work',
+    message:
+      `Pull request #${context.pullRequest.number} merged. Assess whether the linked Work item is complete. ` +
+      'Do not mark it Done solely because this PR merged; use factory_transition_work_item only after verifying the work.',
+  } as const;
+}
+
+function addressReviewFeedback(context: FactoryGithubRuleContext) {
+  if (!context.item || !context.pullRequest || !context.review) return;
+  // Only the Work item that authored the PR can act on the feedback. Provenance
+  // binds the event there; a Review card seeing its own posted review must not
+  // react to it (that would loop the reviewer against itself).
+  if (context.board !== 'work') return;
+  // A closed or merged pull request has no branch left to push fixes to.
+  if (context.pullRequest.state !== 'open' || context.pullRequest.merged) return;
+  // `approved` needs no work, and `commented` (a review body with no verdict)
+  // is how a reviewer leaves notes without blocking — only a verdict that asks
+  // for changes should pull the author back in.
+  if (context.review.state.toLowerCase() !== 'changes_requested') return;
+  // The authoring thread is already subscribed to this PR (`gh pr create`
+  // subscribes automatically), so it can read the individual line comments
+  // from its own notification inbox — the message only has to wake it and
+  // point at the review.
+  return {
+    type: 'sendMessage',
+    idempotencyKey: `${context.ingress.id}:address-review-feedback`,
+    role: 'work',
+    priority: 'high',
+    message:
+      `Changes were requested on pull request #${context.pullRequest.number} (${context.review.url}). ` +
+      'Read the review comments on this PR, address the ones you agree with, and push the fixes to the PR branch. ' +
+      'Reply on GitHub to anything you are deliberately not changing, explaining why.',
+  } as const;
+}
+
+/**
+ * Detects the `factory-review` handoff verdict in a comment body.
+ *
+ * GitHub forbids an app from reviewing a pull request it authored, so on
+ * Factory-authored PRs the review skill falls back to posting its verdict as a
+ * plain comment. That comment is the only signal the authoring agent gets, so
+ * it has to be readable back out. The skill's handoff contract puts the verdict
+ * on the first line (`Verdict: request changes`), so only that line is
+ * inspected — a verdict quoted later in the findings must not count.
+ */
+function requestsChangesVerdict(body: string | undefined): boolean {
+  const firstLine = body
+    ?.split('\n')
+    .map(line => line.trim())
+    .find(line => line.length > 0);
+  if (!firstLine) return false;
+  // Tolerate the markdown the skill wraps the line in (`**Verdict: ...**`).
+  const normalized = firstLine
+    .replaceAll(/[*_`#>\s]+/g, ' ')
+    .trim()
+    .toLowerCase();
+  // Match the verdict exactly so negated phrasings ("Verdict: do not request
+  // changes") cannot wake the author.
+  return /^verdict: ?(request changes|changes requested)$/.test(normalized);
+}
+
+function addressPullRequestComment(context: FactoryGithubRuleContext) {
+  // A validated Factory mention is a review-entry request, not feedback for the
+  // authoring Work session. Invalid or unrecognized comments retain the normal
+  // feedback route below.
+  if (context.reviewCommand) return reReviewRequestedPullRequest(context);
+  if (!context.item || !context.pullRequest || !context.issueComment) return;
+  // Provenance binds the comment to the Work item that authored the PR — the
+  // only session that can act on it. A Review card must not react to comments
+  // on the PR it is reviewing.
+  if (context.board !== 'work') return;
+  if (context.pullRequest.state !== 'open' || context.pullRequest.merged) return;
+  // `factoryAuthored` is one bit for the whole Factory, so Factory's own
+  // comments are indistinguishable between roles — waking on all of them would
+  // let the Work agent's own progress comments wake itself in a loop. The one
+  // exception is the review verdict the Review run had to post as a comment
+  // because GitHub refused a self-review: that is the handoff, and it only ever
+  // asks for changes once per review, so it cannot sustain a loop.
+  if (
+    context.actor.type === 'github' &&
+    context.actor.factoryAuthored &&
+    !requestsChangesVerdict(context.issueComment.body)
+  ) {
+    return;
+  }
+  return {
+    type: 'sendMessage',
+    idempotencyKey: `${context.ingress.id}:address-pull-request-comment`,
+    role: 'work',
+    priority: 'high',
+    message:
+      `${context.issueComment.author ?? 'Someone'} commented on pull request #${context.pullRequest.number} ` +
+      `(${context.issueComment.url ?? context.pullRequest.url}). Read the comment, address it if you agree, and push ` +
+      'the fixes to the PR branch. Reply on GitHub to anything you are deliberately not changing, explaining why.',
+  } as const;
+}
+
+function pullRequestClosed(context: FactoryGithubRuleContext) {
+  if (!context.item || !context.pullRequest || context.pullRequest.merged) return;
+  if (context.board !== 'review') return;
+  // A PR closed without merging is abandoned review work: clear the card off
+  // the board instead of leaving it in Reviewing forever.
+  return {
+    type: 'transition',
+    idempotencyKey: `${context.ingress.id}:pull-request-closed`,
+    board: 'review',
+    stage: 'canceled',
+    message: {
+      text:
+        `Pull request #${context.pullRequest.number} was closed without merging; ` +
+        'this Review card was moved to Canceled.',
+    },
+  } as const;
+}
+
+function reReviewRequestedPullRequest(context: FactoryGithubRuleContext) {
+  // GitHub reviewer requests and Factory's exact mention command are both
+  // explicit requests to enter the same Review lifecycle.
+  const factoryReviewEntry = context.reviewRequest?.factoryReviewer || context.reviewCommand !== undefined;
+  if ((context.item && context.board !== 'review') || !factoryReviewEntry) return;
+  if (!context.pullRequest || context.pullRequest.state !== 'open' || context.pullRequest.merged) return;
+  // Trusted (write/admin) requesters only: creating or re-entering review checks
+  // out and executes PR code, the same bar pullRequestOpened applies to auto-review.
+  if (!trustedGithubActor(context)) return;
+  if (context.actor.type === 'github' && context.actor.factoryAuthored) return;
+  if (!context.item) {
+    // On this path the actor is the *requester*, so the materialized
+    // `authorTrusted` stamp records their trust (always true past the gate
+    // above), not the PR author's: a trusted maintainer requesting a Factory
+    // review vouches for the PR.
+    return materializePullRequestIntake(context, {
+      idempotencyKey: `${context.ingress.id}:pull-request-review-requested-intake`,
+      autoStartCandidate: true,
+    });
+  }
+  // Already in Reviewing: a review pass is pending or running; re-entering
+  // would be a same-stage no-op anyway (stage rules only fire on change).
+  if (context.item.stages.length === 1 && context.item.stages[0] === 'review') return;
+  return {
+    type: 'transition',
+    idempotencyKey: `${context.ingress.id}:re-review-requested`,
+    board: 'review',
+    stage: 'review',
+  } as const;
+}
+
+function reReviewUpdatedPullRequest(context: FactoryGithubRuleContext) {
+  if (!context.item || context.board !== 'review') return;
+  if (!context.pullRequest || context.pullRequest.state !== 'open' || context.pullRequest.merged) return;
+  // Intake has not started a review pass yet, so a push there is just more of
+  // the code the first pass will read. A push to a card sitting in Reviewing is
+  // different: it invalidates whatever that pass is reading, so re-enter the
+  // stage to supersede it. `reviewPullRequest` cancels the stale run and picks
+  // the right skill for the entry it sees.
+  if (context.item.stages.some(stage => stage === 'intake')) return;
+  const alreadyReviewing = context.item.stages.some(stage => stage === 'review');
+  return {
+    type: 'transition',
+    idempotencyKey: `${context.ingress.id}:re-review-updated`,
+    board: 'review',
+    stage: 'review',
+    // Re-entry is the point when the card is already Reviewing: the stage's
+    // entry rule is what cancels the superseded pass and starts one on the code
+    // that just landed.
+    ...(alreadyReviewing ? { reenter: true } : {}),
+  } as const;
+}
+
+export const defaultGithubRules = Object.freeze({
+  issueOpened: issueOpened,
+  issueEdited: retriageGithubIssue,
+  issueClosed: issueClosed,
+  issueCommentCreated: retriageGithubIssue,
+  issueCommentEdited: retriageGithubIssue,
+  issueCommentDeleted: retriageGithubIssue,
+  pullRequestOpened: pullRequestOpened,
+  pullRequestUpdated: reReviewUpdatedPullRequest,
+  pullRequestCommentCreated: addressPullRequestComment,
+  pullRequestReviewRequested: reReviewRequestedPullRequest,
+  pullRequestReviewSubmitted: addressReviewFeedback,
+  pullRequestMerged: pullRequestMerged,
+  pullRequestClosed: pullRequestClosed,
+} satisfies GithubEventRules);
+
+export function resolveGithubRules(overrides?: GithubRuleOverrides): GithubEventRules {
+  if (overrides !== undefined && (overrides === null || typeof overrides !== 'object' || Array.isArray(overrides))) {
+    throw new Error('GitHub rules must be an object.');
+  }
+  const rules: Record<string, FactoryRuleHandler<FactoryGithubRuleContext> | null> = { ...defaultGithubRules };
+  for (const key of Reflect.ownKeys(overrides ?? {})) {
+    if (typeof key !== 'string' || !Object.hasOwn(defaultGithubRules, key)) {
+      throw new Error(`Unknown GitHub rule event: ${String(key)}.`);
+    }
+    const handler = overrides?.[key as FactoryGithubEventName];
+    if (handler !== undefined && handler !== null && typeof handler !== 'function') {
+      throw new Error(`GitHub rule ${key} must be a function, null, or undefined.`);
+    }
+    if (handler !== undefined) rules[key] = handler;
+  }
+  return Object.freeze(rules) as GithubEventRules;
+}

--- a/mastracode/factory/src/integrations/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/github/integration.test.ts
@@ -78,6 +78,24 @@ describe('normalizePrivateKey', () => {
 });
 
 describe('GithubIntegration constructor', () => {
+  it('isolates frozen event handlers between installations and caller mutations', () => {
+    const handler = vi.fn();
+    const rules = { issueOpened: handler, issueClosed: null };
+    const first = new GithubIntegration({ ...validConfig(), rules });
+    rules.issueOpened = vi.fn();
+    const second = new GithubIntegration(validConfig());
+    expect(first.rules.issueOpened).toBe(handler);
+    expect(first.rules.issueClosed).toBeNull();
+    expect(second.rules.issueOpened).not.toBe(handler);
+    expect(second.rules.issueClosed).toBeTypeOf('function');
+    expect(Object.isFrozen(first.rules)).toBe(true);
+    expect(first.rules).not.toBe(second.rules);
+  });
+
+  it('rejects invalid event overrides at construction', () => {
+    // @ts-expect-error Verify JavaScript configuration validation.
+    expect(() => new GithubIntegration({ ...validConfig(), rules: { issueOpened: false } })).toThrow();
+  });
   it('constructs from a full config', () => {
     const github = new GithubIntegration(validConfig());
     expect(github.id).toBe('github');
@@ -193,39 +211,111 @@ describe('GithubIntegration triage comment upsert', () => {
       .fn()
       .mockResolvedValueOnce({
         data: [
-          { id: 20, body: '<!-- mastra-factory-triage --> human quote', user: { login: 'person' }, html_url: 'https://github.com/acme/app/issues/7#issuecomment-20' },
-          { id: 30, body: '<!-- mastra-factory-triage --> newer', user: { login: 'test-app[bot]' }, html_url: 'https://github.com/acme/app/issues/7#issuecomment-30' },
-          ...Array.from({ length: 98 }, (_, index) => ({ id: 100 + index, body: 'unmarked', user: { login: 'person' }, html_url: `https://github.com/acme/app/issues/7#issuecomment-${100 + index}` })),
+          {
+            id: 20,
+            body: '<!-- mastra-factory-triage --> human quote',
+            user: { login: 'person' },
+            html_url: 'https://github.com/acme/app/issues/7#issuecomment-20',
+          },
+          {
+            id: 30,
+            body: '<!-- mastra-factory-triage --> newer',
+            user: { login: 'test-app[bot]' },
+            html_url: 'https://github.com/acme/app/issues/7#issuecomment-30',
+          },
+          ...Array.from({ length: 98 }, (_, index) => ({
+            id: 100 + index,
+            body: 'unmarked',
+            user: { login: 'person' },
+            html_url: `https://github.com/acme/app/issues/7#issuecomment-${100 + index}`,
+          })),
         ],
       })
       .mockResolvedValueOnce({
-        data: [{ id: 10, body: '<!-- mastra-factory-triage --> oldest', user: { login: 'TEST-APP[bot]' }, html_url: 'https://github.com/acme/app/issues/7#issuecomment-10' }],
+        data: [
+          {
+            id: 10,
+            body: '<!-- mastra-factory-triage --> oldest',
+            user: { login: 'TEST-APP[bot]' },
+            html_url: 'https://github.com/acme/app/issues/7#issuecomment-10',
+          },
+        ],
       });
-    const updateComment = vi.fn(async () => ({ data: { id: 10, html_url: 'https://github.com/acme/app/issues/7#issuecomment-10' } }));
+    const updateComment = vi.fn(async () => ({
+      data: { id: 10, html_url: 'https://github.com/acme/app/issues/7#issuecomment-10' },
+    }));
     const createComment = vi.fn();
-    vi.spyOn(github, 'getInstallationOctokit').mockReturnValue({ issues: { listComments, updateComment, createComment } } as any);
+    vi.spyOn(github, 'getInstallationOctokit').mockReturnValue({
+      issues: { listComments, updateComment, createComment },
+    } as any);
 
     await expect(
-      github.upsertFactoryTriageComment({ installationId: 7, repository: 'acme/app', issueNumber: 7, body: '<!-- mastra-factory-triage -->\nFinal' }),
-    ).resolves.toEqual({ action: 'updated', commentId: '10', url: 'https://github.com/acme/app/issues/7#issuecomment-10' });
+      github.upsertFactoryTriageComment({
+        installationId: 7,
+        repository: 'acme/app',
+        issueNumber: 7,
+        body: '<!-- mastra-factory-triage -->\nFinal',
+      }),
+    ).resolves.toEqual({
+      action: 'updated',
+      commentId: '10',
+      url: 'https://github.com/acme/app/issues/7#issuecomment-10',
+    });
 
-    expect(listComments).toHaveBeenNthCalledWith(1, { owner: 'acme', repo: 'app', issue_number: 7, per_page: 100, page: 1 });
-    expect(listComments).toHaveBeenNthCalledWith(2, { owner: 'acme', repo: 'app', issue_number: 7, per_page: 100, page: 2 });
-    expect(updateComment).toHaveBeenCalledWith({ owner: 'acme', repo: 'app', comment_id: 10, body: '<!-- mastra-factory-triage -->\nFinal' });
+    expect(listComments).toHaveBeenNthCalledWith(1, {
+      owner: 'acme',
+      repo: 'app',
+      issue_number: 7,
+      per_page: 100,
+      page: 1,
+    });
+    expect(listComments).toHaveBeenNthCalledWith(2, {
+      owner: 'acme',
+      repo: 'app',
+      issue_number: 7,
+      per_page: 100,
+      page: 2,
+    });
+    expect(updateComment).toHaveBeenCalledWith({
+      owner: 'acme',
+      repo: 'app',
+      comment_id: 10,
+      body: '<!-- mastra-factory-triage -->\nFinal',
+    });
     expect(createComment).not.toHaveBeenCalled();
   });
 
   it('creates a marker comment when no Factory-authored marker exists', async () => {
     const github = new GithubIntegration(validConfig());
-    const listComments = vi.fn(async () => ({ data: [{ id: 9, body: '<!-- mastra-factory-triage --> quoted', user: { login: 'person' } }] }));
-    const createComment = vi.fn(async () => ({ data: { id: 42, html_url: 'https://github.com/acme/app/issues/7#issuecomment-42' } }));
+    const listComments = vi.fn(async () => ({
+      data: [{ id: 9, body: '<!-- mastra-factory-triage --> quoted', user: { login: 'person' } }],
+    }));
+    const createComment = vi.fn(async () => ({
+      data: { id: 42, html_url: 'https://github.com/acme/app/issues/7#issuecomment-42' },
+    }));
     const updateComment = vi.fn();
-    vi.spyOn(github, 'getInstallationOctokit').mockReturnValue({ issues: { listComments, updateComment, createComment } } as any);
+    vi.spyOn(github, 'getInstallationOctokit').mockReturnValue({
+      issues: { listComments, updateComment, createComment },
+    } as any);
 
     await expect(
-      github.upsertFactoryTriageComment({ installationId: 7, repository: 'acme/app', issueNumber: 7, body: '<!-- mastra-factory-triage -->\nPending' }),
-    ).resolves.toEqual({ action: 'created', commentId: '42', url: 'https://github.com/acme/app/issues/7#issuecomment-42' });
-    expect(createComment).toHaveBeenCalledWith({ owner: 'acme', repo: 'app', issue_number: 7, body: '<!-- mastra-factory-triage -->\nPending' });
+      github.upsertFactoryTriageComment({
+        installationId: 7,
+        repository: 'acme/app',
+        issueNumber: 7,
+        body: '<!-- mastra-factory-triage -->\nPending',
+      }),
+    ).resolves.toEqual({
+      action: 'created',
+      commentId: '42',
+      url: 'https://github.com/acme/app/issues/7#issuecomment-42',
+    });
+    expect(createComment).toHaveBeenCalledWith({
+      owner: 'acme',
+      repo: 'app',
+      issue_number: 7,
+      body: '<!-- mastra-factory-triage -->\nPending',
+    });
     expect(updateComment).not.toHaveBeenCalled();
   });
 });
@@ -734,11 +824,13 @@ describe('GithubIntegration OAuth', () => {
   it('allows 30 seconds for the OAuth token exchange', async () => {
     const github = new GithubIntegration(validConfig());
     const timeout = vi.spyOn(AbortSignal, 'timeout');
-    const fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ access_token: 'user-token' }), { status: 200 }),
-    );
+    const fetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify({ access_token: 'user-token' }), { status: 200 }));
 
-    await expect(github.exchangeOAuthCode('code', 'https://example.com/auth/github/callback')).resolves.toBe('user-token');
+    await expect(github.exchangeOAuthCode('code', 'https://example.com/auth/github/callback')).resolves.toBe(
+      'user-token',
+    );
     expect(timeout).toHaveBeenCalledWith(10_000);
 
     timeout.mockRestore();

--- a/mastracode/factory/src/integrations/github/integration.ts
+++ b/mastracode/factory/src/integrations/github/integration.ts
@@ -47,6 +47,8 @@ import type {
   VersionControl,
 } from '../../capabilities/version-control.js';
 import type { FactoryIntegration, IntegrationContext, IntegrationTools } from '../base.js';
+import type { GithubEventRules, GithubRuleOverrides } from './default-rules.js';
+import { resolveGithubRules } from './default-rules.js';
 import { attachGithubIssueReconciler } from './issue-reconciler.js';
 import { GithubReconcileWorker } from './reconcile-worker.js';
 import { reconcileInterval, reconciliationEnabled } from './reconciliation-config.js';
@@ -154,6 +156,8 @@ export interface ListRepoOpenIssuesOptions {
 }
 
 export interface GithubIntegrationConfig {
+  /** Replace an event handler, or disable it with null; omitted events keep defaults. */
+  rules?: GithubRuleOverrides;
   /** GitHub App id (the numeric id, as a string). */
   appId: string;
   /**
@@ -188,6 +192,11 @@ const REQUIRED_FIELDS = ['appId', 'privateKey', 'clientId', 'clientSecret', 'slu
 export class GithubIntegration implements FactoryIntegration {
   /** Stable integration identifier (see `../factory-integration.ts`). */
   readonly id = 'github';
+  readonly #rules: GithubEventRules;
+
+  get rules(): GithubEventRules {
+    return this.#rules;
+  }
   readonly intake: Intake = {
     resolveIntakeDispatch: input => this.#resolveIntakeDispatch(input),
     listSources: async ({ orgId }) => {
@@ -365,6 +374,7 @@ export class GithubIntegration implements FactoryIntegration {
   readonly #collaboratorPermissionInFlight = new Map<string, Promise<GithubRepositoryPermission | undefined>>();
 
   constructor(config: GithubIntegrationConfig) {
+    this.#rules = resolveGithubRules(config.rules);
     const missing = REQUIRED_FIELDS.filter(field => !config[field]);
     if (missing.length > 0) {
       throw new Error(

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -6,11 +6,13 @@ import { FactoryTransitionService } from '../../rules/transition-service.js';
 import { FACTORY_PULL_REQUEST_RECONCILIATION_KEY } from '../../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../../storage/test-utils.js';
 import { GithubAppIdentity } from './app-identity.js';
+import { resolveGithubRules } from './default-rules.js';
+import type { GithubRuleOverrides } from './default-rules.js';
 import { createGithubPullRequestReconciler, GithubRules, reconciledClosedEvent } from './rules.js';
 import type { ReconcileIssueState, ReconcilePullRequestState } from './rules.js';
 import { changeRequestTargetKey } from './subscriptions.js';
 
-async function setup(permission: string | undefined) {
+async function setup(permission: string | undefined, rules?: GithubRuleOverrides) {
   const seeded = await createFactoryStorageForTests();
   const workItems = seeded.workItems;
   const sourceControl = seeded.sourceControl.forIntegration('github');
@@ -48,6 +50,7 @@ async function setup(permission: string | undefined) {
     sandboxWorkdir: '/workspace',
   });
   const github = {
+    rules: resolveGithubRules(rules),
     slug: 'factory-app',
     getRepositoryCollaboratorPermission: vi.fn().mockResolvedValue(permission),
   } as unknown as GithubIntegration;
@@ -136,7 +139,13 @@ function issueComment(
 
 function pullRequestComment(
   deliveryId: string,
-  options: { action?: 'created' | 'edited' | 'deleted'; sender?: string; author?: string; body?: string; state?: string } = {},
+  options: {
+    action?: 'created' | 'edited' | 'deleted';
+    sender?: string;
+    author?: string;
+    body?: string;
+    state?: string;
+  } = {},
 ) {
   const sender = options.sender ?? 'maintainer';
   const author = options.author ?? sender;
@@ -219,6 +228,61 @@ function pullRequest(
 }
 
 describe('GithubRules', () => {
+  it('persists only replacement decisions with the shared audit version', async () => {
+    const handler = vi.fn<NonNullable<GithubRuleOverrides['issueClosed']>>(context => ({
+      type: 'transition',
+      board: 'work',
+      stage: 'canceled',
+      idempotencyKey: `${context.deliveryId}:custom-close`,
+    }));
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write', {
+      issueClosed: handler,
+    });
+    await createLinkedIssue(workItems, project.id);
+    const commitEvaluation = vi.spyOn(workItems, 'commitRuleEvaluation');
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: defaultFactoryRules({ version: 'custom-github-v2' }),
+    });
+    await expect(service.ingest(issueClosed('custom-close', 'completed'))).resolves.toEqual({ status: 'committed' });
+    await expect(service.ingest(issueClosed('custom-close', 'completed'))).resolves.toEqual({ status: 'replayed' });
+    // Evaluation precedes durable replay detection; only the effects are deduplicated.
+    expect(handler).toHaveBeenCalledTimes(2);
+    const decisions = await workItems.listDeferredDecisions('org-1', project.id);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.decision).toMatchObject({ type: 'transition', board: 'work', stage: 'canceled' });
+    expect(commitEvaluation).toHaveBeenCalledWith(expect.objectContaining({ ruleSetVersion: 'custom-github-v2' }));
+  });
+
+  it('records disabled ingress without decisions and still evaluates unrelated events', async () => {
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write', {
+      issueOpened: null,
+    });
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await expect(service.ingest(issueOpened())).resolves.toEqual({ status: 'committed' });
+    await expect(service.ingest(issueOpened())).resolves.toEqual({ status: 'replayed' });
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual([]);
+    await createLinkedIssue(workItems, project.id);
+    await expect(service.ingest(issueClosed('close-after-disabled-open', 'completed'))).resolves.toEqual({
+      status: 'committed',
+    });
+    const decisions = await workItems.listDeferredDecisions('org-1', project.id);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.decision).toMatchObject({ type: 'transition', board: 'work', stage: 'done' });
+  });
+
   it('commits one trusted issue intake decision and replays immutable delivery ingress', async () => {
     const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
     const service = new GithubRules({
@@ -796,7 +860,9 @@ describe('GithubRules', () => {
       },
     });
 
-    await expect(service.ingest(reviewRequested('delivery-review-requested'))).resolves.toEqual({ status: 'committed' });
+    await expect(service.ingest(reviewRequested('delivery-review-requested'))).resolves.toEqual({
+      status: 'committed',
+    });
     await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
 
     const [card] = await workItems.list({ orgId: 'org-1', factoryProjectId: project.id });
@@ -826,7 +892,7 @@ describe('GithubRules', () => {
     expect(await workItems.list({ orgId: 'org-1', factoryProjectId: project.id })).toHaveLength(1);
   });
 
-  it('materializes a Review card from Factory\'s exact PR comment command', async () => {
+  it("materializes a Review card from Factory's exact PR comment command", async () => {
     const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
     const rules = builtInFactoryRules();
     const service = new GithubRules({
@@ -845,7 +911,9 @@ describe('GithubRules', () => {
       ownerId: 'worker-1',
     });
 
-    await expect(service.ingest(pullRequestComment('delivery-comment-review'))).resolves.toEqual({ status: 'committed' });
+    await expect(service.ingest(pullRequestComment('delivery-comment-review'))).resolves.toEqual({
+      status: 'committed',
+    });
     await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
 
     const [card] = await workItems.list({ orgId: 'org-1', factoryProjectId: project.id });
@@ -863,7 +931,9 @@ describe('GithubRules', () => {
       ]),
     );
 
-    await expect(service.ingest(pullRequestComment('delivery-comment-review'))).resolves.toEqual({ status: 'replayed' });
+    await expect(service.ingest(pullRequestComment('delivery-comment-review'))).resolves.toEqual({
+      status: 'replayed',
+    });
     await expect(
       service.ingest(pullRequestComment('delivery-comment-prose', { body: 'Please @factory-app review this PR.' })),
     ).resolves.toEqual({ status: 'committed' });
@@ -1177,7 +1247,9 @@ describe('GithubRules', () => {
     await expect(service.ingest(reviewRequested('delivery-rr-dispatch'))).resolves.toEqual({ status: 'replayed' });
     // A second re-request while the card is already Reviewing is a guarded no-op.
     await expect(service.ingest(reviewRequested('delivery-rr-again'))).resolves.toEqual({ status: 'committed' });
-    await expect(service.ingest(pullRequestComment('delivery-rr-comment-again'))).resolves.toEqual({ status: 'committed' });
+    await expect(service.ingest(pullRequestComment('delivery-rr-comment-again'))).resolves.toEqual({
+      status: 'committed',
+    });
     const decisions = await workItems.listDeferredDecisions('org-1', project.id);
     expect(decisions.filter(entry => entry.decision.type === 'transition')).toHaveLength(1);
     expect(decisions.filter(entry => entry.decision.type === 'invokeSkill')).toHaveLength(1);
@@ -1299,9 +1371,11 @@ describe('GithubRules', () => {
   });
 
   it.each(['maintain', 'triage', 'read', undefined])('fails closed for GitHub permission %s', async permission => {
-    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup(permission);
     const seen = vi.fn(() => undefined);
-    const rules = defaultFactoryRules({ version: 'test-1', overrides: { github: { issueOpened: { onEvent: seen } } } });
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup(permission, {
+      issueOpened: seen,
+    });
+    const rules = defaultFactoryRules({ version: 'test-1' });
     const service = new GithubRules({
       github,
       sourceControl,
@@ -2698,7 +2772,10 @@ describe('createGithubPullRequestReconciler', () => {
       },
     });
 
-    await createReconciler(context, vi.fn(async () => mergedState(31)))([repositoryTarget]);
+    await createReconciler(
+      context,
+      vi.fn(async () => mergedState(31)),
+    )([repositoryTarget]);
 
     const stamped = await context.workItems.get({ orgId: 'org-1', id: card.item.id });
     expect(stamped?.metadata?.authorTrusted).toBe(answered ? true : undefined);

--- a/mastracode/factory/src/integrations/github/rules.ts
+++ b/mastracode/factory/src/integrations/github/rules.ts
@@ -1,4 +1,3 @@
-import { resolveFactoryGithubRule } from '../../rules/resolve.js';
 import type {
   FactoryGithubEventName,
   FactoryGithubRuleContext,
@@ -18,6 +17,7 @@ import type { WorkItemRow, WorkItemsStorage } from '../../storage/domains/work-i
 import { FACTORY_PULL_REQUEST_RECONCILIATION_KEY } from '../../storage/domains/work-items/base.js';
 import type { IntegrationContext } from '../base.js';
 import type { GithubAppIdentity } from './app-identity.js';
+import type { GithubEventRules } from './default-rules.js';
 import type { GithubRepositoryPermission } from './integration.js';
 import { changeRequestTargetKey } from './subscriptions.js';
 import type { ParsedGithubWebhook } from './webhook.js';
@@ -184,7 +184,8 @@ function authorAwaitingTrust(item: WorkItemRow, repository: ReconcileRepository)
   if (tracked === undefined) return undefined;
   // A canonical key with no URL names no repository, and the pull request matcher takes it anyway.
   // Asking GitHub about the wrong repository of a multi-repository project would record a wrong answer.
-  const unattributed = !item.externalSource?.url && /^github-(?:pr|issue):\d+$/.test(item.externalSource?.externalId ?? '');
+  const unattributed =
+    !item.externalSource?.url && /^github-(?:pr|issue):\d+$/.test(item.externalSource?.externalId ?? '');
   if (unattributed && metadata.githubRepositoryId !== repository.id) return undefined;
   return metadata.author;
 }
@@ -237,6 +238,7 @@ function pullRequestProvenance(
 }
 
 export interface GithubRulesIntegration {
+  readonly rules: GithubEventRules;
   readonly slug?: string;
   /**
    * Factory's own GitHub login, used to ignore its own writes. Optional because
@@ -259,7 +261,7 @@ export interface GithubRulesOptions {
   integrationStorage: IntegrationStorageHandle;
   projects: FactoryProjectsStorage;
   storage: WorkItemsStorage;
-  rules: FactoryRules;
+  rules: Pick<FactoryRules, 'version'>;
 }
 
 export class GithubRules {
@@ -519,7 +521,7 @@ export class GithubRules {
           : {}),
       };
 
-      const rule = resolveFactoryGithubRule(this.options.rules, event);
+      const rule = this.options.github.rules[event];
       let decision: FactoryRuleDecision | void;
       let decisions: Record<string, unknown>[] = [];
       let outcome: { status: 'accepted' | 'rejected'; code?: string; reason?: string } = { status: 'accepted' };
@@ -1073,7 +1075,9 @@ export function createGithubPullRequestReconciler(
                 orgId: card.orgId,
                 id: card.id,
                 userId: 'factory-rule-dispatcher',
-                patch: { metadata: reconciledPullRequestMetadata(state, 'clear', trustStale ? authorTrusted : undefined) },
+                patch: {
+                  metadata: reconciledPullRequestMetadata(state, 'clear', trustStale ? authorTrusted : undefined),
+                },
               });
             } catch (error) {
               recordFailure(repository, error, pullRequestNumber);
@@ -1105,7 +1109,9 @@ export function createGithubPullRequestReconciler(
                 orgId: card.orgId,
                 id: card.id,
                 userId: 'factory-rule-dispatcher',
-                patch: { metadata: reconciledPullRequestMetadata(state, 'settled', trustStale ? authorTrusted : undefined) },
+                patch: {
+                  metadata: reconciledPullRequestMetadata(state, 'settled', trustStale ? authorTrusted : undefined),
+                },
               });
             } catch (error) {
               recordFailure(repository, error, pullRequestNumber);

--- a/mastracode/factory/src/integrations/issue-reconciler.test.ts
+++ b/mastracode/factory/src/integrations/issue-reconciler.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 import type { Intake, IntakeIssueDetail } from '../capabilities/intake.js';
 import { builtInFactoryRules } from '../rules/defaults.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
+import { resolveGithubRules } from './github/default-rules.js';
+import type { GithubRuleOverrides } from './github/default-rules.js';
 import { createGithubIssueReconciler } from './github/issue-reconciler.js';
 import type { GithubIssueFetcher, ReconcileIssueState } from './github/rules.js';
 import type { LinearIntegration } from './linear/integration.js';
@@ -33,14 +35,17 @@ function issue(overrides: Partial<IntakeIssueDetail> = {}): IntakeIssueDetail {
 
 const repository = { id: 10, fullName: 'acme/repo', installationId: 7 };
 
-async function githubSetup(input: {
-  stages?: string[];
-  metadata?: Record<string, unknown>;
-  externalId?: string;
-  url?: string;
-  fetchIssue?: GithubIssueFetcher;
-  permission?: string;
-} = {}) {
+async function githubSetup(
+  input: {
+    stages?: string[];
+    metadata?: Record<string, unknown>;
+    externalId?: string;
+    url?: string;
+    fetchIssue?: GithubIssueFetcher;
+    permission?: string;
+    rules?: GithubRuleOverrides;
+  } = {},
+) {
   const seeded = await createFactoryStorageForTests();
   const project = await seeded.projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'Factory' } });
   const sourceControl = seeded.sourceControl.forIntegration('github');
@@ -51,7 +56,12 @@ async function githubSetup(input: {
   });
   const storedRepository = await sourceControl.repositories.upsert({
     orgId: project.orgId,
-    input: { installationId: installation.id, externalId: String(repository.id), slug: repository.fullName, defaultBranch: 'main' },
+    input: {
+      installationId: installation.id,
+      externalId: String(repository.id),
+      slug: repository.fullName,
+      defaultBranch: 'main',
+    },
   });
   const connection = await sourceControl.connections.create({
     orgId: project.orgId,
@@ -89,7 +99,7 @@ async function githubSetup(input: {
   const permissionLookup = vi.fn().mockResolvedValue(input.permission);
   const reconciler = createGithubIssueReconciler(
     {
-      github: { getRepositoryCollaboratorPermission: permissionLookup },
+      github: { rules: resolveGithubRules(input.rules), getRepositoryCollaboratorPermission: permissionLookup },
       sourceControl,
       integrationStorage: seeded.integrations.forIntegration('github'),
       projects: seeded.projects,
@@ -118,7 +128,12 @@ describe('issue reconcilers', () => {
     const fetchIssue = vi.fn().mockResolvedValue(githubState());
     const setup = await githubSetup({ metadata: { assignees: ['old'] }, fetchIssue });
 
-    await expect(setup.reconciler([repository])).resolves.toMatchObject({ repositories: 1, checked: 1, updated: 1, failed: 0 });
+    await expect(setup.reconciler([repository])).resolves.toMatchObject({
+      repositories: 1,
+      checked: 1,
+      updated: 1,
+      failed: 0,
+    });
     expect(fetchIssue).toHaveBeenCalledWith({ installationId: 7, repository: 'acme/repo', number: 42 });
     const [updated] = await setup.workItems.list({ orgId: 'org-1', factoryProjectId: setup.project.id });
     expect(updated?.metadata).toMatchObject({ author: 'octocat', assignees: ['hubot', 'monalisa'], labels: ['bug'] });
@@ -212,6 +227,29 @@ describe('issue reconcilers', () => {
     expect(decisions[0]?.decision).toMatchObject({ type: 'transition', stage: 'canceled' });
   });
 
+  it('uses a replacement handler for reconciled closures without running the default', async () => {
+    const issueClosed = vi.fn(() => undefined);
+    const setup = await githubSetup({
+      rules: { issueClosed },
+      fetchIssue: vi.fn().mockResolvedValue(githubState({ state: 'closed' })),
+    });
+    await expect(setup.reconciler([repository])).resolves.toMatchObject({ checked: 1, closed: 1, failed: 0 });
+    expect(issueClosed).toHaveBeenCalledOnce();
+    expect(issueClosed).toHaveBeenCalledWith(expect.objectContaining({ event: 'issueClosed' }));
+    expect(await setup.workItems.listDeferredDecisions('org-1', setup.project.id)).toEqual([]);
+  });
+
+  it('disables reconciled closures without breaking bookkeeping or another instance', async () => {
+    const fetchIssue = vi.fn().mockResolvedValue(githubState({ state: 'closed' }));
+    const disabled = await githubSetup({ rules: { issueClosed: null }, fetchIssue });
+    const defaults = await githubSetup({ fetchIssue });
+    await expect(disabled.reconciler([repository])).resolves.toMatchObject({ checked: 1, closed: 1, failed: 0 });
+    await expect(disabled.reconciler([repository])).resolves.toMatchObject({ checked: 1, closed: 1, failed: 0 });
+    expect(await disabled.workItems.listDeferredDecisions('org-1', disabled.project.id)).toEqual([]);
+    await expect(defaults.reconciler([repository])).resolves.toMatchObject({ checked: 1, closed: 1, failed: 0 });
+    expect(await defaults.workItems.listDeferredDecisions('org-1', defaults.project.id)).toHaveLength(1);
+  });
+
   it('skips terminal GitHub cards and preserves undefined provider metadata', async () => {
     const terminalFetch = vi.fn();
     const terminal = await githubSetup({ stages: ['done'], fetchIssue: terminalFetch });
@@ -235,7 +273,12 @@ describe('issue reconcilers', () => {
       userId: project.createdBy,
       factoryProjectId: project.id,
       input: {
-        externalSource: { integrationId: 'linear', type: 'issue', externalId: 'linear:ENG-42', url: 'https://linear.app/acme/issue/ENG-42' },
+        externalSource: {
+          integrationId: 'linear',
+          type: 'issue',
+          externalId: 'linear:ENG-42',
+          url: 'https://linear.app/acme/issue/ENG-42',
+        },
         title: 'ENG-42: Issue',
         stages: ['planning'],
         sessions: {},
@@ -243,7 +286,9 @@ describe('issue reconcilers', () => {
       },
     });
     const intake = {
-      resolveIntakeDispatch: vi.fn().mockResolvedValue({ connection: { type: 'oauth', accessToken: 'token' }, issueId: 'linear-uuid' }),
+      resolveIntakeDispatch: vi
+        .fn()
+        .mockResolvedValue({ connection: { type: 'oauth', accessToken: 'token' }, issueId: 'linear-uuid' }),
       getIssue: vi.fn().mockResolvedValue(issue({ state: 'Canceled', stateType: 'canceled' })),
     } as unknown as Intake;
     const reconcile = attachLinearIssueReconciler(

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -77,42 +77,86 @@ function createIntegration(fetchImpl?: typeof fetch): PlatformGithubIntegration 
 
 describe('PlatformGithubIntegration', () => {
   it('updates the oldest Platform-owned triage marker across comment pages and learns the actual writer', async () => {
-    const older = { id: 10, body: '<!-- mastra-factory-triage --> oldest', htmlUrl: 'https://github.com/acme/app/issues/7#issuecomment-10', user: { login: 'mastra-platform[bot]', avatarUrl: null, htmlUrl: 'https://github.com/apps/mastra-platform' }, createdAt: '2026-07-01T00:00:00Z', updatedAt: '2026-07-01T00:00:00Z' };
+    const older = {
+      id: 10,
+      body: '<!-- mastra-factory-triage --> oldest',
+      htmlUrl: 'https://github.com/acme/app/issues/7#issuecomment-10',
+      user: { login: 'mastra-platform[bot]', avatarUrl: null, htmlUrl: 'https://github.com/apps/mastra-platform' },
+      createdAt: '2026-07-01T00:00:00Z',
+      updatedAt: '2026-07-01T00:00:00Z',
+    };
     const fetchImpl = vi
       .fn<typeof fetch>()
-      .mockResolvedValueOnce(json({ comments: [
-        { ...older, id: 20, user: { ...older.user, login: 'person' } },
-        { ...older, id: 30 },
-        ...Array.from({ length: 28 }, (_, index) => ({ ...older, id: 100 + index, body: 'unmarked', user: { ...older.user, login: 'person' } })),
-      ] }))
+      .mockResolvedValueOnce(
+        json({
+          comments: [
+            { ...older, id: 20, user: { ...older.user, login: 'person' } },
+            { ...older, id: 30 },
+            ...Array.from({ length: 28 }, (_, index) => ({
+              ...older,
+              id: 100 + index,
+              body: 'unmarked',
+              user: { ...older.user, login: 'person' },
+            })),
+          ],
+        }),
+      )
       .mockResolvedValueOnce(json({ comments: [older] }))
       .mockResolvedValueOnce(json({ ...older, user: { ...older.user, login: 'actual-factory-writer[bot]' } }));
     const integration = createIntegration(fetchImpl);
 
     await expect(
-      integration.upsertFactoryTriageComment({ installationId: 7, repository: 'acme/app', issueNumber: 7, body: '<!-- mastra-factory-triage -->\nFinal' }),
+      integration.upsertFactoryTriageComment({
+        installationId: 7,
+        repository: 'acme/app',
+        issueNumber: 7,
+        body: '<!-- mastra-factory-triage -->\nFinal',
+      }),
     ).resolves.toEqual({ action: 'updated', commentId: '10', url: older.htmlUrl });
 
-    expect(fetchImpl.mock.calls.map(([url, init]) => `${init?.method ?? 'GET'} ${new URL(String(url)).pathname}${new URL(String(url)).search}`)).toEqual([
+    expect(
+      fetchImpl.mock.calls.map(
+        ([url, init]) => `${init?.method ?? 'GET'} ${new URL(String(url)).pathname}${new URL(String(url)).search}`,
+      ),
+    ).toEqual([
       'GET /v1/server/github/repos/acme/app/issues/7/comments?page=1&per_page=30',
       'GET /v1/server/github/repos/acme/app/issues/7/comments?page=2&per_page=30',
       'PATCH /v1/server/github/repos/acme/app/issues/comments/10',
     ]);
-    expect(JSON.parse(String(fetchImpl.mock.calls[2]![1]?.body))).toEqual({ body: '<!-- mastra-factory-triage -->\nFinal' });
+    expect(JSON.parse(String(fetchImpl.mock.calls[2]![1]?.body))).toEqual({
+      body: '<!-- mastra-factory-triage -->\nFinal',
+    });
     expect(integration.isFactoryCommentAuthor('actual-factory-writer[bot]')).toBe(true);
   });
 
   it('creates a triage marker through the Platform proxy when no Factory marker exists', async () => {
-    const created = { id: 42, body: '<!-- mastra-factory-triage --> Pending', htmlUrl: 'https://github.com/acme/app/issues/7#issuecomment-42', user: { login: 'mastra-platform[bot]', avatarUrl: null, htmlUrl: 'https://github.com/apps/mastra-platform' }, createdAt: '2026-07-01T00:00:00Z', updatedAt: '2026-07-01T00:00:00Z' };
-    const fetchImpl = vi.fn<typeof fetch>()
+    const created = {
+      id: 42,
+      body: '<!-- mastra-factory-triage --> Pending',
+      htmlUrl: 'https://github.com/acme/app/issues/7#issuecomment-42',
+      user: { login: 'mastra-platform[bot]', avatarUrl: null, htmlUrl: 'https://github.com/apps/mastra-platform' },
+      createdAt: '2026-07-01T00:00:00Z',
+      updatedAt: '2026-07-01T00:00:00Z',
+    };
+    const fetchImpl = vi
+      .fn<typeof fetch>()
       .mockResolvedValueOnce(json({ comments: [{ ...created, id: 9, user: { ...created.user, login: 'person' } }] }))
       .mockResolvedValueOnce(json(created));
     const integration = createIntegration(fetchImpl);
 
     await expect(
-      integration.upsertFactoryTriageComment({ installationId: 7, repository: 'acme/app', issueNumber: 7, body: '<!-- mastra-factory-triage -->\nPending' }),
+      integration.upsertFactoryTriageComment({
+        installationId: 7,
+        repository: 'acme/app',
+        issueNumber: 7,
+        body: '<!-- mastra-factory-triage -->\nPending',
+      }),
     ).resolves.toEqual({ action: 'created', commentId: '42', url: created.htmlUrl });
-    expect(fetchImpl.mock.calls.map(([url, init]) => `${init?.method ?? 'GET'} ${new URL(String(url)).pathname}${new URL(String(url)).search}`)).toEqual([
+    expect(
+      fetchImpl.mock.calls.map(
+        ([url, init]) => `${init?.method ?? 'GET'} ${new URL(String(url)).pathname}${new URL(String(url)).search}`,
+      ),
+    ).toEqual([
       'GET /v1/server/github/repos/acme/app/issues/7/comments?page=1&per_page=30',
       'POST /v1/server/github/repos/acme/app/issues/7/comments',
     ]);
@@ -843,6 +887,22 @@ describe('PlatformGithubIntegration', () => {
     );
   });
 
+  it('isolates frozen constructor rules and rejects unknown events', () => {
+    const handler = vi.fn();
+    const rules = { issueOpened: handler, issueClosed: null };
+    const first = new PlatformGithubIntegration({ rules });
+    rules.issueOpened = vi.fn();
+    const second = new PlatformGithubIntegration();
+    expect(first.rules.issueOpened).toBe(handler);
+    expect(first.rules.issueClosed).toBeNull();
+    expect(second.rules.issueOpened).not.toBe(handler);
+    expect(second.rules.issueClosed).toBeTypeOf('function');
+    expect(Object.isFrozen(first.rules)).toBe(true);
+    expect(first.rules).not.toBe(second.rules);
+    // @ts-expect-error Verify JavaScript configuration validation.
+    expect(() => new PlatformGithubIntegration({ rules: { unknown: null } })).toThrow();
+  });
+
   it('attaches GitHub rules to polled issue ingress', async () => {
     const seed = await createPlatformStorageForTests();
     const fetchImpl = vi.fn<typeof fetch>(async input => {
@@ -850,7 +910,9 @@ describe('PlatformGithubIntegration', () => {
       if (url.includes('/issues?')) return json({ issues: [issue] });
       throw new Error(`Unexpected request: ${url}`);
     });
-    const integration = createIntegration(fetchImpl);
+    vi.stubGlobal('fetch', fetchImpl);
+    const onEvent = vi.fn();
+    const integration = new PlatformGithubIntegration({ rules: { issueOpened: onEvent } });
     const sourceControl = seed.sourceControl.forIntegration('github');
     const project = await seed.projects.create({
       orgId: 'org-1',
@@ -880,7 +942,6 @@ describe('PlatformGithubIntegration', () => {
       sandboxProvider: 'local',
       sandboxWorkdir: '/tmp/app',
     });
-    const onEvent = vi.fn();
     const context = {
       auth: fakeAuth(),
       // Only presence is read here; the callback is never invoked.
@@ -896,7 +957,6 @@ describe('PlatformGithubIntegration', () => {
       rules: {
         config: defaultFactoryRules({
           version: 'test-rules',
-          overrides: { github: { issueOpened: { onEvent } } },
         }),
         workItems: seed.workItems,
       },
@@ -1475,6 +1535,4 @@ describe('PlatformGithubIntegration', () => {
       expect(fetchImpl).toHaveBeenCalledTimes(1);
     });
   });
-
-
 });

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -45,6 +45,8 @@ import type {
 } from '../../../storage/domains/source-control/base.js';
 import type { FactoryIntegration, IntegrationContext, IntegrationTools } from '../../base.js';
 import { GithubAppIdentity } from '../../github/app-identity.js';
+import type { GithubEventRules, GithubRuleOverrides } from '../../github/default-rules.js';
+import { resolveGithubRules } from '../../github/default-rules.js';
 import type {
   GithubIntegration,
   GithubRepositoryPermission,
@@ -215,6 +217,11 @@ function routeBaseUrl(ctx: IntegrationContext, requestUrl: string): string {
 
 export class PlatformGithubIntegration implements FactoryIntegration {
   readonly id = 'github';
+  readonly #rules: GithubEventRules;
+
+  get rules(): GithubEventRules {
+    return this.#rules;
+  }
   readonly #client: PlatformApiClient;
   readonly #endpointHost: string;
   readonly #slug: string | undefined;
@@ -495,10 +502,13 @@ export class PlatformGithubIntegration implements FactoryIntegration {
 
   constructor(
     options: {
+      /** Replace an event handler, or disable it with null; omitted events keep defaults. */
+      rules?: GithubRuleOverrides;
       /** GitHub App slug used to recognize Factory's own webhook writes. */
       slug?: string;
     } = {},
   ) {
+    this.#rules = resolveGithubRules(options.rules);
     const config = platformApiClientConfigFromEnv();
     this.#client = new PlatformApiClient(config);
     this.#endpointHost = new URL(config.baseUrl).host;
@@ -528,7 +538,8 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     this.#pullRequestReconcileIntervalMs =
       reconcileInterval(process.env.MASTRACODE_PLATFORM_GITHUB_PR_RECONCILE_INTERVAL_MS) ?? legacyReconcileIntervalMs;
     this.#issueReconcileIntervalMs =
-      reconcileInterval(process.env.MASTRACODE_PLATFORM_GITHUB_ISSUE_RECONCILE_INTERVAL_MS) ?? legacyReconcileIntervalMs;
+      reconcileInterval(process.env.MASTRACODE_PLATFORM_GITHUB_ISSUE_RECONCILE_INTERVAL_MS) ??
+      legacyReconcileIntervalMs;
   }
 
   /** GitHub App slug when the deployment explicitly provides it. */
@@ -901,7 +912,9 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         state: result.state === 'closed' ? 'closed' : 'open',
         ...(result.state_reason ? { stateReason: result.state_reason } : {}),
         assignees: (result.assignees ?? []).flatMap(assignee => (assignee.login ? [assignee.login] : [])),
-        labels: (result.labels ?? []).map(label => (typeof label === 'string' ? label : label.name)).filter((name): name is string => Boolean(name)),
+        labels: (result.labels ?? [])
+          .map(label => (typeof label === 'string' ? label : label.name))
+          .filter((name): name is string => Boolean(name)),
         ...(result.user?.login ? { author: result.user.login } : {}),
         ...(result.created_at ? { createdAt: result.created_at } : {}),
         ...(result.updated_at ? { updatedAt: result.updated_at } : {}),
@@ -923,7 +936,10 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       if (result.comments.length < PAGE_SIZE) break;
     }
     const existing = comments
-      .filter(comment => comment.body.includes('<!-- mastra-factory-triage -->') && this.isFactoryCommentAuthor(comment.user?.login))
+      .filter(
+        comment =>
+          comment.body.includes('<!-- mastra-factory-triage -->') && this.isFactoryCommentAuthor(comment.user?.login),
+      )
       .sort((left, right) => left.id - right.id)[0];
     if (existing) {
       const comment = await this.#client.request<GithubComment>(

--- a/mastracode/factory/src/rules/defaults.test.ts
+++ b/mastracode/factory/src/rules/defaults.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { defaultGithubRules } from '../integrations/github/default-rules.js';
 import { defaultFactoryRules, mergeFactoryRuleOverrides } from './defaults.js';
 import type {
   FactoryBoardRuleLeaf,
@@ -140,15 +141,15 @@ describe('defaultFactoryRules', () => {
     expect(rules.review.intake?.pullRequest?.onEnter).toBeTypeOf('function');
     expect(rules.review.review?.pullRequest?.onEnter).toBeTypeOf('function');
     expect(rules.tools.submit_plan?.onResult).toBeTypeOf('function');
-    expect(rules.github.issueOpened?.onEvent).toBeTypeOf('function');
-    expect(rules.github.issueEdited?.onEvent).toBeTypeOf('function');
-    expect(rules.github.issueCommentCreated?.onEvent).toBeTypeOf('function');
-    expect(rules.github.issueCommentEdited?.onEvent).toBeTypeOf('function');
-    expect(rules.github.issueCommentDeleted?.onEvent).toBeTypeOf('function');
-    expect(rules.github.pullRequestOpened?.onEvent).toBeTypeOf('function');
-    expect(rules.github.pullRequestUpdated?.onEvent).toBeTypeOf('function');
-    expect(rules.github.pullRequestReviewRequested?.onEvent).toBeTypeOf('function');
-    expect(rules.github.pullRequestMerged?.onEvent).toBeTypeOf('function');
+    expect(defaultGithubRules.issueOpened).toBeTypeOf('function');
+    expect(defaultGithubRules.issueEdited).toBeTypeOf('function');
+    expect(defaultGithubRules.issueCommentCreated).toBeTypeOf('function');
+    expect(defaultGithubRules.issueCommentEdited).toBeTypeOf('function');
+    expect(defaultGithubRules.issueCommentDeleted).toBeTypeOf('function');
+    expect(defaultGithubRules.pullRequestOpened).toBeTypeOf('function');
+    expect(defaultGithubRules.pullRequestUpdated).toBeTypeOf('function');
+    expect(defaultGithubRules.pullRequestReviewRequested).toBeTypeOf('function');
+    expect(defaultGithubRules.pullRequestMerged).toBeTypeOf('function');
     expect(rules.linear.issueObserved?.onEvent).toBeTypeOf('function');
     expect(rules.work.triage?.linearIssue?.onEnter).toBeTypeOf('function');
   });
@@ -185,7 +186,7 @@ describe('defaultFactoryRules', () => {
   });
 
   it('transitions linked GitHub issue cards deterministically on closure', async () => {
-    const rule = defaultFactoryRules({ version: 'deployment-7' }).github.issueClosed?.onEvent;
+    const rule = defaultGithubRules.issueClosed;
     const github = githubContext('issueClosed');
     const done = await rule?.({
       ...github,
@@ -224,7 +225,7 @@ describe('defaultFactoryRules', () => {
   });
 
   it('only closes non-terminal linked work-board issue cards', async () => {
-    const githubRule = defaultFactoryRules({ version: 'deployment-7' }).github.issueClosed?.onEvent;
+    const githubRule = defaultGithubRules.issueClosed;
     const linearRule = defaultFactoryRules({ version: 'deployment-7' }).linear.issueClosed?.onEvent;
     const github = githubContext('issueClosed');
     const linear = linearContext();
@@ -313,7 +314,7 @@ describe('defaultFactoryRules', () => {
   it.each(['issueEdited', 'issueCommentCreated', 'issueCommentEdited', 'issueCommentDeleted'] as const)(
     're-runs investigation when %s arrives for a linked GitHub issue',
     async event => {
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github[event]?.onEvent;
+      const rule = defaultGithubRules[event];
       const decision = await rule?.({
         ...githubContext(event),
         item: { ...item, source: 'github-issue' },
@@ -668,7 +669,7 @@ describe('defaultFactoryRules', () => {
     }
 
     it('wakes the authoring Work agent when changes are requested', async () => {
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestReviewSubmitted?.onEvent;
+      const rule = defaultGithubRules.pullRequestReviewSubmitted;
       const decision = await rule?.(reviewContext());
       expect(decision).toMatchObject({
         type: 'sendMessage',
@@ -682,7 +683,7 @@ describe('defaultFactoryRules', () => {
     });
 
     it('stays quiet for reviews that are not asking for changes', async () => {
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestReviewSubmitted?.onEvent;
+      const rule = defaultGithubRules.pullRequestReviewSubmitted;
       for (const state of ['approved', 'commented', 'dismissed']) {
         expect(
           await rule?.(reviewContext({ review: { id: 99, state, url: 'https://github.test/r' } })),
@@ -693,7 +694,7 @@ describe('defaultFactoryRules', () => {
     it('stays quiet when the pull request is closed or merged', async () => {
       // A closed or merged PR has no branch left to push fixes to, so waking
       // the author would only send them to a dead end.
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestReviewSubmitted?.onEvent;
+      const rule = defaultGithubRules.pullRequestReviewSubmitted;
       const base = reviewContext();
       for (const pullRequest of [
         { ...base.pullRequest!, state: 'closed' },
@@ -706,7 +707,7 @@ describe('defaultFactoryRules', () => {
     it('never fires on the Review card that posted the review', async () => {
       // Only the PR's author can act on the feedback. Reacting on the Review
       // card would loop the reviewer against its own output.
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestReviewSubmitted?.onEvent;
+      const rule = defaultGithubRules.pullRequestReviewSubmitted;
       expect(await rule?.(reviewContext({ board: 'review' }))).toBeUndefined();
       expect(await rule?.(reviewContext({ item: undefined, board: undefined }))).toBeUndefined();
       expect(await rule?.(reviewContext({ review: undefined }))).toBeUndefined();
@@ -731,7 +732,7 @@ describe('defaultFactoryRules', () => {
     }
 
     it('wakes the authoring Work agent when someone comments on the pull request', async () => {
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestCommentCreated?.onEvent;
+      const rule = defaultGithubRules.pullRequestCommentCreated;
       const decision = await rule?.(commentContext());
       expect(decision).toMatchObject({
         type: 'sendMessage',
@@ -746,7 +747,7 @@ describe('defaultFactoryRules', () => {
       // `factoryAuthored` cannot tell the Work role from the Review role, so
       // reacting to Factory's own comments would let the Work agent's progress
       // notes wake it in a loop.
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestCommentCreated?.onEvent;
+      const rule = defaultGithubRules.pullRequestCommentCreated;
       expect(
         await rule?.(
           commentContext({
@@ -757,7 +758,7 @@ describe('defaultFactoryRules', () => {
     });
 
     it('stays quiet on the Review card and on pull requests that are no longer open', async () => {
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestCommentCreated?.onEvent;
+      const rule = defaultGithubRules.pullRequestCommentCreated;
       expect(await rule?.(commentContext({ board: 'review' }))).toBeUndefined();
       expect(await rule?.(commentContext({ issueComment: undefined }))).toBeUndefined();
       const openPr = commentContext().pullRequest!;
@@ -769,7 +770,7 @@ describe('defaultFactoryRules', () => {
       // GitHub refuses a self-review, so on Factory-authored PRs the verdict
       // arrives as a comment under Factory's own login. It is the handoff, so it
       // has to survive the self-loop guard.
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestCommentCreated?.onEvent;
+      const rule = defaultGithubRules.pullRequestCommentCreated;
       const decision = await rule?.(
         commentContext({
           actor: { type: 'github', login: 'factory[bot]', trusted: true, factoryAuthored: true },
@@ -785,7 +786,7 @@ describe('defaultFactoryRules', () => {
     });
 
     it('ignores a Factory verdict that approves, and a verdict only quoted in the body', async () => {
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestCommentCreated?.onEvent;
+      const rule = defaultGithubRules.pullRequestCommentCreated;
       const factoryActor = { type: 'github', login: 'factory[bot]', trusted: true, factoryAuthored: true } as const;
       expect(
         await rule?.(
@@ -837,7 +838,7 @@ describe('defaultFactoryRules', () => {
     }
 
     it('re-enters Review when review is re-requested from Factory on a finished card', async () => {
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestReviewRequested?.onEvent;
+      const rule = defaultGithubRules.pullRequestReviewRequested;
       expect(await rule?.(reReviewContext())).toMatchObject({
         type: 'transition',
         idempotencyKey: 'delivery-1:re-review-requested',
@@ -847,7 +848,7 @@ describe('defaultFactoryRules', () => {
     });
 
     it('ignores re-requests that do not target Factory or come from untrusted senders', async () => {
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestReviewRequested?.onEvent;
+      const rule = defaultGithubRules.pullRequestReviewRequested;
       for (const context of [
         // Review requested from a human reviewer, not Factory's bot.
         reReviewContext({ reviewRequest: { reviewer: 'ada', factoryReviewer: false } }),
@@ -864,7 +865,7 @@ describe('defaultFactoryRules', () => {
     });
 
     it('ignores re-requests on closed or merged pull requests', async () => {
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestReviewRequested?.onEvent;
+      const rule = defaultGithubRules.pullRequestReviewRequested;
       const closed = reReviewContext();
       closed.pullRequest = { ...closed.pullRequest!, state: 'closed' };
       const merged = reReviewContext();
@@ -895,7 +896,7 @@ describe('defaultFactoryRules', () => {
     }
 
     it('re-enters Review when a push arrives for a PR whose card already finished Reviewing', async () => {
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestUpdated?.onEvent;
+      const rule = defaultGithubRules.pullRequestUpdated;
       expect(await rule?.(pushContext())).toMatchObject({
         type: 'transition',
         idempotencyKey: 'delivery-1:re-review-updated',
@@ -908,7 +909,7 @@ describe('defaultFactoryRules', () => {
       // The push invalidates whatever the running pass is reading, so it has to
       // start over on the new head. Re-entering the stage is how that pass gets
       // cancelled; dropping the push would strand the review on stale code.
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestUpdated?.onEvent;
+      const rule = defaultGithubRules.pullRequestUpdated;
       expect(await rule?.(pushContext({ item: { ...prItem, stages: ['review'] } }))).toMatchObject({
         type: 'transition',
         board: 'review',
@@ -920,7 +921,7 @@ describe('defaultFactoryRules', () => {
     });
 
     it('does nothing when the PR is still in Intake, is unlinked, or is not on the Review board', async () => {
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestUpdated?.onEvent;
+      const rule = defaultGithubRules.pullRequestUpdated;
       for (const context of [
         // Card is still in intake — a review pass has not started yet.
         pushContext({ item: { ...prItem, stages: ['intake'] } }),
@@ -934,7 +935,7 @@ describe('defaultFactoryRules', () => {
     });
 
     it('ignores push events on closed or merged pull requests', async () => {
-      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestUpdated?.onEvent;
+      const rule = defaultGithubRules.pullRequestUpdated;
       const closed = pushContext();
       closed.pullRequest = { ...closed.pullRequest!, state: 'closed' };
       const merged = pushContext();
@@ -971,7 +972,7 @@ describe('defaultFactoryRules', () => {
         [untrusted, false],
         [factoryAuthored, expectedEligibility.factoryAuthored],
       ] as const) {
-        expect(await rules.github[event]?.onEvent?.(actor)).toMatchObject({
+        expect(await defaultGithubRules[event]?.(actor)).toMatchObject({
           type: 'upsertLinkedWorkItem',
           stage: 'intake',
           metadata: { autoStartCandidate: eligible },
@@ -1039,7 +1040,7 @@ describe('defaultFactoryRules', () => {
       actor: { type: 'github', login: 'factory-bot', trusted: false, factoryAuthored: true } as const,
     };
 
-    expect(await rules.github.pullRequestOpened?.onEvent?.(older)).toMatchObject({
+    expect(await defaultGithubRules.pullRequestOpened?.(older)).toMatchObject({
       type: 'upsertLinkedWorkItem',
       stage: 'intake',
       metadata: { autoStartCandidate: false },
@@ -1052,7 +1053,7 @@ describe('defaultFactoryRules', () => {
       const rules = defaultFactoryRules({ version: 'deployment-7' });
       const olderContext = githubContext(event, '2026-05-01T00:00:00Z');
 
-      expect(await rules.github[event]?.onEvent?.(olderContext)).toMatchObject({
+      expect(await defaultGithubRules[event]?.(olderContext)).toMatchObject({
         type: 'upsertLinkedWorkItem',
         stage: 'intake',
         metadata: { autoStartCandidate: false },
@@ -1062,11 +1063,11 @@ describe('defaultFactoryRules', () => {
 
   it('uses the same issue and pull-request identities as board Intake', async () => {
     const rules = defaultFactoryRules({ version: 'deployment-7' });
-    expect(await rules.github.issueOpened?.onEvent?.(githubContext('issueOpened'))).toMatchObject({
+    expect(await defaultGithubRules.issueOpened?.(githubContext('issueOpened'))).toMatchObject({
       source: 'github-issue',
       sourceKey: 'github-issue:42',
     });
-    expect(await rules.github.pullRequestOpened?.onEvent?.(githubContext('pullRequestOpened'))).toMatchObject({
+    expect(await defaultGithubRules.pullRequestOpened?.(githubContext('pullRequestOpened'))).toMatchObject({
       source: 'github-pr',
       sourceKey: 'github-pr:17',
     });
@@ -1076,7 +1077,7 @@ describe('defaultFactoryRules', () => {
     const rules = defaultFactoryRules({ version: 'deployment-7' });
     const context = githubContext('pullRequestOpened');
     context.pullRequest = { ...context.pullRequest!, draft: true };
-    expect(await rules.github.pullRequestOpened?.onEvent?.(context)).toMatchObject({
+    expect(await defaultGithubRules.pullRequestOpened?.(context)).toMatchObject({
       metadata: {
         state: 'open',
         draft: true,
@@ -1091,10 +1092,10 @@ describe('defaultFactoryRules', () => {
 
   it('stamps the GitHub author login on issue and PR intake metadata', async () => {
     const rules = defaultFactoryRules({ version: 'deployment-7' });
-    expect(await rules.github.issueOpened?.onEvent?.(githubContext('issueOpened'))).toMatchObject({
+    expect(await defaultGithubRules.issueOpened?.(githubContext('issueOpened'))).toMatchObject({
       metadata: { author: 'author' },
     });
-    expect(await rules.github.pullRequestOpened?.onEvent?.(githubContext('pullRequestOpened'))).toMatchObject({
+    expect(await defaultGithubRules.pullRequestOpened?.(githubContext('pullRequestOpened'))).toMatchObject({
       metadata: { author: 'author' },
     });
   });
@@ -1118,7 +1119,7 @@ describe('defaultFactoryRules', () => {
     context.item = { ...item, source: 'github-pr', sourceKey: 'github-pr:17' };
     context.board = 'review';
     context.pullRequest = { ...context.pullRequest!, state: 'closed', merged: true };
-    const decision = await rules.github.pullRequestMerged?.onEvent?.(context);
+    const decision = await defaultGithubRules.pullRequestMerged?.(context);
     expect(decision).toMatchObject({
       type: 'transition',
       board: 'review',
@@ -1133,7 +1134,7 @@ describe('defaultFactoryRules', () => {
     context.item = item;
     context.board = 'work';
     context.pullRequest = { ...context.pullRequest!, state: 'closed', merged: true };
-    const decision = await rules.github.pullRequestMerged?.onEvent?.(context);
+    const decision = await defaultGithubRules.pullRequestMerged?.(context);
     expect(decision).toMatchObject({ type: 'sendMessage', role: 'work' });
     expect(decision).not.toMatchObject({ type: 'transition', stage: 'done' });
   });
@@ -1144,7 +1145,7 @@ describe('defaultFactoryRules', () => {
     context.item = { ...item, source: 'github-pr', sourceKey: 'github-pr:17' };
     context.board = 'review';
     context.pullRequest = { ...context.pullRequest!, state: 'closed', merged: false };
-    const decision = await rules.github.pullRequestClosed?.onEvent?.(context);
+    const decision = await defaultGithubRules.pullRequestClosed?.(context);
     expect(decision).toMatchObject({
       type: 'transition',
       board: 'review',
@@ -1159,7 +1160,7 @@ describe('defaultFactoryRules', () => {
     context.item = item;
     context.board = 'work';
     context.pullRequest = { ...context.pullRequest!, state: 'closed', merged: false };
-    expect(await rules.github.pullRequestClosed?.onEvent?.(context)).toBeUndefined();
+    expect(await defaultGithubRules.pullRequestClosed?.(context)).toBeUndefined();
   });
 
   it('replaces exact handler leaves while preserving siblings', () => {
@@ -1167,7 +1168,6 @@ describe('defaultFactoryRules', () => {
     const workExit = vi.fn(() => undefined);
     const reviewEnter = vi.fn(() => undefined);
     const toolResult = vi.fn(() => undefined);
-    const githubEvent = vi.fn(() => undefined);
     const linearEvent = vi.fn(() => undefined);
     const rules = defaultFactoryRules({
       version: 'deployment-8',
@@ -1175,7 +1175,6 @@ describe('defaultFactoryRules', () => {
         work: { planning: { issue: { onEnter: workEnter, onExit: workExit } } },
         review: { intake: { pullRequest: { onEnter: reviewEnter } } },
         tools: { submit_plan: { onResult: toolResult } },
-        github: { pullRequestMerged: { onEvent: githubEvent } },
         linear: { issueObserved: { onEvent: linearEvent } },
       },
     });
@@ -1184,8 +1183,7 @@ describe('defaultFactoryRules', () => {
     expect(rules.work.planning?.issue?.onExit).toBe(workExit);
     expect(rules.review.intake?.pullRequest?.onEnter).toBe(reviewEnter);
     expect(rules.tools.submit_plan?.onResult).toBe(toolResult);
-    expect(rules.github.pullRequestMerged?.onEvent).toBe(githubEvent);
-    expect(rules.github.issueOpened?.onEvent).toBeTypeOf('function');
+    expect(defaultGithubRules.issueOpened).toBeTypeOf('function');
     expect(rules.linear.issueObserved?.onEvent).toBe(linearEvent);
   });
 
@@ -1215,7 +1213,6 @@ describe('defaultFactoryRules', () => {
       {
         work: { planning: { issue: { onEnter: undefined, onExit: undefined } } },
         tools: { submit_plan: { onResult: undefined } },
-        github: { pullRequestCommentCreated: { onEvent: undefined } },
         linear: { issueObserved: { onEvent: undefined } },
       },
       {},
@@ -1224,20 +1221,17 @@ describe('defaultFactoryRules', () => {
     expect(merged.work.planning?.issue).toHaveProperty('onEnter', undefined);
     expect(merged.work.planning?.issue).toHaveProperty('onExit', undefined);
     expect(merged.tools.submit_plan).toHaveProperty('onResult', undefined);
-    expect(merged.github.pullRequestCommentCreated).toHaveProperty('onEvent', undefined);
     expect(merged.linear.issueObserved).toHaveProperty('onEvent', undefined);
   });
 
-  it('keeps a disabled built-in disabled across repeated composition', () => {
-    const configured = defaultFactoryRules({
-      version: 'deployment-9',
-      overrides: { github: { pullRequestCommentCreated: { onEvent: undefined } } },
-    });
-    const composed = mergeFactoryRuleOverrides(configured, {});
-    const effective = defaultFactoryRules({ version: 'deployment-10', overrides: composed });
-
-    expect(composed.github.pullRequestCommentCreated).toHaveProperty('onEvent', undefined);
-    expect(effective.github.pullRequestCommentCreated).toHaveProperty('onEvent', undefined);
+  it('rejects legacy global GitHub configuration with migration guidance', () => {
+    for (const github of [{}, undefined, { issueOpened: { onEvent: passThrough } }]) {
+      const overrides = { github };
+      expect(() => defaultFactoryRules({ version: 'migration', overrides: Object.assign({}, overrides) })).toThrow(
+        /GitHub integration constructor/,
+      );
+      expect(() => mergeFactoryRuleOverrides(Object.assign({}, overrides))).toThrow(/GitHub integration constructor/);
+    }
   });
 
   it('copies override containers so later mutation cannot replace configured leaves', () => {

--- a/mastracode/factory/src/rules/defaults.test.ts
+++ b/mastracode/factory/src/rules/defaults.test.ts
@@ -1224,16 +1224,6 @@ describe('defaultFactoryRules', () => {
     expect(merged.linear.issueObserved).toHaveProperty('onEvent', undefined);
   });
 
-  it('rejects legacy global GitHub configuration with migration guidance', () => {
-    for (const github of [{}, undefined, { issueOpened: { onEvent: passThrough } }]) {
-      const overrides = { github };
-      expect(() => defaultFactoryRules({ version: 'migration', overrides: Object.assign({}, overrides) })).toThrow(
-        /GitHub integration constructor/,
-      );
-      expect(() => mergeFactoryRuleOverrides(Object.assign({}, overrides))).toThrow(/GitHub integration constructor/);
-    }
-  });
-
   it('copies override containers so later mutation cannot replace configured leaves', () => {
     const leaf: FactoryBoardRuleLeaf = { onEnter: passThrough };
     const overrides: FactoryRulesOverrides = { work: { intake: { issue: leaf } } };

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -167,13 +167,6 @@ export function mergeFactoryRuleOverrides(
   base: FactoryRulesOverrides,
   overrides: FactoryRulesOverrides = {},
 ): Omit<FactoryRules, 'version'> {
-  for (const config of [base, overrides]) {
-    if ('github' in config) {
-      throw new FactoryRuleValidationError(
-        'Factory rules.github is no longer supported. Configure rules[event] on the GitHub integration constructor instead.',
-      );
-    }
-  }
   return {
     work: mergeBoardRules(base.work, overrides.work),
     review: mergeBoardRules(base.review, overrides.review),

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -3,9 +3,6 @@ import { workBoard } from '../boards/work.js';
 import type {
   FactoryBoardRuleLeaf,
   FactoryBoardRules,
-  FactoryGithubRuleLeaf,
-  FactoryGithubEventName,
-  FactoryGithubRuleContext,
   FactoryLinearEventName,
   FactoryLinearRuleContext,
   FactoryLinearRuleLeaf,
@@ -19,39 +16,6 @@ import type {
 import { assertFactoryRules, FactoryRuleValidationError } from './validation.js';
 
 export const DEFAULT_FACTORY_RULE_VERSION = 'factory-default-v1';
-
-function trustedGithubActor(context: Pick<FactoryGithubRuleContext, 'actor'>): boolean {
-  return context.actor.type === 'github' && context.actor.trusted;
-}
-
-function githubActorLogin(context: Pick<FactoryGithubRuleContext, 'actor'>): string | undefined {
-  return context.actor.type === 'github' ? context.actor.login : undefined;
-}
-
-function retriageGithubIssue(context: FactoryGithubRuleContext) {
-  if (!context.item || context.item.source !== 'github-issue' || !context.item.url) return;
-  if (context.actor.type === 'github' && context.actor.factoryAuthored) return;
-
-  const reason =
-    context.event === 'issueEdited'
-      ? context.issueChange?.title && context.issueChange.body
-        ? 'issue title and body edited'
-        : context.issueChange?.title
-          ? 'issue title edited'
-          : 'issue body edited'
-      : context.event === 'issueCommentDeleted'
-        ? 'comment deleted'
-        : context.event === 'issueCommentEdited'
-          ? 'comment edited'
-          : 'comment created';
-  return {
-    type: 'invokeSkill',
-    idempotencyKey: `${context.ingress.id}:factory-triage`,
-    role: 'triage',
-    skillName: 'factory-triage',
-    arguments: `Re-triage GitHub issue (${context.item.url}) after ${reason}.`,
-  } as const;
-}
 
 function resultContent(value: unknown): string | undefined {
   if (typeof value === 'string') return value;
@@ -79,302 +43,6 @@ function advanceApprovedPlan(context: FactoryToolResultRuleContext) {
     idempotencyKey: `${context.ingress.id}:approved-plan`,
     board: 'work',
     stage: 'execute',
-  } as const;
-}
-
-function createdAfterFactory(createdAt: string | undefined, factoryCreatedAt: string): boolean {
-  if (!createdAt) return false;
-  const sourceCreatedAt = Date.parse(createdAt);
-  const projectCreatedAt = Date.parse(factoryCreatedAt);
-  return Number.isFinite(sourceCreatedAt) && Number.isFinite(projectCreatedAt) && sourceCreatedAt > projectCreatedAt;
-}
-
-function issueOpened(context: FactoryGithubRuleContext) {
-  if (!context.issue) return;
-  // Everything arrives in Intake; arrival only stamps whether `onArrival` may
-  // suggest this card's run without a person.
-  return {
-    type: 'upsertLinkedWorkItem',
-    idempotencyKey: `${context.ingress.id}:issue-intake`,
-    board: 'work',
-    source: 'github-issue',
-    sourceKey: `github-issue:${context.issue.number}`,
-    title: context.issue.title,
-    url: context.issue.url,
-    stage: 'intake',
-    metadata: {
-      githubRepositoryId: context.repository.id,
-      githubIssueNumber: context.issue.number,
-      ...(context.issue.createdAt ? { sourceCreatedAt: context.issue.createdAt } : {}),
-      ...(githubActorLogin(context) ? { author: githubActorLogin(context) } : {}),
-      authorTrusted: trustedGithubActor(context),
-      autoStartCandidate:
-        trustedGithubActor(context) && createdAfterFactory(context.issue.createdAt, context.factory.createdAt),
-      assignees: context.issue.assignees ?? [],
-      labels: context.issue.labels ?? [],
-    },
-  } as const;
-}
-
-function issueClosed(context: FactoryGithubRuleContext) {
-  if (!context.item || context.item.source !== 'github-issue' || !context.issue) return;
-  if (context.board !== 'work') return;
-  // Already off the board: nothing to reconcile.
-  if (context.item.stages.some(stage => stage === 'done' || stage === 'canceled')) return;
-  // Issue closure is a repository fact, not third-party input — no actor trust
-  // gate. `not_planned` (and `duplicate`) means abandoned, everything else is
-  // completed work.
-  const canceled = context.issue.stateReason === 'not_planned' || context.issue.stateReason === 'duplicate';
-  return {
-    type: 'transition',
-    idempotencyKey: `${context.ingress.id}:issue-closed`,
-    board: 'work',
-    stage: canceled ? 'canceled' : 'done',
-    message: {
-      text:
-        `GitHub issue #${context.issue.number} was closed` +
-        `${context.issue.stateReason ? ` (${context.issue.stateReason})` : ''}; ` +
-        `this Work card was moved to ${canceled ? 'Canceled' : 'Done'}.`,
-    },
-  } as const;
-}
-
-function materializePullRequestIntake(
-  context: FactoryGithubRuleContext,
-  { idempotencyKey, autoStartCandidate }: { idempotencyKey: string; autoStartCandidate: boolean },
-) {
-  if (!context.pullRequest) return;
-  return {
-    type: 'upsertLinkedWorkItem',
-    idempotencyKey,
-    board: 'review',
-    source: 'github-pr',
-    sourceKey: `github-pr:${context.pullRequest.number}`,
-    title: context.pullRequest.title,
-    url: context.pullRequest.url,
-    stage: 'intake',
-    metadata: {
-      githubRepositoryId: context.repository.id,
-      githubPullRequestNumber: context.pullRequest.number,
-      ...(context.pullRequest.createdAt ? { sourceCreatedAt: context.pullRequest.createdAt } : {}),
-      factoryAuthored: context.pullRequest.factoryAuthored,
-      authorTrusted: trustedGithubActor(context),
-      autoStartCandidate,
-      state: context.pullRequest.state,
-      draft: context.pullRequest.draft,
-      merged: context.pullRequest.merged,
-      assignees: context.pullRequest.assignees ?? [],
-      requestedReviewers: context.pullRequest.requestedReviewers ?? [],
-      labels: context.pullRequest.labels ?? [],
-      headBranch: context.pullRequest.headBranch,
-      baseBranch: context.pullRequest.baseBranch,
-      ...(context.pullRequest.author ? { author: context.pullRequest.author } : {}),
-    },
-  } as const;
-}
-
-function pullRequestOpened(context: FactoryGithubRuleContext) {
-  if (!context.pullRequest) return;
-  // A GitHub App bot is never a collaborator, so Factory's own PRs score
-  // untrusted; their authorship is the trust signal.
-  const autoStartCandidate =
-    (trustedGithubActor(context) || context.pullRequest.factoryAuthored) &&
-    createdAfterFactory(context.pullRequest.createdAt, context.factory.createdAt);
-  return materializePullRequestIntake(context, {
-    idempotencyKey: `${context.ingress.id}:pull-request-intake`,
-    autoStartCandidate,
-  });
-}
-
-function pullRequestMerged(context: FactoryGithubRuleContext) {
-  if (!context.item || !context.pullRequest?.merged) return;
-  if (context.board === 'review') {
-    // The event is bound to the PR's own Review card: a merged PR is finished
-    // review work, so always move the card to Done. The message only reaches
-    // an active session (if any) — cards without one just move, instead of
-    // failing retries against a binding that never existed.
-    return {
-      type: 'transition',
-      idempotencyKey: `${context.ingress.id}:pull-request-merged`,
-      board: 'review',
-      stage: 'done',
-      message: {
-        text:
-          `Pull request #${context.pullRequest.number} merged; this Review card was moved to Done. ` +
-          'No further review is needed unless follow-up work was requested.',
-      },
-    } as const;
-  }
-  // Provenance bound the event to the originating Work item instead: remind
-  // its agent to assess completion — never auto-complete the Work item.
-  return {
-    type: 'sendMessage',
-    idempotencyKey: `${context.ingress.id}:assess-work-completion`,
-    role: 'work',
-    message:
-      `Pull request #${context.pullRequest.number} merged. Assess whether the linked Work item is complete. ` +
-      'Do not mark it Done solely because this PR merged; use factory_transition_work_item only after verifying the work.',
-  } as const;
-}
-
-function addressReviewFeedback(context: FactoryGithubRuleContext) {
-  if (!context.item || !context.pullRequest || !context.review) return;
-  // Only the Work item that authored the PR can act on the feedback. Provenance
-  // binds the event there; a Review card seeing its own posted review must not
-  // react to it (that would loop the reviewer against itself).
-  if (context.board !== 'work') return;
-  // A closed or merged pull request has no branch left to push fixes to.
-  if (context.pullRequest.state !== 'open' || context.pullRequest.merged) return;
-  // `approved` needs no work, and `commented` (a review body with no verdict)
-  // is how a reviewer leaves notes without blocking — only a verdict that asks
-  // for changes should pull the author back in.
-  if (context.review.state.toLowerCase() !== 'changes_requested') return;
-  // The authoring thread is already subscribed to this PR (`gh pr create`
-  // subscribes automatically), so it can read the individual line comments
-  // from its own notification inbox — the message only has to wake it and
-  // point at the review.
-  return {
-    type: 'sendMessage',
-    idempotencyKey: `${context.ingress.id}:address-review-feedback`,
-    role: 'work',
-    priority: 'high',
-    message:
-      `Changes were requested on pull request #${context.pullRequest.number} (${context.review.url}). ` +
-      'Read the review comments on this PR, address the ones you agree with, and push the fixes to the PR branch. ' +
-      'Reply on GitHub to anything you are deliberately not changing, explaining why.',
-  } as const;
-}
-
-/**
- * Detects the `factory-review` handoff verdict in a comment body.
- *
- * GitHub forbids an app from reviewing a pull request it authored, so on
- * Factory-authored PRs the review skill falls back to posting its verdict as a
- * plain comment. That comment is the only signal the authoring agent gets, so
- * it has to be readable back out. The skill's handoff contract puts the verdict
- * on the first line (`Verdict: request changes`), so only that line is
- * inspected — a verdict quoted later in the findings must not count.
- */
-function requestsChangesVerdict(body: string | undefined): boolean {
-  const firstLine = body
-    ?.split('\n')
-    .map(line => line.trim())
-    .find(line => line.length > 0);
-  if (!firstLine) return false;
-  // Tolerate the markdown the skill wraps the line in (`**Verdict: ...**`).
-  const normalized = firstLine
-    .replaceAll(/[*_`#>\s]+/g, ' ')
-    .trim()
-    .toLowerCase();
-  // Match the verdict exactly so negated phrasings ("Verdict: do not request
-  // changes") cannot wake the author.
-  return /^verdict: ?(request changes|changes requested)$/.test(normalized);
-}
-
-function addressPullRequestComment(context: FactoryGithubRuleContext) {
-  // A validated Factory mention is a review-entry request, not feedback for the
-  // authoring Work session. Invalid or unrecognized comments retain the normal
-  // feedback route below.
-  if (context.reviewCommand) return reReviewRequestedPullRequest(context);
-  if (!context.item || !context.pullRequest || !context.issueComment) return;
-  // Provenance binds the comment to the Work item that authored the PR — the
-  // only session that can act on it. A Review card must not react to comments
-  // on the PR it is reviewing.
-  if (context.board !== 'work') return;
-  if (context.pullRequest.state !== 'open' || context.pullRequest.merged) return;
-  // `factoryAuthored` is one bit for the whole Factory, so Factory's own
-  // comments are indistinguishable between roles — waking on all of them would
-  // let the Work agent's own progress comments wake itself in a loop. The one
-  // exception is the review verdict the Review run had to post as a comment
-  // because GitHub refused a self-review: that is the handoff, and it only ever
-  // asks for changes once per review, so it cannot sustain a loop.
-  if (
-    context.actor.type === 'github' &&
-    context.actor.factoryAuthored &&
-    !requestsChangesVerdict(context.issueComment.body)
-  ) {
-    return;
-  }
-  return {
-    type: 'sendMessage',
-    idempotencyKey: `${context.ingress.id}:address-pull-request-comment`,
-    role: 'work',
-    priority: 'high',
-    message:
-      `${context.issueComment.author ?? 'Someone'} commented on pull request #${context.pullRequest.number} ` +
-      `(${context.issueComment.url ?? context.pullRequest.url}). Read the comment, address it if you agree, and push ` +
-      'the fixes to the PR branch. Reply on GitHub to anything you are deliberately not changing, explaining why.',
-  } as const;
-}
-
-function pullRequestClosed(context: FactoryGithubRuleContext) {
-  if (!context.item || !context.pullRequest || context.pullRequest.merged) return;
-  if (context.board !== 'review') return;
-  // A PR closed without merging is abandoned review work: clear the card off
-  // the board instead of leaving it in Reviewing forever.
-  return {
-    type: 'transition',
-    idempotencyKey: `${context.ingress.id}:pull-request-closed`,
-    board: 'review',
-    stage: 'canceled',
-    message: {
-      text:
-        `Pull request #${context.pullRequest.number} was closed without merging; ` +
-        'this Review card was moved to Canceled.',
-    },
-  } as const;
-}
-
-function reReviewRequestedPullRequest(context: FactoryGithubRuleContext) {
-  // GitHub reviewer requests and Factory's exact mention command are both
-  // explicit requests to enter the same Review lifecycle.
-  const factoryReviewEntry = context.reviewRequest?.factoryReviewer || context.reviewCommand !== undefined;
-  if ((context.item && context.board !== 'review') || !factoryReviewEntry) return;
-  if (!context.pullRequest || context.pullRequest.state !== 'open' || context.pullRequest.merged) return;
-  // Trusted (write/admin) requesters only: creating or re-entering review checks
-  // out and executes PR code, the same bar pullRequestOpened applies to auto-review.
-  if (!trustedGithubActor(context)) return;
-  if (context.actor.type === 'github' && context.actor.factoryAuthored) return;
-  if (!context.item) {
-    // On this path the actor is the *requester*, so the materialized
-    // `authorTrusted` stamp records their trust (always true past the gate
-    // above), not the PR author's: a trusted maintainer requesting a Factory
-    // review vouches for the PR.
-    return materializePullRequestIntake(context, {
-      idempotencyKey: `${context.ingress.id}:pull-request-review-requested-intake`,
-      autoStartCandidate: true,
-    });
-  }
-  // Already in Reviewing: a review pass is pending or running; re-entering
-  // would be a same-stage no-op anyway (stage rules only fire on change).
-  if (context.item.stages.length === 1 && context.item.stages[0] === 'review') return;
-  return {
-    type: 'transition',
-    idempotencyKey: `${context.ingress.id}:re-review-requested`,
-    board: 'review',
-    stage: 'review',
-  } as const;
-}
-
-function reReviewUpdatedPullRequest(context: FactoryGithubRuleContext) {
-  if (!context.item || context.board !== 'review') return;
-  if (!context.pullRequest || context.pullRequest.state !== 'open' || context.pullRequest.merged) return;
-  // Intake has not started a review pass yet, so a push there is just more of
-  // the code the first pass will read. A push to a card sitting in Reviewing is
-  // different: it invalidates whatever that pass is reading, so re-enter the
-  // stage to supersede it. `reviewPullRequest` cancels the stale run and picks
-  // the right skill for the entry it sees.
-  if (context.item.stages.some(stage => stage === 'intake')) return;
-  const alreadyReviewing = context.item.stages.some(stage => stage === 'review');
-  return {
-    type: 'transition',
-    idempotencyKey: `${context.ingress.id}:re-review-updated`,
-    board: 'review',
-    stage: 'review',
-    // Re-entry is the point when the card is already Reviewing: the stage's
-    // entry rule is what cancels the superseded pass and starts one on the code
-    // that just landed.
-    ...(alreadyReviewing ? { reenter: true } : {}),
   } as const;
 }
 
@@ -430,21 +98,6 @@ const BUILT_IN_DEFAULTS: FactoryRulesOverrides = {
   work: workBoard.rules,
   review: reviewBoard.rules,
   tools: { submit_plan: { onResult: advanceApprovedPlan } },
-  github: {
-    issueOpened: { onEvent: issueOpened },
-    issueEdited: { onEvent: retriageGithubIssue },
-    issueClosed: { onEvent: issueClosed },
-    issueCommentCreated: { onEvent: retriageGithubIssue },
-    issueCommentEdited: { onEvent: retriageGithubIssue },
-    issueCommentDeleted: { onEvent: retriageGithubIssue },
-    pullRequestOpened: { onEvent: pullRequestOpened },
-    pullRequestUpdated: { onEvent: reReviewUpdatedPullRequest },
-    pullRequestCommentCreated: { onEvent: addressPullRequestComment },
-    pullRequestReviewRequested: { onEvent: reReviewRequestedPullRequest },
-    pullRequestReviewSubmitted: { onEvent: addressReviewFeedback },
-    pullRequestMerged: { onEvent: pullRequestMerged },
-    pullRequestClosed: { onEvent: pullRequestClosed },
-  },
   linear: { issueObserved: { onEvent: linearIssueObserved }, issueClosed: { onEvent: linearIssueClosed } },
 };
 
@@ -493,23 +146,6 @@ function mergeToolRules(
   return result;
 }
 
-function mergeGithubRules(
-  base: FactoryRulesOverrides['github'],
-  overrides: FactoryRulesOverrides['github'],
-): NonNullable<FactoryRulesOverrides['github']> {
-  const result: Partial<Record<FactoryGithubEventName, FactoryGithubRuleLeaf>> = {};
-  const events = new Set([...Object.keys(base ?? {}), ...Object.keys(overrides ?? {})]) as Set<FactoryGithubEventName>;
-  for (const event of events) {
-    const baseLeaf = base?.[event];
-    const overrideLeaf = overrides?.[event];
-    result[event] = {
-      ...(baseLeaf && 'onEvent' in baseLeaf ? { onEvent: baseLeaf.onEvent } : {}),
-      ...(overrideLeaf && 'onEvent' in overrideLeaf ? { onEvent: overrideLeaf.onEvent } : {}),
-    };
-  }
-  return result;
-}
-
 function mergeLinearRules(
   base: FactoryRulesOverrides['linear'],
   overrides: FactoryRulesOverrides['linear'],
@@ -531,11 +167,17 @@ export function mergeFactoryRuleOverrides(
   base: FactoryRulesOverrides,
   overrides: FactoryRulesOverrides = {},
 ): Omit<FactoryRules, 'version'> {
+  for (const config of [base, overrides]) {
+    if ('github' in config) {
+      throw new FactoryRuleValidationError(
+        'Factory rules.github is no longer supported. Configure rules[event] on the GitHub integration constructor instead.',
+      );
+    }
+  }
   return {
     work: mergeBoardRules(base.work, overrides.work),
     review: mergeBoardRules(base.review, overrides.review),
     tools: mergeToolRules(base.tools, overrides.tools),
-    github: mergeGithubRules(base.github, overrides.github),
     linear: mergeLinearRules(base.linear, overrides.linear),
   };
 }

--- a/mastracode/factory/src/rules/index.ts
+++ b/mastracode/factory/src/rules/index.ts
@@ -1,10 +1,5 @@
 export { builtInFactoryRules, defaultFactoryRules, DEFAULT_FACTORY_RULE_VERSION } from './defaults.js';
-export {
-  resolveFactoryGithubRule,
-  resolveFactoryLinearRule,
-  resolveFactoryStageRules,
-  resolveFactoryToolRule,
-} from './resolve.js';
+export { resolveFactoryLinearRule, resolveFactoryStageRules, resolveFactoryToolRule } from './resolve.js';
 export type { ResolvedFactoryStageRule, ResolvedFactoryToolRule } from './resolve.js';
 export {
   FACTORY_GITHUB_EVENTS,
@@ -22,7 +17,6 @@ export type {
   FactoryCommitDecision,
   FactoryGithubEventName,
   FactoryGithubRuleContext,
-  FactoryGithubRuleLeaf,
   FactoryLinearEventName,
   FactoryLinearRuleContext,
   FactoryLinearRuleLeaf,

--- a/mastracode/factory/src/rules/resolve.test.ts
+++ b/mastracode/factory/src/rules/resolve.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { defaultFactoryRules } from './defaults.js';
-import {
-  resolveFactoryGithubRule,
-  resolveFactoryLinearRule,
-  resolveFactoryStageRules,
-  resolveFactoryToolRule,
-} from './resolve.js';
+import { resolveFactoryLinearRule, resolveFactoryStageRules, resolveFactoryToolRule } from './resolve.js';
 
 describe('Factory rule resolution', () => {
   it('resolves a board stage transition in exit-before-enter order', () => {
@@ -88,22 +83,17 @@ describe('Factory rule resolution', () => {
 
   it('resolves open tool names and closed integration event leaves', () => {
     const onResult = vi.fn(() => undefined);
-    const onEvent = vi.fn(() => undefined);
     const onLinearEvent = vi.fn(() => undefined);
     const rules = defaultFactoryRules({
       version: 'resolve-v3',
       overrides: {
         tools: { submit_plan: { onResult } },
-        github: { pullRequestMerged: { onEvent } },
         linear: { issueObserved: { onEvent: onLinearEvent } },
       },
     });
 
     expect(resolveFactoryToolRule(rules, 'submit_plan')).toBe(onResult);
     expect(resolveFactoryToolRule(rules, 'unknown_tool')).toBeUndefined();
-    expect(resolveFactoryGithubRule(rules, 'pullRequestMerged')).toBe(onEvent);
-    expect(resolveFactoryGithubRule(rules, 'issueOpened')).toEqual(expect.any(Function));
-    expect(resolveFactoryGithubRule(rules, 'pullRequestUpdated')).toEqual(expect.any(Function));
     expect(resolveFactoryLinearRule(rules, 'issueObserved')).toBe(onLinearEvent);
   });
 });

--- a/mastracode/factory/src/rules/resolve.ts
+++ b/mastracode/factory/src/rules/resolve.ts
@@ -1,7 +1,5 @@
 import type { BoardRegistry } from '../boards/index.js';
 import type {
-  FactoryGithubEventName,
-  FactoryGithubRuleLeaf,
   FactoryLinearEventName,
   FactoryLinearRuleLeaf,
   FactoryRuleHandler,
@@ -52,13 +50,6 @@ export function resolveFactoryStageRules(
 
 export function resolveFactoryToolRule(rules: FactoryRules, toolName: string): FactoryToolRuleLeaf['onResult'] {
   return rules.tools[toolName]?.onResult;
-}
-
-export function resolveFactoryGithubRule(
-  rules: FactoryRules,
-  event: FactoryGithubEventName,
-): FactoryGithubRuleLeaf['onEvent'] {
-  return rules.github[event]?.onEvent;
 }
 
 export function resolveFactoryLinearRule(

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -297,10 +297,6 @@ export interface FactoryToolRuleLeaf {
   onResult?: FactoryRuleHandler<FactoryToolResultRuleContext>;
 }
 
-export interface FactoryGithubRuleLeaf {
-  onEvent?: FactoryRuleHandler<FactoryGithubRuleContext>;
-}
-
 export interface FactoryLinearRuleLeaf {
   onEvent?: FactoryRuleHandler<FactoryLinearRuleContext>;
 }
@@ -312,7 +308,6 @@ export interface FactoryRules {
   work: FactoryBoardRules;
   review: FactoryBoardRules;
   tools: Record<string, FactoryToolRuleLeaf>;
-  github: Partial<Record<FactoryGithubEventName, FactoryGithubRuleLeaf>>;
   linear: Partial<Record<FactoryLinearEventName, FactoryLinearRuleLeaf>>;
 }
 
@@ -320,7 +315,6 @@ export interface FactoryRulesOverrides {
   work?: FactoryBoardRules;
   review?: FactoryBoardRules;
   tools?: Record<string, FactoryToolRuleLeaf>;
-  github?: Partial<Record<FactoryGithubEventName, FactoryGithubRuleLeaf>>;
   linear?: Partial<Record<FactoryLinearEventName, FactoryLinearRuleLeaf>>;
 }
 

--- a/mastracode/factory/src/rules/validation.test.ts
+++ b/mastracode/factory/src/rules/validation.test.ts
@@ -250,7 +250,8 @@ describe('Factory rule validation', () => {
         ...rules,
         github: { madeUpEvent: { onEvent: () => undefined } },
       }),
-    ).toThrow(/GitHub event is invalid/i);
+    ).toThrow(/GitHub integration constructor/i);
+    expect(() => assertFactoryRules({ ...rules, github: undefined })).toThrow(/GitHub integration constructor/i);
     expect(() =>
       assertFactoryRules({
         ...rules,

--- a/mastracode/factory/src/rules/validation.test.ts
+++ b/mastracode/factory/src/rules/validation.test.ts
@@ -250,8 +250,8 @@ describe('Factory rule validation', () => {
         ...rules,
         github: { madeUpEvent: { onEvent: () => undefined } },
       }),
-    ).toThrow(/GitHub integration constructor/i);
-    expect(() => assertFactoryRules({ ...rules, github: undefined })).toThrow(/GitHub integration constructor/i);
+    ).toThrow(/unsupported field/i);
+    expect(() => assertFactoryRules({ ...rules, github: undefined })).toThrow(/unsupported field/i);
     expect(() =>
       assertFactoryRules({
         ...rules,

--- a/mastracode/factory/src/rules/validation.ts
+++ b/mastracode/factory/src/rules/validation.ts
@@ -153,11 +153,6 @@ function validateBoardRules(rules: unknown, label: string): asserts rules is Fac
 
 export function assertFactoryRules(rules: unknown): asserts rules is FactoryRules {
   if (!isPlainObject(rules)) throw new FactoryRuleValidationError('Factory rules must be an object.');
-  if ('github' in rules) {
-    throw new FactoryRuleValidationError(
-      'Factory rules.github is no longer supported. Configure rules[event] on the GitHub integration constructor instead.',
-    );
-  }
   assertExactKeys(rules, ['version', 'work', 'review', 'tools', 'linear'], 'Factory rules');
   boundedString(rules.version, 'Factory rule version', MAX_VERSION_LENGTH);
   validateBoardRules(rules.work, 'Factory rules.work');

--- a/mastracode/factory/src/rules/validation.ts
+++ b/mastracode/factory/src/rules/validation.ts
@@ -1,10 +1,4 @@
-import {
-  FACTORY_GITHUB_EVENTS,
-  FACTORY_LINEAR_EVENTS,
-  FACTORY_RULE_BOARDS,
-  FACTORY_RULE_SOURCES,
-  FACTORY_RULE_STAGES,
-} from './types.js';
+import { FACTORY_LINEAR_EVENTS, FACTORY_RULE_BOARDS, FACTORY_RULE_SOURCES, FACTORY_RULE_STAGES } from './types.js';
 import type {
   FactoryBoardRules,
   FactoryCommitDecision,
@@ -159,7 +153,12 @@ function validateBoardRules(rules: unknown, label: string): asserts rules is Fac
 
 export function assertFactoryRules(rules: unknown): asserts rules is FactoryRules {
   if (!isPlainObject(rules)) throw new FactoryRuleValidationError('Factory rules must be an object.');
-  assertExactKeys(rules, ['version', 'work', 'review', 'tools', 'github', 'linear'], 'Factory rules');
+  if ('github' in rules) {
+    throw new FactoryRuleValidationError(
+      'Factory rules.github is no longer supported. Configure rules[event] on the GitHub integration constructor instead.',
+    );
+  }
+  assertExactKeys(rules, ['version', 'work', 'review', 'tools', 'linear'], 'Factory rules');
   boundedString(rules.version, 'Factory rule version', MAX_VERSION_LENGTH);
   validateBoardRules(rules.work, 'Factory rules.work');
   validateBoardRules(rules.review, 'Factory rules.review');
@@ -172,16 +171,6 @@ export function assertFactoryRules(rules: unknown): asserts rules is FactoryRule
     assertExactKeys(leaf, ['onResult'], `Factory rules.tools.${toolName}`);
     if (leaf.onResult !== undefined && typeof leaf.onResult !== 'function') {
       throw new FactoryRuleValidationError(`Factory rules.tools.${toolName}.onResult must be a function.`);
-    }
-  }
-
-  if (!isPlainObject(rules.github)) throw new FactoryRuleValidationError('Factory rules.github must be an object.');
-  for (const [event, leaf] of Object.entries(rules.github)) {
-    enumValue(event, FACTORY_GITHUB_EVENTS, 'Factory GitHub event');
-    if (!isPlainObject(leaf)) throw new FactoryRuleValidationError(`Factory rules.github.${event} must be an object.`);
-    assertExactKeys(leaf, ['onEvent'], `Factory rules.github.${event}`);
-    if (leaf.onEvent !== undefined && typeof leaf.onEvent !== 'function') {
-      throw new FactoryRuleValidationError(`Factory rules.github.${event}.onEvent must be a function.`);
     }
   }
 

--- a/mastracode/web/src/mastra/index.test.ts
+++ b/mastracode/web/src/mastra/index.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Hono } from 'hono';
 import type * as factoryModule from '@mastra/factory';
-import { resolveFactoryGithubRule } from '@mastra/factory/rules/resolve';
 
 const factoryConfigs = vi.hoisted(() => [] as Array<ConstructorParameters<typeof factoryModule.MastraFactory>[0]>);
 vi.mock('@mastra/factory', async importOriginal => {
@@ -97,8 +96,20 @@ describe('platform entry (src/mastra/index.ts)', () => {
     expect(factoryConfigs[0]?.dispatcher).toEqual({ maxInFlight: 7 });
   });
 
-  it('uses the production Factory rules to retriage linked issue updates without moving their stage', async () => {
+  it('uses the installed GitHub rules to retriage linked issue updates without moving their stage', async () => {
+    vi.stubEnv('GITHUB_APP_ID', '123');
+    vi.stubEnv('GITHUB_APP_PRIVATE_KEY', 'test-private-key');
+    vi.stubEnv('GITHUB_APP_CLIENT_ID', 'client-id');
+    vi.stubEnv('GITHUB_APP_CLIENT_SECRET', 'client-secret');
+    vi.stubEnv('GITHUB_APP_SLUG', 'factory-app');
+    vi.stubEnv('GITHUB_APP_WEBHOOK_SECRET', 'test-webhook-secret');
     const { factoryRules } = await import('./index.js');
+    const { GithubIntegration } = await import('@mastra/factory/integrations/github/integration');
+    const github = factoryConfigs[0]?.integrations?.find(
+      (integration): integration is InstanceType<typeof GithubIntegration> => integration instanceof GithubIntegration,
+    );
+    expect(github).toBeDefined();
+    if (!github) throw new Error('Expected the configured GitHub integration');
     const item = {
       id: 'issue-42',
       source: 'github-issue' as const,
@@ -120,8 +131,7 @@ describe('platform entry (src/mastra/index.ts)', () => {
       itemRevision: 3,
     };
 
-    const issueEdited = resolveFactoryGithubRule(factoryRules, 'issueEdited');
-    const issueCommentCreated = resolveFactoryGithubRule(factoryRules, 'issueCommentCreated');
+    const { issueEdited, issueCommentCreated } = github.rules;
 
     expect(
       issueEdited?.({


### PR DESCRIPTION
GitHub event rules now belong to each installed GithubIntegration or PlatformGithubIntegration, rather than global Factory configuration. Existing installations retain their default handlers. Constructor rules accept per-event replacements, null to disable a handler, and undefined to retain the default; each installation owns a validated, frozen copy.

Move global rules.github[event].onEvent to the GitHub constructor rules[event]. Work, Review, tool, and Linear configuration are unchanged, and GitHub evaluations retain shared audit-version metadata and durable replay semantics. Package documentation, configuration guidance, and a changeset cover the API change.

Test plan completed: focused GitHub/rules suite and full Factory suite (2,120 passed, 6 skipped), plus web consumer tests (15 passed). Factory TypeScript check, lint, changed-file formatting, library build, and dist import smoke test all passed. Regression coverage includes constructor isolation, replacement-only decisions, disabled ingress bookkeeping, and issue reconciliation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Each GitHub integration can now choose its own event behavior. It can use default handlers, replace individual handlers, or disable them without affecting other integrations.

## Changes

- Added validated, immutable GitHub event rules for `GithubIntegration` and `PlatformGithubIntegration`.
- Added support for custom handlers, `null` to disable handlers, and `undefined` or omitted values to keep defaults.
- Removed GitHub rules from global `FactoryRules`.
- Preserved shared audit-version metadata and durable replay behavior.
- Kept Work, Review, tool, and Linear rules unchanged.
- Removed obsolete global GitHub rule types and resolver exports.
- Added documentation, migration guidance, and a changeset.
- Added coverage for rule isolation, validation, disabled handlers, replacement behavior, issue reconciliation, and Platform GitHub flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->