### PR TITLE
feat(factory): let Linear integrations own event rules

### DIFF
--- a/.changeset/yummy-ants-obey.md
+++ b/.changeset/yummy-ants-obey.md
@@ -1,0 +1,17 @@
+---
+'@mastra/factory': minor
+---
+
+Moved Linear event rules into `LinearIntegration` and `PlatformLinearIntegration`. Built-in handlers remain enabled without configuration. Constructor `rules` accept replacements or `null` to disable an event; omitted events retain defaults.
+
+Move former global `rules.linear[event].onEvent` values to the owning integration constructor:
+
+```typescript
+// Before: global Factory overrides
+const overrides = { linear: { issueClosed: { onEvent: null } } };
+
+// After: integration constructor options
+const linear = new PlatformLinearIntegration({ rules: { issueClosed: null } });
+```
+
+Both direct and platform integrations use their own handlers for fetched issues and reconciliation while preserving shared audit metadata.

--- a/mastracode/factory/README.md
+++ b/mastracode/factory/README.md
@@ -60,9 +60,44 @@ const overrides = { github: { issueCommentCreated: { onEvent: null } } };
 const github = new PlatformGithubIntegration({ rules: { issueCommentCreated: null } });
 ```
 
-Work, Review, tool, and Linear configuration remain unchanged. The global rule version remains shared audit metadata, including for GitHub evaluations; it is not a hash of custom handler code and does not change delivery replay semantics. Update the deployment-owned version when changing handler behavior.
+Work, Review, and tool configuration remain global. The global rule version remains shared audit metadata, including for GitHub evaluations; it is not a hash of custom handler code and does not change delivery replay semantics. Update the deployment-owned version when changing handler behavior.
 
 Handlers receive the existing typed GitHub context and return one decision or `undefined`. External titles, bodies, and comments remain untrusted data after webhook authentication. Custom handlers must preserve any required actor-permission checks explicitly.
+
+### Linear event rules
+
+Both `LinearIntegration` and `PlatformLinearIntegration` automatically install the built-in `issueObserved` and `issueClosed` handlers. No default-rule imports or configuration are needed, including for `new PlatformLinearIntegration()` or direct construction with credentials only.
+
+```typescript
+import { PlatformLinearIntegration } from '@mastra/factory/integrations/platform/linear/integration';
+
+const linear = new PlatformLinearIntegration({
+  rules: {
+    issueObserved: context => ({
+      type: 'reject',
+      code: 'manual_intake',
+      reason: 'This deployment manages issue intake manually.',
+    }),
+    issueClosed: null,
+  },
+});
+```
+
+Install `linear` in `MastraFactory`'s `integrations` array. The direct `LinearIntegration` accepts the same `rules` option alongside `clientId` and `clientSecret`. A function replaces one default handler without composition; `null` disables that handler, not issue ingestion or reconciliation bookkeeping. Omitted events and `undefined` retain defaults. Both constructors validate event names and handler values, then copy and freeze an isolated resolved map.
+
+**Migration:** Move global `rules.linear[event].onEvent` values into the owning integration constructor's `rules[event]` option:
+
+```typescript
+// Before: global Factory rule overrides
+const overrides = { linear: { issueClosed: { onEvent: null } } };
+
+// After: Linear integration constructor options
+const linear = new PlatformLinearIntegration({ rules: { issueClosed: null } });
+```
+
+Linear event handlers are configured exclusively on the integration. Fetched issues, platform polling, and issue reconciliation use that instance's handlers. Defaults create intake items for observed open issues and close linked non-terminal Work items as Done or Canceled; closed unlinked issues do not create new items. Custom handlers receive the existing typed Linear context and return one decision or `undefined`. Treat issue titles, descriptions, and other external content as untrusted data.
+
+The global rule version remains shared audit metadata for Linear evaluations. Update the deployment-owned version when handler behavior changes; it does not change ingress identity or replay semantics.
 
 ### GitHub review commands
 

--- a/mastracode/factory/factory-skills/configure-factory-rules/SKILL.md
+++ b/mastracode/factory/factory-skills/configure-factory-rules/SKILL.md
@@ -9,29 +9,29 @@ Help the user change Factory policy in the typed deployment configuration. Facto
 
 ## Find the configuration
 
-1. Search for `new MastraFactory`, `defaultFactoryRules`, and the `rules` property.
+1. Search for `new MastraFactory`, `defaultFactoryRules`, and the installed `GithubIntegration`, `PlatformGithubIntegration`, `LinearIntegration`, or `PlatformLinearIntegration` constructors and their `rules` options.
 2. Read the existing rule configuration and its tests before editing.
 3. Import rule helpers and types from the same local Factory module used by the deployment.
-4. For board, tool, or Linear rules, start with `defaultFactoryRules({ version, overrides })` if needed and pass the result to `MastraFactory`. For GitHub rules, configure the installed GitHub integration constructor directly.
+4. For board or tool rules, start with `defaultFactoryRules({ version, overrides })` if needed and pass the result to `MastraFactory`. For GitHub or Linear rules, configure the installed integration constructor directly.
 
 Do not guess a file path. Factory deployments can assemble `MastraFactory` from different entry points.
 
 ## Preserve the public shape
 
-Use the global rules tree for board, tool, and Linear handlers:
+Use the global rules tree for board and tool handlers:
 
 - `work.<stage>.<source>.onEnter` or `onExit`
 - `review.<stage>.<source>.onEnter` or `onExit`
 - `tools.<toolName>.onResult`
-- `linear.<event>.onEvent`
 
-Configure GitHub on the installed `GithubIntegration` or `PlatformGithubIntegration` constructor instead:
+Configure GitHub on the installed `GithubIntegration` or `PlatformGithubIntegration` constructor, and Linear on `LinearIntegration` or `PlatformLinearIntegration`, instead:
 
 ```typescript
 new PlatformGithubIntegration({ rules: { issueCommentCreated: null } });
