### PR TITLE
fix(convex): preserve snapshot creation time in atomic upserts

### DIFF
--- a/.changeset/cozy-dodos-win.md
+++ b/.changeset/cozy-dodos-win.md
@@ -2,4 +2,4 @@
 '@mastra/convex': patch
 ---
 
-Fixed workflow snapshot saves to preserve their original creation time atomically, removing a redundant read before each save. Redeploy the Convex server functions before upgrading the application runtime so both sides use the updated snapshot upsert behavior.
+Fixed single and batched workflow snapshot saves to preserve their original creation time atomically, removing a redundant read before each full snapshot save. Redeploy the Convex server functions before upgrading the application runtime so both sides use the updated snapshot upsert behavior.

--- a/.changeset/cozy-dodos-win.md
+++ b/.changeset/cozy-dodos-win.md
@@ -1,0 +1,5 @@
+---
+'@mastra/convex': patch
+---
+
+Fixed workflow snapshot saves to preserve their original creation time atomically, removing a redundant read before each save. Redeploy the Convex server functions before upgrading the application runtime so both sides use the updated snapshot upsert behavior.

--- a/stores/convex/src/server/storage.test.ts
+++ b/stores/convex/src/server/storage.test.ts
@@ -143,12 +143,12 @@ describe('mastraStorage typed load', () => {
   });
 });
 