+new PlatformLinearIntegration({ rules: { issueClosed: null } });
 ```
 
-GitHub integrations exclusively own their event handlers; configure them through constructor `rules[event]`, not the global Factory rules tree. A function replaces the default, `null` disables that event's handler, and omitted or `undefined` values retain defaults. Constructors validate names and handler values, then copy and freeze the effective map per instance. Disabling a handler does not disable webhook authentication or reconciliation bookkeeping.
+GitHub and Linear integrations exclusively own their event handlers; configure them through constructor `rules[event]`, not the global Factory rules tree. Move former `rules.linear[event].onEvent` values to the Linear constructor's `rules[event]`. Every built-in handler is enabled automatically; never import or spread defaults just to install an integration. A function replaces the default, `null` disables that event's handler, and omitted or `undefined` values retain defaults. Constructors validate names and handler values, then copy and freeze the effective map per instance. Disabling a handler does not disable authentication, ingestion, or reconciliation bookkeeping. Linear fetch, platform polling, and reconciliation all use the owning instance's handlers.
 
 Do not create an `actions` config or execute authoritative policy in React. Each handler returns one typed `FactoryRuleDecision` or `undefined`.
 
@@ -43,7 +43,7 @@ An override replaces the exact handler leaf. It does not compose with the built-
 
 Before replacing a built-in leaf:
 
-1. Find and read the built-in handler: GitHub handlers live in `src/integrations/github/default-rules.ts` within the Factory package; global defaults live in `src/rules/defaults.ts`.
+1. Find and read the built-in handler: GitHub handlers live in `src/integrations/github/default-rules.ts`, Linear handlers in `src/integrations/linear/default-rules.ts`, and global defaults in `src/rules/defaults.ts` within the Factory package.
 2. Decide whether the replacement must preserve part of that behavior explicitly.
 3. Use only fields exposed by the typed context. Do not reach into Factory storage or raw webhook payloads.
 4. Return `undefined` to allow the ingress with no decision, or return a typed rejection or bounded structured decision.

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -369,7 +369,7 @@ describe('MastraFactory.prepare', () => {
     expect(rules?.review.review?.pullRequest?.onEnter).toBeTypeOf('function');
     expect(rules?.tools.submit_plan?.onResult).toBeTypeOf('function');
     expect(rules).not.toHaveProperty('github');
-    expect(rules?.linear.issueObserved?.onEvent).toBeTypeOf('function');
+    expect(rules).not.toHaveProperty('linear');
   });
 
   it('threads explicitly configured Factory rules without composing handler leaves', async () => {

--- a/mastracode/factory/src/integrations/issue-reconciler.test.ts
+++ b/mastracode/factory/src/integrations/issue-reconciler.test.ts
@@ -7,7 +7,7 @@ import { resolveGithubRules } from './github/default-rules.js';
 import type { GithubRuleOverrides } from './github/default-rules.js';
 import { createGithubIssueReconciler } from './github/issue-reconciler.js';
 import type { GithubIssueFetcher, ReconcileIssueState } from './github/rules.js';
-import type { LinearIntegration } from './linear/integration.js';
+import { resolveLinearRules } from './linear/default-rules.js';
 import { attachLinearIssueReconciler } from './linear/issue-reconciler.js';
 
 function issue(overrides: Partial<IntakeIssueDetail> = {}): IntakeIssueDetail {
@@ -265,43 +265,60 @@ describe('issue reconcilers', () => {
     expect(updated?.metadata).toMatchObject({ author: 'stored author', labels: ['stored'], assignees: ['new'] });
   });
 
-  it('replays canceled Linear issues through rules ingress', async () => {
-    const seeded = await createFactoryStorageForTests();
-    const project = await seeded.projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'Factory' } });
-    await seeded.workItems.upsert({
-      orgId: project.orgId,
-      userId: project.createdBy,
-      factoryProjectId: project.id,
-      input: {
-        externalSource: {
-          integrationId: 'linear',
-          type: 'issue',
-          externalId: 'linear:ENG-42',
-          url: 'https://linear.app/acme/issue/ENG-42',
+  it.each(['default', 'replacement', 'disabled'] as const)(
+    'replays canceled Linear issues with %s instance rules',
+    async mode => {
+      const seeded = await createFactoryStorageForTests();
+      const project = await seeded.projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'Factory' } });
+      await seeded.workItems.upsert({
+        orgId: project.orgId,
+        userId: project.createdBy,
+        factoryProjectId: project.id,
+        input: {
+          externalSource: {
+            integrationId: 'linear',
+            type: 'issue',
+            externalId: 'linear:ENG-42',
+            url: 'https://linear.app/acme/issue/ENG-42',
+          },
+          title: 'ENG-42: Issue',
+          stages: ['planning'],
+          sessions: {},
+          metadata: { linearIssueId: 'linear-uuid' },
         },
-        title: 'ENG-42: Issue',
-        stages: ['planning'],
-        sessions: {},
-        metadata: { linearIssueId: 'linear-uuid' },
-      },
-    });
-    const intake = {
-      resolveIntakeDispatch: vi
-        .fn()
-        .mockResolvedValue({ connection: { type: 'oauth', accessToken: 'token' }, issueId: 'linear-uuid' }),
-      getIssue: vi.fn().mockResolvedValue(issue({ state: 'Canceled', stateType: 'canceled' })),
-    } as unknown as Intake;
-    const reconcile = attachLinearIssueReconciler(
-      { intake } as Pick<LinearIntegration, 'intake'>,
-      {
-        storage: { projects: seeded.projects },
-        rules: { config: builtInFactoryRules(), workItems: seeded.workItems },
-      } as never,
-    );
+      });
+      const intake = {
+        resolveIntakeDispatch: vi
+          .fn()
+          .mockResolvedValue({ connection: { type: 'oauth', accessToken: 'token' }, issueId: 'linear-uuid' }),
+        getIssue: vi.fn().mockResolvedValue(issue({ state: 'Canceled', stateType: 'canceled' })),
+      } as unknown as Intake;
+      const replacement = vi.fn(() => ({
+        type: 'notify' as const,
+        idempotencyKey: 'reconciled-linear',
+        title: 'Closed issue',
+      }));
+      const reconcile = attachLinearIssueReconciler(
+        {
+          intake,
+          rules: resolveLinearRules(
+            mode === 'default' ? undefined : { issueClosed: mode === 'disabled' ? null : replacement },
+          ),
+        },
+        {
+          storage: { projects: seeded.projects },
+          rules: { config: builtInFactoryRules(), workItems: seeded.workItems },
+        } as never,
+      );
 
-    await expect(reconcile?.()).resolves.toMatchObject({ checked: 1, closed: 1, updated: 0 });
-    const decisions = await seeded.workItems.listDeferredDecisions('org-1', project.id);
-    expect(decisions).toHaveLength(1);
-    expect(decisions[0]?.decision).toMatchObject({ type: 'transition', stage: 'canceled' });
-  });
+      await expect(reconcile?.()).resolves.toMatchObject({ checked: 1, closed: 1, updated: 0 });
+      const decisions = await seeded.workItems.listDeferredDecisions('org-1', project.id);
+      expect(decisions).toHaveLength(mode === 'disabled' ? 0 : 1);
+      if (mode === 'default') expect(decisions[0]?.decision).toMatchObject({ type: 'transition', stage: 'canceled' });
+      if (mode === 'replacement') {
+        expect(replacement).toHaveBeenCalledOnce();
+        expect(decisions[0]?.decision).toMatchObject({ type: 'notify', title: 'Closed issue' });
+      }
+    },
+  );
 });

--- a/mastracode/factory/src/integrations/linear/default-rules.test.ts
+++ b/mastracode/factory/src/integrations/linear/default-rules.test.ts
@@ -33,6 +33,26 @@ describe('Linear rule resolution', () => {
     expect(resolveLinearRules().issueObserved).toBe(defaultLinearRules.issueObserved);
   });
 
+  it('accepts null-prototype rule maps', () => {
+    const overrides = Object.assign(Object.create(null), { issueObserved: null });
+    const resolved = resolveLinearRules(overrides);
+    expect(resolved.issueObserved).toBeNull();
+    expect(resolved.issueClosed).toBe(defaultLinearRules.issueClosed);
+    expect(Object.isFrozen(resolved)).toBe(true);
+  });
+
+  it.each([
+    new Map([['issueObserved', null]]),
+    new Date(0),
+    new Set(['issueObserved']),
+    new (class {
+      issueObserved = null;
+    })(),
+  ])('rejects non-plain rule maps %j', overrides => {
+    // @ts-expect-error Exercise invalid runtime configuration.
+    expect(() => resolveLinearRules(overrides)).toThrow(/plain object/);
+  });
+
   it.each([
     null,
     [],

--- a/mastracode/factory/src/integrations/linear/default-rules.test.ts
+++ b/mastracode/factory/src/integrations/linear/default-rules.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { defaultLinearRules, resolveLinearRules } from './default-rules.js';
+
+describe('Linear rule resolution', () => {
+  it.each(['issueObserved', 'issueClosed'] as const)('preserves the default for %s', event => {
+    expect(resolveLinearRules()[event]).toBe(defaultLinearRules[event]);
+    expect(resolveLinearRules({ [event]: undefined })[event]).toBe(defaultLinearRules[event]);
+  });
+
+  it.each(['issueObserved', 'issueClosed'] as const)('replaces or disables only %s', event => {
+    const handler = vi.fn();
+    const sibling = event === 'issueObserved' ? 'issueClosed' : 'issueObserved';
+    const replaced = resolveLinearRules({ [event]: handler });
+    expect(replaced[event]).toBe(handler);
+    expect(replaced[sibling]).toBe(defaultLinearRules[sibling]);
+    const disabled = resolveLinearRules({ [event]: null });
+    expect(disabled[event]).toBeNull();
+    expect(disabled[sibling]).toBe(defaultLinearRules[sibling]);
+  });
+
+  it('copies and freezes maps independently of caller mutation', () => {
+    const original = vi.fn();
+    const overrides = { issueObserved: original };
+    const first = resolveLinearRules(overrides);
+    overrides.issueObserved = vi.fn();
+    const second = resolveLinearRules(overrides);
+    expect(first.issueObserved).toBe(original);
+    expect(second.issueObserved).toBe(overrides.issueObserved);
+    expect(first).not.toBe(second);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Object.isFrozen(second)).toBe(true);
+    expect(Reflect.set(first, 'issueClosed', null)).toBe(false);
+    expect(resolveLinearRules().issueObserved).toBe(defaultLinearRules.issueObserved);
+  });
+
+  it.each([
+    null,
+    [],
+    'rules',
+    { unknown: null },
+    { toString: null },
+    { issueObserved: false },
+    { issueClosed: {} },
+    { [Symbol('event')]: null },
+  ])('rejects invalid configuration %j', overrides => {
+    // @ts-expect-error Exercise invalid configuration from JavaScript callers.
+    expect(() => resolveLinearRules(overrides)).toThrow();
+  });
+});

--- a/mastracode/factory/src/integrations/linear/default-rules.ts
+++ b/mastracode/factory/src/integrations/linear/default-rules.ts
@@ -61,8 +61,14 @@ export const defaultLinearRules = Object.freeze({
 } satisfies LinearEventRules);
 
 export function resolveLinearRules(overrides?: LinearRuleOverrides): LinearEventRules {
-  if (overrides !== undefined && (overrides === null || typeof overrides !== 'object' || Array.isArray(overrides))) {
-    throw new Error('Linear rules must be an object.');
+  if (
+    overrides !== undefined &&
+    (overrides === null ||
+      typeof overrides !== 'object' ||
+      Array.isArray(overrides) ||
+      ![Object.prototype, null].includes(Object.getPrototypeOf(overrides)))
+  ) {
+    throw new Error('Linear rules must be a plain object.');
   }
   const rules: Record<string, FactoryRuleHandler<FactoryLinearRuleContext> | null> = { ...defaultLinearRules };
   for (const key of Reflect.ownKeys(overrides ?? {})) {

--- a/mastracode/factory/src/integrations/linear/default-rules.ts
+++ b/mastracode/factory/src/integrations/linear/default-rules.ts
@@ -1,0 +1,79 @@
+import type { FactoryLinearEventName, FactoryLinearRuleContext, FactoryRuleHandler } from '../../rules/types.js';
+
+export type LinearRuleOverrides = Partial<
+  Record<FactoryLinearEventName, FactoryRuleHandler<FactoryLinearRuleContext> | null | undefined>
+>;
+export type LinearEventRules = Readonly<
+  Record<FactoryLinearEventName, FactoryRuleHandler<FactoryLinearRuleContext> | null>
+>;
+
+function linearIssueObserved(context: FactoryLinearRuleContext) {
+  if (context.item) return;
+  return {
+    type: 'upsertLinkedWorkItem',
+    idempotencyKey: `${context.ingress.id}:issue-triage`,
+    board: 'work',
+    source: 'linear-issue',
+    sourceKey: `linear:${context.issue.identifier}`,
+    title: `${context.issue.identifier}: ${context.issue.title}`,
+    url: context.issue.url,
+    stage: 'triage',
+    metadata: {
+      linearIssueId: context.issue.id,
+      identifier: context.issue.identifier,
+      sourceCreatedAt: context.issue.createdAt,
+      linearState: context.issue.state,
+      linearStateType: context.issue.stateType,
+      linearPriority: context.issue.priorityLabel,
+      linearAssignee: context.issue.assignee,
+      linearCreator: context.issue.creator,
+      linearTeam: context.issue.team,
+      labels: [...context.issue.labels] as string[],
+      ...(context.issue.assignee ? { assignee: context.issue.assignee } : {}),
+      ...(context.issue.creator ? { creator: context.issue.creator, author: context.issue.creator } : {}),
+    },
+  } as const;
+}
+
+function linearIssueClosed(context: FactoryLinearRuleContext) {
+  if (!context.item || context.item.source !== 'linear-issue') return;
+  if (context.board !== 'work') return;
+  // Already off the board: nothing to reconcile.
+  if (context.item.stages.some(stage => stage === 'done' || stage === 'canceled')) return;
+  // Only terminal state types trigger close.
+  const stateType = context.issue.stateType;
+  if (stateType !== 'completed' && stateType !== 'canceled') return;
+  const canceled = stateType === 'canceled';
+  return {
+    type: 'transition',
+    idempotencyKey: `${context.ingress.id}:issue-closed`,
+    board: 'work',
+    stage: canceled ? 'canceled' : 'done',
+    message: {
+      text: `Linear issue ${context.issue.identifier} was ${canceled ? 'canceled' : 'completed'}; this Work card was moved to ${canceled ? 'Canceled' : 'Done'}.`,
+    },
+  } as const;
+}
+
+export const defaultLinearRules = Object.freeze({
+  issueObserved: linearIssueObserved,
+  issueClosed: linearIssueClosed,
+} satisfies LinearEventRules);
+
+export function resolveLinearRules(overrides?: LinearRuleOverrides): LinearEventRules {
+  if (overrides !== undefined && (overrides === null || typeof overrides !== 'object' || Array.isArray(overrides))) {
+    throw new Error('Linear rules must be an object.');
+  }
+  const rules: Record<string, FactoryRuleHandler<FactoryLinearRuleContext> | null> = { ...defaultLinearRules };
+  for (const key of Reflect.ownKeys(overrides ?? {})) {
+    if (typeof key !== 'string' || !Object.hasOwn(defaultLinearRules, key)) {
+      throw new Error(`Unknown Linear rule event: ${String(key)}.`);
+    }
+    const handler = overrides?.[key as FactoryLinearEventName];
+    if (handler !== undefined && handler !== null && typeof handler !== 'function') {
+      throw new Error(`Linear rule ${key} must be a function, null, or undefined.`);
+    }
+    if (handler !== undefined) rules[key] = handler;
+  }
+  return Object.freeze(rules) as LinearEventRules;
+}

--- a/mastracode/factory/src/integrations/linear/integration.test.ts
+++ b/mastracode/factory/src/integrations/linear/integration.test.ts
@@ -8,6 +8,7 @@ vi.mock('../issue-reconcile-worker.js', () => ({
   },
 }));
 
+import { defaultLinearRules } from './default-rules.js';
 import { LinearIntegration } from './integration.js';
 import type { LinearIssue, LinearIssueDetail } from './integration.js';
 
@@ -40,6 +41,29 @@ afterEach(() => {
 });
 
 describe('LinearIntegration capability surface', () => {
+  it('owns isolated immutable rules with defaults and constructor overrides', () => {
+    const handler = vi.fn();
+    const rules = { issueObserved: handler, issueClosed: null };
+    const first = new LinearIntegration({ clientId: 'client', clientSecret: 'secret', rules });
+    rules.issueObserved = vi.fn();
+    expect(first.rules.issueObserved).toBe(handler);
+    expect(first.rules.issueClosed).toBeNull();
+    expect(Object.isFrozen(first.rules)).toBe(true);
+    expect(integration().rules).toEqual(defaultLinearRules);
+  });
+
+  it('validates rules at construction', () => {
+    expect(
+      () =>
+        new LinearIntegration({
+          clientId: 'client',
+          clientSecret: 'secret',
+          // @ts-expect-error Validate JavaScript configuration at the boundary.
+          rules: { issueObserved: false },
+        }),
+    ).toThrow(/must be a function/);
+  });
+
   it('normalizes Linear issues through the shared Intake contract', async () => {
     const linear = integration();
     const listActiveIssues = vi

--- a/mastracode/factory/src/integrations/linear/integration.ts
+++ b/mastracode/factory/src/integrations/linear/integration.ts
@@ -38,6 +38,8 @@ import type { FactoryProjectsStorage } from '../../storage/domains/projects/base
 import type { FactoryIntegration, IntegrationContext, IntegrationTools } from '../base.js';
 import { IssueReconcileWorker } from '../issue-reconcile-worker.js';
 import { buildLinearAgentTools } from './agent-tools.js';
+import type { LinearEventRules, LinearRuleOverrides } from './default-rules.js';
+import { resolveLinearRules } from './default-rules.js';
 import { attachLinearIssueReconciler } from './issue-reconciler.js';
 import { linearIssueReconciliationEnabled, linearIssueReconciliationInterval } from './reconciliation-config.js';
 import { buildLinearRoutes } from './routes.js';
@@ -48,8 +50,10 @@ const LINEAR_GRAPHQL_URL = 'https://api.linear.app/graphql';
 const LINEAR_TOKEN_URL = 'https://api.linear.app/oauth/token';
 const LINEAR_AUTHORIZE_URL = 'https://linear.app/oauth/authorize';
 
-/** Credentials for the Linear OAuth application. All fields are required. */
+/** Credentials and optional event rules for the Linear OAuth application. */
 export interface LinearIntegrationConfig {
+  /** Per-event replacements; omitted events retain defaults, null disables. */
+  rules?: LinearRuleOverrides;
   /** OAuth client id of the Linear application. */
   clientId: string;
   /** OAuth client secret of the Linear application. */
@@ -574,7 +578,14 @@ export class LinearIntegration implements FactoryIntegration {
   readonly #clientId: string;
   readonly #clientSecret: string;
 
+  readonly #rules: LinearEventRules;
+
+  get rules(): LinearEventRules {
+    return this.#rules;
+  }
+
   constructor(config: LinearIntegrationConfig) {
+    this.#rules = resolveLinearRules(config.rules);
     const missing = (['clientId', 'clientSecret'] as const).filter(key => !config[key]);
     if (missing.length > 0) {
       throw new Error(`LinearIntegration is missing required config: ${missing.join(', ')}.`);
@@ -1000,7 +1011,7 @@ export class LinearIntegration implements FactoryIntegration {
       baseUrl: ctx.baseUrl,
       intake: ctx.storage.intake,
       projects: ctx.storage.projects,
-      ingestFactoryIssues: attachLinearRules(ctx),
+      ingestFactoryIssues: attachLinearRules(this, ctx),
     });
   }
 

--- a/mastracode/factory/src/integrations/linear/issue-reconciler.ts
+++ b/mastracode/factory/src/integrations/linear/issue-reconciler.ts
@@ -26,7 +26,7 @@ function issueToIngress(issue: import('../../capabilities/intake.js').IntakeIssu
 }
 
 export function attachLinearIssueReconciler(
-  linear: Pick<LinearIntegration, 'intake'>,
+  linear: Pick<LinearIntegration, 'intake' | 'rules'>,
   context: IntegrationContext,
 ): LinearIssueReconciler | undefined {
   if (!context.rules || !linear.intake.resolveIntakeDispatch) return undefined;
@@ -35,6 +35,7 @@ export function attachLinearIssueReconciler(
     projects: context.storage.projects,
     storage: context.rules.workItems,
     rules: context.rules.config,
+    linearRules: linear.rules,
   });
 
   return createIssueReconciler({

--- a/mastracode/factory/src/integrations/linear/rules.test.ts
+++ b/mastracode/factory/src/integrations/linear/rules.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { builtInFactoryRules } from '../../rules/defaults.js';
 import { createFactoryStorageForTests } from '../../storage/test-utils.js';
+import { resolveLinearRules } from './default-rules.js';
+import type { LinearRuleOverrides } from './default-rules.js';
 import { LinearRules } from './rules.js';
 
 const issue = {
@@ -19,7 +21,7 @@ const issue = {
   updatedAt: '2026-07-02T00:00:00Z',
 };
 
-async function setup() {
+async function setup(overrides?: LinearRuleOverrides) {
   const seeded = await createFactoryStorageForTests();
   const project = await seeded.projects.create({
     orgId: 'org-1',
@@ -30,11 +32,123 @@ async function setup() {
     projects: seeded.projects,
     storage: seeded.workItems,
     rules: builtInFactoryRules(),
+    linearRules: resolveLinearRules(overrides),
   });
   return { project, service, workItems: seeded.workItems };
 }
 
 describe('LinearRules', () => {
+  it.each(['completed', 'canceled'])('closes linked issues in state %s with shared audit metadata', async stateType => {
+    const { project, service, workItems } = await setup();
+    await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        title: issue.title,
+        stages: ['planning'],
+        sessions: {},
+        externalSource: { integrationId: 'linear', type: 'issue', externalId: 'linear:ENG-42', url: issue.url },
+      },
+    });
+    const commit = vi.spyOn(workItems, 'commitRuleEvaluation');
+    await service.ingest({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      issues: [{ ...issue, stateType }],
+    });
+    expect(commit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ruleSetVersion: builtInFactoryRules().version,
+        ingress: { identity: `linear:${issue.id}:${issue.updatedAt}`, triggerType: 'linear.issueObserved' },
+      }),
+    );
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toMatchObject([
+      { decision: { type: 'transition', stage: stateType === 'completed' ? 'done' : 'canceled' } },
+    ]);
+  });
+
+  it.each(['completed', 'canceled'])(
+    'does not invoke overrides or create intake for unlinked %s issues',
+    async stateType => {
+      const handler = vi.fn();
+      const { project, service, workItems } = await setup({ issueClosed: handler });
+      await expect(
+        service.ingest({
+          orgId: 'org-1',
+          userId: 'user-1',
+          factoryProjectId: project.id,
+          issues: [{ ...issue, stateType }],
+        }),
+      ).resolves.toEqual({ status: 'missing', ingested: 1 });
+      expect(handler).not.toHaveBeenCalled();
+      expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual([]);
+    },
+  );
+
+  it('retains ingestion bookkeeping when an event is disabled', async () => {
+    const { project, service, workItems } = await setup({ issueObserved: null });
+    const input = { orgId: 'org-1', userId: 'user-1', factoryProjectId: project.id, issues: [issue] };
+    await expect(service.ingest(input)).resolves.toEqual({ status: 'committed', ingested: 1 });
+    await expect(service.ingest(input)).resolves.toEqual({ status: 'replayed', ingested: 1 });
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual([]);
+  });
+
+  it('persists replacement decisions without composing the default intake', async () => {
+    const handler = vi.fn(() => ({
+      type: 'notify' as const,
+      idempotencyKey: 'custom-notify',
+      title: 'Custom observation',
+    }));
+    const { project, service, workItems } = await setup({ issueObserved: handler });
+    const commit = vi.spyOn(workItems, 'commitRuleEvaluation');
+    const input = { orgId: 'org-1', userId: 'user-1', factoryProjectId: project.id, issues: [issue] };
+    await service.ingest(input);
+    await service.ingest(input);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(commit).toHaveBeenCalledWith(expect.objectContaining({ outcome: { status: 'accepted' } }));
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toMatchObject([
+      { decision: { type: 'notify', idempotencyKey: 'custom-notify' } },
+    ]);
+  });
+
+  it.each(['throw', 'invalid', 'timeout'] as const)(
+    'records %s handler failures without dispatching decisions',
+    async failure => {
+      const handler = () => {
+        if (failure === 'throw') throw new Error('handler failed');
+        if (failure === 'timeout') return new Promise<never>(() => {});
+        return { type: 'notify' as const, idempotencyKey: '', title: 'invalid decision' };
+      };
+      const { project, service, workItems } = await setup({ issueObserved: handler });
+      const commit = vi.spyOn(workItems, 'commitRuleEvaluation');
+      if (failure === 'timeout') vi.useFakeTimers();
+      try {
+        const pending = service.ingest({
+          orgId: 'org-1',
+          userId: 'user-1',
+          factoryProjectId: project.id,
+          issues: [issue],
+        });
+        if (failure === 'timeout') await vi.advanceTimersByTimeAsync(5_001);
+        await pending;
+        expect(commit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            outcome: expect.objectContaining({
+              status: 'rejected',
+              code: failure === 'timeout' ? 'timeout' : 'rule_error',
+            }),
+            decisions: [],
+          }),
+        );
+        expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual([]);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it('commits one triage decision and replays an unchanged observation', async () => {
     const { project, service, workItems } = await setup();
     const input = { orgId: 'org-1', factoryProjectId: project.id, userId: 'user-1', issues: [issue] };

--- a/mastracode/factory/src/integrations/linear/rules.ts
+++ b/mastracode/factory/src/integrations/linear/rules.ts
@@ -1,9 +1,9 @@
-import { resolveFactoryLinearRule } from '../../rules/resolve.js';
 import type { FactoryLinearRuleContext, FactoryRuleDecision, FactoryRules } from '../../rules/types.js';
 import { validateFactoryRuleDecisions } from '../../rules/validation.js';
 import type { FactoryProjectsStorage } from '../../storage/domains/projects/base.js';
 import type { WorkItemRow, WorkItemsStorage } from '../../storage/domains/work-items/base.js';
 import type { IntegrationContext } from '../base.js';
+import type { LinearEventRules } from './default-rules.js';
 
 const RULE_TIMEOUT_MS = 5_000;
 
@@ -42,6 +42,7 @@ export interface LinearRulesOptions {
   projects: Pick<FactoryProjectsStorage, 'get'>;
   storage: WorkItemsStorage;
   rules: FactoryRules;
+  linearRules: LinearEventRules;
 }
 
 export interface LinearRulesIngress {
@@ -114,7 +115,7 @@ export class LinearRules {
       issue,
     };
 
-    const rule = resolveFactoryLinearRule(this.options.rules, context.event);
+    const rule = this.options.linearRules[context.event];
     let decision: FactoryRuleDecision | void;
     let decisions: Record<string, unknown>[] = [];
     let outcome: { status: 'accepted' | 'rejected'; code?: string; reason?: string } = { status: 'accepted' };
@@ -156,6 +157,7 @@ export class LinearRules {
 }
 
 export function attachLinearRules(
+  linear: { readonly rules: LinearEventRules },
   context: IntegrationContext,
 ): ((input: LinearRulesIngress) => Promise<unknown>) | undefined {
   if (!context.rules) return undefined;
@@ -163,6 +165,7 @@ export function attachLinearRules(
     projects: context.storage.projects,
     storage: context.rules.workItems,
     rules: context.rules.config,
+    linearRules: linear.rules,
   });
   return input => rules.ingest(input);
 }

--- a/mastracode/factory/src/integrations/platform/linear/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.test.ts
@@ -506,7 +506,9 @@ describe('PlatformLinearIntegration', () => {
       }
       throw new Error(`Unexpected request: ${url}`);
     });
-    const integration = createIntegration(fetchImpl);
+    vi.stubGlobal('fetch', fetchImpl);
+    const onEvent = vi.fn();
+    const integration = new PlatformLinearIntegration({ rules: { issueObserved: onEvent } });
     const projectRecord = await seed.projects.create({
       orgId: 'org-1',
       userId: 'user-1',
@@ -517,7 +519,6 @@ describe('PlatformLinearIntegration', () => {
       userId: 'user-1',
       config: { linear: { enabled: true, sourceIds: [project1SourceId] } },
     });
-    const onEvent = vi.fn();
     const context = {
       auth: fakeAuth(),
       storage: {
@@ -529,7 +530,6 @@ describe('PlatformLinearIntegration', () => {
       rules: {
         config: defaultFactoryRules({
           version: 'test-rules',
-          overrides: { linear: { issueObserved: { onEvent } } },
         }),
         workItems: seed.workItems,
       },

--- a/mastracode/factory/src/integrations/platform/linear/integration.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.ts
@@ -10,9 +10,14 @@ import type { RouteAuth } from '../../../routes/route.js';
 import type { FactoryProjectsStorage } from '../../../storage/domains/projects/base.js';
 import type { FactoryIntegration, IntegrationContext, IntegrationTools } from '../../base.js';
 import { buildLinearAgentTools } from '../../linear/agent-tools.js';
+import type { LinearEventRules, LinearRuleOverrides } from '../../linear/default-rules.js';
+import { resolveLinearRules } from '../../linear/default-rules.js';
 import type { LinearConnectionCheck, LinearIntegration } from '../../linear/integration.js';
 import { attachLinearIssueReconciler } from '../../linear/issue-reconciler.js';
-import { linearIssueReconciliationEnabled, linearIssueReconciliationInterval } from '../../linear/reconciliation-config.js';
+import {
+  linearIssueReconciliationEnabled,
+  linearIssueReconciliationInterval,
+} from '../../linear/reconciliation-config.js';
 import { buildLinearRoutes } from '../../linear/routes.js';
 import { attachLinearRules } from '../../linear/rules.js';
 import type { LinearConnectionData, LinearConnectionRow, LinearStorageHandle } from '../../linear/storage.js';
@@ -248,7 +253,14 @@ export class PlatformLinearIntegration implements FactoryIntegration {
     },
   };
 
-  constructor() {
+  readonly #rules: LinearEventRules;
+
+  get rules(): LinearEventRules {
+    return this.#rules;
+  }
+
+  constructor({ rules }: { rules?: LinearRuleOverrides } = {}) {
+    this.#rules = resolveLinearRules(rules);
     const config = platformApiClientConfigFromEnv();
     this.#client = new PlatformApiClient(config);
     this.#endpointHost = new URL(config.baseUrl).host;
@@ -366,8 +378,8 @@ export class PlatformLinearIntegration implements FactoryIntegration {
     const reconcileEnabled = linearIssueReconciliationEnabled();
     if (!pollingEnabled && !reconcileEnabled) return [];
 
-    const ingest = attachLinearRules(ctx);
-    const reconcile = reconcileEnabled ? attachLinearIssueReconciler(this as unknown as LinearIntegration, ctx) : undefined;
+    const ingest = attachLinearRules(this, ctx);
+    const reconcile = reconcileEnabled ? attachLinearIssueReconciler(this, ctx) : undefined;
     const workItems = ctx.rules?.workItems;
     if (!workItems) return [];
     if (!ingest && !reconcile) return [];
@@ -401,7 +413,7 @@ export class PlatformLinearIntegration implements FactoryIntegration {
         baseUrl: ctx.baseUrl,
         intake: ctx.storage.intake,
         projects: ctx.storage.projects,
-        ingestFactoryIssues: attachLinearRules(ctx),
+        ingestFactoryIssues: attachLinearRules(this, ctx),
       }).filter(route => !route.path.startsWith('/auth/linear/')),
     ];
   }

--- a/mastracode/factory/src/rules/defaults.test.ts
+++ b/mastracode/factory/src/rules/defaults.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { defaultGithubRules } from '../integrations/github/default-rules.js';
+import { defaultLinearRules } from '../integrations/linear/default-rules.js';
 import { defaultFactoryRules, mergeFactoryRuleOverrides } from './defaults.js';
 import type {
   FactoryBoardRuleLeaf,
@@ -150,12 +151,12 @@ describe('defaultFactoryRules', () => {
     expect(defaultGithubRules.pullRequestUpdated).toBeTypeOf('function');
     expect(defaultGithubRules.pullRequestReviewRequested).toBeTypeOf('function');
     expect(defaultGithubRules.pullRequestMerged).toBeTypeOf('function');
-    expect(rules.linear.issueObserved?.onEvent).toBeTypeOf('function');
+    expect(defaultLinearRules.issueObserved).toBeTypeOf('function');
     expect(rules.work.triage?.linearIssue?.onEnter).toBeTypeOf('function');
   });
 
   it('materializes observed Linear issues directly in Triage', async () => {
-    const rule = defaultFactoryRules({ version: 'deployment-7' }).linear.issueObserved?.onEvent;
+    const rule = defaultLinearRules.issueObserved;
 
     expect(await rule?.(linearContext())).toMatchObject({
       type: 'upsertLinkedWorkItem',
@@ -168,7 +169,7 @@ describe('defaultFactoryRules', () => {
   });
 
   it('does not move an existing Linear issue backward when polling observes an update', async () => {
-    const rule = defaultFactoryRules({ version: 'deployment-7' }).linear.issueObserved?.onEvent;
+    const rule = defaultLinearRules.issueObserved;
 
     expect(
       await rule?.({
@@ -226,7 +227,7 @@ describe('defaultFactoryRules', () => {
 
   it('only closes non-terminal linked work-board issue cards', async () => {
     const githubRule = defaultGithubRules.issueClosed;
-    const linearRule = defaultFactoryRules({ version: 'deployment-7' }).linear.issueClosed?.onEvent;
+    const linearRule = defaultLinearRules.issueClosed;
     const github = githubContext('issueClosed');
     const linear = linearContext();
 
@@ -1101,8 +1102,7 @@ describe('defaultFactoryRules', () => {
   });
 
   it('mirrors the Linear assignee under `assignee` and the creator under `author` for provider-agnostic attribution', async () => {
-    const rules = defaultFactoryRules({ version: 'deployment-7' });
-    expect(await rules.linear.issueObserved?.onEvent?.(linearContext())).toMatchObject({
+    expect(await defaultLinearRules.issueObserved?.(linearContext())).toMatchObject({
       metadata: {
         linearAssignee: 'ada',
         assignee: 'ada',
@@ -1168,14 +1168,12 @@ describe('defaultFactoryRules', () => {
     const workExit = vi.fn(() => undefined);
     const reviewEnter = vi.fn(() => undefined);
     const toolResult = vi.fn(() => undefined);
-    const linearEvent = vi.fn(() => undefined);
     const rules = defaultFactoryRules({
       version: 'deployment-8',
       overrides: {
         work: { planning: { issue: { onEnter: workEnter, onExit: workExit } } },
         review: { intake: { pullRequest: { onEnter: reviewEnter } } },
         tools: { submit_plan: { onResult: toolResult } },
-        linear: { issueObserved: { onEvent: linearEvent } },
       },
     });
 
@@ -1184,7 +1182,6 @@ describe('defaultFactoryRules', () => {
     expect(rules.review.intake?.pullRequest?.onEnter).toBe(reviewEnter);
     expect(rules.tools.submit_plan?.onResult).toBe(toolResult);
     expect(defaultGithubRules.issueOpened).toBeTypeOf('function');
-    expect(rules.linear.issueObserved?.onEvent).toBe(linearEvent);
   });
 
   it('merges defaults and overrides at each exact handler leaf', () => {
@@ -1213,7 +1210,6 @@ describe('defaultFactoryRules', () => {
       {
         work: { planning: { issue: { onEnter: undefined, onExit: undefined } } },
         tools: { submit_plan: { onResult: undefined } },
-        linear: { issueObserved: { onEvent: undefined } },
       },
       {},
     );
@@ -1221,7 +1217,6 @@ describe('defaultFactoryRules', () => {
     expect(merged.work.planning?.issue).toHaveProperty('onEnter', undefined);
     expect(merged.work.planning?.issue).toHaveProperty('onExit', undefined);
     expect(merged.tools.submit_plan).toHaveProperty('onResult', undefined);
-    expect(merged.linear.issueObserved).toHaveProperty('onEvent', undefined);
   });
 
   it('copies override containers so later mutation cannot replace configured leaves', () => {

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -3,9 +3,6 @@ import { workBoard } from '../boards/work.js';
 import type {
   FactoryBoardRuleLeaf,
   FactoryBoardRules,
-  FactoryLinearEventName,
-  FactoryLinearRuleContext,
-  FactoryLinearRuleLeaf,
   FactoryRules,
   FactoryRulesOverrides,
   FactoryRuleSource,
@@ -46,59 +43,10 @@ function advanceApprovedPlan(context: FactoryToolResultRuleContext) {
   } as const;
 }
 
-function linearIssueObserved(context: FactoryLinearRuleContext) {
-  if (context.item) return;
-  return {
-    type: 'upsertLinkedWorkItem',
-    idempotencyKey: `${context.ingress.id}:issue-triage`,
-    board: 'work',
-    source: 'linear-issue',
-    sourceKey: `linear:${context.issue.identifier}`,
-    title: `${context.issue.identifier}: ${context.issue.title}`,
-    url: context.issue.url,
-    stage: 'triage',
-    metadata: {
-      linearIssueId: context.issue.id,
-      identifier: context.issue.identifier,
-      sourceCreatedAt: context.issue.createdAt,
-      linearState: context.issue.state,
-      linearStateType: context.issue.stateType,
-      linearPriority: context.issue.priorityLabel,
-      linearAssignee: context.issue.assignee,
-      linearCreator: context.issue.creator,
-      linearTeam: context.issue.team,
-      labels: [...context.issue.labels] as string[],
-      ...(context.issue.assignee ? { assignee: context.issue.assignee } : {}),
-      ...(context.issue.creator ? { creator: context.issue.creator, author: context.issue.creator } : {}),
-    },
-  } as const;
-}
-
-function linearIssueClosed(context: FactoryLinearRuleContext) {
-  if (!context.item || context.item.source !== 'linear-issue') return;
-  if (context.board !== 'work') return;
-  // Already off the board: nothing to reconcile.
-  if (context.item.stages.some(stage => stage === 'done' || stage === 'canceled')) return;
-  // Only terminal state types trigger close.
-  const stateType = context.issue.stateType;
-  if (stateType !== 'completed' && stateType !== 'canceled') return;
-  const canceled = stateType === 'canceled';
-  return {
-    type: 'transition',
-    idempotencyKey: `${context.ingress.id}:issue-closed`,
-    board: 'work',
-    stage: canceled ? 'canceled' : 'done',
-    message: {
-      text: `Linear issue ${context.issue.identifier} was ${canceled ? 'canceled' : 'completed'}; this Work card was moved to ${canceled ? 'Canceled' : 'Done'}.`,
-    },
-  } as const;
-}
-
 const BUILT_IN_DEFAULTS: FactoryRulesOverrides = {
   work: workBoard.rules,
   review: reviewBoard.rules,
   tools: { submit_plan: { onResult: advanceApprovedPlan } },
-  linear: { issueObserved: { onEvent: linearIssueObserved }, issueClosed: { onEvent: linearIssueClosed } },
 };
 
 function mergeBoardRules(
@@ -146,23 +94,6 @@ function mergeToolRules(
   return result;
 }
 
-function mergeLinearRules(
-  base: FactoryRulesOverrides['linear'],
-  overrides: FactoryRulesOverrides['linear'],
-): NonNullable<FactoryRulesOverrides['linear']> {
-  const result: Partial<Record<FactoryLinearEventName, FactoryLinearRuleLeaf>> = {};
-  const events = new Set([...Object.keys(base ?? {}), ...Object.keys(overrides ?? {})]) as Set<FactoryLinearEventName>;
-  for (const event of events) {
-    const baseLeaf = base?.[event];
-    const overrideLeaf = overrides?.[event];
-    result[event] = {
-      ...(baseLeaf && 'onEvent' in baseLeaf ? { onEvent: baseLeaf.onEvent } : {}),
-      ...(overrideLeaf && 'onEvent' in overrideLeaf ? { onEvent: overrideLeaf.onEvent } : {}),
-    };
-  }
-  return result;
-}
-
 export function mergeFactoryRuleOverrides(
   base: FactoryRulesOverrides,
   overrides: FactoryRulesOverrides = {},
@@ -171,7 +102,6 @@ export function mergeFactoryRuleOverrides(
     work: mergeBoardRules(base.work, overrides.work),
     review: mergeBoardRules(base.review, overrides.review),
     tools: mergeToolRules(base.tools, overrides.tools),
-    linear: mergeLinearRules(base.linear, overrides.linear),
   };
 }
 

--- a/mastracode/factory/src/rules/index.ts
+++ b/mastracode/factory/src/rules/index.ts
@@ -1,5 +1,5 @@
 export { builtInFactoryRules, defaultFactoryRules, DEFAULT_FACTORY_RULE_VERSION } from './defaults.js';
-export { resolveFactoryLinearRule, resolveFactoryStageRules, resolveFactoryToolRule } from './resolve.js';
+export { resolveFactoryStageRules, resolveFactoryToolRule } from './resolve.js';
 export type { ResolvedFactoryStageRule, ResolvedFactoryToolRule } from './resolve.js';
 export {
   FACTORY_GITHUB_EVENTS,
@@ -19,7 +19,6 @@ export type {
   FactoryGithubRuleContext,
   FactoryLinearEventName,
   FactoryLinearRuleContext,
-  FactoryLinearRuleLeaf,
   FactoryInvokeSkillDecision,
   FactoryNotifyDecision,
   FactoryRuleActor,

--- a/mastracode/factory/src/rules/resolve.test.ts
+++ b/mastracode/factory/src/rules/resolve.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { defaultFactoryRules } from './defaults.js';
-import { resolveFactoryLinearRule, resolveFactoryStageRules, resolveFactoryToolRule } from './resolve.js';
+import { resolveFactoryStageRules, resolveFactoryToolRule } from './resolve.js';
 
 describe('Factory rule resolution', () => {
   it('resolves a board stage transition in exit-before-enter order', () => {
@@ -81,19 +81,14 @@ describe('Factory rule resolution', () => {
     ).toEqual([{ phase: 'enter', handler: onEnter }]);
   });
 
-  it('resolves open tool names and closed integration event leaves', () => {
+  it('resolves open tool names', () => {
     const onResult = vi.fn(() => undefined);
-    const onLinearEvent = vi.fn(() => undefined);
     const rules = defaultFactoryRules({
       version: 'resolve-v3',
-      overrides: {
-        tools: { submit_plan: { onResult } },
-        linear: { issueObserved: { onEvent: onLinearEvent } },
-      },
+      overrides: { tools: { submit_plan: { onResult } } },
     });
 
     expect(resolveFactoryToolRule(rules, 'submit_plan')).toBe(onResult);
     expect(resolveFactoryToolRule(rules, 'unknown_tool')).toBeUndefined();
-    expect(resolveFactoryLinearRule(rules, 'issueObserved')).toBe(onLinearEvent);
   });
 });

--- a/mastracode/factory/src/rules/resolve.ts
+++ b/mastracode/factory/src/rules/resolve.ts
@@ -1,7 +1,5 @@
 import type { BoardRegistry } from '../boards/index.js';
 import type {
-  FactoryLinearEventName,
-  FactoryLinearRuleLeaf,
   FactoryRuleHandler,
   FactoryRuleSource,
   FactoryRuleStage,
@@ -50,13 +48,6 @@ export function resolveFactoryStageRules(
 
 export function resolveFactoryToolRule(rules: FactoryRules, toolName: string): FactoryToolRuleLeaf['onResult'] {
   return rules.tools[toolName]?.onResult;
-}
-
-export function resolveFactoryLinearRule(
-  rules: FactoryRules,
-  event: FactoryLinearEventName,
-): FactoryLinearRuleLeaf['onEvent'] {
-  return rules.linear[event]?.onEvent;
 }
 
 export type ResolvedFactoryToolRule = FactoryRuleHandler<FactoryToolResultRuleContext>;

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -297,10 +297,6 @@ export interface FactoryToolRuleLeaf {
   onResult?: FactoryRuleHandler<FactoryToolResultRuleContext>;
 }
 
-export interface FactoryLinearRuleLeaf {
-  onEvent?: FactoryRuleHandler<FactoryLinearRuleContext>;
-}
-
 export type FactoryBoardRules = Partial<Record<string, Partial<Record<FactoryRuleSource, FactoryBoardRuleLeaf>>>>;
 
 export interface FactoryRules {
@@ -308,14 +304,12 @@ export interface FactoryRules {
   work: FactoryBoardRules;
   review: FactoryBoardRules;
   tools: Record<string, FactoryToolRuleLeaf>;
-  linear: Partial<Record<FactoryLinearEventName, FactoryLinearRuleLeaf>>;
 }
 
 export interface FactoryRulesOverrides {
   work?: FactoryBoardRules;
   review?: FactoryBoardRules;
   tools?: Record<string, FactoryToolRuleLeaf>;
-  linear?: Partial<Record<FactoryLinearEventName, FactoryLinearRuleLeaf>>;
 }
 
 export type FactoryRuleRejectionCode =

--- a/mastracode/factory/src/rules/validation.test.ts
+++ b/mastracode/factory/src/rules/validation.test.ts
@@ -257,6 +257,6 @@ describe('Factory rule validation', () => {
         ...rules,
         linear: { madeUpEvent: { onEvent: () => undefined } },
       }),
-    ).toThrow(/Linear event is invalid/i);
+    ).toThrow(/unsupported field/i);
   });
 });

--- a/mastracode/factory/src/rules/validation.ts
+++ b/mastracode/factory/src/rules/validation.ts
@@ -1,4 +1,4 @@
-import { FACTORY_LINEAR_EVENTS, FACTORY_RULE_BOARDS, FACTORY_RULE_SOURCES, FACTORY_RULE_STAGES } from './types.js';
+import { FACTORY_RULE_BOARDS, FACTORY_RULE_SOURCES, FACTORY_RULE_STAGES } from './types.js';
 import type {
   FactoryBoardRules,
   FactoryCommitDecision,
@@ -153,7 +153,7 @@ function validateBoardRules(rules: unknown, label: string): asserts rules is Fac
 
 export function assertFactoryRules(rules: unknown): asserts rules is FactoryRules {
   if (!isPlainObject(rules)) throw new FactoryRuleValidationError('Factory rules must be an object.');
-  assertExactKeys(rules, ['version', 'work', 'review', 'tools', 'linear'], 'Factory rules');
+  assertExactKeys(rules, ['version', 'work', 'review', 'tools'], 'Factory rules');
   boundedString(rules.version, 'Factory rule version', MAX_VERSION_LENGTH);
   validateBoardRules(rules.work, 'Factory rules.work');
   validateBoardRules(rules.review, 'Factory rules.review');
@@ -166,16 +166,6 @@ export function assertFactoryRules(rules: unknown): asserts rules is FactoryRule
     assertExactKeys(leaf, ['onResult'], `Factory rules.tools.${toolName}`);
     if (leaf.onResult !== undefined && typeof leaf.onResult !== 'function') {
       throw new FactoryRuleValidationError(`Factory rules.tools.${toolName}.onResult must be a function.`);
-    }
-  }
-
-  if (!isPlainObject(rules.linear)) throw new FactoryRuleValidationError('Factory rules.linear must be an object.');
-  for (const [event, leaf] of Object.entries(rules.linear)) {
-    enumValue(event, FACTORY_LINEAR_EVENTS, 'Factory Linear event');
-    if (!isPlainObject(leaf)) throw new FactoryRuleValidationError(`Factory rules.linear.${event} must be an object.`);
-    assertExactKeys(leaf, ['onEvent'], `Factory rules.linear.${event}`);
-    if (leaf.onEvent !== undefined && typeof leaf.onEvent !== 'function') {
-      throw new FactoryRuleValidationError(`Factory rules.linear.${event}.onEvent must be a function.`);
     }
   }
 }


### PR DESCRIPTION
LinearIntegration and PlatformLinearIntegration now own their event handlers, matching GitHub integration ownership. Existing constructors retain all built-in behavior without importing or passing default rules.

```ts
new PlatformLinearIntegration({
  rules: {
    issueObserved: context => ({
      type: "reject",
      code: "manual_intake",
      reason: "This deployment manages issue intake manually.",
    }),
    issueClosed: null,
  },
});
```

The direct LinearIntegration accepts the same rules option alongside clientId and clientSecret. Functions replace handlers, null disables one handler, and omitted or undefined entries retain defaults. Constructors validate and freeze isolated maps. Fetch, polling, and reconciliation use the owning instance while preserving ingestion bookkeeping, shared audit version, and replay behavior.

Move former global rules.linear[event].onEvent values to constructor rules[event]. Linear has no supported global configuration path; generic global validation policy is unchanged. Board, tool, and GitHub behavior remains unchanged. Includes README and configuration-skill guidance plus an @mastra/factory changeset.

Verification: focused Linear/runtime/reconciliation tests and the full Factory suite pass (2,148 passed, 6 skipped across 113 files). Package check (tsc --noEmit), lint, changed-file Prettier checks, build:lib, smoke:dist, and public integration import/constructor checks pass. Coverage includes defaults, replacements, disabling, immutable isolation, decision validation, tenant/existence checks, duplicate delivery, failures/timeouts, polling, and reconciliation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Linear integrations now manage their own event handlers. Each integration can use defaults, replace handlers, or disable handlers without changing global Factory settings.

## Changes

- Added constructor-level `rules` support to `LinearIntegration` and `PlatformLinearIntegration`.
- Added validated, isolated, frozen rule maps with default preservation, handler replacement, and `null` disabling.
- Rejected non-plain rule maps, including `Map`, `Date`, `Set`, and class instances.
- Removed Linear event rules from global Factory configuration.
- Updated fetching, polling, and reconciliation to use the owning integration’s rules.
- Preserved ingestion bookkeeping, audit versioning, and replay behavior.
- Updated README and configuration guidance with migration examples.
- Added a Factory changeset.
- Added coverage for defaults, overrides, disabling, immutability, validation, tenant and existence checks, duplicate delivery, failures, timeouts, polling, and reconciliation.
- Verified focused and full tests, type checking, linting, formatting, builds, distribution smoke tests, and public integration imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->