-describe('mastraStorage workflow snapshot upsert', () => {
+describe.each(['insert', 'batchInsert'] as const)('mastraStorage workflow snapshot %s', op => {
   it.each([
     ['mastra_workflow_snapshots', TABLE_WORKFLOW_SNAPSHOT, '2026-05-15T00:00:00.000Z', '2026-05-15T00:00:00.000Z'],
     ['mastra_workflow_snapshots', TABLE_WORKFLOW_SNAPSHOT, undefined, '2026-05-16T00:00:00.000Z'],
     ['mastra_threads', TABLE_THREADS, '2026-05-15T00:00:00.000Z', '2026-05-16T00:00:00.000Z'],
-  ] as const)('upserts %s with existing createdAt %s', async (table, tableName, createdAt, expectedCreatedAt) => {
+  ] as const)('upserts %s (%s) with existing createdAt %s', async (table, tableName, createdAt, expectedCreatedAt) => {
     const existing = { _id: asConvexId('existing-doc'), id: 'record-1', createdAt };
     const unique = vi.fn(async () => existing);
     const withIndex = vi.fn(() => ({ unique }));
@@ -161,7 +161,10 @@ describe('mastraStorage workflow snapshot upsert', () => {
       updatedAt: '2026-05-17T00:00:00.000Z',
     };
 
-    await handleTypedOperation(ctx, table, { op: 'insert', tableName, record });
+    await handleTypedOperation(ctx, table, {
+      tableName,
+      ...(op === 'insert' ? { op, record } : { op, records: [record] }),
+    });
 
     expect(withIndex).toHaveBeenCalledWith('by_record_id', expect.any(Function));
     expect(patch).toHaveBeenCalledExactlyOnceWith(existing._id, {
@@ -189,9 +192,8 @@ describe('mastraStorage workflow snapshot upsert', () => {
     };
 
     await handleTypedOperation(ctx, 'mastra_workflow_snapshots', {
-      op: 'insert',
       tableName: TABLE_WORKFLOW_SNAPSHOT,
-      record,
+      ...(op === 'insert' ? { op, record } : { op, records: [record] }),
     });
 
     expect(insert).toHaveBeenCalledExactlyOnceWith('mastra_workflow_snapshots', record);

--- a/stores/convex/src/server/storage.test.ts
+++ b/stores/convex/src/server/storage.test.ts
@@ -143,6 +143,61 @@ describe('mastraStorage typed load', () => {
   });
 });
 
+describe('mastraStorage workflow snapshot upsert', () => {
+  it.each([
+    ['mastra_workflow_snapshots', TABLE_WORKFLOW_SNAPSHOT, '2026-05-15T00:00:00.000Z', '2026-05-15T00:00:00.000Z'],
+    ['mastra_workflow_snapshots', TABLE_WORKFLOW_SNAPSHOT, undefined, '2026-05-16T00:00:00.000Z'],
+    ['mastra_threads', TABLE_THREADS, '2026-05-15T00:00:00.000Z', '2026-05-16T00:00:00.000Z'],
+  ] as const)('upserts %s with existing createdAt %s', async (table, tableName, createdAt, expectedCreatedAt) => {
+    const existing = { _id: asConvexId('existing-doc'), id: 'record-1', createdAt };
+    const unique = vi.fn(async () => existing);
+    const withIndex = vi.fn(() => ({ unique }));
+    const patch = vi.fn();
+    const ctx = { db: { query: vi.fn(() => ({ withIndex })), patch } } as unknown as TypedOperationCtx;
+    const record = {
+      id: 'record-1',
+      snapshot: JSON.stringify({ status: 'suspended', value: { checkpoint: 2 } }),
+      createdAt: '2026-05-16T00:00:00.000Z',
+      updatedAt: '2026-05-17T00:00:00.000Z',
+    };
+
+    await handleTypedOperation(ctx, table, { op: 'insert', tableName, record });
+
+    expect(withIndex).toHaveBeenCalledWith('by_record_id', expect.any(Function));
+    expect(patch).toHaveBeenCalledExactlyOnceWith(existing._id, {
+      snapshot: record.snapshot,
+      createdAt: expectedCreatedAt,
+      updatedAt: record.updatedAt,
+    });
+  });
+
+  it('retains the supplied creation time on the first snapshot insert', async () => {
+    const insert = vi.fn();
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({ withIndex: vi.fn(() => ({ unique: vi.fn(async () => null) })) })),
+        insert,
+      },
+    } as unknown as TypedOperationCtx;
+    const record = {
+      id: 'workflow-a-run-1',
+      workflow_name: 'workflow-a',
+      run_id: 'run-1',
+      snapshot: '{}',
+      createdAt: '2026-05-15T00:00:00.000Z',
+      updatedAt: '2026-05-16T00:00:00.000Z',
+    };
+
+    await handleTypedOperation(ctx, 'mastra_workflow_snapshots', {
+      op: 'insert',
+      tableName: TABLE_WORKFLOW_SNAPSHOT,
+      record,
+    });
+
+    expect(insert).toHaveBeenCalledExactlyOnceWith('mastra_workflow_snapshots', record);
+  });
+});
+
 describe('mastraStorage workflow snapshot merge operations', () => {
   function createWorkflowSnapshotCtx(snapshot: unknown, { missing = false }: { missing?: boolean } = {}) {
     const patches: Array<{ id: GenericId<string>; data: Record<string, unknown> }> = [];

--- a/stores/convex/src/server/storage.ts
+++ b/stores/convex/src/server/storage.ts
@@ -505,6 +505,9 @@ export async function handleTypedOperation(
       if (existing) {
         // Update existing - don't include id in patch (it's already set)
         const { id: _, ...updateData } = record;
+        if (convexTable === CONVEX_TABLE_WORKFLOW_SNAPSHOTS) {
+          updateData.createdAt = existing.createdAt ?? updateData.createdAt;
+        }
         await ctx.db.patch(existing._id, updateData);
       } else {
         // Insert new - include id as a regular field

--- a/stores/convex/src/server/storage.ts
+++ b/stores/convex/src/server/storage.ts
@@ -527,6 +527,9 @@ export async function handleTypedOperation(
 
         if (existing) {
           const { id: _, ...updateData } = record;
+          if (convexTable === CONVEX_TABLE_WORKFLOW_SNAPSHOTS) {
+            updateData.createdAt = existing.createdAt ?? updateData.createdAt;
+          }
           await ctx.db.patch(existing._id, updateData);
         } else {
           await ctx.db.insert(convexTable, record);

--- a/stores/convex/src/storage/domains/workflows/index.ts
+++ b/stores/convex/src/storage/domains/workflows/index.ts
@@ -71,12 +71,6 @@ export class WorkflowsConvex extends WorkflowsStorage {
     updatedAt?: Date;
   }): Promise<void> {
     const now = new Date();
-    // Check if a record already exists to preserve createdAt
-    const existing = await this.#db.load<{ createdAt?: string } | null>({
-      tableName: TABLE_WORKFLOW_SNAPSHOT,
-      keys: { workflow_name: workflowName, run_id: runId },
-    });
-
     await this.#db.insert({
       tableName: TABLE_WORKFLOW_SNAPSHOT,
       record: {
@@ -88,7 +82,7 @@ export class WorkflowsConvex extends WorkflowsStorage {
         // contain $schema/$ref/$defs/$id keys, so we serialize the snapshot here.
         // loadWorkflowSnapshot / ensureSnapshot already handle the string case.
         snapshot: JSON.stringify(snapshot),
-        createdAt: existing?.createdAt ?? (createdAt ? new Date(createdAt).toISOString() : now.toISOString()),
+        createdAt: createdAt ? new Date(createdAt).toISOString() : now.toISOString(),
         updatedAt: updatedAt ? new Date(updatedAt).toISOString() : now.toISOString(),
       },
     });

--- a/stores/convex/src/storage/domains/workflows/workflows.test.ts
+++ b/stores/convex/src/storage/domains/workflows/workflows.test.ts
@@ -24,8 +24,7 @@ type CapturedRequest = Extract<StorageRequest, { op: 'insert' }>;
 
 function createFakeClient() {
   const requests: StorageRequest[] = [];
-  // We mock callStorage directly. Pretend load returns null (no existing row),
-  // so persist takes the "insert new" branch.
+  // Capture storage requests without making network calls.
   const callStorage = vi.fn(async (request: StorageRequest) => {
     requests.push(request);
     if (request.op === 'load') return null;

--- a/stores/convex/src/storage/domains/workflows/workflows.test.ts
+++ b/stores/convex/src/storage/domains/workflows/workflows.test.ts
@@ -128,6 +128,38 @@ describe('WorkflowsConvex.persistWorkflowSnapshot — $-prefixed keys', () => {
   });
 });
 
+describe('WorkflowsConvex snapshot persistence', () => {
+  it('persists each checkpoint in one request without a client-side read', async () => {
+    const { client, requests } = createFakeClient();
+    const workflows = new WorkflowsConvex({ client });
+    const createdAt = new Date('2026-05-15T00:00:00.000Z');
+    const updatedAt = new Date('2026-05-16T00:00:00.000Z');
+    const snapshot = snapshotWithDollarKeys();
+
+    for (let checkpoint = 0; checkpoint < 2; checkpoint++) {
+      await workflows.persistWorkflowSnapshot({
+        workflowName: 'agentic-loop',
+        runId: 'run-1',
+        snapshot,
+        createdAt,
+        updatedAt,
+      });
+    }
+
+    expect(requests).toHaveLength(2);
+    for (const request of requests) {
+      expect(request).toMatchObject({
+        op: 'insert',
+        record: {
+          snapshot: JSON.stringify(snapshot),
+          createdAt: createdAt.toISOString(),
+          updatedAt: updatedAt.toISOString(),
+        },
+      });
+    }
+  });
+});
+
 describe('WorkflowsConvex atomic workflow updates', () => {
   it('advertises concurrent update support', () => {
     const { client } = createFakeClient();


### PR DESCRIPTION
Fixes #23118.

Supersedes #23119, which was automatically closed while the issue awaited triage and could not be reopened after the blocking label was removed.

A stale first-save request can overwrite a workflow snapshot's original `createdAt`. Preserve that timestamp inside the existing Convex transaction for both `insert` and `batchInsert`, and remove the client's pre-save lookup. Snapshot contents and `updatedAt` still update, and other typed tables keep their existing behavior. Each full snapshot save now takes one storage request instead of two; checkpoint persistence remains enabled.

The runtime change is +7/-7 lines across two files. Regression tests cover existing timestamps, first inserts, missing historical timestamps, unchanged thread upserts, both single and batched writes, and one request per checkpoint. The additional batch-write regression fails before the server fix and passes afterward. All 78 tests in `src/server/storage.test.ts` and `src/storage/domains/workflows/workflows.test.ts` pass. The targeted Convex package build, changed-file oxlint/ESLint, and formatting checks pass. Package-wide `tsc --noEmit -p tsconfig.json` still reports the same six diagnostics as the recorded untouched-main baseline in existing schema/observational-memory tests and memory imports.

The patch changeset documents the upgrade order: deploy the updated Convex server functions before upgrading the application runtime. Old clients remain compatible with the updated server. A new client against old server functions would lose timestamp preservation, so the server update must ship first. No schema migration is needed. This PR does not claim a measured production latency improvement.

Run the focused tests with `pnpm --dir stores/convex exec vitest run src/server/storage.test.ts src/storage/domains/workflows/workflows.test.ts`; no deployment credentials or model calls are required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The system now keeps the original creation time when it saves a workflow snapshot again. It also removes an extra lookup, so each full snapshot save uses one storage request.

## Changes

- Preserve existing `createdAt` values during single and batch workflow snapshot upserts.
- Preserve supplied `createdAt` values for new snapshots.
- Keep updating snapshot contents and `updatedAt`.
- Remove the client-side pre-save snapshot lookup.
- Keep unchanged timestamp behavior for thread upserts.
- Add regression tests for single writes, batch writes, first inserts, existing records, and request counts.
- Add a changeset that requires deploying updated Convex server functions before upgrading the application runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->