### PR TITLE
fix(core): preserve durable session cancellation and failures

### DIFF
--- a/.changeset/chilly-cars-know.md
+++ b/.changeset/chilly-cars-know.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Generate bundled storage declarations in a stable project order so the same source produces reproducible packages.

--- a/.changeset/curvy-llamas-help.md
+++ b/.changeset/curvy-llamas-help.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed tool approval prompts staying visible after a valid approval or decline.

--- a/.changeset/few-cases-stay.md
+++ b/.changeset/few-cases-stay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed AI SDK v6 message conversion crashing when an opening reasoning part has no text or details. Empty parts omitted by the existing v5 conversion stay omitted, while text, tool state, and nonempty reasoning remain unchanged.

--- a/.changeset/full-teeth-tell.md
+++ b/.changeset/full-teeth-tell.md
@@ -1,0 +1,6 @@
+---
+'@mastra/deployer': patch
+'@mastra/core': patch
+---
+
+Fixed resumed approvals for skill and tool discovery after a process restart.

--- a/.changeset/funny-streets-eat.md
+++ b/.changeset/funny-streets-eat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Keep storage open until accepted native Stop requests finish; propagate cancellation failures during shutdown.

--- a/.changeset/heavy-sloths-think.md
+++ b/.changeset/heavy-sloths-think.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed durable agents entering a new tool approval wait or executing a tool after cancellation during response processing. Completed usage now reaches the normal final processors, and closed waits no longer return in saved messages.

--- a/.changeset/khaki-tools-behave.md
+++ b/.changeset/khaki-tools-behave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Session Stop for delegated workflows and restored sessions. Workflow cancellation preserves completed results and reports storage failures after delivering the abort signal.

--- a/.changeset/lazy-plants-clap.md
+++ b/.changeset/lazy-plants-clap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed automatic durable-agent recovery on production server startup without delaying startup or duplicating development recovery.

--- a/.changeset/pretty-roses-sip.md
+++ b/.changeset/pretty-roses-sip.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed completed durable runs replaying old tool approval prompts. Canceled runs now preserve queued follow-up requests.

--- a/.changeset/purple-loops-fry.md
+++ b/.changeset/purple-loops-fry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed durable agent error events arriving before final message history is saved. Session history read at agent_end now retains approved tool results when a later model call fails.

--- a/.changeset/shaky-glasses-remain.md
+++ b/.changeset/shaky-glasses-remain.md
@@ -1,0 +1,6 @@
+---
+'@mastra/deployer': patch
+'@mastra/core': patch
+---
+
+Fixed stopping a saved durable run after a restart so it saves the abort result and completed usage. Reuse native recovery ownership to reject competing restoration, preserve later runs on the same thread, and finish accepted cancellation before shutdown.

--- a/.changeset/social-dodos-rush.md
+++ b/.changeset/social-dodos-rush.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Stop to cancel paused runs through their owning agent after a mode switch or later navigation, including when reopening a saved session. Other threads, resources and runs created after Stop remain untouched. Shutdown waits for owner discovery, and reports an error if a paused run's owner cannot be found.

--- a/.changeset/tough-lands-smoke.md
+++ b/.changeset/tough-lands-smoke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed durable agent crash recovery to restore saved active-step input and refuse new recovery work during shutdown while preserving recoverable snapshots.

--- a/.changeset/true-planets-drive.md
+++ b/.changeset/true-planets-drive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workflow tools losing tripwire details. Workflow tools now return the native tripwire status, reason, retry option, metadata, processor ID, and run ID so parent guardrails can inspect the result. This does not automatically stop the parent or change ordinary workflow failure results.

--- a/.changeset/warm-cycles-pay.md
+++ b/.changeset/warm-cycles-pay.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the built-in web reader to stop on cancellation and finish within one 15-second deadline across redirects and response bodies.
+
+Fetch failures and timeouts still return `isError: true`. Explicit cancellation through the native tool context now rejects with the abort signal's reason, allowing the agent or workflow to stop.

--- a/docs/src/content/en/docs/agents/tools.mdx
+++ b/docs/src/content/en/docs/agents/tools.mdx
@@ -221,6 +221,18 @@ export const researchAgent = new Agent({
 })
 ```
 
+When a workflow ends with `status: 'tripwire'`, its tool returns the workflow run ID and the original tripwire details:
+
+```typescript
+const toolResult = {
+  status: 'tripwire',
+  tripwire: { reason, retry, metadata, processorId },
+  runId,
+}
+```
+
+The result keeps optional fields without defaults and leaves the decision to stop with the parent's guardrail policy. Ordinary workflow failures still return `{ error, runId }`, and successful workflows return `{ result, runId }`.
+
 ## Share tools across agents
 
 Direct imports are the best choice when one tool is used by multiple agents. Each agent imports the tool and adds it to its `tools` record. Dependencies remain explicit and each agent can be used independently.

--- a/docs/src/content/en/docs/agents/tools.mdx
+++ b/docs/src/content/en/docs/agents/tools.mdx
@@ -584,9 +584,9 @@ The tool takes a single `url` input and returns `content`, `truncated`, `status`
 - Only `http:` and `https:` URLs are allowed.
 - Requests to `localhost` and to private or reserved IP addresses are blocked, including addresses returned by DNS resolution.
 - Responses are truncated at 100,000 characters, with `truncated: true` in the result.
-- Requests follow at most 5 redirects and time out after 15 seconds.
+- Requests follow at most 5 redirects. One 15-second deadline covers DNS resolution, redirects, and reading the response body.
 
-Failures don't throw. The tool returns `isError: true` with the reason in `content`, so the agent can retry or explain the problem.
+Fetch failures, including the deadline, return `isError: true` with the reason in `content`, so the agent can retry or explain the problem. Explicit cancellation through the tool execution context's `abortSignal` stops the request and rejects with the signal's reason.
 
 ### Ask the user a question
 

--- a/docs/src/content/en/docs/agents/tools.mdx
+++ b/docs/src/content/en/docs/agents/tools.mdx
@@ -203,6 +203,8 @@ export const supervisor = new Agent({
 
 ## Workflows as tools
 
+Canceling an agent run also cancels its active workflow tools through the native workflow abort signal. Workflow steps should pass that signal to models and other operations they start. Cancellation prevents later steps from running; a current operation that ignores the signal can continue until it returns.
+
 Add workflows through the `workflows` configuration. Mastra converts each workflow to a `workflow-<key>` tool that uses the workflow's `inputSchema` and `outputSchema`. Include a `description` on the workflow so the agent knows when to trigger it.
 
 ```typescript title="src/mastra/agents/research-agent.ts"

--- a/docs/src/content/en/docs/harness/durable-agents.mdx
+++ b/docs/src/content/en/docs/harness/durable-agents.mdx
@@ -230,6 +230,10 @@ Visit [Background tasks](/docs/harness/background-tasks) for the full background
 
 Every `stream()` and `observe()` call returns a `cleanup` function. Calling it unsubscribes from PubSub and removes the run from the internal registry. If you forget to call it, an automatic timer fires after the stream ends, but calling `cleanup()` yourself frees resources immediately.
 
+Register the AgentController on its owning Mastra instance before calling `init()`. For native `DurableAgent` runs, `Mastra.shutdown()` waits for previously accepted Session Stop requests to finish discovering saved runs and writing their cancellation state before closing storage. New Stop requests can't start storage work after shutdown begins. Repeated shutdown calls share the same completion promise.
+
+If an accepted cancellation fails, shutdown finishes resource cleanup and rejects with an `AggregateError`. Session Stop still reports the error through its native error event. Other durable wrappers keep their existing cancellation behavior. This storage completion guarantee applies to the native `DurableAgent`. The generated server's shutdown deadline still applies.
+
 ## Tool approval
 
 Durable agents support tool approval (human-in-the-loop). When a tool call requires approval, the workflow suspends, emits an `onSuspended` callback, and waits for the caller to resume with `resume()`:

--- a/docs/src/content/en/docs/harness/durable-agents.mdx
+++ b/docs/src/content/en/docs/harness/durable-agents.mdx
@@ -255,7 +255,7 @@ If the server process crashes while a durable agent run is in progress, that run
 
 ### Automatic recovery
 
-Set `recovery.durableAgents` to `'auto'` in the Mastra config. The deployer calls `recoverAllDurableAgents()` on boot, right after restarting active workflow runs:
+Set `recovery.durableAgents` to `'auto'` in the Mastra config. The production server calls `recoverAllDurableAgents()` after installing its shutdown handlers. Startup does not wait for recovered turns to finish. Development keeps using its restart endpoint, and `'off'` disables automatic recovery:
 
 ```typescript title="src/mastra/index.ts" {4}
 export const mastra = new Mastra({
@@ -266,6 +266,8 @@ export const mastra = new Mastra({
 ```
 
 On startup, this discovers every registered durable agent with runs stuck in `running` status and re-drives them from the last persisted snapshot.
+
+`Mastra.shutdown()` closes recovery admission before teardown. Pending discovery can finish reading storage, but cannot start another recovered turn. Runs refused during shutdown keep their saved snapshots for the next process. Already-running turns retain the normal shutdown drain behavior; the generated server's shutdown deadline still applies. Storage stays open while admitted `recoverAllDurableAgents()` calls settle.
 
 :::warning
 

--- a/docs/src/content/en/reference/agent-controller/session.mdx
+++ b/docs/src/content/en/reference/agent-controller/session.mdx
@@ -195,6 +195,8 @@ Returns: `string | null`
 
 Abort the active run and clear pending suspension display state.
 
+This synchronous method requests cancellation. Its return does not confirm that storage has saved a terminal state. Native cancellation errors are reported through the session's error events. A restored session uses native run discovery for its exact resource and thread when it has no local run identity.
+
 ```typescript
 session.abort()
 ```

--- a/docs/src/content/en/reference/workflows/run-methods/cancel.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/cancel.mdx
@@ -9,7 +9,7 @@ packages:
 
 The `.cancel()` method cancels a workflow run, stopping execution and cleaning up resources.
 
-This method aborts any running steps and updates the workflow status to 'canceled'. It works for both actively running workflows and suspended/waiting workflows.
+This method aborts any running steps and updates a nonterminal workflow status to 'canceled'. It works for both actively running workflows and suspended/waiting workflows. A stored terminal result is preserved if completion wins a race with cancellation.
 
 ## Usage example
 
@@ -17,7 +17,6 @@ This method aborts any running steps and updates the workflow status to 'cancele
 const run = await workflow.createRun()
 
 await run.cancel()
-// Returns: { message: 'Workflow run canceled' }
 ```
 
 ## Parameters
@@ -39,8 +38,9 @@ await run.cancel()
   content={[
   {
     name: 'result',
-    type: 'Promise<{ message: string }>',
-    description: "A promise that resolves with { message: 'Workflow run canceled' } when cancellation succeeds",
+    type: 'Promise<void>',
+    description:
+      'Resolves after the cancellation write, or without changing an already terminal result. Rejects if configured storage cannot save the canceled status. For a nonterminal run, the abort signal is delivered before that write.',
   },
 ]}
 />

--- a/e2e-tests/_local-registry-setup/publish-roots.js
+++ b/e2e-tests/_local-registry-setup/publish-roots.js
@@ -12,6 +12,7 @@ const SHARED_REGISTRY_SUITES = {
   monorepo: {
     tag: 'monorepo-test',
     manifestGlobs: ['e2e-tests/monorepo/template/**/package.json'],
+    extraRoots: ['@mastra/libsql'],
   },
   'no-bundling': {
     tag: 'no-bundling-test',

--- a/e2e-tests/monorepo/native-recovery-lifecycle.test.ts
+++ b/e2e-tests/monorepo/native-recovery-lifecycle.test.ts
@@ -1,0 +1,173 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { execa, execaNode } from 'execa';
+import getPort from 'get-port';
+import { beforeAll, describe, expect, inject, it } from 'vitest';
+import { setupMonorepo } from './prepare';
+
+describe.sequential('generated server recovery admission', () => {
+  let fixture: string;
+  let output: string;
+
+  beforeAll(async () => {
+    fixture = await mkdtemp(join(tmpdir(), 'mastra-native-recovery-'));
+    process.env.pnpm_config_registry = inject('registry');
+    await setupMonorepo(fixture, 'pnpm');
+    const app = join(fixture, 'apps', 'custom');
+    await execa('pnpm', ['add', `@mastra/libsql@${inject('tag')}`], { cwd: app, env: process.env });
+    await writeFile(
+      join(app, 'src', 'mastra', 'index.ts'),
+      `
+import { Mastra } from '@mastra/core/mastra';
+import { Agent } from '@mastra/core/agent';
+import { createDurableAgent } from '@mastra/core/agent/durable';
+import { LibSQLStore } from '@mastra/libsql';
+import { registerApiRoute } from '@mastra/core/server';
+let calls = 0;
+let result;
+let modelCalls = 0;
+let text;
+let executionError;
+const runId = 'disposable-generated-crash';
+const storage = new LibSQLStore({ id: 'generated-crash-proof', url: process.env.RECOVERY_DB });
+const agent = createDurableAgent({ cleanupTimeoutMs: 0, agent: new Agent({
+  id: 'generated-crash-proof', name: 'Generated crash proof', instructions: 'Return the local response.',
+  model: {
+    specificationVersion: 'v2', provider: 'local-fixture', modelId: 'unpaid', supportedUrls: {},
+    doGenerate: async () => { throw new Error('No generation expected'); },
+    doStream: async () => {
+      modelCalls++;
+      if (process.env.CRASH_MODE === 'yes') await new Promise(() => {});
+      return { stream: new ReadableStream({ start(controller) {
+        controller.enqueue({ type: 'text-start', id: 'text-1' });
+        controller.enqueue({ type: 'text-delta', id: 'text-1', delta: 'Recovered local response.' });
+        controller.enqueue({ type: 'text-end', id: 'text-1' });
+        controller.enqueue({ type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 4 } });
+        controller.close();
+      } }) };
+    },
+  },
+}) });
+const recoverOne = agent.recover.bind(agent);
+agent.recover = (id, options) => recoverOne(id, { ...options, onFinish: async value => { text = value.text; await options?.onFinish?.(value); } });
+export const mastra = new Mastra({
+  agents: { agent }, storage,
+  recovery: { durableAgents: process.env.RECOVERY_MODE === 'auto' ? 'auto' : 'off' },
+  server: {
+    host: '127.0.0.1',
+    port: Number(process.env.MASTRA_PORT),
+    apiRoutes: [
+      registerApiRoute('/recovery-status', { method: 'GET', handler: async c => {
+        const row = await (await storage.getStore('workflows')).getWorkflowRunById({ workflowName: 'durable-agentic-loop', runId });
+        return c.json({ calls, result, modelCalls, text, executionError, savedStatus: row?.snapshot?.status ?? null });
+      } }),
+      registerApiRoute('/start-crash-run', { method: 'POST', handler: async c => {
+        void (async () => {
+          const response = await agent.stream('Complete this disposable task.', { runId, maxSteps: 1 });
+          for await (const chunk of response.fullStream) void chunk;
+        })().catch(error => { executionError = String(error); });
+        return c.json({ accepted: true }, 202);
+      } }),
+    ],
+  },
+});
+const recover = mastra.recoverAllDurableAgents.bind(mastra);
+mastra.recoverAllDurableAgents = async () => { calls++; return result = await recover(); };
+`,
+    );
+    await execa('pnpm', ['build'], {
+      cwd: app,
+      env: {
+        ...process.env,
+        MASTRA_TELEMETRY_DISABLED: 'true',
+        MASTRA_PORT: '0',
+        RECOVERY_DB: pathToFileURL(join(fixture, 'build.db')).href,
+      },
+    });
+    output = join(app, '.mastra', 'output');
+    // Enforce no outbound traffic in the generated runtime. The test reaches it
+    // only through its loopback HTTP listener.
+    await writeFile(
+      join(output, 'deny-network.mjs'),
+      `
+import net from 'node:net';
+import dns from 'node:dns';
+const deny = () => { throw new Error('Outbound network prohibited by recovery test'); };
+globalThis.fetch = deny;
+net.Socket.prototype.connect = deny;
+const lookup = dns.lookup;
+dns.lookup = (host, ...args) => host === '127.0.0.1' ? lookup(host, ...args) : deny();
+dns.promises.lookup = deny;
+`,
+    );
+    expect(await readFile(join(output, 'index.mjs'), 'utf8')).toContain('createNodeServer');
+  }, 10 * 60_000);
+
+  async function start(mode: string, database: string, crash = false) {
+    const port = await getPort({ host: '127.0.0.1' });
+    const server = execaNode('index.mjs', {
+      cwd: output,
+      nodeOptions: ['--import', './deny-network.mjs'],
+      env: {
+        ...process.env,
+        MASTRA_PORT: String(port),
+        RECOVERY_MODE: mode,
+        RECOVERY_DB: pathToFileURL(database).href,
+        CRASH_MODE: crash ? 'yes' : 'no',
+        MASTRA_TELEMETRY_DISABLED: 'true',
+      },
+      reject: false,
+    });
+    const origin = `http://127.0.0.1:${port}`;
+    const status = async () => (await fetch(`${origin}/recovery-status`)).json();
+    return { server, origin, status };
+  }
+
+  it.each(['auto', 'off'])(
+    'honors recovery mode %s in generated output',
+    async mode => {
+      const { server, status } = await start(mode, join(fixture, `${mode}.db`));
+      try {
+        await expect
+          .poll(status, { timeout: 30_000 })
+          .toMatchObject(
+            mode === 'auto'
+              ? { calls: 1, result: { agents: 1, recovered: 0, succeeded: 0, failed: 0 }, modelCalls: 0 }
+              : { calls: 0, modelCalls: 0 },
+          );
+      } finally {
+        server.kill('SIGTERM');
+        await server;
+      }
+    },
+    45_000,
+  );
+
+  it('automatically completes a real crashed run through the generated server', async () => {
+    const database = join(fixture, 'crashed.db');
+    const first = await start('off', database, true);
+    try {
+      await expect.poll(first.status, { timeout: 30_000 }).toMatchObject({ calls: 0, modelCalls: 0 });
+      expect((await fetch(`${first.origin}/start-crash-run`, { method: 'POST' })).status).toBe(202);
+      await expect.poll(first.status, { timeout: 30_000 }).toMatchObject({ modelCalls: 1, savedStatus: 'running' });
+    } finally {
+      first.server.kill('SIGKILL');
+      await first.server;
+    }
+    const second = await start('auto', database);
+    try {
+      await expect.poll(second.status, { timeout: 30_000 }).toMatchObject({
+        calls: 1,
+        result: { agents: 1, recovered: 1, succeeded: 1, failed: 0 },
+        modelCalls: 1,
+        text: 'Recovered local response.',
+        savedStatus: null,
+      });
+    } finally {
+      second.server.kill('SIGTERM');
+      await second.server;
+    }
+  }, 90_000);
+});

--- a/e2e-tests/monorepo/vitest.config.ts
+++ b/e2e-tests/monorepo/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['monorepo.test.ts'],
+    include: ['monorepo.test.ts', 'native-recovery-lifecycle.test.ts'],
     globalSetup: './setup.ts',
   },
 });

--- a/packages/_internal-core/tsdown.config.ts
+++ b/packages/_internal-core/tsdown.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   fixedExtension: false,
   nodeProtocol: 'strip',
   clean: true,
-  dts: true,
+  dts: { build: true },
   treeshake: true,
   sourcemap: true,
 });

--- a/packages/core/src/agent-controller/__tests__/session-approval-display.integration.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-approval-display.integration.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from 'vitest';
+import z from 'zod';
+import { Agent } from '../../agent';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage';
+import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
+import { createTool } from '../../tools';
+import { AgentController } from '../agent-controller';
+import { createMockWorkspace } from '../test-utils';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function modelStream(toolCall: boolean) {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: 'stream-start', warnings: [] });
+      controller.enqueue({ type: 'response-metadata', id: 'response', modelId: 'mock', timestamp: new Date(0) });
+      if (toolCall) {
+        controller.enqueue({
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'findUser',
+          input: '{"name":"Ada"}',
+          providerExecuted: false,
+        });
+      } else {
+        controller.enqueue({ type: 'text-start', id: 'text-1' });
+        controller.enqueue({ type: 'text-delta', id: 'text-1', delta: 'Done.' });
+        controller.enqueue({ type: 'text-end', id: 'text-1' });
+      }
+      controller.enqueue({
+        type: 'finish',
+        finishReason: toolCall ? 'tool-calls' : 'stop',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      });
+      controller.close();
+    },
+  });
+}
+
+async function createHarness(id: string) {
+  const toolStarted = deferred();
+  const finishTool = deferred();
+  const modelContinued = deferred();
+  const finishModel = deferred();
+  const approvalRequired = deferred();
+  const execute = vi.fn(async () => {
+    toolStarted.resolve();
+    await finishTool.promise;
+    return { email: 'ada@example.com' };
+  });
+  const findUser = createTool({
+    id: 'find-user',
+    description: 'Look up a user by name.',
+    inputSchema: z.object({ name: z.string() }),
+    requireApproval: true,
+    execute,
+  });
+  let modelCalls = 0;
+  const agent = new Agent({
+    id: `${id}-agent`,
+    name: 'Approval test agent',
+    instructions: 'Look up the requested user.',
+    model: new MastraLanguageModelV2Mock({
+      doStream: async () => {
+        modelCalls++;
+        if (modelCalls > 1) {
+          modelContinued.resolve();
+          await finishModel.promise;
+        }
+        return { stream: modelStream(modelCalls === 1) };
+      },
+    }),
+    tools: { findUser },
+  });
+  const storage = new InMemoryStore();
+  const mastra = new Mastra({ agents: { agent }, logger: false, storage });
+  const controller = new AgentController({
+    id: `${id}-controller`,
+    storage,
+    workspace: createMockWorkspace(),
+    modes: [{ id: 'default', name: 'Default', default: true, agent: mastra.getAgent('agent') }],
+  });
+  await controller.init();
+  const session = await controller.createSession({ id: `${id}-session`, ownerId: 'owner-1' });
+  await session.thread.create();
+  const snapshots: Array<{ pendingToolCallId: string | null; isRunning: boolean }> = [];
+  const errors: unknown[] = [];
+  session.subscribe(event => {
+    if (event.type === 'tool_approval_required') approvalRequired.resolve();
+    if (event.type === 'error') errors.push(event);
+    if (event.type === 'display_state_changed') {
+      snapshots.push({
+        pendingToolCallId: event.displayState.pendingApproval?.toolCallId ?? null,
+        isRunning: event.displayState.isRunning,
+      });
+    }
+  });
+  return {
+    session,
+    toolStarted,
+    finishTool,
+    modelContinued,
+    finishModel,
+    approvalRequired,
+    execute,
+    snapshots,
+    errors,
+  };
+}
+
+describe('AgentController approval display during a native run', () => {
+  it.each(['approve', 'decline', 'new user message'] as const)(
+    'clears the resolved prompt after %s before the run finishes',
+    async decision => {
+      const harness = await createHarness(`approval-${decision.replaceAll(' ', '-')}`);
+      const { session, execute, snapshots } = harness;
+      const turn = session.sendMessage({ content: 'Find Ada.' });
+      try {
+        await harness.approvalRequired.promise;
+        expect(session.displayState.get().pendingApproval?.toolCallId).toBe('call-1');
+
+        if (decision === 'new user message') {
+          await session.sendSignal({ content: 'Skip that lookup.' }).accepted;
+        } else {
+          session.respondToToolApproval({ decision, toolCallId: 'call-1' });
+        }
+
+        expect(session.displayState.get().pendingApproval).toBeNull();
+        expect(snapshots.at(-1)).toEqual({ pendingToolCallId: null, isRunning: true });
+
+        if (decision === 'approve') {
+          await harness.toolStarted.promise;
+          expect(execute).toHaveBeenCalledTimes(1);
+          expect(session.displayState.get().activeTools.get('call-1')?.status).toBe('running');
+          expect(session.displayState.get().pendingApproval).toBeNull();
+          harness.finishTool.resolve();
+        }
+        await harness.modelContinued.promise;
+        expect(session.displayState.get().pendingApproval).toBeNull();
+        expect(session.displayState.get().isRunning).toBe(true);
+        expect(execute).toHaveBeenCalledTimes(decision === 'approve' ? 1 : 0);
+      } finally {
+        session.respondToToolApproval({ decision: 'decline' });
+        harness.finishTool.resolve();
+        harness.finishModel.resolve();
+        await turn;
+      }
+      expect(session.displayState.get().pendingApproval).toBeNull();
+      expect(session.displayState.get().isRunning).toBe(false);
+      expect(harness.errors).toEqual([]);
+    },
+    30_000,
+  );
+});

--- a/packages/core/src/agent-controller/__tests__/session-durable-terminal.integration.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-durable-terminal.integration.test.ts
@@ -1,0 +1,306 @@
+import { setTimeout as delay } from 'node:timers/promises';
+import { describe, expect, it, vi } from 'vitest';
+import z from 'zod';
+// Exercise real persisted approval history without adding a Core -> Memory dependency cycle.
+import { Memory } from '../../../../memory/src';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../../agent/durable';
+import { Mastra } from '../../mastra';
+import type { Processor } from '../../processors';
+import { InMemoryStore } from '../../storage';
+import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
+import { createTool } from '../../tools';
+import { Workspace } from '../../workspace';
+import { AgentController } from '../agent-controller';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+type Ending = 'complete' | 'response abort' | 'step abort';
+
+async function createHarness(ending: Ending, parallel = false, suspendFirstTool = false) {
+  const reachedBoundary = deferred();
+  const releaseBoundary = deferred();
+  const firstEnd = deferred();
+  const calls = { model: 0, tool: 0, abort: 0, results: [] as string[] };
+  const approvals: string[] = [];
+  const ends: Array<string | undefined> = [];
+  const errors: unknown[] = [];
+  const runIds: Array<string | null> = [];
+  const model = new MastraLanguageModelV2Mock({
+    doStream: async () => {
+      const step = ++calls.model;
+      if (step > 7) throw new Error('Unexpected model step after terminal completion');
+      const toolCall = step < 5 || (step === 5 && ending !== 'complete') || step === 6;
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings: [] });
+            controller.enqueue({
+              type: 'response-metadata',
+              id: `response-${step}`,
+              modelId: 'mock',
+              timestamp: new Date(0),
+            });
+            if (toolCall) {
+              for (const suffix of parallel && step === 1 ? ['', '-parallel'] : ['']) {
+                controller.enqueue({
+                  type: 'tool-call',
+                  toolCallId: `call-${step}${suffix}`,
+                  toolName: 'localAction',
+                  input: '{}',
+                });
+              }
+            } else {
+              controller.enqueue({ type: 'text-start', id: `text-${step}` });
+              controller.enqueue({ type: 'text-delta', id: `text-${step}`, delta: 'Done.' });
+              controller.enqueue({ type: 'text-end', id: `text-${step}` });
+            }
+            controller.enqueue({
+              type: 'finish',
+              finishReason: toolCall ? 'tool-calls' : 'stop',
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            });
+            controller.close();
+          },
+        }),
+      };
+    },
+  });
+  const processor = {
+    id: 'terminal-test',
+    processLLMResponse: async () => {
+      if (calls.model === 5 && ending !== 'step abort') {
+        reachedBoundary.resolve();
+        await releaseBoundary.promise;
+      }
+    },
+    processOutputStep: async args => {
+      if (calls.model === 5 && ending === 'step abort') {
+        reachedBoundary.resolve();
+        await releaseBoundary.promise;
+      }
+      return args.messageList;
+    },
+    processOutputResult: async args => {
+      calls.results.push(args.result?.finishReason ?? 'missing');
+      return args.messageList;
+    },
+  } satisfies Processor;
+  const storage = new InMemoryStore();
+  const agent = createDurableAgent({
+    agent: new Agent({
+      id: 'terminal-test-agent',
+      name: 'Terminal test',
+      instructions: 'Call the local action.',
+      model,
+      memory: new Memory({ storage }),
+      inputProcessors: [processor],
+      outputProcessors: [processor],
+      defaultOptions: {
+        maxSteps: 1000,
+        onAbort: () => {
+          calls.abort++;
+        },
+      },
+      tools: {
+        localAction: createTool({
+          id: 'localAction',
+          description: 'Local test action',
+          inputSchema: z.object({}),
+          requireApproval: true,
+          suspendSchema: z.object({ prompt: z.string() }),
+          resumeSchema: z.object({ confirmed: z.boolean() }),
+          execute: async (_input, context) => {
+            if (suspendFirstTool && calls.tool === 0 && !context?.agent?.resumeData?.confirmed) {
+              return context?.agent?.suspend({ prompt: 'Confirm the local action.' });
+            }
+            calls.tool++;
+            return { ok: true };
+          },
+        }),
+      },
+    }),
+  });
+  const mastra = new Mastra({
+    agents: { agent },
+    storage,
+    logger: false,
+    workers: false,
+    scheduler: { enabled: false },
+    recovery: { durableAgents: 'off' },
+  });
+  await mastra.startWorkers();
+  const workspace = new Workspace({ id: 'terminal-test-workspace', name: 'Test', skills: () => [] });
+  const controller = new AgentController({
+    id: 'terminal-test-controller',
+    agent: mastra.getAgentById(agent.id),
+    storage,
+    workspace,
+    defaultModeId: 'chat',
+    modes: [{ id: 'chat', name: 'Chat', default: true }],
+    disableBuiltinTools: [
+      'ask_user',
+      'submit_plan',
+      'task_write',
+      'task_update',
+      'task_complete',
+      'task_check',
+      'subagent',
+    ],
+  });
+  await controller.init();
+  const session = await controller.createSession({ ownerId: 'owner', resourceId: 'resource', workspace });
+  await session.thread.create({ title: 'Terminal test' });
+  const unsubscribe = session.subscribe(event => {
+    if (event.type === 'error') errors.push(event.error);
+    if (event.type === 'agent_start') runIds.push(session.getCurrentRunId());
+    if (event.type === 'agent_end') {
+      ends.push(event.reason);
+      firstEnd.resolve();
+    }
+    if (event.type === 'tool_approval_required') {
+      approvals.push(event.toolCallId);
+      if (calls.model < 5) session.respondToToolApproval({ decision: 'approve', toolCallId: event.toolCallId });
+    }
+  });
+  return {
+    session,
+    storage,
+    calls,
+    approvals,
+    ends,
+    errors,
+    runIds,
+    reachedBoundary,
+    releaseBoundary,
+    firstEnd,
+    async close() {
+      releaseBoundary.resolve();
+      session.abort();
+      unsubscribe();
+      controller.stopIntervals();
+      await mastra.stopWorkers();
+    },
+  };
+}
+
+describe('durable Session terminal consumption with real Memory', () => {
+  it('preserves an actual tool suspension and its same-run resume', async () => {
+    const network = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network is forbidden in this test'));
+    const harness = await createHarness('complete', false, true);
+    const { session, calls, approvals, errors } = harness;
+    const parked = deferred();
+    const suspendedCalls: string[] = [];
+    const off = session.subscribe(event => {
+      if (event.type === 'tool_suspended') {
+        suspendedCalls.push(event.toolCallId);
+        parked.resolve();
+      }
+    });
+    const turn = session.sendMessage({ content: 'Run the local actions.' });
+    let resumed: Promise<void> | undefined;
+    try {
+      await parked.promise;
+      expect(suspendedCalls).toEqual(['call-1']);
+      expect(calls.tool).toBe(0);
+      resumed = session.respondToToolSuspension({ toolCallId: 'call-1', resumeData: { confirmed: true } });
+      await vi.waitFor(
+        () => expect({ model: calls.model, errors, suspendedCalls }).toMatchObject({ model: 5, errors: [] }),
+        { timeout: 5_000 },
+      );
+      await harness.reachedBoundary.promise;
+      harness.releaseBoundary.resolve();
+      await vi.waitFor(() => expect(calls.results).toEqual(['stop']));
+      await delay(100);
+      expect(approvals).toEqual(['call-1', 'call-2', 'call-3', 'call-4']);
+      expect(calls.tool).toBe(4);
+      expect(calls.model).toBe(5);
+      expect(session.approval.isArmed()).toBe(false);
+      expect(session.displayState.get().pendingApproval).toBeNull();
+      expect(session.displayState.get().isRunning).toBe(false);
+      expect(errors).toEqual([]);
+      expect(network).not.toHaveBeenCalled();
+    } finally {
+      off();
+      await harness.close();
+      void Promise.allSettled([turn, ...(resumed ? [resumed] : [])]);
+      network.mockRestore();
+    }
+  }, 20_000);
+
+  it.each([
+    { ending: 'complete' as const, queued: false, parallel: false },
+    { ending: 'complete' as const, queued: true, parallel: false },
+    { ending: 'complete' as const, queued: false, parallel: true },
+    { ending: 'response abort' as const, queued: false, parallel: false },
+    { ending: 'response abort' as const, queued: true, parallel: false },
+    { ending: 'step abort' as const, queued: false, parallel: false },
+    { ending: 'step abort' as const, queued: true, parallel: false },
+  ])(
+    'does not replay resolved approvals after $ending (queued=$queued, parallel=$parallel)',
+    async ({ ending, queued, parallel }) => {
+      const network = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network is forbidden in this test'));
+      const harness = await createHarness(ending, parallel);
+      const { session, calls, approvals, ends, errors, runIds } = harness;
+      const turns: Promise<void>[] = [];
+      try {
+        turns.push(session.sendMessage({ content: 'Run the local actions.' }));
+        await vi.waitFor(
+          () => expect({ model: calls.model, errors, approvals }).toMatchObject({ model: 5, errors: [] }),
+          { timeout: 5_000 },
+        );
+        await harness.reachedBoundary.promise;
+        const expectedApprovals = parallel
+          ? ['call-1', 'call-1-parallel', 'call-2', 'call-3', 'call-4']
+          : ['call-1', 'call-2', 'call-3', 'call-4'];
+        expect(approvals).toEqual(expectedApprovals);
+        if (queued) await session.followUp({ content: 'Run one more local action.' });
+        if (ending !== 'complete') session.abort();
+        harness.releaseBoundary.resolve();
+        await harness.firstEnd.promise;
+
+        if (!queued) {
+          // Let queued native resume readers drain; a transient idle snapshot alone is insufficient.
+          await delay(100);
+          expect(approvals).toEqual(expectedApprovals);
+          expect(session.approval.isArmed()).toBe(false);
+          expect(session.displayState.get().pendingApproval).toBeNull();
+          expect(session.displayState.get().isRunning).toBe(false);
+          expect(calls.model).toBe(5);
+          expect(calls.tool).toBe(expectedApprovals.length);
+          turns.push(session.sendMessage({ content: 'Run one more local action.' }));
+        }
+        await vi.waitFor(() => expect(approvals).toEqual([...expectedApprovals, 'call-6']));
+        expect(session.approval.isArmed()).toBe(true);
+        expect(session.displayState.get().pendingApproval?.toolCallId).toBe('call-6');
+        session.respondToToolApproval({ decision: 'approve', toolCallId: 'call-6' });
+        await vi.waitFor(() => expect(calls.results).toEqual([ending === 'complete' ? 'stop' : 'abort', 'stop']));
+        await delay(100);
+        expect(ends).toEqual([ending === 'complete' ? 'complete' : 'aborted', 'complete']);
+        expect(runIds).toHaveLength(2);
+        expect(runIds[0]).not.toBe(runIds[1]);
+        expect(session.approval.isArmed()).toBe(false);
+        expect(session.displayState.get().pendingApproval).toBeNull();
+        expect(session.displayState.get().isRunning).toBe(false);
+        expect(approvals).toEqual([...expectedApprovals, 'call-6']);
+        expect(calls.model).toBe(7);
+        expect(calls.tool).toBe(expectedApprovals.length + 1);
+        expect(calls.abort).toBe(ending === 'complete' ? 0 : 1);
+        expect((await (await harness.storage.getStore('workflows'))!.listWorkflowRuns({})).runs).toEqual([]);
+        expect(errors).toEqual([]);
+        expect(network).not.toHaveBeenCalled();
+      } finally {
+        await harness.close();
+        void Promise.allSettled(turns);
+        network.mockRestore();
+      }
+    },
+    20_000,
+  );
+});

--- a/packages/core/src/agent-controller/__tests__/session-error-history.integration.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-error-history.integration.test.ts
@@ -1,0 +1,224 @@
+import dns from 'node:dns';
+import net from 'node:net';
+import { setImmediate } from 'node:timers/promises';
+import { afterEach, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { Memory } from '../../../../memory/src';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../../agent/durable';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage';
+import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
+import { createTool } from '../../tools';
+import { AgentController } from '../agent-controller';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+it.each([
+  { fails: false, holdSave: false },
+  { fails: true, holdSave: false },
+  { fails: false, holdSave: true },
+  { fails: true, holdSave: true },
+])('settles approved history before terminal events: %j', async ({ fails, holdSave }) => {
+  const network = vi.fn(() => {
+    throw new Error('Network is forbidden');
+  });
+  vi.spyOn(globalThis, 'fetch').mockImplementation(network);
+  vi.spyOn(net.Socket.prototype, 'connect').mockImplementation(network);
+  vi.spyOn(dns, 'lookup').mockImplementation(network);
+  const storage = new InMemoryStore();
+  const memory = new Memory({ storage, options: { generateTitle: false, observationalMemory: false } });
+  const reachedSave = deferred();
+  const releaseSave = deferred();
+  const approval = deferred();
+  const terminal = deferred();
+  const calls = { model: 0, tool: 0, output: [] as string[], saved: false };
+  const originalError = new Error('Second model call rejected');
+  originalError.name = 'ProviderRejection';
+  const saveMessages = memory.saveMessages.bind(memory);
+  vi.spyOn(memory, 'saveMessages').mockImplementation(async args => {
+    if (
+      holdSave &&
+      calls.model === 2 &&
+      args.messages.some(row =>
+        row.content.parts.some(
+          part =>
+            part.type === 'tool-invocation' &&
+            part.toolInvocation.toolCallId === 'approved-call' &&
+            part.toolInvocation.state === 'result',
+        ),
+      )
+    ) {
+      reachedSave.resolve();
+      await releaseSave.promise;
+    }
+    const result = await saveMessages(args);
+    if (calls.model === 2) calls.saved = true;
+    return result;
+  });
+  const durable: unknown = createDurableAgent({
+    agent: new Agent({
+      id: 'error-history-agent',
+      name: 'Error history',
+      instructions: 'Run the local lookup.',
+      maxRetries: 0,
+      memory,
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => {
+          const call = ++calls.model;
+          if (call > 2) throw new Error('Unexpected model call');
+          if (fails && call === 2) throw originalError;
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+                if (call === 1)
+                  controller.enqueue({
+                    type: 'tool-call',
+                    toolCallId: 'approved-call',
+                    toolName: 'lookup',
+                    input: '{}',
+                  });
+                else {
+                  controller.enqueue({ type: 'text-start', id: 'answer' });
+                  controller.enqueue({ type: 'text-delta', id: 'answer', delta: 'Done.' });
+                  controller.enqueue({ type: 'text-end', id: 'answer' });
+                }
+                controller.enqueue({
+                  type: 'finish',
+                  finishReason: call === 1 ? 'tool-calls' : 'stop',
+                  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                });
+                controller.close();
+              },
+            }),
+          };
+        },
+      }),
+      tools: {
+        lookup: createTool({
+          id: 'lookup',
+          description: 'Local lookup',
+          inputSchema: z.object({}),
+          requireApproval: true,
+          execute: async () => {
+            calls.tool++;
+            return { value: 'saved-result' };
+          },
+        }),
+      },
+      outputProcessors: [
+        {
+          id: 'observe-final-output',
+          processOutputResult: args => {
+            calls.output.push(args.result?.finishReason ?? 'missing');
+            return args.messageList;
+          },
+        },
+      ],
+    }),
+  });
+  if (!(durable instanceof Agent)) throw new TypeError('Expected native Agent');
+  const controller = new AgentController({
+    id: 'history-controller',
+    agent: durable,
+    storage,
+    memory,
+    modes: [{ id: 'chat', name: 'Chat', default: true }],
+    disableBuiltinTools: [
+      'ask_user',
+      'submit_plan',
+      'task_write',
+      'task_update',
+      'task_complete',
+      'task_check',
+      'subagent',
+    ],
+  });
+  const mastra = new Mastra({
+    agents: { durable },
+    agentControllers: { controller },
+    storage,
+    logger: false,
+    workers: false,
+    scheduler: { enabled: false },
+    recovery: { durableAgents: 'off' },
+  });
+  await controller.init();
+  expect(controller.getMastra()).toBe(mastra);
+  expect(durable.getMastraInstance()).toBe(mastra);
+  expect(mastra.getAgentController('controller')).toBe(controller);
+  const session = await controller.createSession({ resourceId: 'resource', threadId: 'history-thread' });
+  await session.state.set({ yolo: false });
+  const ends: string[] = [];
+  const errors: unknown[] = [];
+  const histories: Array<ReturnType<typeof session.thread.listActiveMessages>> = [];
+  const savedAtEnd: boolean[] = [];
+  const off = session.subscribe(event => {
+    if (event.type === 'tool_approval_required') approval.resolve();
+    if (event.type === 'error') errors.push(event.error);
+    if (event.type === 'agent_end' && event.reason !== 'suspended') {
+      ends.push(event.reason ?? 'missing');
+      savedAtEnd.push(calls.saved);
+      histories.push(session.thread.listActiveMessages());
+      terminal.resolve();
+    }
+  });
+  const turn = session.sendMessage({ content: 'Run the lookup.' });
+  try {
+    await approval.promise;
+    expect(calls.tool).toBe(0);
+    session.respondToToolApproval({ decision: 'approve', toolCallId: 'approved-call' });
+    if (holdSave) {
+      await reachedSave.promise;
+      await setImmediate();
+      expect(calls.output).toEqual([fails ? 'error' : 'stop']);
+      expect(ends).toEqual([]);
+      expect(errors).toEqual([]);
+      expect(calls.saved).toBe(false);
+      releaseSave.resolve();
+    }
+    await terminal.promise;
+    await turn;
+    expect(ends).toEqual([fails ? 'error' : 'complete']);
+    expect(savedAtEnd).toEqual([true]);
+    for (const rows of await Promise.all(histories)) {
+      const row = rows.find(row =>
+        row.content.parts.some(
+          part => part.type === 'tool-invocation' && part.toolInvocation.toolCallId === 'approved-call',
+        ),
+      );
+      expect(row?.content.metadata?.pendingToolApprovals).toBeUndefined();
+      expect(row?.content.parts).toContainEqual(
+        expect.objectContaining({
+          type: 'tool-invocation',
+          toolInvocation: expect.objectContaining({
+            toolCallId: 'approved-call',
+            state: 'result',
+            result: { value: 'saved-result' },
+          }),
+        }),
+      );
+    }
+    if (fails) expect(errors).toEqual([expect.objectContaining({ message: originalError.message })]);
+    else expect(errors).toEqual([]);
+    expect(calls.model).toBe(2);
+    expect(calls.tool).toBe(1);
+    expect(session.displayState.get().pendingApproval).toBeNull();
+    expect(network).not.toHaveBeenCalled();
+  } finally {
+    releaseSave.resolve();
+    session.abort();
+    await turn.catch(() => undefined);
+    off();
+    await mastra.shutdown();
+  }
+});

--- a/packages/core/src/agent-controller/__tests__/session-stop-owner-cold.integration.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-stop-owner-cold.integration.test.ts
@@ -44,6 +44,13 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+// DurableAgent intentionally narrows the base stream/generate signatures.
+// The controller accepts the native base class; keep the same checked object.
+function requireNativeAgent(agent: unknown) {
+  if (!(agent instanceof Agent)) throw new TypeError('Expected a native Agent');
+  return agent;
+}
+
 it.each(['mode-plan', 'mode-build', 'single-agent', 'single-agent-navigation', 'single-agent-future'] as const)(
   'Cold reopened Session Stop keeps its captured target: %s',
   async scenario => {
@@ -105,11 +112,17 @@ it.each(['mode-plan', 'mode-build', 'single-agent', 'single-agent-navigation', '
         workspace,
         initialState: { yolo: true },
         ...(singleAgent
-          ? { agent: planAgent, modes: [{ id: 'web', name: 'Web', default: true }] }
+          ? { agent: requireNativeAgent(planAgent), modes: [{ id: 'web', name: 'Web', default: true }] }
           : {
               modes: [
-                { id: 'plan', name: 'Plan', default: true, transitionsTo: 'build', agent: planAgent },
-                { id: 'build', name: 'Build', agent: buildAgent },
+                {
+                  id: 'plan',
+                  name: 'Plan',
+                  default: true,
+                  transitionsTo: 'build',
+                  agent: requireNativeAgent(planAgent),
+                },
+                { id: 'build', name: 'Build', agent: requireNativeAgent(buildAgent) },
               ],
             }),
       });

--- a/packages/core/src/agent-controller/__tests__/session-stop-owner-cold.integration.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-stop-owner-cold.integration.test.ts
@@ -1,0 +1,371 @@
+// Adapted from the independent public-package cold Stop regression.
+import dns from 'node:dns';
+import fs from 'node:fs';
+import net from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, expect, it, vi } from 'vitest';
+import { LibSQLStore } from '../../../../../stores/libsql/src';
+import { Memory } from '../../../../memory/src';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../../agent/durable';
+import { Mastra } from '../../mastra';
+import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
+import { submitPlanTool } from '../../tools/builtin/submit-plan';
+import type { WorkflowRunState } from '../../workflows/types';
+import { Workspace } from '../../workspace';
+import { AgentController } from '../agent-controller';
+
+function response(call: number) {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: 'stream-start', warnings: [] });
+      controller.enqueue({ type: 'response-metadata', id: `id-${call}`, modelId: 'mock', timestamp: new Date(0) });
+      controller.enqueue({
+        type: 'tool-call',
+        toolCallId: `plan-call-${call}`,
+        toolName: 'submit_plan',
+        input: '{"path":"plan.md"}',
+        providerExecuted: false,
+      });
+      controller.enqueue({
+        type: 'finish',
+        finishReason: 'tool-calls',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      });
+      controller.close();
+    },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it.each(['mode-plan', 'mode-build', 'single-agent', 'single-agent-navigation', 'single-agent-future'] as const)(
+  'Cold reopened Session Stop keeps its captured target: %s',
+  async scenario => {
+    const switchFirst = scenario === 'mode-build';
+    const singleAgent = scenario.startsWith('single-agent');
+    const navigate = scenario === 'single-agent-navigation' || scenario === 'single-agent-future';
+    const startFutureRun = scenario === 'single-agent-future';
+    const directory = fs.mkdtempSync(path.join(tmpdir(), `mastra-cold-mode-stop-${scenario}-`));
+    const url = pathToFileURL(path.join(directory, 'native.db')).href;
+    const calls = { plan: 0, build: 0, network: 0 };
+    const deny = () => {
+      calls.network++;
+      throw new Error('Unexpected network');
+    };
+    vi.stubGlobal('fetch', vi.fn(deny));
+    vi.spyOn(net.Socket.prototype, 'connect').mockImplementation(deny as never);
+    vi.spyOn(dns, 'lookup').mockImplementation(deny as never);
+    const receipt: Record<string, any> = {
+      scope: 'native source cold Session Stop',
+      scenario,
+      switchFirst,
+      directory,
+      owners: [],
+      events: [],
+      calls,
+    };
+
+    async function createHost() {
+      const storage = new LibSQLStore({ id: 'mode-stop-proof', url });
+      await storage.init();
+      const planAgent = createDurableAgent({
+        agent: new Agent<string, { submit_plan: typeof submitPlanTool }, any>({
+          id: 'plan-agent',
+          name: 'Plan',
+          instructions: 'Submit a local plan.',
+          model: new MastraLanguageModelV2Mock({ doStream: async () => ({ stream: response(++calls.plan) }) }),
+          memory: new Memory({ storage }),
+          tools: { submit_plan: submitPlanTool },
+        }),
+      });
+      const buildAgent = createDurableAgent({
+        agent: new Agent<string, {}, any>({
+          id: 'build-agent',
+          name: 'Build',
+          instructions: 'Do local work.',
+          model: new MastraLanguageModelV2Mock({
+            doStream: async () => {
+              calls.build++;
+              throw new Error('Build must not execute in this proof');
+            },
+          }),
+          memory: new Memory({ storage }),
+        }),
+      });
+      const workspace = new Workspace({ name: 'Cold mode Stop proof', skills: () => [] });
+      const controller = new AgentController({
+        id: 'mode-stop-controller',
+        storage,
+        workspace,
+        initialState: { yolo: true },
+        ...(singleAgent
+          ? { agent: planAgent, modes: [{ id: 'web', name: 'Web', default: true }] }
+          : {
+              modes: [
+                { id: 'plan', name: 'Plan', default: true, transitionsTo: 'build', agent: planAgent },
+                { id: 'build', name: 'Build', agent: buildAgent },
+              ],
+            }),
+      });
+      const mastra = new Mastra({
+        agents: singleAgent ? { planAgent } : { planAgent, buildAgent },
+        agentControllers: { proof: controller },
+        storage,
+        logger: false,
+        workers: false,
+        scheduler: { enabled: false },
+        recovery: { durableAgents: 'off' },
+      });
+      return { storage, planAgent, buildAgent, workspace, controller, mastra };
+    }
+    const owners = (host: Awaited<ReturnType<typeof createHost>>, stage: string) => {
+      const checks = {
+        controller: host.controller.getMastra() === host.mastra,
+        registered: host.mastra.getAgentController('proof') === host.controller,
+        plan: host.planAgent.getMastraInstance() === host.mastra,
+        ...(singleAgent ? {} : { build: host.buildAgent.getMastraInstance() === host.mastra }),
+        storage: host.controller.getMastra()?.getStorage() === host.mastra.getStorage(),
+      };
+      receipt.owners.push({ stage, ...checks });
+      expect(Object.values(checks).every(Boolean)).toBe(true);
+    };
+    const rows = async (storage: LibSQLStore) =>
+      (await (await storage.getStore('workflows'))!.listWorkflowRuns({})).runs.map(row => {
+        const snapshot =
+          typeof row.snapshot === 'string' ? (JSON.parse(row.snapshot) as WorkflowRunState) : row.snapshot;
+        return {
+          workflowName: row.workflowName,
+          runId: row.runId,
+          createdAt: row.createdAt,
+          status: snapshot?.status,
+          agentId: (snapshot?.context?.input as any)?.agentId,
+          resourceId: row.resourceId,
+        };
+      });
+    const events = (session: Awaited<ReturnType<AgentController['createSession']>>, phase: string) =>
+      session.subscribe(event => {
+        if (
+          ['tool_suspended', 'tool_suspension_cancelled', 'agent_end', 'error', 'mode_changed'].includes(event.type)
+        ) {
+          receipt.events.push({
+            phase,
+            type: event.type,
+            reason: (event as any).reason,
+            toolCallId: (event as any).toolCallId,
+            modeId: (event as any).modeId,
+            error: (event as any).error?.message,
+          });
+        }
+      });
+    let host = await createHost();
+    let unsubscribe = () => {};
+    const discoveries: Array<{ mode: string; kind: string; spy: any }> = [];
+    let planAbort: ReturnType<typeof vi.spyOn> | undefined;
+    let buildAbort: ReturnType<typeof vi.spyOn> | undefined;
+    let releaseRead = () => {};
+    try {
+      await host.controller.init();
+      owners(host, 'writer');
+      const warm = await host.controller.createSession({
+        id: 'mode-stop-session',
+        ownerId: 'owner',
+        resourceId: 'resource',
+        workspace: host.workspace,
+      });
+      await warm.thread.create();
+      unsubscribe = events(warm, 'writer');
+      await warm.sendMessage({ content: 'Create a plan.' });
+      await vi.waitFor(
+        async () => {
+          receipt.beforeRows = await rows(host.storage);
+          expect(receipt.beforeRows.filter((row: any) => row.status === 'suspended')).toHaveLength(2);
+        },
+        { timeout: 5000, interval: 20 },
+      );
+      if (switchFirst) await warm.mode.switch({ modeId: 'build' });
+      receipt.savedMode = warm.mode.get();
+      const threadId = warm.thread.getId()!;
+      receipt.threadId = threadId;
+      let emptyThreadId: string | undefined;
+      if (singleAgent) {
+        const empty = await host.controller.createSession({
+          scope: 'empty-thread',
+          ownerId: 'owner',
+          resourceId: 'resource',
+          workspace: host.workspace,
+        });
+        emptyThreadId = (await empty.thread.create()).id;
+        receipt.emptyThreadId = emptyThreadId;
+      }
+      unsubscribe();
+      await host.mastra.shutdown();
+
+      const writer = host;
+      host = await createHost();
+      await host.controller.init();
+      owners(host, 'reopened');
+      expect(host.mastra).not.toBe(writer.mastra);
+      expect(host.controller).not.toBe(writer.controller);
+      expect(host.storage).not.toBe(writer.storage);
+      expect(host.planAgent).not.toBe(writer.planAgent);
+      expect(host.buildAgent).not.toBe(writer.buildAgent);
+      const fresh = await host.controller.createSession({
+        id: 'mode-stop-session',
+        ownerId: 'owner',
+        resourceId: 'resource',
+        workspace: host.workspace,
+      });
+      expect(fresh).not.toBe(warm);
+      unsubscribe = events(fresh, 'reopened');
+      await fresh.thread.switch({ threadId });
+      receipt.reopened = {
+        mode: fresh.mode.get(),
+        runId: fresh.getCurrentRunId(),
+        pending: fresh.suspensions.hasPending(),
+        agentId: host.controller.getCurrentAgent(fresh).id,
+        resourceId: fresh.identity.getResourceId(),
+        threadId: fresh.thread.getId(),
+      };
+      expect(receipt.reopened).toEqual({
+        mode: singleAgent ? 'web' : switchFirst ? 'build' : 'plan',
+        runId: null,
+        pending: false,
+        agentId: switchFirst ? 'build-agent' : 'plan-agent',
+        resourceId: 'resource',
+        threadId,
+      });
+      receipt.beforeStopRows = await rows(host.storage);
+      expect(receipt.beforeStopRows.map((row: any) => row.status)).toEqual(['suspended', 'suspended']);
+
+      const backingAgents = singleAgent
+        ? ([['web', host.planAgent]] as const)
+        : ([
+            ['plan', host.planAgent],
+            ['build', host.buildAgent],
+          ] as const);
+      const realReads = {
+        listSuspendedRuns: host.planAgent.listSuspendedRuns.bind(host.planAgent),
+        listActiveRuns: host.planAgent.listActiveRuns.bind(host.planAgent),
+      };
+      for (const [mode, agent] of backingAgents) {
+        discoveries.push({ mode, kind: 'suspended', spy: vi.spyOn(agent, 'listSuspendedRuns') });
+        discoveries.push({ mode, kind: 'active', spy: vi.spyOn(agent, 'listActiveRuns') });
+      }
+      planAbort = vi.spyOn(host.planAgent, 'abortRunStream');
+      buildAbort = vi.spyOn(host.buildAgent, 'abortRunStream');
+      let enteredResolve = () => {};
+      const entered = new Promise<void>(resolve => {
+        enteredResolve = resolve;
+      });
+      const held = new Promise<void>(resolve => {
+        releaseRead = resolve;
+      });
+      if (singleAgent) {
+        for (const method of ['listSuspendedRuns', 'listActiveRuns'] as const) {
+          const spy = discoveries.find(
+            item => item.kind === (method === 'listSuspendedRuns' ? 'suspended' : 'active'),
+          )!.spy;
+          spy.mockImplementation(async (input: Parameters<typeof host.planAgent.listSuspendedRuns>[0]) => {
+            receipt.heldScope = input;
+            enteredResolve();
+            await held;
+            return realReads[method](input);
+          });
+        }
+      }
+      owners(host, 'before-stop');
+      fresh.abortRun();
+      if (singleAgent) {
+        await entered;
+        expect(fresh.run.isAbortRequested()).toBe(true);
+        expect(receipt.heldScope).toMatchObject({ resourceId: 'resource', threadId });
+        expect(receipt.heldScope.toDate).toBeInstanceOf(Date);
+        if (navigate) {
+          await fresh.thread.switch({ threadId: emptyThreadId! });
+          expect(fresh.thread.getId()).toBe(emptyThreadId);
+        }
+        if (startFutureRun) {
+          await vi.waitFor(() => expect(Date.now()).toBeGreaterThan(receipt.heldScope.toDate.getTime()), {
+            interval: 2,
+          });
+          const later = await host.controller.createSession({
+            scope: 'future-run',
+            ownerId: 'owner',
+            resourceId: 'resource',
+            workspace: host.workspace,
+          });
+          await later.thread.switch({ threadId });
+          await later.sendMessage({ content: 'Create another plan after Stop.' });
+          await vi.waitFor(
+            async () => {
+              const oldIds = new Set(receipt.beforeStopRows.map((row: any) => row.runId));
+              receipt.futureRows = (await rows(host.storage)).filter(row => !oldIds.has(row.runId));
+              expect(receipt.futureRows).toHaveLength(2);
+              expect(receipt.futureRows.every((row: any) => row.status === 'suspended')).toBe(true);
+            },
+            { timeout: 5000, interval: 20 },
+          );
+          expect(
+            receipt.futureRows.every((row: any) => row.createdAt.getTime() > receipt.heldScope.toDate.getTime()),
+          ).toBe(true);
+        }
+        releaseRead();
+      }
+      await host.mastra.shutdown();
+      const reader = new LibSQLStore({ id: 'readback', url });
+      try {
+        await reader.init();
+        receipt.afterRows = await rows(reader);
+        if (singleAgent) {
+          const memory = new Memory({ storage: reader });
+          const empty = await memory.recall({ threadId: emptyThreadId!, resourceId: 'resource' });
+          expect(empty.messages).toHaveLength(0);
+        }
+      } finally {
+        await reader.close();
+      }
+      const oldIds = new Set(receipt.beforeStopRows.map((row: any) => row.runId));
+      expect(receipt.afterRows.filter((row: any) => oldIds.has(row.runId)).map((row: any) => row.status)).toEqual([
+        'canceled',
+        'canceled',
+      ]);
+      expect(receipt.afterRows.filter((row: any) => !oldIds.has(row.runId)).map((row: any) => row.status)).toEqual(
+        startFutureRun ? ['suspended', 'suspended'] : [],
+      );
+      expect(calls).toEqual({ plan: startFutureRun ? 2 : 1, build: 0, network: 0 });
+    } finally {
+      releaseRead();
+      await host.mastra.shutdown();
+      unsubscribe();
+      receipt.discovery = await Promise.all(
+        discoveries.map(async ({ mode, kind, spy }) => ({
+          mode,
+          kind,
+          inputs: spy.mock.calls,
+          outputs: await Promise.all(
+            spy.mock.results.map(async (result: any) => {
+              if (result.type !== 'return') return { error: String(result.value) };
+              try {
+                const value = await result.value;
+                return { runs: value.runs.map((run: any) => ({ runId: run.runId, agentId: run.agentId })) };
+              } catch (error) {
+                return { error: String(error) };
+              }
+            }),
+          ),
+        })),
+      );
+      receipt.planAbort = planAbort?.mock.calls;
+      receipt.buildAbort = buildAbort?.mock.calls;
+      receipt.finishedAt = new Date().toISOString();
+      fs.writeFileSync(path.join(directory, 'result.json'), JSON.stringify(receipt, null, 2) + '\n');
+    }
+  },
+  15000,
+);

--- a/packages/core/src/agent-controller/__tests__/session-stop-owner-cold.integration.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-stop-owner-cold.integration.test.ts
@@ -51,7 +51,23 @@ function requireNativeAgent(agent: unknown) {
   return agent;
 }
 
-it.each(['mode-plan', 'mode-build', 'single-agent', 'single-agent-navigation', 'single-agent-future'] as const)(
+function describeError(error: unknown): unknown {
+  if (!(error instanceof Error)) return String(error);
+  return {
+    message: error.message,
+    id: (error as Error & { id?: string }).id,
+    errors: error instanceof AggregateError ? error.errors.map(describeError) : undefined,
+  };
+}
+
+it.each([
+  'mode-plan',
+  'mode-build',
+  'single-agent',
+  'single-agent-navigation',
+  'single-agent-future',
+  'single-agent-duplicate',
+] as const)(
   'Cold reopened Session Stop keeps its captured target: %s',
   async scenario => {
     const switchFirst = scenario === 'mode-build';
@@ -75,6 +91,7 @@ it.each(['mode-plan', 'mode-build', 'single-agent', 'single-agent-navigation', '
       directory,
       owners: [],
       events: [],
+      terminalOutputs: [],
       calls,
     };
 
@@ -89,6 +106,15 @@ it.each(['mode-plan', 'mode-build', 'single-agent', 'single-agent-navigation', '
           model: new MastraLanguageModelV2Mock({ doStream: async () => ({ stream: response(++calls.plan) }) }),
           memory: new Memory({ storage }),
           tools: { submit_plan: submitPlanTool },
+          outputProcessors: [
+            {
+              id: 'cold-stop-terminal-observer',
+              processOutputResult({ messageList, result }) {
+                receipt.terminalOutputs.push({ finishReason: result.finishReason, usage: result.usage });
+                return messageList;
+              },
+            },
+          ],
         }),
       });
       const buildAgent = createDurableAgent({
@@ -236,7 +262,8 @@ it.each(['mode-plan', 'mode-build', 'single-agent', 'single-agent-navigation', '
       });
       expect(fresh).not.toBe(warm);
       unsubscribe = events(fresh, 'reopened');
-      await fresh.thread.switch({ threadId });
+      if (fresh.thread.getId() !== threadId) await fresh.thread.switch({ threadId });
+      expect(fresh.thread.getId()).toBe(threadId);
       receipt.reopened = {
         mode: fresh.mode.get(),
         runId: fresh.getCurrentRunId(),
@@ -294,6 +321,17 @@ it.each(['mode-plan', 'mode-build', 'single-agent', 'single-agent-navigation', '
       }
       owners(host, 'before-stop');
       fresh.abortRun();
+      if (scenario === 'single-agent-duplicate') {
+        const duplicate = await host.controller.createSession({
+          id: 'duplicate-stop-session',
+          scope: 'duplicate-stop',
+          ownerId: 'owner',
+          resourceId: 'resource',
+          workspace: host.workspace,
+        });
+        if (duplicate.thread.getId() !== threadId) await duplicate.thread.switch({ threadId });
+        duplicate.abortRun();
+      }
       if (singleAgent) {
         await entered;
         expect(fresh.run.isAbortRequested()).toBe(true);
@@ -313,7 +351,7 @@ it.each(['mode-plan', 'mode-build', 'single-agent', 'single-agent-navigation', '
             resourceId: 'resource',
             workspace: host.workspace,
           });
-          await later.thread.switch({ threadId });
+          if (later.thread.getId() !== threadId) await later.thread.switch({ threadId });
           await later.sendMessage({ content: 'Create another plan after Stop.' });
           await vi.waitFor(
             async () => {
@@ -330,11 +368,26 @@ it.each(['mode-plan', 'mode-build', 'single-agent', 'single-agent-navigation', '
         }
         releaseRead();
       }
-      await host.mastra.shutdown();
+      const shutdown = host.mastra.shutdown();
+      if (scenario === 'single-agent-duplicate') {
+        // Recovery admits one owner. The competing Session gets an explicit
+        // conflict; it must not prepare a second stream or resurrect a row.
+        await expect(shutdown).rejects.toMatchObject({
+          errors: [
+            expect.objectContaining({
+              errors: [expect.objectContaining({ id: 'DURABLE_AGENT_RECOVER_ALREADY_IN_PROGRESS' })],
+            }),
+          ],
+        });
+      } else {
+        await shutdown;
+      }
       const reader = new LibSQLStore({ id: 'readback', url });
       try {
         await reader.init();
         receipt.afterRows = await rows(reader);
+        const stoppedMessages = await new Memory({ storage: reader }).recall({ threadId, resourceId: 'resource' });
+        receipt.stoppedMessages = stoppedMessages.messages;
         if (singleAgent) {
           const memory = new Memory({ storage: reader });
           const empty = await memory.recall({ threadId: emptyThreadId!, resourceId: 'resource' });
@@ -344,17 +397,26 @@ it.each(['mode-plan', 'mode-build', 'single-agent', 'single-agent-navigation', '
         await reader.close();
       }
       const oldIds = new Set(receipt.beforeStopRows.map((row: any) => row.runId));
-      expect(receipt.afterRows.filter((row: any) => oldIds.has(row.runId)).map((row: any) => row.status)).toEqual([
-        'canceled',
-        'canceled',
+      expect(receipt.terminalOutputs).toEqual([
+        { finishReason: 'abort', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
       ]);
+      expect(receipt.events.filter((event: { type: string }) => event.type === 'error')).toEqual([]);
+      for (const message of receipt.stoppedMessages) {
+        expect(message.content.metadata?.suspendedTools?.['plan-call-1']).toBeUndefined();
+        expect(message.content.metadata?.pendingToolApprovals?.['plan-call-1']).toBeUndefined();
+      }
+      expect(receipt.afterRows.filter((row: any) => oldIds.has(row.runId))).toEqual([]);
       expect(receipt.afterRows.filter((row: any) => !oldIds.has(row.runId)).map((row: any) => row.status)).toEqual(
         startFutureRun ? ['suspended', 'suspended'] : [],
       );
       expect(calls).toEqual({ plan: startFutureRun ? 2 : 1, build: 0, network: 0 });
     } finally {
       releaseRead();
-      await host.mastra.shutdown();
+      try {
+        await host.mastra.shutdown();
+      } catch (error) {
+        receipt.shutdownError = describeError(error);
+      }
       unsubscribe();
       receipt.discovery = await Promise.all(
         discoveries.map(async ({ mode, kind, spy }) => ({

--- a/packages/core/src/agent-controller/__tests__/session-stop-owner-cold.integration.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-stop-owner-cold.integration.test.ts
@@ -67,6 +67,12 @@ it.each([
   'single-agent-navigation',
   'single-agent-future',
   'single-agent-duplicate',
+  'single-agent-save-delay',
+  'single-agent-end-navigation',
+  'single-agent-save-failure',
+  'single-agent-approval',
+  'single-agent-end-new-run',
+  'single-agent-end-preparing-run',
 ] as const)(
   'Cold reopened Session Stop keeps its captured target: %s',
   async scenario => {
@@ -74,9 +80,22 @@ it.each([
     const singleAgent = scenario.startsWith('single-agent');
     const navigate = scenario === 'single-agent-navigation' || scenario === 'single-agent-future';
     const startFutureRun = scenario === 'single-agent-future';
+    const failSave = scenario === 'single-agent-save-failure';
+    const approval = scenario === 'single-agent-approval';
+    const preparingRun = scenario === 'single-agent-end-preparing-run';
+    const newRunAtEnd = scenario === 'single-agent-end-new-run' || preparingRun;
+    const holdEnd = scenario === 'single-agent-end-navigation' || newRunAtEnd;
     const directory = fs.mkdtempSync(path.join(tmpdir(), `mastra-cold-mode-stop-${scenario}-`));
     const url = pathToFileURL(path.join(directory, 'native.db')).href;
     const calls = { plan: 0, build: 0, network: 0 };
+    let enterNewModel = () => {};
+    let releaseNewModel = () => {};
+    const newModelEntered = new Promise<void>(resolve => {
+      enterNewModel = resolve;
+    });
+    const heldNewModel = new Promise<void>(resolve => {
+      releaseNewModel = resolve;
+    });
     const deny = () => {
       calls.network++;
       throw new Error('Unexpected network');
@@ -103,8 +122,17 @@ it.each([
           id: 'plan-agent',
           name: 'Plan',
           instructions: 'Submit a local plan.',
-          model: new MastraLanguageModelV2Mock({ doStream: async () => ({ stream: response(++calls.plan) }) }),
-          memory: new Memory({ storage }),
+          model: new MastraLanguageModelV2Mock({
+            doStream: async () => {
+              const call = ++calls.plan;
+              if (call === 2 && preparingRun) {
+                enterNewModel();
+                await heldNewModel;
+              }
+              return { stream: response(call) };
+            },
+          }),
+          memory: new Memory({ storage, options: { generateTitle: approval } }),
           tools: { submit_plan: submitPlanTool },
           outputProcessors: [
             {
@@ -136,7 +164,7 @@ it.each([
         id: 'mode-stop-controller',
         storage,
         workspace,
-        initialState: { yolo: true },
+        initialState: { yolo: !approval },
         ...(singleAgent
           ? { agent: requireNativeAgent(planAgent), modes: [{ id: 'web', name: 'Web', default: true }] }
           : {
@@ -190,7 +218,15 @@ it.each([
     const events = (session: Awaited<ReturnType<AgentController['createSession']>>, phase: string) =>
       session.subscribe(event => {
         if (
-          ['tool_suspended', 'tool_suspension_cancelled', 'agent_end', 'error', 'mode_changed'].includes(event.type)
+          [
+            'tool_suspended',
+            'tool_suspension_cancelled',
+            'agent_end',
+            'message_end',
+            'display_state_changed',
+            'error',
+            'mode_changed',
+          ].includes(event.type)
         ) {
           receipt.events.push({
             phase,
@@ -199,6 +235,8 @@ it.each([
             toolCallId: (event as any).toolCallId,
             modeId: (event as any).modeId,
             error: (event as any).error?.message,
+            message: event.type === 'message_end' ? structuredClone(event.message) : undefined,
+            displayState: event.type === 'display_state_changed' ? structuredClone(event.displayState) : undefined,
           });
         }
       });
@@ -208,6 +246,8 @@ it.each([
     let planAbort: ReturnType<typeof vi.spyOn> | undefined;
     let buildAbort: ReturnType<typeof vi.spyOn> | undefined;
     let releaseRead = () => {};
+    let releaseSave = () => {};
+    let releaseEnd = () => {};
     try {
       await host.controller.init();
       owners(host, 'writer');
@@ -219,7 +259,9 @@ it.each([
       });
       await warm.thread.create();
       unsubscribe = events(warm, 'writer');
-      await warm.sendMessage({ content: 'Create a plan.' });
+      const initialSend = warm.sendMessage({ content: 'Create a plan.' });
+      if (approval) void initialSend.catch(() => {});
+      else await initialSend;
       await vi.waitFor(
         async () => {
           receipt.beforeRows = await rows(host.storage);
@@ -299,6 +341,17 @@ it.each([
       }
       planAbort = vi.spyOn(host.planAgent, 'abortRunStream');
       buildAbort = vi.spyOn(host.buildAgent, 'abortRunStream');
+      const realCancel = host.planAgent.__abortRunStreamAndWait.bind(host.planAgent);
+      vi.spyOn(host.planAgent, '__abortRunStreamAndWait').mockImplementation(async runId => {
+        const result = await realCancel(runId);
+        receipt.cancelResult = result;
+        receipt.cancelSession = {
+          threadId: fresh.thread.getId(),
+          runId: fresh.getCurrentRunId(),
+          operationId: fresh.run.getOperationId(),
+        };
+        return result;
+      });
       let enteredResolve = () => {};
       const entered = new Promise<void>(resolve => {
         enteredResolve = resolve;
@@ -320,7 +373,45 @@ it.each([
         }
       }
       owners(host, 'before-stop');
-      fresh.abortRun();
+      let saveEntered = Promise.resolve();
+      if (scenario === 'single-agent-save-delay') {
+        let enterSave = () => {};
+        saveEntered = new Promise<void>(resolve => {
+          enterSave = resolve;
+        });
+        const heldSave = new Promise<void>(resolve => {
+          releaseSave = resolve;
+        });
+        const memory = (await host.planAgent.getMemory())!;
+        const save = memory.saveMessages.bind(memory);
+        vi.spyOn(memory, 'saveMessages').mockImplementation(async args => {
+          enterSave();
+          await heldSave;
+          return save(args);
+        });
+      }
+      let endEntered = Promise.resolve();
+      if (failSave) {
+        const memory = (await host.planAgent.getMemory())!;
+        const memoryStore = (await memory.storage.getStore('memory'))!;
+        vi.spyOn(memoryStore, 'saveMessages').mockRejectedValue(new Error('Simulated final save failure'));
+      }
+      if (holdEnd) {
+        let enterEnd = () => {};
+        endEntered = new Promise<void>(resolve => {
+          enterEnd = resolve;
+        });
+        const heldEnd = new Promise<void>(resolve => {
+          releaseEnd = resolve;
+        });
+        fresh.onBeforeAgentEnd(async event => {
+          if (event.reason === 'aborted') {
+            enterEnd();
+            await heldEnd;
+          }
+        });
+      }
+      fresh.abort();
       if (scenario === 'single-agent-duplicate') {
         const duplicate = await host.controller.createSession({
           id: 'duplicate-stop-session',
@@ -368,8 +459,71 @@ it.each([
         }
         releaseRead();
       }
+      if (scenario === 'single-agent-save-delay') {
+        await saveEntered;
+        expect(
+          receipt.events.filter(
+            (event: any) => event.phase === 'reopened' && ['message_end', 'agent_end'].includes(event.type),
+          ),
+        ).toEqual([]);
+        releaseSave();
+      }
+      if (holdEnd) {
+        await endEntered;
+        expect(receipt.events.filter((event: any) => event.phase === 'reopened' && event.type === 'agent_end')).toEqual(
+          [],
+        );
+        if (newRunAtEnd) {
+          const newerSend = fresh.sendMessage({ content: 'Create a newer plan while the old end hook waits.' });
+          if (preparingRun) {
+            await newModelEntered;
+            receipt.preparingRunId = fresh.getCurrentRunId();
+            releaseEnd();
+            await new Promise<void>(resolve => setImmediate(resolve));
+            expect(structuredClone(fresh.displayState.get()).isRunning).toBe(true);
+            expect(fresh.getCurrentRunId()).toBe(receipt.preparingRunId);
+            expect(
+              receipt.events.filter((event: any) => event.phase === 'reopened' && event.type === 'agent_end'),
+            ).toEqual([]);
+            releaseNewModel();
+          }
+          await newerSend;
+          const oldIds = new Set(receipt.beforeStopRows.map((row: any) => row.runId));
+          receipt.futureRows = (await rows(host.storage)).filter(row => !oldIds.has(row.runId));
+          expect(receipt.futureRows).toHaveLength(2);
+          expect(fresh.displayState.get().pendingSuspensions.size).toBe(1);
+        } else {
+          await fresh.thread.switch({ threadId: emptyThreadId! });
+        }
+        receipt.navigatedDisplay = structuredClone(fresh.displayState.get());
+        releaseEnd();
+      }
+      if (failSave) {
+        await vi.waitFor(
+          () => {
+            expect(
+              receipt.events.filter((event: any) => event.phase === 'reopened' && event.type === 'error'),
+            ).toHaveLength(1);
+          },
+          { timeout: 5000, interval: 20 },
+        );
+      } else if (!navigate && scenario !== 'single-agent-duplicate' && !holdEnd) {
+        await vi.waitFor(
+          () => {
+            expect(
+              receipt.events.filter((event: any) => event.phase === 'reopened' && event.type === 'message_end'),
+            ).toHaveLength(1);
+            expect(
+              receipt.events.filter((event: any) => event.phase === 'reopened' && event.type === 'agent_end'),
+            ).toHaveLength(1);
+          },
+          { timeout: 5000, interval: 20 },
+        );
+      }
       const shutdown = host.mastra.shutdown();
-      if (scenario === 'single-agent-duplicate') {
+      if (failSave) {
+        await expect(shutdown).rejects.toThrow('cancellation');
+      } else if (scenario === 'single-agent-duplicate') {
         // Recovery admits one owner. The competing Session gets an explicit
         // conflict; it must not prepare a second stream or resurrect a row.
         await expect(shutdown).rejects.toMatchObject({
@@ -400,18 +554,59 @@ it.each([
       expect(receipt.terminalOutputs).toEqual([
         { finishReason: 'abort', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
       ]);
-      expect(receipt.events.filter((event: { type: string }) => event.type === 'error')).toEqual([]);
-      for (const message of receipt.stoppedMessages) {
+      if (!failSave) expect(receipt.events.filter((event: { type: string }) => event.type === 'error')).toEqual([]);
+      const stoppedEvents = receipt.events.filter((event: any) => event.phase === 'reopened');
+      const stoppedMessageEvents = stoppedEvents.filter((event: any) => event.type === 'message_end');
+      if (failSave) {
+        expect(stoppedMessageEvents).toEqual([]);
+        expect(stoppedEvents.filter((event: any) => event.type === 'agent_end')).toEqual([]);
+        expect(
+          receipt.stoppedMessages.some((message: any) => message.content.metadata?.suspendedTools?.['plan-call-1']),
+        ).toBe(true);
+      } else if (!navigate && scenario !== 'single-agent-duplicate' && !holdEnd) {
+        const originalAssistant = receipt.stoppedMessages.find((message: any) => message.role === 'assistant');
+        expect(originalAssistant).toBeDefined();
+        expect(stoppedMessageEvents.map((event: any) => event.message)).toEqual([originalAssistant]);
+        expect(stoppedEvents.filter((event: any) => event.type === 'agent_end')).toMatchObject([{ reason: 'aborted' }]);
+        const finalDisplay = stoppedEvents
+          .filter((event: any) => event.type === 'display_state_changed')
+          .at(-1)?.displayState;
+        expect(finalDisplay).toMatchObject({ isRunning: false, pendingApproval: null });
+        expect(finalDisplay.pendingSuspensions.size).toBe(0);
+      } else if (holdEnd) {
+        expect(stoppedMessageEvents).toHaveLength(newRunAtEnd ? 2 : 1);
+        expect(
+          stoppedEvents.filter((event: any) => event.type === 'agent_end').map((event: any) => event.reason),
+        ).toEqual(newRunAtEnd ? ['suspended'] : []);
+        expect(fresh.displayState.get()).toEqual(receipt.navigatedDisplay);
+      } else if (navigate) {
+        expect(stoppedMessageEvents).toEqual([]);
+        expect(stoppedEvents.filter((event: any) => event.type === 'agent_end')).toEqual([]);
+      } else {
+        expect(stoppedMessageEvents.length).toBeLessThanOrEqual(1);
+      }
+      for (const message of failSave ? [] : receipt.stoppedMessages) {
         expect(message.content.metadata?.suspendedTools?.['plan-call-1']).toBeUndefined();
         expect(message.content.metadata?.pendingToolApprovals?.['plan-call-1']).toBeUndefined();
       }
+      if (approval) {
+        expect(
+          receipt.stoppedMessages
+            .flatMap((message: any) => message.content.parts)
+            .filter((part: any) => part.type === 'tool-invocation')
+            .map((part: any) => part.toolInvocation.state),
+        ).toEqual(['output-denied']);
+      }
       expect(receipt.afterRows.filter((row: any) => oldIds.has(row.runId))).toEqual([]);
       expect(receipt.afterRows.filter((row: any) => !oldIds.has(row.runId)).map((row: any) => row.status)).toEqual(
-        startFutureRun ? ['suspended', 'suspended'] : [],
+        startFutureRun || newRunAtEnd ? ['suspended', 'suspended'] : [],
       );
-      expect(calls).toEqual({ plan: startFutureRun ? 2 : 1, build: 0, network: 0 });
+      expect(calls).toEqual({ plan: startFutureRun || newRunAtEnd ? 2 : 1, build: 0, network: 0 });
     } finally {
       releaseRead();
+      releaseSave();
+      releaseEnd();
+      releaseNewModel();
       try {
         await host.mastra.shutdown();
       } catch (error) {

--- a/packages/core/src/agent-controller/__tests__/session-stop-owner.integration.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-stop-owner.integration.test.ts
@@ -26,6 +26,13 @@ function snapshotStatus(snapshot: string | WorkflowRunState | null | undefined) 
   return (typeof snapshot === 'string' ? (JSON.parse(snapshot) as WorkflowRunState) : snapshot)?.status;
 }
 
+// DurableAgent intentionally narrows the base stream/generate signatures.
+// The controller accepts the native base class; keep the same checked object.
+function requireNativeAgent(agent: unknown) {
+  if (!(agent instanceof Agent)) throw new TypeError('Expected a native Agent');
+  return agent;
+}
+
 it.each([
   'same-mode',
   'switched-mode',
@@ -106,8 +113,8 @@ it.each([
       workspace,
       initialState: { yolo: true },
       modes: [
-        { id: 'plan', name: 'Plan', default: true, transitionsTo: 'build', agent: planAgent },
-        { id: 'build', name: 'Build', agent: scenario === 'shared-agent' ? planAgent : buildAgent },
+        { id: 'plan', name: 'Plan', default: true, transitionsTo: 'build', agent: requireNativeAgent(planAgent) },
+        { id: 'build', name: 'Build', agent: requireNativeAgent(scenario === 'shared-agent' ? planAgent : buildAgent) },
       ],
     });
     const mastra = new Mastra({

--- a/packages/core/src/agent-controller/__tests__/session-stop-owner.integration.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-stop-owner.integration.test.ts
@@ -1,0 +1,268 @@
+import dns from 'node:dns';
+import net from 'node:net';
+import { afterEach, expect, it, vi } from 'vitest';
+import { Memory } from '../../../../memory/src';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../../agent/durable';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage/mock';
+import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
+import { submitPlanTool } from '../../tools/builtin/submit-plan';
+import type { WorkflowRunState } from '../../workflows/types';
+import { Workspace } from '../../workspace';
+import { AgentController } from '../agent-controller';
+
+afterEach(() => vi.restoreAllMocks());
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function snapshotStatus(snapshot: string | WorkflowRunState | null | undefined) {
+  return (typeof snapshot === 'string' ? (JSON.parse(snapshot) as WorkflowRunState) : snapshot)?.status;
+}
+
+it.each([
+  'same-mode',
+  'switched-mode',
+  'shared-agent',
+  'same-agent-id',
+  'other-scopes',
+  'immediate-stop',
+  'immediate-stop-delayed',
+  'missing-owner',
+  'delayed-discovery',
+  'navigate-during-discovery',
+] as const)(
+  'Stop cancels only its saved owning agent: %s',
+  async scenario => {
+    const switchFirst = scenario !== 'same-mode';
+    const stopInEvent = scenario === 'immediate-stop' || scenario === 'immediate-stop-delayed';
+    const delayDiscovery = scenario === 'delayed-discovery' || scenario === 'navigate-during-discovery';
+    const calls = { plan: 0, build: 0, network: 0 };
+    const denyNetwork = () => {
+      calls.network++;
+      throw new Error('No network is allowed');
+    };
+    vi.spyOn(globalThis, 'fetch').mockImplementation(denyNetwork);
+    vi.spyOn(net.Socket.prototype, 'connect').mockImplementation(denyNetwork);
+    vi.spyOn(dns, 'lookup').mockImplementation(denyNetwork);
+    const storage = new InMemoryStore();
+    const planAgent = createDurableAgent({
+      agent: new Agent<string, { submit_plan: typeof submitPlanTool }, any>({
+        id: 'plan-agent',
+        name: 'Plan',
+        instructions: 'Submit a local plan.',
+        model: new MastraLanguageModelV2Mock({
+          doStream: async () => {
+            const call = ++calls.plan;
+            return {
+              stream: new ReadableStream({
+                start(controller) {
+                  controller.enqueue({ type: 'stream-start', warnings: [] });
+                  controller.enqueue({
+                    type: 'tool-call',
+                    toolCallId: `plan-${call}`,
+                    toolName: 'submit_plan',
+                    input: '{"path":"plan.md"}',
+                  });
+                  controller.enqueue({
+                    type: 'finish',
+                    finishReason: 'tool-calls',
+                    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                  });
+                  controller.close();
+                },
+              }),
+            };
+          },
+        }),
+        memory: new Memory({ storage }),
+        tools: { submit_plan: submitPlanTool },
+      }),
+    });
+    const buildAgent = createDurableAgent({
+      agent: new Agent<string, {}, any>({
+        id: scenario === 'same-agent-id' ? 'plan-agent' : 'build-agent',
+        name: 'Build',
+        instructions: 'Do local work.',
+        model: new MastraLanguageModelV2Mock({
+          doStream: async () => {
+            calls.build++;
+            throw new Error('The build agent must not execute');
+          },
+        }),
+        memory: new Memory({ storage }),
+      }),
+    });
+    const workspace = new Workspace({ name: 'Local proof', skills: () => [] });
+    const controller = new AgentController({
+      id: 'mode-stop',
+      storage,
+      workspace,
+      initialState: { yolo: true },
+      modes: [
+        { id: 'plan', name: 'Plan', default: true, transitionsTo: 'build', agent: planAgent },
+        { id: 'build', name: 'Build', agent: scenario === 'shared-agent' ? planAgent : buildAgent },
+      ],
+    });
+    const mastra = new Mastra({
+      agents: { planAgent, buildAgent },
+      agentControllers: { controller },
+      storage,
+      logger: false,
+      workers: false,
+      scheduler: { enabled: false },
+      recovery: { durableAgents: 'off' },
+    });
+    try {
+      await controller.init();
+      expect(controller.getMastra()).toBe(mastra);
+      expect(mastra.getAgentController('controller')).toBe(controller);
+      expect(planAgent.getMastraInstance()).toBe(mastra);
+      expect(buildAgent.getMastraInstance()).toBe(mastra);
+      const session = await controller.createSession({
+        id: 'target',
+        ownerId: 'owner',
+        resourceId: 'resource',
+        workspace,
+      });
+      await session.thread.create();
+      const planAbort = vi.spyOn(planAgent, 'abortRunStream');
+      const planWait = vi.spyOn(planAgent, '__abortRunStreamAndWait');
+      const buildAbort = vi.spyOn(buildAgent, 'abortRunStream');
+      const buildWait = vi.spyOn(buildAgent, '__abortRunStreamAndWait');
+      const releaseImmediateRead = deferred();
+      if (scenario === 'immediate-stop-delayed') {
+        const suspended = planAgent.listSuspendedRuns.bind(planAgent);
+        const active = planAgent.listActiveRuns.bind(planAgent);
+        vi.spyOn(planAgent, 'listSuspendedRuns').mockImplementation(async input => {
+          await releaseImmediateRead.promise;
+          return suspended(input);
+        });
+        vi.spyOn(planAgent, 'listActiveRuns').mockImplementation(async input => {
+          await releaseImmediateRead.promise;
+          return active(input);
+        });
+      }
+      let immediateStop: Promise<void> | undefined;
+      const errors: Error[] = [];
+      session.subscribe(event => {
+        if (event.type === 'error') errors.push(event.error);
+        if (stopInEvent && event.type === 'tool_suspended') {
+          if (scenario === 'immediate-stop-delayed') {
+            session.abortRun();
+            immediateStop = Promise.resolve();
+          } else {
+            immediateStop = session.mode.switch({ modeId: 'build' }).then(() => session.abortRun());
+          }
+        }
+      });
+      try {
+        await session.sendMessage({ content: 'Create a plan.' });
+        if (scenario === 'immediate-stop-delayed') {
+          // Normal turn cleanup clears the live flag before saved cancellation finishes.
+          expect(session.run.isAbortRequested()).toBe(false);
+        }
+      } finally {
+        releaseImmediateRead.resolve();
+      }
+      await immediateStop;
+      if (stopInEvent) expect(immediateStop).toBeDefined();
+      if (!stopInEvent) expect(session.suspensions.hasPending()).toBe(true);
+      const store = await storage.getStore('workflows');
+      expect(store).toBeDefined();
+      if (!stopInEvent)
+        await vi.waitFor(async () => {
+          expect((await store!.listWorkflowRuns({})).runs.map(row => snapshotStatus(row.snapshot))).toEqual([
+            'suspended',
+            'suspended',
+          ]);
+        });
+      const targetIds = new Set((await store!.listWorkflowRuns({})).runs.map(row => row.runId));
+      const threadId = session.thread.getId()!;
+      if (scenario === 'other-scopes') {
+        for (const resourceId of ['resource', 'another-resource']) {
+          const other = await controller.createSession({
+            scope: `other-${resourceId}`,
+            ownerId: 'owner',
+            resourceId,
+            workspace,
+          });
+          expect(other).not.toBe(session);
+          await other.thread.create();
+          expect(other.thread.getId()).not.toBe(threadId);
+          await other.sendMessage({ content: 'Keep this plan paused.' });
+        }
+        await vi.waitFor(async () => {
+          expect(
+            (await store!.listWorkflowRuns({})).runs.filter(row => snapshotStatus(row.snapshot) === 'suspended'),
+          ).toHaveLength(6);
+        });
+      }
+      if (switchFirst && !stopInEvent) await session.mode.switch({ modeId: 'build' });
+      if (scenario === 'missing-owner') {
+        // Exercise a read failure without changing native saved ownership.
+        vi.spyOn(planAgent, 'listSuspendedRuns').mockResolvedValue({ runs: [], total: 0 });
+      }
+      const entered = deferred();
+      const release = deferred();
+      const close = vi.spyOn(storage, 'close');
+      let nextThreadId: string | undefined;
+      if (scenario === 'navigate-during-discovery') {
+        const other = await controller.createSession({ scope: 'navigation-target', resourceId: 'resource', workspace });
+        nextThreadId = (await other.thread.create()).id;
+      }
+      if (delayDiscovery) {
+        const discover = planAgent.listSuspendedRuns.bind(planAgent);
+        vi.spyOn(planAgent, 'listSuspendedRuns').mockImplementation(async input => {
+          entered.resolve();
+          await release.promise;
+          return discover(input);
+        });
+      }
+      if (!stopInEvent) session.abortRun();
+      if (scenario === 'missing-owner') {
+        await expect(mastra.shutdown()).rejects.toBeInstanceOf(AggregateError);
+        expect(errors.some(error => error.message.includes('Could not find the owning agent'))).toBe(true);
+      } else {
+        if (delayDiscovery) await entered.promise;
+        if (nextThreadId) {
+          await session.thread.switch({ threadId: nextThreadId });
+          expect(session.thread.getId()).not.toBe(threadId);
+        }
+        const shutdown = mastra.shutdown();
+        if (delayDiscovery) {
+          try {
+            await Promise.resolve();
+            expect(close).not.toHaveBeenCalled();
+          } finally {
+            release.resolve();
+          }
+        }
+        await shutdown;
+        expect(errors).toEqual([]);
+      }
+      const after = (await store!.listWorkflowRuns({})).runs;
+      expect(after.filter(row => targetIds.has(row.runId)).map(row => snapshotStatus(row.snapshot))).toEqual(
+        scenario === 'missing-owner' ? ['suspended', 'suspended'] : ['canceled', 'canceled'],
+      );
+      expect(after.filter(row => !targetIds.has(row.runId)).map(row => snapshotStatus(row.snapshot))).toEqual(
+        scenario === 'other-scopes' ? Array(4).fill('suspended') : [],
+      );
+      expect(planAbort.mock.calls.length + planWait.mock.calls.length).toBe(scenario === 'missing-owner' ? 0 : 1);
+      expect(buildAbort).not.toHaveBeenCalled();
+      expect(buildWait).not.toHaveBeenCalled();
+      expect(calls).toEqual({ plan: scenario === 'other-scopes' ? 3 : 1, build: 0, network: 0 });
+    } finally {
+      await mastra.shutdown().catch(error => {
+        if (scenario !== 'missing-owner') throw error;
+      });
+    }
+  },
+  15000,
+);

--- a/packages/core/src/agent-controller/__tests__/session-stop-restoration-concurrency.integration.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-stop-restoration-concurrency.integration.test.ts
@@ -1,0 +1,467 @@
+// Real saved-run overlap: no fabricated rows or private cancellation calls.
+import dns from 'node:dns';
+import fs from 'node:fs';
+import net from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, expect, it, vi } from 'vitest';
+import { LibSQLStore } from '../../../../../stores/libsql/src';
+import { Memory } from '../../../../memory/src';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../../agent/durable';
+import { EventEmitterPubSub } from '../../events/event-emitter';
+import { Mastra } from '../../mastra';
+import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
+import { submitPlanTool } from '../../tools/builtin/submit-plan';
+import { Workspace } from '../../workspace';
+import { AgentController } from '../agent-controller';
+
+function nativeAgent(value: unknown) {
+  if (!(value instanceof Agent)) throw new Error('Expected the same native Agent object');
+  return value;
+}
+function errorInfo(value: unknown): unknown {
+  if (value instanceof AggregateError)
+    return { name: value.name, message: value.message, errors: value.errors.map(errorInfo) };
+  if (value instanceof Error)
+    return {
+      name: value.name,
+      message: value.message,
+      id: 'id' in value ? value.id : undefined,
+      cause: value.cause ? errorInfo(value.cause) : undefined,
+    };
+  return String(value);
+}
+function errorIds(value: unknown): string[] {
+  if (!value || typeof value !== 'object') return [];
+  if (Array.isArray(value)) return value.flatMap(errorIds);
+  const record = value as Record<string, unknown>;
+  return [
+    ...(typeof record.id === 'string' ? [record.id] : []),
+    ...Object.entries(record)
+      .filter(([key]) => key !== 'id')
+      .flatMap(([, child]) => errorIds(child)),
+  ];
+}
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it('direct saved Stop retains lease loss without publishing a terminal error', async () => {
+  const directory = fs.mkdtempSync(path.join(tmpdir(), 'mastra-stop-restoration-lease-loss-'));
+  const url = pathToFileURL(path.join(directory, 'native.db')).href;
+  const calls = { model: 0, network: 0 };
+  const deny = () => {
+    calls.network++;
+    throw new Error('Unexpected network');
+  };
+  vi.stubGlobal('fetch', vi.fn(deny));
+  vi.spyOn(net.Socket.prototype, 'connect').mockImplementation(deny as never);
+  vi.spyOn(dns, 'lookup').mockImplementation(deny as never);
+  const outputs: unknown[] = [];
+  const terminalErrors: unknown[] = [];
+  let holdMemory = false;
+  let enteredMemory = () => {};
+  const memoryEntered = new Promise<void>(resolve => {
+    enteredMemory = resolve;
+  });
+  let releaseMemory = () => {};
+  const memoryGate = new Promise<void>(resolve => {
+    releaseMemory = resolve;
+  });
+  async function createHost() {
+    const storage = new LibSQLStore({ id: 'stop-lease-loss', url });
+    await storage.init();
+    const memory = new Memory({ storage });
+    const pubsub = new EventEmitterPubSub();
+    const agent = createDurableAgent({
+      agent: new Agent({
+        id: 'stop-lease-agent',
+        name: 'Stop lease agent',
+        instructions: 'Submit the local plan.',
+        model: new MastraLanguageModelV2Mock({
+          doStream: async () => {
+            calls.model++;
+            if (calls.model !== 1) throw new Error('Stop must not invoke another model call');
+            return {
+              stream: new ReadableStream({
+                start(controller) {
+                  controller.enqueue({ type: 'stream-start', warnings: [] });
+                  controller.enqueue({
+                    type: 'tool-call',
+                    toolCallId: 'lease-plan-call',
+                    toolName: 'submit_plan',
+                    input: '{"path":"plan.md"}',
+                    providerExecuted: false,
+                  });
+                  controller.enqueue({
+                    type: 'finish',
+                    finishReason: 'tool-calls',
+                    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                  });
+                  controller.close();
+                },
+              }),
+            };
+          },
+        }),
+        memory: async () => {
+          if (holdMemory) {
+            enteredMemory();
+            await memoryGate;
+          }
+          return memory;
+        },
+        tools: { submit_plan: submitPlanTool },
+        outputProcessors: [
+          {
+            id: 'lease-output-observer',
+            processOutputResult({ messageList, result }) {
+              outputs.push({ finishReason: result.finishReason, usage: result.usage });
+              return messageList;
+            },
+          },
+        ],
+      }),
+    });
+    const workspace = new Workspace({ name: 'Stop lease proof', skills: () => [] });
+    const controller = new AgentController({
+      id: 'stop-lease-controller',
+      storage,
+      workspace,
+      initialState: { yolo: true },
+      agent: nativeAgent(agent),
+      modes: [{ id: 'web', name: 'Web', default: true }],
+    });
+    const mastra = new Mastra({
+      agents: { agent },
+      agentControllers: { proof: controller },
+      storage,
+      pubsub,
+      logger: false,
+      workers: false,
+      scheduler: { enabled: false },
+      recovery: { durableAgents: 'off' },
+    });
+    await controller.init();
+    expect(controller.getMastra()).toBe(mastra);
+    expect(mastra.getAgentController('proof')).toBe(controller);
+    expect(agent.getMastraInstance()).toBe(mastra);
+    return { storage, agent, controller, workspace, mastra, pubsub };
+  }
+  const hosts: Awaited<ReturnType<typeof createHost>>[] = [];
+  const rows = async (storage: LibSQLStore) =>
+    (await (await storage.getStore('workflows'))!.listWorkflowRuns({})).runs.map(row => {
+      const snapshot = typeof row.snapshot === 'string' ? JSON.parse(row.snapshot) : row.snapshot;
+      return { workflowName: row.workflowName, runId: row.runId, status: snapshot?.status };
+    });
+  try {
+    const writer = await createHost();
+    hosts.push(writer);
+    const sessionInput = { id: 'stop-lease-session', ownerId: 'owner', resourceId: 'resource' };
+    const session = await writer.controller.createSession({ ...sessionInput, workspace: writer.workspace });
+    const threadId = (await session.thread.create()).id;
+    await session.sendMessage({ content: 'Create a plan.' });
+    await vi.waitFor(async () => {
+      const saved = await rows(writer.storage);
+      expect(saved).toHaveLength(2);
+      expect(saved.every(row => row.status === 'suspended')).toBe(true);
+    });
+    const beforeRows = await rows(writer.storage);
+    const runId = beforeRows.find(row => row.workflowName === 'durable-agentic-loop')!.runId;
+    await writer.mastra.shutdown();
+    const fresh = await createHost();
+    hosts.push(fresh);
+    expect(fresh.mastra).not.toBe(writer.mastra);
+    expect(fresh.agent).not.toBe(writer.agent);
+    expect(fresh.storage).not.toBe(writer.storage);
+    const reopened = await fresh.controller.createSession({ ...sessionInput, workspace: fresh.workspace });
+    expect(reopened.thread.getId()).toBe(threadId);
+    expect(reopened.getCurrentRunId()).toBe(null);
+    expect(reopened.suspensions.hasPending()).toBe(false);
+    const topic = `agent.stream.${runId}`;
+    await fresh.agent.pubsub.subscribe(topic, async event => {
+      if (event.type === 'error') terminalErrors.push(event);
+    });
+    const actualRenew = fresh.pubsub.renewLease.bind(fresh.pubsub);
+    const renew = vi
+      .spyOn(fresh.pubsub, 'renewLease')
+      .mockImplementation(async (key, owner, ttlMs) =>
+        key.startsWith('mastra:durable-agent-recovery:') ? false : actualRenew(key, owner, ttlMs),
+      );
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+    holdMemory = true;
+    fresh.agent.abortRunStream(runId);
+    await memoryEntered;
+    // Use the same renewal interval as the existing native recovery fault tests.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(renew.mock.calls.filter(([key]) => key.startsWith('mastra:durable-agent-recovery:'))).toHaveLength(1);
+    releaseMemory();
+    const shutdown = await Promise.allSettled([fresh.mastra.shutdown()]);
+    expect(shutdown[0]!.status).toBe('rejected');
+    const outcome = shutdown[0]!;
+    if (outcome.status !== 'rejected') throw new Error('Lease loss must reject cancellation');
+    expect(errorIds(errorInfo(outcome.reason))).toEqual(['DURABLE_AGENT_RECOVER_LEASE_LOST']);
+    const reader = new LibSQLStore({ id: 'stop-lease-readback', url });
+    await reader.init();
+    try {
+      expect(await rows(reader)).toEqual(beforeRows);
+    } finally {
+      await reader.close();
+    }
+    expect(outputs).toEqual([]);
+    expect(terminalErrors).toEqual([]);
+    expect(calls).toEqual({ model: 1, network: 0 });
+  } finally {
+    releaseMemory();
+    await Promise.allSettled(hosts.map(host => host.mastra.shutdown()));
+  }
+});
+
+it.each(['session', 'agent'] as const)('concurrent saved Stop isolates the winning run: %s', async entrypoint => {
+  const directory = fs.mkdtempSync(path.join(tmpdir(), `mastra-stop-restoration-${entrypoint}-`));
+  const url = pathToFileURL(path.join(directory, 'native.db')).href;
+  const calls = { model: 0, network: 0 };
+  const deny = () => {
+    calls.network++;
+    throw new Error('Unexpected network');
+  };
+  vi.stubGlobal('fetch', vi.fn(deny));
+  vi.spyOn(net.Socket.prototype, 'connect').mockImplementation(deny as never);
+  vi.spyOn(dns, 'lookup').mockImplementation(deny as never);
+  const receipt = {
+    node: process.version,
+    entrypoint,
+    directory,
+    calls,
+    runTopicErrors: [] as unknown[],
+    owners: [] as unknown[],
+    events: [] as unknown[],
+    outputs: [] as unknown[],
+    heldReads: [] as Array<{ host: string; workflowName: string; runId: string; status: string; at: string }>,
+    beforeRows: [] as unknown[],
+    afterRows: [] as unknown[],
+    messages: [] as unknown[],
+    shutdowns: [] as unknown[],
+    failure: undefined as unknown,
+  };
+  async function createHost(label: string) {
+    const storage = new LibSQLStore({ id: 'two-host-stop-proof', url });
+    await storage.init();
+    const agent = createDurableAgent({
+      agent: new Agent<string, { submit_plan: typeof submitPlanTool }, any>({
+        id: 'shared-plan-agent',
+        name: 'Shared plan agent',
+        instructions: 'Submit the local plan.',
+        model: new MastraLanguageModelV2Mock({
+          doStream: async () => {
+            const call = ++calls.model;
+            if (call !== 1) throw new Error('Stop must not invoke another model call');
+            return {
+              stream: new ReadableStream({
+                start(controller) {
+                  controller.enqueue({ type: 'stream-start', warnings: [] });
+                  controller.enqueue({
+                    type: 'response-metadata',
+                    id: 'local-model-1',
+                    modelId: 'mock',
+                    timestamp: new Date(0),
+                  });
+                  controller.enqueue({
+                    type: 'tool-call',
+                    toolCallId: 'shared-plan-call',
+                    toolName: 'submit_plan',
+                    input: '{"path":"plan.md"}',
+                    providerExecuted: false,
+                  });
+                  controller.enqueue({
+                    type: 'finish',
+                    finishReason: 'tool-calls',
+                    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                  });
+                  controller.close();
+                },
+              }),
+            };
+          },
+        }),
+        memory: new Memory({ storage }),
+        tools: { submit_plan: submitPlanTool },
+        outputProcessors: [
+          {
+            id: 'stop-observer',
+            processOutputResult({ messageList, result }) {
+              receipt.outputs.push({ host: label, finishReason: result.finishReason, usage: result.usage });
+              return messageList;
+            },
+          },
+        ],
+      }),
+    });
+    const workspace = new Workspace({ name: 'Two-host Stop proof', skills: () => [] });
+    const controller = new AgentController({
+      id: 'shared-stop-controller',
+      storage,
+      workspace,
+      initialState: { yolo: true },
+      agent: nativeAgent(agent),
+      modes: [{ id: 'web', name: 'Web', default: true }],
+    });
+    const mastra = new Mastra({
+      agents: { agent },
+      agentControllers: { proof: controller },
+      storage,
+      logger: false,
+      workers: false,
+      scheduler: { enabled: false },
+      recovery: { durableAgents: 'off' },
+    });
+    await controller.init();
+    const checks = {
+      controller: controller.getMastra() === mastra,
+      registered: mastra.getAgentController('proof') === controller,
+      agent: agent.getMastraInstance() === mastra,
+      storage: controller.getMastra()?.getStorage() === mastra.getStorage(),
+    };
+    receipt.owners.push({ host: label, ...checks });
+    expect(Object.values(checks).every(Boolean)).toBe(true);
+    return { label, storage, agent, workspace, controller, mastra };
+  }
+  type Host = Awaited<ReturnType<typeof createHost>>;
+  const hosts: Host[] = [];
+  const topicUnsubscribers: Array<() => Promise<void>> = [];
+  const rowView = async (storage: LibSQLStore) => {
+    const rows = (await (await storage.getStore('workflows'))!.listWorkflowRuns({})).runs;
+    return rows.map(row => {
+      const snap = typeof row.snapshot === 'string' ? JSON.parse(row.snapshot) : row.snapshot;
+      return { workflowName: row.workflowName, runId: row.runId, status: snap?.status, resourceId: row.resourceId };
+    });
+  };
+  let release = () => {};
+  const held = new Promise<void>(resolve => {
+    release = resolve;
+  });
+  try {
+    const writer = await createHost('writer');
+    hosts.push(writer);
+    const sessionInput = { id: 'shared-stop-session', ownerId: 'owner', resourceId: 'resource' };
+    const warm = await writer.controller.createSession({ ...sessionInput, workspace: writer.workspace });
+    const threadId = (await warm.thread.create()).id;
+    await warm.sendMessage({ content: 'Create a plan.' });
+    await vi.waitFor(
+      async () => {
+        receipt.beforeRows = await rowView(writer.storage);
+        expect(receipt.beforeRows).toHaveLength(2);
+        expect(receipt.beforeRows.every((row: any) => row.status === 'suspended')).toBe(true);
+      },
+      { timeout: 4000, interval: 20 },
+    );
+    const runId = (receipt.beforeRows as any[]).find(row => row.workflowName === 'durable-agentic-loop').runId;
+    await writer.mastra.shutdown();
+    const a = await createHost('host-a');
+    hosts.push(a);
+    const b = await createHost('host-b');
+    hosts.push(b);
+    for (const key of ['mastra', 'controller', 'agent', 'storage'] as const) expect(a[key]).not.toBe(b[key]);
+    const sessions = await Promise.all(
+      [a, b].map(async host => {
+        const session = await host.controller.createSession({ ...sessionInput, workspace: host.workspace });
+        expect(session.thread.getId()).toBe(threadId);
+        expect(session.getCurrentRunId()).toBe(null);
+        expect(session.suspensions.hasPending()).toBe(false);
+        session.subscribe(event => {
+          if (event.type === 'error' || event.type === 'agent_end')
+            receipt.events.push({ host: host.label, type: event.type, error: errorInfo((event as any).error) });
+        });
+        const topic = 'agent.stream.' + runId;
+        const observe = async (event: any) => {
+          if (event.type === 'error')
+            receipt.runTopicErrors.push({ host: host.label, type: event.type, data: event.data });
+        };
+        await host.agent.pubsub.subscribe(topic, observe);
+        topicUnsubscribers.push(() => host.agent.pubsub.unsubscribe(topic, observe));
+        const store = (await host.storage.getStore('workflows'))!;
+        const actualRead = store.loadWorkflowSnapshot.bind(store);
+        let heldOnce = false;
+        vi.spyOn(store, 'loadWorkflowSnapshot').mockImplementation(async input => {
+          const result = await actualRead(input);
+          if (!heldOnce && input.workflowName === 'durable-agentic-loop' && input.runId === runId) {
+            heldOnce = true;
+            receipt.heldReads.push({
+              host: host.label,
+              workflowName: input.workflowName,
+              runId,
+              status: result?.status ?? 'missing',
+              at: new Date().toISOString(),
+            });
+            await held;
+          }
+          return result;
+        });
+        return session;
+      }),
+    );
+    if (entrypoint === 'session') {
+      sessions[0]!.abort();
+      sessions[1]!.abort();
+    } else {
+      a.agent.abortRunStream(runId);
+      b.agent.abortRunStream(runId);
+    }
+    await vi.waitFor(() => expect(receipt.heldReads).toHaveLength(2), { timeout: 4000, interval: 10 });
+    expect(receipt.heldReads.map(read => read.host).sort()).toEqual(['host-a', 'host-b']);
+    expect(receipt.heldReads.every(read => read.runId === runId && read.status === 'suspended')).toBe(true);
+    expect(receipt.outputs).toEqual([]);
+    release();
+    const shutdowns = await Promise.allSettled([a.mastra.shutdown(), b.mastra.shutdown()]);
+    receipt.shutdowns = shutdowns.map((result, i) => ({
+      host: i === 0 ? 'host-a' : 'host-b',
+      status: result.status,
+      ...(result.status === 'rejected' ? { error: errorInfo(result.reason) } : {}),
+    }));
+    const reader = new LibSQLStore({ id: 'two-host-readback', url });
+    await reader.init();
+    try {
+      receipt.afterRows = await rowView(reader);
+      receipt.messages = (await new Memory({ storage: reader }).recall({ threadId, resourceId: 'resource' })).messages;
+    } finally {
+      await reader.close();
+    }
+    expect(calls).toEqual({ model: 1, network: 0 });
+    expect(receipt.runTopicErrors).toEqual([]);
+    const rejected = receipt.shutdowns.filter((item: any) => item.status === 'rejected');
+    const completed = receipt.shutdowns.filter((item: any) => item.status === 'fulfilled');
+    expect(rejected).toHaveLength(1);
+    expect(completed).toHaveLength(1);
+    expect(errorIds(rejected)).toEqual(['DURABLE_AGENT_RECOVER_ALREADY_IN_PROGRESS']);
+    const errors = receipt.events.filter((item: any) => item.type === 'error');
+    if (entrypoint === 'session') {
+      expect(errors).toHaveLength(1);
+      expect(errorIds(errors)).toEqual(['DURABLE_AGENT_RECOVER_ALREADY_IN_PROGRESS']);
+      expect((errors[0] as any).host).toBe((rejected[0] as any).host);
+    } else {
+      expect(errors).toEqual([]);
+    }
+    expect(receipt.outputs).toHaveLength(1);
+    expect(receipt.outputs[0]).toMatchObject({
+      finishReason: 'abort',
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    });
+    expect(receipt.afterRows).toEqual([]);
+    for (const message of receipt.messages as any[]) {
+      expect(message.content.metadata?.suspendedTools?.['shared-plan-call']).toBeUndefined();
+      expect(message.content.metadata?.pendingToolApprovals?.['shared-plan-call']).toBeUndefined();
+    }
+  } catch (error) {
+    receipt.failure = errorInfo(error);
+    throw error;
+  } finally {
+    release();
+    await Promise.allSettled(hosts.map(host => host.mastra.shutdown()));
+    await Promise.allSettled(topicUnsubscribers.map(unsubscribe => unsubscribe()));
+    fs.writeFileSync(path.join(directory, 'result.json'), JSON.stringify(receipt, null, 2) + '\n');
+  }
+});

--- a/packages/core/src/agent-controller/__tests__/session-stop-shutdown.integration.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-stop-shutdown.integration.test.ts
@@ -222,7 +222,7 @@ it.each(['discovery', 'snapshot', 'write', 'discovery-error', 'write-error', 'la
       removeEvents = fresh.subscribe(event => {
         if (event.type === 'error') errors.push(String(event.error));
       });
-      await fresh.thread.switch({ threadId });
+      expect(fresh.thread.getId()).toBe(threadId);
       restoredRunId = fresh.getCurrentRunId();
       expect(restoredRunId).toBeNull();
       expect(host.controller.getCurrentAgent(fresh).getMastraInstance()).toBe(host.mastra);

--- a/packages/core/src/agent-controller/__tests__/session-stop-shutdown.integration.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-stop-shutdown.integration.test.ts
@@ -1,0 +1,351 @@
+import assert from 'node:assert/strict';
+import dns from 'node:dns';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import net from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { pathToFileURL } from 'node:url';
+import { afterEach, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { LibSQLStore } from '../../../../../stores/libsql/src';
+import { Memory } from '../../../../memory/src';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../../agent/durable';
+import { Mastra } from '../../mastra';
+import { createWorkflow, createStep } from '../../workflows';
+import { Workspace } from '../../workspace';
+import { AgentController } from '../agent-controller';
+
+const deferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+const bounded = <T>(promise: Promise<T>, label: string) =>
+  Promise.race([
+    promise,
+    delay(5000).then(() => {
+      throw new Error('Timed out: ' + label);
+    }),
+  ]);
+afterEach(() => vi.restoreAllMocks());
+
+it.each(['discovery', 'snapshot', 'write', 'discovery-error', 'write-error', 'late-stop'] as const)(
+  'registered cold host drains Stop at %s',
+  async boundary => {
+    const directory = mkdtempSync(path.join(tmpdir(), 'mastra-cold-owner-'));
+    const url = pathToFileURL(path.join(directory, 'native.db')).href;
+    const calls = { model: 0, following: 0, network: 0 };
+    const order: string[] = [];
+    const identities: Array<Record<string, boolean | string>> = [];
+    const errors: string[] = [];
+    const failure = new Error('Controlled cancellation storage failure');
+    const shouldFail = boundary.endsWith('-error');
+    const denyNetwork = () => {
+      calls.network++;
+      throw new Error('External network is forbidden');
+    };
+    vi.spyOn(globalThis, 'fetch').mockImplementation(denyNetwork);
+    vi.spyOn(net.Socket.prototype, 'connect').mockImplementation(denyNetwork);
+    vi.spyOn(dns, 'lookup').mockImplementation(denyNetwork);
+    const approval = deferred(),
+      parked = deferred(),
+      ended = deferred(),
+      readEntered = deferred(),
+      allowRead = deferred(),
+      closed = deferred();
+    async function createHost() {
+      const storage = new LibSQLStore({ id: 'stop-shutdown-proof', url });
+      await storage.init();
+      const workflow = createWorkflow({ id: 'research', inputSchema: z.object({}), outputSchema: z.object({}) })
+        .then(
+          createStep({
+            id: 'park',
+            inputSchema: z.object({}),
+            outputSchema: z.object({}),
+            suspendSchema: z.object({ prompt: z.string() }),
+            resumeSchema: z.object({ confirmed: z.boolean() }),
+            execute: async ({ suspend }) => suspend({ prompt: 'Wait for the local user.' }),
+          }),
+        )
+        .then(
+          createStep({
+            id: 'following',
+            inputSchema: z.object({}),
+            outputSchema: z.object({}),
+            execute: async () => {
+              calls.following++;
+              return {};
+            },
+          }),
+        )
+        .commit();
+      const agent = createDurableAgent({
+        agent: new Agent({
+          id: 'stop-shutdown-parent',
+          name: 'Local parent',
+          instructions: 'Use the local workflow.',
+          memory: new Memory({ storage }),
+          workflows: { research: workflow },
+          model: {
+            specificationVersion: 'v2',
+            provider: 'local-fixture',
+            modelId: 'unpaid',
+            supportedUrls: {},
+            doGenerate: async () => {
+              throw new Error('No nonstreaming generation expected');
+            },
+            doStream: async () => {
+              calls.model++;
+              assert.equal(calls.model, 1, 'No further model call is allowed');
+              return {
+                stream: new ReadableStream({
+                  start(controller) {
+                    controller.enqueue({ type: 'stream-start', warnings: [] });
+                    controller.enqueue({
+                      type: 'tool-call',
+                      toolCallId: 'research-call',
+                      toolName: 'workflow-research',
+                      input: '{"inputData":{}}',
+                    });
+                    controller.enqueue({
+                      type: 'finish',
+                      finishReason: 'tool-calls',
+                      usage: { inputTokens: 1, outputTokens: 1 },
+                    });
+                    controller.close();
+                  },
+                }),
+              };
+            },
+          },
+        }),
+      });
+
+      const workspace = new Workspace({ id: 'proof-workspace', name: 'Local', skills: () => [] });
+      const controller = new AgentController({
+        id: 'proof-controller',
+        agent,
+        storage,
+        workspace,
+        defaultModeId: 'chat',
+        modes: [{ id: 'chat', name: 'Chat', default: true }],
+        disableBuiltinTools: [
+          'ask_user',
+          'submit_plan',
+          'task_write',
+          'task_update',
+          'task_complete',
+          'task_check',
+          'subagent',
+        ],
+      });
+      const mastra = new Mastra({
+        agents: { agent },
+        workflows: { research: workflow },
+        storage,
+        logger: false,
+        agentControllers: { proof: controller },
+        workers: false,
+        scheduler: { enabled: false },
+        recovery: { durableAgents: 'off' },
+      });
+      return { storage, agent, controller, mastra, workspace };
+    }
+    const assertOwner = (host: Awaited<ReturnType<typeof createHost>>, stage: string) => {
+      const row = {
+        stage,
+        controller: host.controller.getMastra() === host.mastra,
+        registered: host.mastra.getAgentController('proof') === host.controller,
+        agent: host.agent.getMastraInstance() === host.mastra,
+        registryAgent: host.mastra.getAgentById(host.agent.id).getMastraInstance() === host.mastra,
+        storage: host.controller.getMastra()?.getStorage() === host.mastra.getStorage(),
+      };
+      identities.push(row);
+      for (const [key, value] of Object.entries(row)) if (key !== 'stage') expect(value, key + ' ' + stage).toBe(true);
+    };
+    let host = await createHost();
+    let shutdown: Promise<void> | undefined;
+    let removeEvents = () => {};
+    let parentRunId: string | undefined;
+    let restoredRunId: string | null | undefined;
+    let closedBeforeRelease: boolean | undefined;
+    let afterRows: unknown;
+    try {
+      assertOwner(host, 'writer-before-init');
+      await host.controller.init();
+      assertOwner(host, 'writer-after-init');
+      const session = await host.controller.createSession({
+        ownerId: 'owner',
+        resourceId: 'resource',
+        workspace: host.workspace,
+      });
+      await session.thread.create();
+      removeEvents = session.subscribe(event => {
+        if (event.type === 'tool_approval_required') approval.resolve();
+        if (event.type === 'tool_suspended') parked.resolve();
+        if (event.type === 'agent_end') ended.resolve();
+        if (event.type === 'error') errors.push(String(event.error));
+      });
+      const turn = session.sendMessage({ content: 'Park the local workflow.' });
+      await bounded(approval.promise, 'native approval');
+      session.respondToToolApproval({ decision: 'approve', toolCallId: 'research-call' });
+      await bounded(Promise.all([parked.promise, ended.promise, turn]), 'native parked turn');
+      const threadId = session.thread.getId()!;
+      const writerStore = await host.storage.getStore('workflows');
+      assert(writerStore);
+      const beforeRows = await writerStore.listWorkflowRuns({});
+      const parent = beforeRows.runs.find(row => row.workflowName === 'durable-agentic-loop');
+      assert(parent);
+      parentRunId = parent.runId;
+      expect(beforeRows.runs.filter(row => row.snapshot?.status === 'suspended')).toHaveLength(3);
+      removeEvents();
+      await bounded(host.mastra.shutdown(), 'writer normal shutdown');
+      order.push('writer-shutdown-finished');
+
+      const oldHost = host;
+      host = await createHost();
+      expect(host.mastra).not.toBe(oldHost.mastra);
+      expect(host.agent).not.toBe(oldHost.agent);
+      expect(host.storage).not.toBe(oldHost.storage);
+      assertOwner(host, 'restored-before-init');
+      await host.controller.init();
+      assertOwner(host, 'restored-after-init');
+      const fresh = await host.controller.createSession({
+        ownerId: 'owner',
+        resourceId: 'resource',
+        workspace: host.workspace,
+      });
+      removeEvents = fresh.subscribe(event => {
+        if (event.type === 'error') errors.push(String(event.error));
+      });
+      await fresh.thread.switch({ threadId });
+      restoredRunId = fresh.getCurrentRunId();
+      expect(restoredRunId).toBeNull();
+      expect(host.controller.getCurrentAgent(fresh).getMastraInstance()).toBe(host.mastra);
+      const store = await host.storage.getStore('workflows');
+      assert(store);
+      const restoredRows = await store.listWorkflowRuns({});
+      expect(restoredRows.runs.filter(row => row.snapshot?.status === 'suspended')).toHaveLength(3);
+      if (boundary === 'late-stop') {
+        const currentAgent = host.controller.getCurrentAgent(fresh);
+        const suspended = vi.spyOn(currentAgent, 'listSuspendedRuns');
+        const active = vi.spyOn(currentAgent, 'listActiveRuns');
+        await host.mastra.shutdown();
+        fresh.abortRun();
+        await delay(20);
+        expect(suspended).not.toHaveBeenCalled();
+        expect(active).not.toHaveBeenCalled();
+        expect(errors).toContainEqual(expect.stringContaining('cancellation admission is closed'));
+        expect(calls).toEqual({ model: 1, following: 0, network: 0 });
+        return;
+      }
+      if (boundary === 'discovery-error') {
+        const currentAgent = host.controller.getCurrentAgent(fresh);
+        const active = currentAgent.listActiveRuns.bind(currentAgent);
+        vi.spyOn(currentAgent, 'listSuspendedRuns').mockRejectedValueOnce(failure);
+        vi.spyOn(currentAgent, 'listActiveRuns').mockImplementationOnce(async input => {
+          readEntered.resolve();
+          await allowRead.promise;
+          return active(input);
+        });
+      } else if (boundary === 'discovery') {
+        const currentAgent = host.controller.getCurrentAgent(fresh);
+        const discover = currentAgent.listSuspendedRuns.bind(currentAgent);
+        vi.spyOn(currentAgent, 'listSuspendedRuns').mockImplementationOnce(async input => {
+          readEntered.resolve();
+          await allowRead.promise;
+          return discover(input);
+        });
+      } else if (boundary === 'snapshot') {
+        const load = store.loadWorkflowSnapshot.bind(store);
+        vi.spyOn(store, 'loadWorkflowSnapshot').mockImplementationOnce(async input => {
+          readEntered.resolve();
+          await allowRead.promise;
+          return load(input);
+        });
+      } else {
+        const update = store.updateWorkflowState.bind(store);
+        vi.spyOn(store, 'updateWorkflowState').mockImplementationOnce(async input => {
+          readEntered.resolve();
+          await allowRead.promise;
+          if (shouldFail) throw failure;
+          return update(input);
+        });
+      }
+      const close = host.storage.close.bind(host.storage);
+      vi.spyOn(host.storage, 'close').mockImplementation(async () => {
+        order.push('storage-close-start');
+        await close();
+        order.push('storage-close-finished');
+        closed.resolve();
+      });
+      assertOwner(host, 'before-stop');
+      fresh.abortRun();
+      await bounded(readEntered.promise, 'Stop reaching real saved run read');
+      assertOwner(host, 'before-shutdown');
+      shutdown = host.mastra.shutdown().then(() => {
+        order.push('shutdown-finished');
+      });
+      const completion = shouldFail ? expect(shutdown).rejects.toBeInstanceOf(AggregateError) : shutdown;
+      closedBeforeRelease = await Promise.race([closed.promise.then(() => true), delay(150).then(() => false)]);
+      order.push('release-storage-read');
+      allowRead.resolve();
+      await bounded(completion, 'shutdown after released read');
+      expect(closedBeforeRelease).toBe(false);
+      expect(calls).toEqual({ model: 1, following: 0, network: 0 });
+      const reader = new LibSQLStore({ id: 'readback', url });
+      try {
+        await reader.init();
+        const readback = await reader.getStore('workflows');
+        assert(readback);
+        afterRows = (await readback.listWorkflowRuns({})).runs.map(row => ({
+          workflowName: row.workflowName,
+          runId: row.runId,
+          status: row.snapshot?.status,
+        }));
+        const pendingRows = (afterRows as Array<{ status?: string }>).filter(row =>
+          ['running', 'pending', 'waiting', 'suspended'].includes(row.status ?? ''),
+        );
+        expect(pendingRows).toHaveLength(shouldFail ? 3 : 0);
+        if (shouldFail) expect(errors.length).toBeGreaterThan(0);
+      } finally {
+        await reader.close();
+      }
+    } finally {
+      allowRead.resolve();
+      removeEvents();
+      if (shutdown)
+        await bounded(
+          shutdown.catch(error => {
+            errors.push(String(error));
+          }),
+          'cleanup shutdown',
+        );
+      else await host.mastra.shutdown();
+      writeFileSync(
+        path.join(directory, 'result.json'),
+        JSON.stringify(
+          {
+            scope:
+              'registered cold owner public Session abortRun and Mastra shutdown; real file LibSQL; real read hold',
+            calls,
+            order,
+            identities,
+            errors,
+            parentRunId,
+            restoredRunId,
+            closedBeforeRelease,
+            afterRows,
+          },
+          null,
+          2,
+        ),
+      );
+    }
+  },
+  15000,
+);

--- a/packages/core/src/agent-controller/__tests__/session-stop-shutdown.integration.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-stop-shutdown.integration.test.ts
@@ -14,6 +14,7 @@ import { Agent } from '../../agent';
 import { createDurableAgent } from '../../agent/durable';
 import { Mastra } from '../../mastra';
 import { createWorkflow, createStep } from '../../workflows';
+import type { WorkflowRunState } from '../../workflows/types';
 import { Workspace } from '../../workspace';
 import { AgentController } from '../agent-controller';
 
@@ -24,6 +25,18 @@ const deferred = () => {
   });
   return { promise, resolve };
 };
+const describeError = (error: unknown): unknown =>
+  error instanceof AggregateError
+    ? { message: error.message, errors: error.errors.map(describeError) }
+    : error instanceof Error
+      ? { message: error.message, cause: error.cause ? describeError(error.cause) : undefined }
+      : String(error);
+const snapshotStatus = (snapshot: string | WorkflowRunState | null | undefined) =>
+  (typeof snapshot === 'string' ? (JSON.parse(snapshot) as WorkflowRunState) : snapshot)?.status;
+function requireNativeAgent(agent: unknown) {
+  if (!(agent instanceof Agent)) throw new TypeError('Expected a native Agent');
+  return agent;
+}
 const bounded = <T>(promise: Promise<T>, label: string) =>
   Promise.race([
     promise,
@@ -114,7 +127,7 @@ it.each(['discovery', 'snapshot', 'write', 'discovery-error', 'write-error', 'la
                     controller.enqueue({
                       type: 'finish',
                       finishReason: 'tool-calls',
-                      usage: { inputTokens: 1, outputTokens: 1 },
+                      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
                     });
                     controller.close();
                   },
@@ -128,7 +141,7 @@ it.each(['discovery', 'snapshot', 'write', 'discovery-error', 'write-error', 'la
       const workspace = new Workspace({ id: 'proof-workspace', name: 'Local', skills: () => [] });
       const controller = new AgentController({
         id: 'proof-controller',
-        agent,
+        agent: requireNativeAgent(agent),
         storage,
         workspace,
         defaultModeId: 'chat',
@@ -201,7 +214,7 @@ it.each(['discovery', 'snapshot', 'write', 'discovery-error', 'write-error', 'la
       const parent = beforeRows.runs.find(row => row.workflowName === 'durable-agentic-loop');
       assert(parent);
       parentRunId = parent.runId;
-      expect(beforeRows.runs.filter(row => row.snapshot?.status === 'suspended')).toHaveLength(3);
+      expect(beforeRows.runs.filter(row => snapshotStatus(row.snapshot) === 'suspended')).toHaveLength(3);
       removeEvents();
       await bounded(host.mastra.shutdown(), 'writer normal shutdown');
       order.push('writer-shutdown-finished');
@@ -229,7 +242,7 @@ it.each(['discovery', 'snapshot', 'write', 'discovery-error', 'write-error', 'la
       const store = await host.storage.getStore('workflows');
       assert(store);
       const restoredRows = await store.listWorkflowRuns({});
-      expect(restoredRows.runs.filter(row => row.snapshot?.status === 'suspended')).toHaveLength(3);
+      expect(restoredRows.runs.filter(row => snapshotStatus(row.snapshot) === 'suspended')).toHaveLength(3);
       if (boundary === 'late-stop') {
         const currentAgent = host.controller.getCurrentAgent(fresh);
         const suspended = vi.spyOn(currentAgent, 'listSuspendedRuns');
@@ -305,7 +318,7 @@ it.each(['discovery', 'snapshot', 'write', 'discovery-error', 'write-error', 'la
         afterRows = (await readback.listWorkflowRuns({})).runs.map(row => ({
           workflowName: row.workflowName,
           runId: row.runId,
-          status: row.snapshot?.status,
+          status: snapshotStatus(row.snapshot),
         }));
         const pendingRows = (afterRows as Array<{ status?: string }>).filter(row =>
           ['running', 'pending', 'waiting', 'suspended'].includes(row.status ?? ''),
@@ -321,7 +334,7 @@ it.each(['discovery', 'snapshot', 'write', 'discovery-error', 'write-error', 'la
       if (shutdown)
         await bounded(
           shutdown.catch(error => {
-            errors.push(String(error));
+            errors.push(JSON.stringify(describeError(error)));
           }),
           'cleanup shutdown',
         );

--- a/packages/core/src/agent-controller/__tests__/session-workflow-cancellation.integration.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-workflow-cancellation.integration.test.ts
@@ -1,0 +1,701 @@
+import dns from 'node:dns';
+import net from 'node:net';
+import { setTimeout as delay } from 'node:timers/promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import z from 'zod';
+import { Memory } from '../../../../memory/src';
+import { Agent } from '../../agent';
+import { createDurableAgent, globalRunRegistry } from '../../agent/durable';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage';
+import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
+import { createWorkflow, createStep } from '../../workflows';
+import { Workspace } from '../../workspace';
+import { AgentController } from '../agent-controller';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function response(tool = false) {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: 'stream-start', warnings: [] });
+      if (tool)
+        controller.enqueue({
+          type: 'tool-call',
+          toolCallId: 'research-call',
+          toolName: 'workflow-research',
+          input: '{"inputData":{}}',
+        });
+      else {
+        controller.enqueue({ type: 'text-start', id: 'text' });
+        controller.enqueue({ type: 'text-delta', id: 'text', delta: 'Done.' });
+        controller.enqueue({ type: 'text-end', id: 'text' });
+      }
+      controller.enqueue({
+        type: 'finish',
+        finishReason: tool ? 'tool-calls' : 'stop',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      });
+      controller.close();
+    },
+  });
+}
+
+async function createHarness(parkChild = false) {
+  const started = deferred();
+  const release = deferred();
+  const approval = deferred();
+  const ended = deferred();
+  const suspended = deferred();
+  const calls = { parent: 0, child: 0, followingStep: 0 };
+  const signals: AbortSignal[] = [];
+  const ends: Array<string | undefined> = [];
+  const approvals: string[] = [];
+  const errors: unknown[] = [];
+  const storage = new InMemoryStore();
+  const child = new Agent({
+    id: 'child',
+    name: 'Child',
+    instructions: 'Research locally.',
+    model: new MastraLanguageModelV2Mock({
+      doStream: async options => {
+        calls.child++;
+        signals.push(options.abortSignal!);
+        started.resolve();
+        return {
+          stream: new ReadableStream({
+            start(controller) {
+              const abort = () => controller.error(options.abortSignal!.reason);
+              options.abortSignal!.addEventListener('abort', abort, { once: true });
+              void release.promise.then(() => {
+                options.abortSignal!.removeEventListener('abort', abort);
+                if (!options.abortSignal!.aborted) {
+                  controller.enqueue({
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                  });
+                  controller.close();
+                }
+              });
+            },
+          }),
+        };
+      },
+    }),
+  });
+  const research = createWorkflow({ id: 'research', inputSchema: z.object({}), outputSchema: z.object({}) })
+    .then(
+      createStep({
+        id: 'read',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+        suspendSchema: z.object({ prompt: z.string() }),
+        resumeSchema: z.object({ confirmed: z.boolean() }),
+        execute: async ({ abortSignal, suspend, resumeData }) => {
+          if (parkChild && !resumeData?.confirmed) return suspend({ prompt: 'Confirm research.' });
+          const output = await child.stream('Read the local evidence.', { abortSignal });
+          await output.getFullOutput();
+          return {};
+        },
+      }),
+    )
+    .then(
+      createStep({
+        id: 'following',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+        execute: async () => {
+          calls.followingStep++;
+          return {};
+        },
+      }),
+    )
+    .commit();
+  const durable = createDurableAgent({
+    agent: new Agent({
+      id: 'research-parent',
+      name: 'Research parent',
+      instructions: 'Use research.',
+      model: new MastraLanguageModelV2Mock({ doStream: async () => ({ stream: response(++calls.parent === 1) }) }),
+      memory: new Memory({ storage }),
+      workflows: { research },
+    }),
+  });
+  const mastra = new Mastra({
+    agents: { durable, child },
+    workflows: { research },
+    storage,
+    logger: false,
+    workers: false,
+    scheduler: { enabled: false },
+    recovery: { durableAgents: 'off' },
+  });
+  await mastra.startWorkers();
+  const workspace = new Workspace({ id: 'cancel-workspace', name: 'Local', skills: () => [] });
+  const controllerOptions = {
+    id: 'cancel-controller',
+    agent: mastra.getAgentById(durable.id),
+    storage,
+    workspace,
+    defaultModeId: 'chat',
+    modes: [{ id: 'chat', name: 'Chat', default: true }],
+    disableBuiltinTools: [
+      'ask_user',
+      'submit_plan',
+      'task_write',
+      'task_update',
+      'task_complete',
+      'task_check',
+      'subagent',
+    ],
+  };
+  const controller = new AgentController(controllerOptions);
+  await controller.init();
+  const session = await controller.createSession({ ownerId: 'owner', resourceId: 'resource', workspace });
+  await session.thread.create();
+  const off = session.subscribe(event => {
+    if (event.type === 'tool_approval_required') {
+      approvals.push(event.toolCallId);
+      approval.resolve();
+    }
+    if (event.type === 'agent_end') {
+      ends.push(event.reason);
+      ended.resolve();
+    }
+    if (event.type === 'error') errors.push(event.error);
+    if (event.type === 'tool_suspended') suspended.resolve();
+  });
+  return {
+    session,
+    storage,
+    calls,
+    signals,
+    ends,
+    errors,
+    approvals,
+    started,
+    approval,
+    ended,
+    release,
+    suspended,
+    research,
+    durable,
+    async reopen() {
+      const freshController = new AgentController(controllerOptions);
+      await freshController.init();
+      const fresh = await freshController.createSession({ ownerId: 'owner', resourceId: 'resource', workspace });
+      await fresh.thread.switch({ threadId: session.thread.getId()! });
+      return { session: fresh, close: () => freshController.stopIntervals() };
+    },
+    async close() {
+      release.resolve();
+      session.abort();
+      off();
+      controller.stopIntervals();
+      await mastra.stopWorkers();
+    },
+  };
+}
+
+describe('native Session cancellation reaches workflow tools', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('External network is forbidden'));
+    vi.spyOn(net.Socket.prototype, 'connect').mockImplementation(() => {
+      throw new Error('External socket is forbidden');
+    });
+    vi.spyOn(dns, 'lookup').mockImplementation(() => {
+      throw new Error('External DNS is forbidden');
+    });
+  });
+  afterEach(() => {
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(net.Socket.prototype.connect).not.toHaveBeenCalled();
+    expect(dns.lookup).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it('Stop during child creation never starts the child stream', async () => {
+    const h = await createHarness();
+    const created = deferred();
+    const releaseCreate = deferred();
+    const createRun = h.research.createRun.bind(h.research);
+    vi.spyOn(h.research, 'createRun').mockImplementationOnce(async options => {
+      const run = await createRun(options);
+      created.resolve();
+      await releaseCreate.promise;
+      return run;
+    });
+    const turn = h.session.sendMessage({ content: 'Research locally.' });
+    try {
+      await h.approval.promise;
+      h.session.respondToToolApproval({ decision: 'approve', toolCallId: 'research-call' });
+      await created.promise;
+      h.session.abort();
+      releaseCreate.resolve();
+      await h.ended.promise;
+      await delay(50);
+      expect(h.calls).toEqual({ parent: 1, child: 0, followingStep: 0 });
+      expect(h.errors).toEqual([]);
+    } finally {
+      releaseCreate.resolve();
+      await h.close();
+      void turn.catch(() => {});
+    }
+  });
+
+  it('a rejected executor does not skip cancellation of its stored suspended work', async () => {
+    const h = await createHarness(true);
+    const turn = h.session.sendMessage({ content: 'Research locally.' });
+    try {
+      await h.approval.promise;
+      h.session.respondToToolApproval({ decision: 'approve', toolCallId: 'research-call' });
+      await h.suspended.promise;
+      await h.ended.promise;
+      const store = (await h.storage.getStore('workflows'))!;
+      const parent = (await store.listWorkflowRuns({ workflowName: 'durable-agentic-loop' })).runs[0]!;
+      const entry = globalRunRegistry.get(parent.runId)!;
+      const rejection = Promise.reject(new Error('Executor already reported its failure'));
+      void rejection.catch(() => {});
+      entry.workflowExecution = rejection;
+      h.session.abort();
+      await vi.waitFor(async () => expect((await store.listWorkflowRuns({ status: 'suspended' })).total).toBe(0), {
+        timeout: 1500,
+      });
+      expect(h.calls.child).toBe(0);
+    } finally {
+      await h.close();
+      void turn.catch(() => {});
+    }
+  });
+
+  it('Stop cancels a running child model after workflow approval and prevents further steps', async () => {
+    const h = await createHarness();
+    const turn = h.session.sendMessage({ content: 'Research locally.' });
+    try {
+      await h.approval.promise;
+      h.session.respondToToolApproval({ decision: 'approve', toolCallId: 'research-call' });
+      await h.started.promise;
+      h.session.abort();
+      await vi.waitFor(() => expect(h.signals[0]?.aborted).toBe(true), { timeout: 1500 });
+      await vi.waitFor(
+        () => expect({ ends: h.ends, errors: h.errors }).toMatchObject({ ends: ['aborted'], errors: [] }),
+        { timeout: 1500 },
+      );
+      await delay(100);
+      expect(h.calls).toEqual({ parent: 1, child: 1, followingStep: 0 });
+      expect(h.approvals).toEqual(['research-call']);
+      expect(h.session.displayState.get().isRunning).toBe(false);
+      const runs = await (await h.storage.getStore('workflows'))!.listWorkflowRuns({});
+      expect(
+        runs.runs.every(run => !['running', 'suspended', 'waiting', 'pending'].includes(run.snapshot?.status)),
+      ).toBe(true);
+      expect(h.errors).toEqual([]);
+    } finally {
+      await h.close();
+      void turn.catch(() => {});
+    }
+  });
+
+  it('Stop at pending approval starts no child and leaves no resumable durable run', async () => {
+    const h = await createHarness();
+    const turn = h.session.sendMessage({ content: 'Research locally.' });
+    try {
+      await h.approval.promise;
+      h.session.abort();
+      await h.ended.promise;
+      await delay(100);
+      expect(h.calls).toEqual({ parent: 1, child: 0, followingStep: 0 });
+      expect({ ends: h.ends, errors: h.errors }).toEqual({ ends: ['aborted'], errors: [] });
+      expect(h.session.displayState.get().pendingApproval).toBeNull();
+      const runs = await (await h.storage.getStore('workflows'))!.listWorkflowRuns({});
+      expect(runs.runs).toEqual([]);
+      expect(h.errors).toEqual([]);
+    } finally {
+      await h.close();
+      void turn.catch(() => {});
+    }
+  });
+
+  it('an approved workflow can complete normally', async () => {
+    const h = await createHarness();
+    const turn = h.session.sendMessage({ content: 'Research locally.' });
+    try {
+      await h.approval.promise;
+      h.session.respondToToolApproval({ decision: 'approve', toolCallId: 'research-call' });
+      await h.started.promise;
+      h.release.resolve();
+      await h.ended.promise;
+      await delay(100);
+      expect(h.calls).toEqual({ parent: 2, child: 1, followingStep: 1 });
+      expect(h.ends).toEqual(['complete']);
+      expect(h.errors).toEqual([]);
+    } finally {
+      await h.close();
+      void turn.catch(() => {});
+    }
+  });
+
+  it('Stop during async approval preparation cannot start the approved workflow', async () => {
+    const h = await createHarness();
+    const turn = h.session.sendMessage({ content: 'Research locally.' });
+    const preparing = deferred();
+    const prepared = deferred();
+    try {
+      await h.approval.promise;
+      const original = h.session.machinery.buildRequestContext.bind(h.session.machinery);
+      vi.spyOn(h.session.machinery, 'buildRequestContext').mockImplementationOnce(async (...args) => {
+        preparing.resolve();
+        await prepared.promise;
+        return original(...args);
+      });
+      h.session.respondToToolApproval({ decision: 'approve', toolCallId: 'research-call' });
+      await preparing.promise;
+      h.session.abort();
+      prepared.resolve();
+      await delay(150);
+      expect(h.calls).toEqual({ parent: 1, child: 0, followingStep: 0 });
+      expect(h.ends).toEqual(['aborted']);
+      expect(h.errors).toEqual([]);
+    } finally {
+      prepared.resolve();
+      await h.close();
+      void turn.catch(() => {});
+    }
+  });
+
+  it('Stop cancels stored child and durable runs even when a parked session projects idle', async () => {
+    const h = await createHarness(true);
+    const turn = h.session.sendMessage({ content: 'Research locally.' });
+    try {
+      await h.approval.promise;
+      h.session.respondToToolApproval({ decision: 'approve', toolCallId: 'research-call' });
+      await h.suspended.promise;
+      await h.ended.promise;
+      const store = (await h.storage.getStore('workflows'))!;
+      await vi.waitFor(
+        async () =>
+          expect(
+            (await store.listWorkflowRuns({})).runs.map(run => ({ id: run.runId, status: run.snapshot?.status })),
+          ).toContainEqual(expect.objectContaining({ status: 'suspended' })),
+        { timeout: 1500 },
+      );
+      expect(h.session.displayState.get().isRunning).toBe(false);
+      h.session.abort();
+      await vi.waitFor(
+        async () => {
+          const runs = await store.listWorkflowRuns({});
+          expect(
+            runs.runs
+              .filter(run => ['running', 'suspended', 'waiting', 'pending'].includes(run.snapshot?.status))
+              .map(run => ({ id: run.runId, workflow: run.workflowName, status: run.snapshot?.status })),
+          ).toEqual([]);
+        },
+        { timeout: 1500 },
+      );
+      await h.session.respondToToolSuspension({ toolCallId: 'research-call', resumeData: { confirmed: true } });
+      expect(h.calls).toEqual({ parent: 1, child: 0, followingStep: 0 });
+    } finally {
+      await h.close();
+      void turn.catch(() => {});
+    }
+  });
+
+  it('a fresh Session cannot reopen a canceled workflow suspension', async () => {
+    const h = await createHarness(true);
+    const turn = h.session.sendMessage({ content: 'Research locally.' });
+    let reopened: Awaited<ReturnType<typeof h.reopen>> | undefined;
+    try {
+      await h.approval.promise;
+      h.session.respondToToolApproval({ decision: 'approve', toolCallId: 'research-call' });
+      await h.suspended.promise;
+      await h.ended.promise;
+      h.session.abort();
+      await delay(100);
+      reopened = await h.reopen();
+      await delay(100);
+      expect(reopened.session.displayState.get().pendingSuspensions.size).toBe(0);
+      expect(reopened.session.displayState.get().pendingApproval).toBeNull();
+      await reopened.session.respondToToolSuspension({ toolCallId: 'research-call', resumeData: { confirmed: true } });
+      await delay(100);
+      expect(h.calls).toEqual({ parent: 1, child: 0, followingStep: 0 });
+    } finally {
+      reopened?.close();
+      await h.close();
+      void turn.catch(() => {});
+    }
+  });
+
+  it('Stop from a recreated Session cancels the existing stored workflow suspension', async () => {
+    const h = await createHarness(true);
+    const turn = h.session.sendMessage({ content: 'Research locally.' });
+    let reopened: Awaited<ReturnType<typeof h.reopen>> | undefined;
+    try {
+      await h.approval.promise;
+      h.session.respondToToolApproval({ decision: 'approve', toolCallId: 'research-call' });
+      await h.suspended.promise;
+      await h.ended.promise;
+      reopened = await h.reopen();
+      await delay(50);
+      expect(reopened.session.displayState.get().isRunning).toBe(false);
+      reopened.session.abort();
+      const store = (await h.storage.getStore('workflows'))!;
+      await vi.waitFor(
+        async () =>
+          expect({
+            pending: (await store.listWorkflowRuns({ status: 'suspended' })).total,
+            runId: reopened!.session.getCurrentRunId(),
+          }).toMatchObject({ pending: 0 }),
+        { timeout: 1500 },
+      );
+      expect(h.calls).toEqual({ parent: 1, child: 0, followingStep: 0 });
+    } finally {
+      reopened?.close();
+      await h.close();
+      void turn.catch(() => {});
+    }
+  });
+
+  it('Stop from a recreated Session cancels an already running child promptly', async () => {
+    const h = await createHarness();
+    const turn = h.session.sendMessage({ content: 'Research locally.' });
+    let reopened: Awaited<ReturnType<typeof h.reopen>> | undefined;
+    try {
+      await h.approval.promise;
+      h.session.respondToToolApproval({ decision: 'approve', toolCallId: 'research-call' });
+      await h.started.promise;
+      reopened = await h.reopen();
+      reopened.session.abort();
+      await vi.waitFor(() => expect(h.signals[0].aborted).toBe(true), { timeout: 1500 });
+      expect(h.calls.followingStep).toBe(0);
+      expect(h.calls.parent).toBe(1);
+    } finally {
+      reopened?.close();
+      await h.close();
+      void turn.catch(() => {});
+    }
+  });
+
+  it('late Stop discovery cannot cancel a later thread and user turn', async () => {
+    const h = await createHarness(true);
+    const turn = h.session.sendMessage({ content: 'Research locally.' });
+    const discovered = deferred();
+    const releaseDiscovery = deferred();
+    let reopened: Awaited<ReturnType<typeof h.reopen>> | undefined;
+    try {
+      await h.approval.promise;
+      h.session.respondToToolApproval({ decision: 'approve', toolCallId: 'research-call' });
+      await h.suspended.promise;
+      await h.ended.promise;
+      reopened = await h.reopen();
+      const agent = reopened.session.machinery.getAgent();
+      const discover = agent.listSuspendedRuns.bind(agent);
+      vi.spyOn(agent, 'listSuspendedRuns').mockImplementationOnce(async options => {
+        const result = await discover(options);
+        discovered.resolve();
+        await releaseDiscovery.promise;
+        return result;
+      });
+      const abort = vi.spyOn(agent, 'abortRunStream');
+      reopened.session.abort();
+      await discovered.promise;
+      await reopened.session.thread.create();
+      await reopened.session.sendMessage({ content: 'A new local turn.' });
+      const completedCalls = h.calls.parent;
+      releaseDiscovery.resolve();
+      await delay(50);
+      expect(abort).not.toHaveBeenCalled();
+      expect(h.calls.parent).toBe(completedCalls);
+    } finally {
+      releaseDiscovery.resolve();
+      reopened?.close();
+      await h.close();
+      void turn.catch(() => {});
+    }
+  });
+
+  it('a delegated child that resumes during Stop is canceled before its following step', async () => {
+    const h = await createHarness(true);
+    const turn = h.session.sendMessage({ content: 'Research locally.' });
+    const lookingUpChild = deferred();
+    const allowLookup = deferred();
+    let childResume: Promise<unknown> | undefined;
+    try {
+      await h.approval.promise;
+      h.session.respondToToolApproval({ decision: 'approve', toolCallId: 'research-call' });
+      await h.suspended.promise;
+      await h.ended.promise;
+      const store = (await h.storage.getStore('workflows'))!;
+      const child = (await store.listWorkflowRuns({ workflowName: 'research' })).runs[0]!;
+      const childRun = await h.research.createRun({ runId: child.runId, resourceId: 'resource' });
+      const get = store.getWorkflowRunById.bind(store);
+      vi.spyOn(store, 'getWorkflowRunById').mockImplementation(async options => {
+        if (options.workflowName === 'research') {
+          lookingUpChild.resolve();
+          await allowLookup.promise;
+        }
+        return get(options);
+      });
+      h.session.abort();
+      await lookingUpChild.promise;
+      childResume = childRun.resume({ resumeData: { confirmed: true } });
+      await h.started.promise;
+      allowLookup.resolve();
+      await vi.waitFor(() => expect(h.signals[0].aborted).toBe(true), { timeout: 1500 });
+      await childResume;
+      expect(h.calls.followingStep).toBe(0);
+      expect(h.calls.parent).toBe(1);
+    } finally {
+      allowLookup.resolve();
+      await h.close();
+      void Promise.allSettled([turn, ...(childResume ? [childResume] : [])]);
+    }
+  });
+
+  it('a failed parked cancellation stays observable and retains stored pending runs', async () => {
+    const h = await createHarness(true);
+    const turn = h.session.sendMessage({ content: 'Research locally.' });
+    try {
+      await h.approval.promise;
+      h.session.respondToToolApproval({ decision: 'approve', toolCallId: 'research-call' });
+      await h.suspended.promise;
+      await h.ended.promise;
+      const store = (await h.storage.getStore('workflows'))!;
+      const failure = new Error('Local cancellation persistence failed');
+      vi.spyOn(store, 'updateWorkflowState').mockRejectedValueOnce(failure);
+      h.session.abort();
+      await vi.waitFor(() => expect(h.errors).toContainEqual(expect.objectContaining({ message: failure.message })), {
+        timeout: 1500,
+      });
+      expect((await store.listWorkflowRuns({ status: 'suspended' })).runs).toHaveLength(3);
+      expect(h.calls).toEqual({ parent: 1, child: 0, followingStep: 0 });
+    } finally {
+      await h.close();
+      void turn.catch(() => {});
+    }
+  });
+
+  it.each([false, true])('cancels an unscoped native durable workflow (string row snapshot=%s)', async stringRow => {
+    const storage = new InMemoryStore();
+    const research = createWorkflow({ id: 'unscoped-research', inputSchema: z.object({}), outputSchema: z.object({}) })
+      .then(
+        createStep({
+          id: 'park',
+          inputSchema: z.object({}),
+          outputSchema: z.object({}),
+          execute: async ({ suspend }) => suspend({ prompt: 'Wait.' }),
+        }),
+      )
+      .commit();
+    const durable = createDurableAgent({
+      agent: new Agent({
+        id: 'unscoped-agent',
+        name: 'Unscoped',
+        instructions: 'Use research.',
+        model: new MastraLanguageModelV2Mock({ doStream: async () => ({ stream: response(true) }) }),
+        workflows: { research },
+      }),
+    });
+    const mastra = new Mastra({
+      agents: { durable },
+      workflows: { research },
+      storage,
+      logger: false,
+      workers: false,
+      scheduler: { enabled: false },
+      recovery: { durableAgents: 'off' },
+    });
+    await mastra.startWorkers();
+    try {
+      expect((await durable.generate('Run locally.', { runId: 'unscoped-run' })).finishReason).toBe('suspended');
+      const store = (await storage.getStore('workflows'))!;
+      if (stringRow) {
+        const get = store.getWorkflowRunById.bind(store);
+        vi.spyOn(store, 'getWorkflowRunById').mockImplementation(async options => {
+          const row = await get(options);
+          return row ? { ...row, snapshot: JSON.stringify(row.snapshot) } : row;
+        });
+      }
+      durable.abortRunStream('unscoped-run');
+      await vi.waitFor(async () => expect((await store.listWorkflowRuns({ status: 'suspended' })).total).toBe(0), {
+        timeout: 1500,
+      });
+    } finally {
+      await mastra.stopWorkers();
+    }
+  });
+
+  it('cancels stored running parent identities without an executor and exposes the missing active-child link', async () => {
+    const h = await createHarness();
+    const turn = h.session.sendMessage({ content: 'Research locally.' });
+    const restored = new InMemoryStore();
+    try {
+      await h.approval.promise;
+      h.session.respondToToolApproval({ decision: 'approve', toolCallId: 'research-call' });
+      await h.started.promise;
+      const original = (await h.storage.getStore('workflows'))!;
+      const frozen = (await original.listWorkflowRuns({})).runs;
+      const parent = frozen.find(row => row.workflowName === 'durable-agentic-loop')!;
+      const observer = await h.durable.observe(parent.runId);
+      await h.close();
+      observer.cleanup();
+      await delay(50);
+      const store = (await restored.getStore('workflows'))!;
+      for (const row of frozen) {
+        await store.persistWorkflowSnapshot({
+          workflowName: row.workflowName,
+          runId: row.runId,
+          resourceId: row.resourceId,
+          snapshot: row.snapshot as any,
+        });
+      }
+      const model = vi.fn(async () => {
+        throw new Error('Canceled stored work must never start a model');
+      });
+      const agent = createDurableAgent({
+        agent: new Agent({
+          id: h.durable.id,
+          name: 'Restored',
+          instructions: 'Use research.',
+          model: new MastraLanguageModelV2Mock({ doStream: model }),
+          workflows: { research: h.research },
+        }),
+      });
+      new Mastra({
+        agents: { agent },
+        workflows: { research: h.research },
+        storage: restored,
+        logger: false,
+        workers: false,
+        scheduler: { enabled: false },
+        recovery: { durableAgents: 'off' },
+      });
+      agent.abortRunStream(parent.runId);
+      await vi.waitFor(
+        async () => {
+          expect(
+            (await store.loadWorkflowSnapshot({ workflowName: 'durable-agentic-loop', runId: parent.runId }))?.status,
+          ).toBe('canceled');
+          expect(
+            (await store.loadWorkflowSnapshot({ workflowName: 'durable-agentic-execution', runId: parent.runId }))
+              ?.status,
+          ).toBe('canceled');
+        },
+        { timeout: 1500 },
+      );
+      expect(model).not.toHaveBeenCalled();
+      // The running tool has not yet saved suspendedToolRunId. No unrelated
+      // workflow can be inferred from a shared resource, so this remains a gap.
+      expect((await store.listWorkflowRuns({ workflowName: 'research', status: 'running' })).total).toBe(1);
+    } finally {
+      await h.close();
+      void turn.catch(() => {});
+    }
+  });
+});

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -407,6 +407,7 @@ export class AgentController<TState = {}> {
     session.thread.connect(this.createThreadDataStore(session), session as Session);
     session.setMachinery({
       getAgent: () => this.getCurrentAgent(session),
+      getAgents: () => [...this.backingAgents()],
       getRunScope: runId => this.getMastra()?.__getRunScope(runId),
       subscribeToThread: ({ agent, resourceId, threadId }) =>
         (agent ?? this.getCurrentAgent(session)).subscribeToThread({ resourceId, threadId }),

--- a/packages/core/src/agent-controller/session-approval-display.test.ts
+++ b/packages/core/src/agent-controller/session-approval-display.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RequestContext } from '../request-context';
+import { Session } from './session';
+
+function createSession() {
+  const session = new Session({ resourceId: 'r1', id: 's1', ownerId: 'o1' });
+  session.emit({ type: 'agent_start' });
+  return session;
+}
+
+function requestApproval(session: Session, toolCallId: string) {
+  const toolName = 'write_file';
+  const args = { path: `${toolCallId}.txt` };
+  session.emit({ type: 'tool_start', toolCallId, toolName, args });
+  const decision = session.approval.arm({ toolName, toolCallId });
+  session.emit({ type: 'tool_approval_required', toolCallId, toolName, args });
+  return decision;
+}
+
+function observeDisplay(session: Session) {
+  const changed = vi.fn();
+  session.subscribe(event => {
+    if (event.type === 'display_state_changed') {
+      // Copy the fields under test: the native snapshot remains mutable.
+      changed({
+        pendingApproval: event.displayState.pendingApproval,
+        isRunning: event.displayState.isRunning,
+        toolStatus: event.displayState.activeTools.get('t1')?.status,
+      });
+    }
+  });
+  return changed;
+}
+
+describe('Session approval display', () => {
+  it.each(['approve', 'decline', 'always_allow_category'] as const)(
+    'clears the prompt immediately after %s while preserving the running tool and decision',
+    async decision => {
+      const session = createSession();
+      session.setCategoryResolver(() => 'edit');
+      const approval = requestApproval(session, 't1');
+      const changed = observeDisplay(session);
+      const requestContext = new RequestContext();
+      const declineContext = { reason: 'not needed', message: 'Skip this file' };
+
+      session.respondToToolApproval({ decision, toolCallId: 't1', requestContext, declineContext });
+
+      expect(session.approval.isArmed()).toBe(false);
+      expect(session.displayState.get().pendingApproval).toBeNull();
+      expect(changed).toHaveBeenCalledExactlyOnceWith({
+        pendingApproval: null,
+        isRunning: true,
+        toolStatus: 'running',
+      });
+      await expect(approval).resolves.toEqual({
+        decision: decision === 'decline' ? 'decline' : 'approve',
+        requestContext,
+        declineContext,
+      });
+      expect(session.hasCategoryGrant('edit')).toBe(decision === 'always_allow_category');
+
+      session.emit({ type: 'tool_end', toolCallId: 't1', result: 'done', isError: false });
+      expect(session.displayState.get().pendingApproval).toBeNull();
+      expect(session.displayState.get().isRunning).toBe(true);
+    },
+  );
+
+  it('accepts a response without an optional tool call id', async () => {
+    const session = createSession();
+    const approval = requestApproval(session, 't1');
+    const changed = observeDisplay(session);
+
+    session.respondToToolApproval({ decision: 'approve' });
+
+    expect(session.displayState.get().pendingApproval).toBeNull();
+    expect(changed).toHaveBeenCalledTimes(1);
+    await expect(approval).resolves.toMatchObject({ decision: 'approve' });
+  });
+
+  it('does not clear a current prompt or grant a category for the wrong tool call id', async () => {
+    const session = createSession();
+    session.setCategoryResolver(() => 'edit');
+    const approval = requestApproval(session, 't1');
+    const changed = observeDisplay(session);
+
+    session.respondToToolApproval({ decision: 'always_allow_category', toolCallId: 'stale' });
+
+    expect(session.approval.isArmed()).toBe(true);
+    expect(session.displayState.get().pendingApproval?.toolCallId).toBe('t1');
+    expect(session.hasCategoryGrant('edit')).toBe(false);
+    expect(changed).not.toHaveBeenCalled();
+
+    session.respondToToolApproval({ decision: 'decline', toolCallId: 't1' });
+    await expect(approval).resolves.toMatchObject({ decision: 'decline' });
+  });
+
+  it('does not emit another snapshot for a duplicate decision after the gate resolves', async () => {
+    const session = createSession();
+    const approval = requestApproval(session, 't1');
+    session.respondToToolApproval({ decision: 'approve', toolCallId: 't1' });
+    await approval;
+    const changed = observeDisplay(session);
+
+    session.respondToToolApproval({ decision: 'decline', toolCallId: 't1' });
+
+    expect(session.displayState.get().pendingApproval).toBeNull();
+    expect(changed).not.toHaveBeenCalled();
+  });
+
+  it('preserves the next queued approval when a stale response or prior tool result arrives', async () => {
+    const session = createSession();
+    const firstApproval = requestApproval(session, 't1');
+    const changed = observeDisplay(session);
+    let nextApproval: ReturnType<typeof requestApproval> | undefined;
+    const nextRequested = firstApproval.then(() => {
+      nextApproval = requestApproval(session, 't2');
+    });
+
+    session.respondToToolApproval({ decision: 'approve', toolCallId: 't1' });
+    expect(changed).toHaveBeenCalledExactlyOnceWith({
+      pendingApproval: null,
+      isRunning: true,
+      toolStatus: 'running',
+    });
+    await nextRequested;
+    expect(session.displayState.get().pendingApproval?.toolCallId).toBe('t2');
+    changed.mockClear();
+
+    session.respondToToolApproval({ decision: 'decline', toolCallId: 't1' });
+    expect(changed).not.toHaveBeenCalled();
+    expect(session.approval.getToolCallId()).toBe('t2');
+    session.emit({ type: 'tool_end', toolCallId: 't1', result: 'done', isError: false });
+    expect(session.displayState.get().pendingApproval?.toolCallId).toBe('t2');
+
+    session.respondToToolApproval({ decision: 'approve', toolCallId: 't2' });
+    await expect(nextApproval).resolves.toMatchObject({ decision: 'approve' });
+    expect(session.displayState.get().pendingApproval).toBeNull();
+  });
+
+  it.each(['complete', 'aborted', 'error', 'suspended'] as const)(
+    'keeps terminal %s cleanup and later decisions from restoring an old prompt',
+    async reason => {
+      const session = createSession();
+      const approval = requestApproval(session, 't1');
+
+      session.emit({ type: 'agent_end', reason });
+      expect(session.displayState.get().pendingApproval).toBeNull();
+      expect(session.displayState.get().isRunning).toBe(false);
+      session.respondToToolApproval({ decision: 'decline', toolCallId: 't1' });
+      await approval;
+      expect(session.displayState.get().pendingApproval).toBeNull();
+      expect(session.displayState.get().isRunning).toBe(false);
+    },
+  );
+
+  it('keeps a thread reset clear after an outstanding decision arrives', async () => {
+    const session = createSession();
+    const approval = requestApproval(session, 't1');
+
+    session.emit({ type: 'thread_changed', threadId: 'new-thread', previousThreadId: 'old-thread' });
+    expect(session.displayState.get().pendingApproval).toBeNull();
+    expect(session.displayState.get().activeTools.size).toBe(0);
+    session.respondToToolApproval({ decision: 'decline', toolCallId: 't1' });
+    await approval;
+    expect(session.displayState.get().pendingApproval).toBeNull();
+    expect(session.displayState.get().activeTools.size).toBe(0);
+  });
+});

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -1301,7 +1301,10 @@ export class SessionRunEngine {
               chunk.type === 'tool-call-suspended' ||
               (streamResult ?? this.finishStreamState(currentRun)).suspended ||
               undefined;
-            const aborted = chunk.type === 'abort';
+            const abortChunk =
+              chunk.type === 'abort' ||
+              (chunk.type === 'finish' && getString(getRecord(getPayload(chunk).stepResult)?.reason) === 'abort');
+            const aborted = abortChunk || this.#session.run.isAbortRequested();
             // A non-success terminal finish reason (e.g. a `claude-fable-5`
             // content-filter refusal) becomes an explicit error so the
             // run never silently stops without a visible terminal state.
@@ -1316,20 +1319,18 @@ export class SessionRunEngine {
               isError = true;
               this.#session.emit({ type: 'error', error: new Error(currentRun.terminalError) });
             }
+            if (abortChunk) {
+              // Detach this canceled consumer before finalization drains follow-ups.
+              // A follow-up may open a new subscription that must remain attached.
+              this.#session.stream.detach();
+            }
             await this.finishSubscribedStreamRun({
               suspended,
               error: isError,
               aborted,
             });
             currentRun = undefined;
-            if (aborted) {
-              // The abort chunk terminates this consumer loop, so the live
-              // subscription is no longer being drained. Detach it so the next
-              // signal (e.g. a follow-up message sent right after Ctrl+C)
-              // re-subscribes and starts a fresh consumer — otherwise the new
-              // run's chunks would never be processed and the follow-up would
-              // get no response.
-              this.#session.stream.detach();
+            if (abortChunk) {
               break;
             }
           }

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3434,7 +3434,7 @@ export class Session<TState = unknown> {
       // run that is already on its way out. Routing a signal to it would hand
       // the message to a run that `completeDeferredAbort()` then terminates.
       if (!submittedAbortRequested && submittedRunId && submittedActiveRunId && submittedIsRunning) {
-        this.approval.respond({
+        this.respondToToolApproval({
           decision: 'decline',
           declineContext: {
             reason: 'interrupted_by_user_message',

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -271,6 +271,8 @@ export interface SessionMachinery {
   getAgent(): Agent;
   /** Get the ephemeral state associated with an active or suspended run. */
   getRunScope(runId: string): RunScope | undefined;
+  /** The distinct backing agents whose saved runs this controller may discover. */
+  getAgents?(): Agent[];
   /** Open a fresh subscription to a thread's agent event stream. */
   subscribeToThread(input: {
     agent?: Agent;
@@ -3145,17 +3147,32 @@ export class Session<TState = unknown> {
 
     const localRunId = this.getCurrentRunId();
     const threadId = this.thread.getId();
-    const operationId = this.run.getOperationId();
-    if (!localRunId && threadId && !this.suspensions.hasPending()) {
+    const resourceId = this.identity.getResourceId();
+    const agents = [...new Set(this.machinery.getAgents?.() ?? [this.machinery.getAgent()])];
+
+    // Retract the prompts, retaining their exact run IDs while saved ownership
+    // is resolved. A mode switch may have selected a different backing agent.
+    const parkedRuns = new Set<string>();
+    for (const { toolCallId, toolName, runId } of this.suspensions.clear()) {
+      parkedRuns.add(runId);
+      this.emit({ type: 'tool_suspension_cancelled', toolCallId, toolName, reason: ABORTED_BY_USER_REASON });
+    }
+    const discoverParkedOwner = parkedRuns.size > 0 && agents.length > 1;
+    if (threadId && ((!localRunId && parkedRuns.size === 0) || discoverParkedOwner)) {
       const agent = this.machinery.getAgent();
       // A restored Session has no live run identity. Use the same scoped native
-      // discovery as cold resume, bounded to runs that existed when Stop arrived.
-      const scope = { threadId, resourceId: this.identity.getResourceId(), toDate: new Date() };
+      // discovery across this controller's backing agents, bounded to runs that
+      // existed when Stop arrived. Warm Stop selects only its parked run IDs.
+      const scope = { threadId, resourceId, toDate: new Date() };
       const cancelDiscoveredRuns = async () => {
-        const discovery = await Promise.allSettled([
-          agent.listSuspendedRuns(scope),
-          isDurableAgentLike(agent) ? agent.listActiveRuns(scope) : Promise.resolve({ runs: [] }),
-        ]);
+        const discovery = await Promise.allSettled(
+          agents.flatMap(owner => [
+            owner.listSuspendedRuns(scope).then(result => ({ owner, runs: result.runs })),
+            ...(isDurableAgentLike(owner)
+              ? [owner.listActiveRuns(scope).then(result => ({ owner, runs: result.runs }))]
+              : []),
+          ]),
+        );
         const discoveryErrors = discovery.flatMap(result =>
           result.status === 'rejected' &&
           !(result.reason instanceof MastraError && result.reason.id === 'AGENT_LIST_SUSPENDED_RUNS_NO_STORAGE')
@@ -3164,19 +3181,27 @@ export class Session<TState = unknown> {
         );
         if (discoveryErrors.length) throw new AggregateError(discoveryErrors, 'Failed to discover runs for Stop');
         const results = discovery.flatMap(result => (result.status === 'fulfilled' ? [result.value] : []));
-        if (
-          this.thread.getId() !== threadId ||
-          this.run.getOperationId() !== operationId ||
-          !this.run.isAbortRequested()
-        )
-          return;
-        const runIds = new Set(results.flatMap(result => result.runs.map(run => run.runId)));
+        // Stop owns the captured saved scope even if turn cleanup or navigation
+        // changes this Session while discovery waits. The native query excludes
+        // runs created after Stop; parked IDs further narrow warm cancellation.
+        const owners = new Map<string, Agent>();
+        for (const { owner, runs } of results) {
+          for (const { runId } of runs) {
+            if (discoverParkedOwner && !parkedRuns.has(runId)) continue;
+            const previous = owners.get(runId);
+            if (previous && previous.id !== owner.id) throw new Error('Multiple agents own a run selected for Stop');
+            owners.set(runId, previous ?? owner);
+          }
+        }
+        if (discoverParkedOwner && owners.size !== parkedRuns.size) {
+          throw new Error('Could not find the owning agent for a parked run selected for Stop');
+        }
         const cancellations = await Promise.allSettled(
-          [...runIds].map(async runId => {
-            if (isDurableAgentLike(agent) && agent.__abortRunStreamAndWait) {
-              await agent.__abortRunStreamAndWait(runId);
+          [...owners].map(async ([runId, owner]) => {
+            if (isDurableAgentLike(owner) && owner.__abortRunStreamAndWait) {
+              await owner.__abortRunStreamAndWait(runId);
             } else {
-              agent.abortRunStream(runId);
+              owner.abortRunStream(runId);
             }
           }),
         );
@@ -3192,15 +3217,9 @@ export class Session<TState = unknown> {
       });
     }
 
-    // Retract the prompts for every parked suspension. Dropping them silently
-    // left the UI rendering `ask_user` / `request_access` prompts whose answers
-    // could never land, since the run they belong to is gone.
-    const parkedRuns = new Set<string>();
-    for (const { toolCallId, toolName, runId } of this.suspensions.clear()) {
-      parkedRuns.add(runId);
-      this.emit({ type: 'tool_suspension_cancelled', toolCallId, toolName, reason: ABORTED_BY_USER_REASON });
+    if (!discoverParkedOwner) {
+      for (const runId of parkedRuns) this.machinery.getAgent().abortRunStream(runId);
     }
-    for (const runId of parkedRuns) this.machinery.getAgent().abortRunStream(runId);
 
     // A parked approval gate is special: the agent-side run is still alive and
     // waiting for the decision, so the gated call must be declined through it

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3151,25 +3151,45 @@ export class Session<TState = unknown> {
       // A restored Session has no live run identity. Use the same scoped native
       // discovery as cold resume, bounded to runs that existed when Stop arrived.
       const scope = { threadId, resourceId: this.identity.getResourceId(), toDate: new Date() };
-      void Promise.all([
-        agent.listSuspendedRuns(scope),
-        isDurableAgentLike(agent) ? agent.listActiveRuns(scope) : Promise.resolve({ runs: [] }),
-      ])
-        .then(results => {
-          if (
-            this.thread.getId() !== threadId ||
-            this.run.getOperationId() !== operationId ||
-            !this.run.isAbortRequested()
-          )
-            return;
-          const runIds = new Set(results.flatMap(result => result.runs.map(run => run.runId)));
-          for (const runId of runIds) agent.abortRunStream(runId);
-        })
-        .catch(error => {
-          if (!(error instanceof MastraError) || error.id !== 'AGENT_LIST_SUSPENDED_RUNS_NO_STORAGE') {
-            this.emit({ type: 'error', error: getErrorFromUnknown(error) });
-          }
-        });
+      const cancelDiscoveredRuns = async () => {
+        const discovery = await Promise.allSettled([
+          agent.listSuspendedRuns(scope),
+          isDurableAgentLike(agent) ? agent.listActiveRuns(scope) : Promise.resolve({ runs: [] }),
+        ]);
+        const discoveryErrors = discovery.flatMap(result =>
+          result.status === 'rejected' &&
+          !(result.reason instanceof MastraError && result.reason.id === 'AGENT_LIST_SUSPENDED_RUNS_NO_STORAGE')
+            ? [result.reason]
+            : [],
+        );
+        if (discoveryErrors.length) throw new AggregateError(discoveryErrors, 'Failed to discover runs for Stop');
+        const results = discovery.flatMap(result => (result.status === 'fulfilled' ? [result.value] : []));
+        if (
+          this.thread.getId() !== threadId ||
+          this.run.getOperationId() !== operationId ||
+          !this.run.isAbortRequested()
+        )
+          return;
+        const runIds = new Set(results.flatMap(result => result.runs.map(run => run.runId)));
+        const cancellations = await Promise.allSettled(
+          [...runIds].map(async runId => {
+            if (isDurableAgentLike(agent) && agent.__abortRunStreamAndWait) {
+              await agent.__abortRunStreamAndWait(runId);
+            } else {
+              agent.abortRunStream(runId);
+            }
+          }),
+        );
+        const errors = cancellations.flatMap(result => (result.status === 'rejected' ? [result.reason] : []));
+        if (errors.length) throw new AggregateError(errors, 'Failed to cancel discovered runs');
+      };
+      const mastra = agent.getMastraInstance();
+      const cancellation = mastra ? mastra.__runDurableAgentCancellation(cancelDiscoveredRuns) : cancelDiscoveredRuns();
+      void cancellation.catch(error => {
+        if (!(error instanceof MastraError) || error.id !== 'AGENT_LIST_SUSPENDED_RUNS_NO_STORAGE') {
+          this.emit({ type: 'error', error: getErrorFromUnknown(error) });
+        }
+      });
     }
 
     // Retract the prompts for every parked suspension. Dropping them silently

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -2252,6 +2252,11 @@ export class SessionDisplayState {
     this.#state.pendingSuspensions.clear();
   }
 
+  /** Clear the resolved approval prompt; the caller dispatches `display_state_changed`. */
+  clearPendingApproval(): void {
+    this.#state.pendingApproval = null;
+  }
+
   /**
    * Clear the modified-files tally without touching the rest of the snapshot.
    * Used after a clone, which starts the cloned thread with a clean working set
@@ -3234,6 +3239,7 @@ export class Session<TState = unknown> {
     requestContext?: RequestContext;
     declineContext?: { reason?: string; message?: string };
   }): void {
+    const wasArmed = this.approval.isArmed();
     this.approval.respond({
       decision,
       toolCallId,
@@ -3244,6 +3250,11 @@ export class Session<TState = unknown> {
         if (category) this.grantCategory(category);
       },
     });
+    // A stale response leaves the gate armed and must keep its prompt visible.
+    if (wasArmed && !this.approval.isArmed()) {
+      this.displayState.clearPendingApproval();
+      this.emit({ type: 'display_state_changed', displayState: this.displayState.get() });
+    }
   }
 
   // ===========================================================================

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -15,7 +15,8 @@ import type {
   SendAgentSignalAccepted,
   ToolsetsInput,
 } from '../agent/types';
-import { getErrorFromUnknown } from '../error';
+import { isDurableAgentLike } from '../agent/types';
+import { getErrorFromUnknown, MastraError } from '../error';
 import type { MastraModelGatewayInterface } from '../llm/model/gateways';
 import { ModelRouterLanguageModel } from '../llm/model/router';
 import type { MastraModelConfig } from '../llm/model/shared.types';
@@ -1150,8 +1151,8 @@ export class SessionSuspensions {
    * Drop all parked suspensions (e.g. on abort or thread switch), returning the
    * dropped entries so callers can retract the corresponding prompts.
    */
-  clear(): Array<{ toolCallId: string; toolName: string }> {
-    const dropped = [...this.#pending].map(([toolCallId, { toolName }]) => ({ toolCallId, toolName }));
+  clear(): Array<{ toolCallId: string; toolName: string; runId: string }> {
+    const dropped = [...this.#pending].map(([toolCallId, { toolName, runId }]) => ({ toolCallId, toolName, runId }));
     this.#pending.clear();
     return dropped;
   }
@@ -1450,6 +1451,11 @@ export class SessionRun {
   /** Bump and return the operation counter at the start of a new operation. */
   nextOperation(): number {
     this.#operationId += 1;
+    return this.#operationId;
+  }
+
+  /** Current operation identity for async work tied to a user command. */
+  getOperationId(): number {
     return this.#operationId;
   }
 
@@ -3137,12 +3143,44 @@ export class Session<TState = unknown> {
     // `tool_approval_required` subscribers each calling abort() is enough.
     if (this.run.isAbortRequested()) return;
 
+    const localRunId = this.getCurrentRunId();
+    const threadId = this.thread.getId();
+    const operationId = this.run.getOperationId();
+    if (!localRunId && threadId && !this.suspensions.hasPending()) {
+      const agent = this.machinery.getAgent();
+      // A restored Session has no live run identity. Use the same scoped native
+      // discovery as cold resume, bounded to runs that existed when Stop arrived.
+      const scope = { threadId, resourceId: this.identity.getResourceId(), toDate: new Date() };
+      void Promise.all([
+        agent.listSuspendedRuns(scope),
+        isDurableAgentLike(agent) ? agent.listActiveRuns(scope) : Promise.resolve({ runs: [] }),
+      ])
+        .then(results => {
+          if (
+            this.thread.getId() !== threadId ||
+            this.run.getOperationId() !== operationId ||
+            !this.run.isAbortRequested()
+          )
+            return;
+          const runIds = new Set(results.flatMap(result => result.runs.map(run => run.runId)));
+          for (const runId of runIds) agent.abortRunStream(runId);
+        })
+        .catch(error => {
+          if (!(error instanceof MastraError) || error.id !== 'AGENT_LIST_SUSPENDED_RUNS_NO_STORAGE') {
+            this.emit({ type: 'error', error: getErrorFromUnknown(error) });
+          }
+        });
+    }
+
     // Retract the prompts for every parked suspension. Dropping them silently
     // left the UI rendering `ask_user` / `request_access` prompts whose answers
     // could never land, since the run they belong to is gone.
-    for (const { toolCallId, toolName } of this.suspensions.clear()) {
+    const parkedRuns = new Set<string>();
+    for (const { toolCallId, toolName, runId } of this.suspensions.clear()) {
+      parkedRuns.add(runId);
       this.emit({ type: 'tool_suspension_cancelled', toolCallId, toolName, reason: ABORTED_BY_USER_REASON });
     }
+    for (const runId of parkedRuns) this.machinery.getAgent().abortRunStream(runId);
 
     // A parked approval gate is special: the agent-side run is still alive and
     // waiting for the decision, so the gated call must be declined through it
@@ -3157,6 +3195,8 @@ export class Session<TState = unknown> {
       return;
     }
 
+    if (!localRunId && threadId && parkedRuns.size === 0)
+      this.machinery.getAgent().abortThreadStream({ threadId, resourceId: this.identity.getResourceId() });
     this.stream.abort();
     this.run.requestAbort();
   }

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3234,7 +3234,9 @@ export class Session<TState = unknown> {
       return;
     }
 
-    if (!localRunId && threadId && parkedRuns.size === 0)
+    // Durable owners already cancel the captured saved scope above. A second
+    // thread abort would bypass discovery failures and race its finalization.
+    if (!localRunId && threadId && parkedRuns.size === 0 && !isDurableAgentLike(this.machinery.getAgent()))
       this.machinery.getAgent().abortThreadStream({ threadId, resourceId: this.identity.getResourceId() });
     this.stream.abort();
     this.run.requestAbort();

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3006,16 +3006,18 @@ export class Session<TState = unknown> {
   /** Await terminal hooks, then emit the terminal event to subscribers. */
   async finishAgentRun(
     reason: NonNullable<Extract<AgentControllerEvent, { type: 'agent_end' }>['reason']>,
+    isCurrent?: () => boolean,
   ): Promise<void> {
     const event = { type: 'agent_end', reason } as const;
     for (const listener of this.#beforeAgentEndListeners) {
+      if (isCurrent && !isCurrent()) return;
       try {
         await listener(event);
       } catch (error) {
         console.error('Error in before-agent-end listener:', error);
       }
     }
-    this.emit(event);
+    if (!isCurrent || isCurrent()) this.emit(event);
   }
 
   /**
@@ -3146,6 +3148,7 @@ export class Session<TState = unknown> {
     if (this.run.isAbortRequested()) return;
 
     const localRunId = this.getCurrentRunId();
+    const operationId = this.run.getOperationId();
     const threadId = this.thread.getId();
     const resourceId = this.identity.getResourceId();
     const agents = [...new Set(this.machinery.getAgents?.() ?? [this.machinery.getAgent()])];
@@ -3199,7 +3202,7 @@ export class Session<TState = unknown> {
         const cancellations = await Promise.allSettled(
           [...owners].map(async ([runId, owner]) => {
             if (isDurableAgentLike(owner) && owner.__abortRunStreamAndWait) {
-              await owner.__abortRunStreamAndWait(runId);
+              return owner.__abortRunStreamAndWait(runId);
             } else {
               owner.abortRunStream(runId);
             }
@@ -3207,6 +3210,31 @@ export class Session<TState = unknown> {
         );
         const errors = cancellations.flatMap(result => (result.status === 'rejected' ? [result.reason] : []));
         if (errors.length) throw new AggregateError(errors, 'Failed to cancel discovered runs');
+        const completed = cancellations.flatMap(result =>
+          result.status === 'fulfilled' && result.value ? [result.value] : [],
+        );
+        const stillOwnsDisplay = () =>
+          this.thread.getId() === threadId &&
+          this.identity.getResourceId() === resourceId &&
+          this.run.getOperationId() === operationId &&
+          (!this.getCurrentRunId() || owners.has(this.getCurrentRunId()!));
+        // A restored cancellation has no subscribed thread stream to finish it.
+        // Publish only its finalized native output, after persistence, and only
+        // while the captured Session still displays that original operation.
+        if (completed.length && stillOwnsDisplay()) {
+          for (const { messages } of completed) {
+            for (const message of messages) {
+              if (!stillOwnsDisplay()) return;
+              if (message.role === 'assistant' && message.threadId === threadId && message.resourceId === resourceId) {
+                this.emit({ type: 'message_end', message });
+              }
+            }
+          }
+          if (stillOwnsDisplay()) {
+            await this.finishAgentRun('aborted', stillOwnsDisplay);
+            if (stillOwnsDisplay()) this.run.reset();
+          }
+        }
       };
       const mastra = agent.getMastraInstance();
       const cancellation = mastra ? mastra.__runDurableAgentCancellation(cancelDiscoveredRuns) : cancelDiscoveredRuns();

--- a/packages/core/src/agent/__tests__/workflow-tool-tripwire.test.ts
+++ b/packages/core/src/agent/__tests__/workflow-tool-tripwire.test.ts
@@ -1,0 +1,285 @@
+import dns from 'node:dns';
+import net from 'node:net';
+import { convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { MastraLanguageModelV2Mock } from '../../loop/test-utils/MastraLanguageModelV2Mock';
+import { Mastra } from '../../mastra';
+import type { Processor } from '../../processors';
+import { MockStore } from '../../storage/mock';
+import { createStep, createWorkflow } from '../../workflows';
+import { Agent } from '../agent';
+
+const tripwire = {
+  reason: 'The child policy blocked this result',
+  retry: false,
+  metadata: { category: 'test-policy', detail: { retained: ['exact', 0, false] } },
+  processorId: 'child-policy',
+};
+
+function modelReply(tool: boolean) {
+  return {
+    stream: convertArrayToReadableStream([
+      { type: 'stream-start' as const, warnings: [] },
+      ...(tool
+        ? [
+            {
+              type: 'tool-call' as const,
+              toolCallId: 'call-1',
+              toolName: 'workflow-child',
+              input: JSON.stringify({ inputData: { prompt: 'test' } }),
+            },
+          ]
+        : [
+            { type: 'text-start' as const, id: 'text' },
+            { type: 'text-delta' as const, id: 'text', delta: 'Done' },
+            { type: 'text-end' as const, id: 'text' },
+          ]),
+      {
+        type: 'finish' as const,
+        finishReason: tool ? ('tool-calls' as const) : ('stop' as const),
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      },
+    ]),
+  };
+}
+
+function createModel(next: () => boolean) {
+  return new MastraLanguageModelV2Mock({
+    doStream: async () => modelReply(next()),
+    doGenerate: async () => {
+      const tool = next();
+      return {
+        content: tool
+          ? [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'workflow-child',
+                input: JSON.stringify({ inputData: { prompt: 'test' } }),
+              },
+            ]
+          : [{ type: 'text', text: 'Done' }],
+        finishReason: tool ? 'tool-calls' : 'stop',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        warnings: [],
+      };
+    },
+  });
+}
+
+describe('workflow tool tripwire results', () => {
+  let networkAttempts = 0;
+
+  beforeEach(() => {
+    networkAttempts = 0;
+    const block = () => {
+      networkAttempts++;
+      throw new Error('External network forbidden');
+    };
+    vi.spyOn(globalThis, 'fetch').mockImplementation(block);
+    vi.spyOn(net.Socket.prototype, 'connect').mockImplementation(block);
+    vi.spyOn(dns, 'lookup').mockImplementation(block);
+  });
+
+  afterEach(() => {
+    expect(networkAttempts).toBe(0);
+    vi.restoreAllMocks();
+  });
+
+  async function fixture(mode: 'tripwire' | 'failed' | 'success', guard = false, suspendFirst = false) {
+    let parentCalls = 0;
+    let childCalls = 0;
+    let followingCalls = 0;
+    const observed: unknown[] = [];
+    const childAgent = new Agent({
+      id: 'child',
+      name: 'Child',
+      instructions: 'Answer',
+      model: createModel(() => {
+        childCalls++;
+        return false;
+      }),
+      inputProcessors:
+        mode === 'tripwire'
+          ? [
+              {
+                id: tripwire.processorId,
+                processInput({ abort }) {
+                  abort(tripwire.reason, { retry: tripwire.retry, metadata: tripwire.metadata });
+                },
+              },
+            ]
+          : [],
+    });
+    const first =
+      mode === 'failed'
+        ? createStep({
+            id: 'failure',
+            inputSchema: z.object({ prompt: z.string() }),
+            outputSchema: z.object({ text: z.string() }),
+            execute: async () => {
+              throw new Error('Ordinary workflow failure');
+            },
+          })
+        : createStep(childAgent, { maxSteps: 1, maxRetries: 0 });
+    const workflow = createWorkflow({
+      id: 'child-workflow',
+      inputSchema: z.object({ prompt: z.string() }),
+      outputSchema: z.object({ text: z.string() }),
+    })
+      .then(
+        createStep({
+          id: 'gate',
+          inputSchema: z.object({ prompt: z.string() }),
+          outputSchema: z.object({ prompt: z.string() }),
+          resumeSchema: z.object({ allow: z.boolean() }),
+          suspendSchema: z.object({ request: z.string() }),
+          execute: async ({ inputData, resumeData, suspend }) => {
+            if (suspendFirst && !resumeData) return suspend({ request: 'Continue?' });
+            return inputData;
+          },
+        }),
+      )
+      .then(first)
+      .then(
+        createStep({
+          id: 'following',
+          inputSchema: z.object({ text: z.string() }),
+          outputSchema: z.object({ text: z.string() }),
+          execute: async ({ inputData }) => {
+            followingCalls++;
+            return inputData;
+          },
+        }),
+      )
+      .commit();
+    const policy: Processor = {
+      id: 'parent-policy',
+      processToolResult({ result, abort }) {
+        observed.push(result);
+        if (guard && result && typeof result === 'object' && 'status' in result && result.status === 'tripwire') {
+          abort('Parent policy blocked the child result', { retry: false });
+        }
+      },
+    };
+    const parent = new Agent({
+      id: 'parent',
+      name: 'Parent',
+      instructions: 'Use child then answer',
+      workflows: { child: workflow },
+      outputProcessors: [policy],
+      model: createModel(() => {
+        parentCalls++;
+        return parentCalls === 1;
+      }),
+    });
+    const mastra = new Mastra({
+      agents: { parent, childAgent },
+      workflows: { child: workflow },
+      storage: new MockStore(),
+      logger: false,
+      workers: false,
+      scheduler: { enabled: false },
+      recovery: { durableAgents: 'off' },
+    });
+    await mastra.startWorkers();
+    return { parent, mastra, workflow, observed, counts: () => ({ parentCalls, childCalls, followingCalls }) };
+  }
+
+  it.each(['generate', 'stream'] as const)(
+    'preserves typed child tripwire in %s without changing parent policy',
+    async method => {
+      const f = await fixture('tripwire');
+      try {
+        const output =
+          method === 'generate'
+            ? await f.parent.generate('Start', { maxSteps: 3 })
+            : await (await f.parent.stream('Start', { maxSteps: 3 })).getFullOutput();
+        expect(f.observed).toEqual([{ status: 'tripwire', tripwire, runId: expect.any(String) }]);
+        expect(f.counts()).toEqual({ parentCalls: 2, childCalls: 0, followingCalls: 0 });
+        expect(output.tripwire).toBeUndefined();
+      } finally {
+        await f.mastra.shutdown();
+      }
+    },
+  );
+
+  it.each(['generate', 'stream'] as const)(
+    'lets the native parent processor stop %s after inspecting typed result',
+    async method => {
+      const f = await fixture('tripwire', true);
+      try {
+        const output =
+          method === 'generate'
+            ? await f.parent.generate('Start', { maxSteps: 3 })
+            : await (await f.parent.stream('Start', { maxSteps: 3 })).getFullOutput();
+        expect(f.observed).toEqual([{ status: 'tripwire', tripwire, runId: expect.any(String) }]);
+        expect(f.counts()).toEqual({ parentCalls: 1, childCalls: 0, followingCalls: 0 });
+        expect(output.tripwire).toMatchObject({
+          reason: 'Parent policy blocked the child result',
+          retry: false,
+          processorId: 'parent-policy',
+        });
+      } finally {
+        await f.mastra.shutdown();
+      }
+    },
+  );
+
+  it.each(['generate', 'stream'] as const)(
+    'keeps ordinary workflow failures as ordinary tool results in %s',
+    async method => {
+      const f = await fixture('failed', true);
+      try {
+        const output =
+          method === 'generate'
+            ? await f.parent.generate('Start', { maxSteps: 3 })
+            : await (await f.parent.stream('Start', { maxSteps: 3 })).getFullOutput();
+        expect(f.observed).toEqual([{ error: 'Ordinary workflow failure', runId: expect.any(String) }]);
+        expect(f.counts()).toEqual({ parentCalls: 2, childCalls: 0, followingCalls: 0 });
+        expect(output.tripwire).toBeUndefined();
+      } finally {
+        await f.mastra.shutdown();
+      }
+    },
+  );
+
+  it('keeps successful workflow results unchanged', async () => {
+    const f = await fixture('success', true);
+    try {
+      await f.parent.generate('Start', { maxSteps: 3 });
+      expect(f.observed).toEqual([{ result: { text: 'Done' }, runId: expect.any(String) }]);
+      expect(f.counts()).toEqual({ parentCalls: 2, childCalls: 1, followingCalls: 1 });
+    } finally {
+      await f.mastra.shutdown();
+    }
+  });
+
+  it.each(['generate', 'stream'] as const)(
+    'preserves tripwire when the workflow tool resumes a suspended run in %s',
+    async methodType => {
+      const f = await fixture('tripwire', false, true);
+      try {
+        const run = await f.workflow.createRun();
+        const suspended = await run.start({ inputData: { prompt: 'test' } });
+        expect(suspended.status).toBe('suspended');
+        expect(f.counts()).toEqual({ parentCalls: 0, childCalls: 0, followingCalls: 0 });
+        const tools = await f.parent.getToolsForExecution({ methodType });
+        const result = await tools['workflow-child']!.execute!(
+          { inputData: { prompt: 'test' }, suspendedToolRunId: run.runId },
+          {
+            toolCallId: 'resume-call',
+            messages: [],
+            resumeData: { allow: true },
+            abortSignal: new AbortController().signal,
+          } as never,
+        );
+        expect(result).toEqual({ status: 'tripwire', tripwire, runId: run.runId });
+        expect(f.counts()).toEqual({ parentCalls: 0, childCalls: 0, followingCalls: 0 });
+      } finally {
+        await f.mastra.shutdown();
+      }
+    },
+  );
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5942,7 +5942,11 @@ export class Agent<
           execute: async (inputData, context) => {
             const invocationActor = getInvocationActor(context);
             const savedMastraMemory = requestContext.get('MastraMemory');
+            const abortSignal = context?.abortSignal;
+            let removeAbortListener: (() => void) | undefined;
+            let cancellation: Promise<void> | undefined;
             try {
+              abortSignal?.throwIfAborted();
               const { initialState, inputData: workflowInputData, suspendedToolRunId } = inputData as any;
               // Use a unique runId for each workflow tool call to prevent parallel calls
               // from sharing the same cached Run instance (see #13473).
@@ -5961,6 +5965,17 @@ export class Agent<
               });
 
               const run = await workflow.createRun({ runId: runIdToUse, resourceId });
+              const cancelRun = () => {
+                cancellation ??= run.cancel();
+                // Observe immediately; finally awaits and propagates a failed cancellation.
+                void cancellation.catch(() => {});
+              };
+              abortSignal?.addEventListener('abort', cancelRun, { once: true });
+              removeAbortListener = () => abortSignal?.removeEventListener('abort', cancelRun);
+              if (abortSignal?.aborted) {
+                await run.cancel();
+                abortSignal.throwIfAborted();
+              }
               const { resumeData, suspend } = context?.agent ?? {};
 
               let result: WorkflowResult<any, any, any, any> | undefined = undefined;
@@ -6080,6 +6095,8 @@ export class Agent<
                 requestContext.set('MastraMemory', savedMastraMemory);
               }
 
+              abortSignal?.throwIfAborted();
+
               const mastraError = new MastraError(
                 {
                   id: 'AGENT_WORKFLOW_TOOL_EXECUTION_FAILED',
@@ -6097,6 +6114,9 @@ export class Agent<
               );
               this.logger.trackException(mastraError);
               throw mastraError;
+            } finally {
+              removeAbortListener?.();
+              await cancellation;
             }
           },
         });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5928,6 +5928,25 @@ export class Agent<
               },
               required: ['runId', 'error'],
             },
+            {
+              type: 'object',
+              properties: {
+                runId: { type: 'string', description: 'Unique identifier for the workflow run' },
+                status: { const: 'tripwire' },
+                tripwire: {
+                  type: 'object',
+                  properties: {
+                    reason: { type: 'string' },
+                    retry: { type: 'boolean' },
+                    metadata: {},
+                    processorId: { type: 'string' },
+                  },
+                  required: ['reason'],
+                  additionalProperties: true,
+                },
+              },
+              required: ['runId', 'status', 'tripwire'],
+            },
           ],
         };
 
@@ -6050,6 +6069,8 @@ export class Agent<
                   error: workflowOutputError?.message || String(workflowOutputError) || 'Workflow execution failed',
                   runId: run.runId,
                 };
+              } else if (result?.status === 'tripwire') {
+                return { status: 'tripwire', tripwire: result.tripwire, runId: run.runId };
               } else if (result?.status === 'suspended') {
                 const suspendedStep = result?.suspended?.[0]?.[0]!;
                 const suspendPayload = result?.steps?.[suspendedStep]?.suspendPayload;

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -320,6 +320,7 @@ type ProcessorLoadedToolsProvider = {
   getLoadedToolsForRequestContext?: (args: {
     requestContext: RequestContext;
     tools?: Record<string, unknown>;
+    includeMetaTools?: boolean;
   }) => Record<string, ToolToConvert> | Promise<Record<string, ToolToConvert>>;
 };
 
@@ -4174,7 +4175,11 @@ export class Agent<
         return;
       }
 
-      const loadedTools = await toolProvider.getLoadedToolsForRequestContext({ requestContext, tools });
+      const loadedTools = await toolProvider.getLoadedToolsForRequestContext({
+        requestContext,
+        tools,
+        includeMetaTools: true,
+      });
       if (!loadedTools || Object.keys(loadedTools).length === 0) {
         return;
       }

--- a/packages/core/src/agent/durable/__tests__/durable-agent-cold-stop-memory-modes.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-cold-stop-memory-modes.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import { Mastra } from '../../../mastra';
+import { MockMemory } from '../../../memory/mock';
+import { InMemoryStore } from '../../../storage';
+import { MastraLanguageModelV2Mock } from '../../../test-utils/llm-mock';
+import { createTool } from '../../../tools';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../create-durable-agent';
+
+describe('cold durable cancellation without message persistence', () => {
+  it.each(['no Memory', 'readOnly Memory'] as const)('preserves %s through public abortRunStream', async mode => {
+    const storage = new InMemoryStore();
+    const threadId = 'cold-stop-memory-mode-thread';
+    const resourceId = 'cold-stop-memory-mode-owner';
+    const network = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('No network in this test'));
+    const execute = vi.fn(async () => 'done');
+    const results: Array<{ finishReason: string; totalTokens: number | undefined }> = [];
+    let modelCalls = 0;
+    const createHost = () => {
+      const pubsub = new EventEmitterPubSub();
+      const memory = mode === 'readOnly Memory' ? new MockMemory({ storage }) : undefined;
+      const agent = createDurableAgent({
+        pubsub,
+        agent: new Agent({
+          id: 'cold-stop-memory-mode-agent',
+          name: 'Cold Stop Memory Mode',
+          instructions: 'Request approval for action.',
+          memory,
+          model: new MastraLanguageModelV2Mock({
+            doGenerate: async () => {
+              modelCalls++;
+              throw new Error('Cancellation must not start generation');
+            },
+            doStream: async () => {
+              modelCalls++;
+              return {
+                stream: new ReadableStream({
+                  start(controller) {
+                    controller.enqueue({ type: 'stream-start', warnings: [] });
+                    controller.enqueue({ type: 'tool-call', toolCallId: 'call-1', toolName: 'action', input: '{}' });
+                    controller.enqueue({
+                      type: 'finish',
+                      finishReason: 'tool-calls',
+                      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+                    });
+                    controller.close();
+                  },
+                }),
+              };
+            },
+          }),
+          tools: {
+            action: createTool({ id: 'action', description: 'Local action', inputSchema: z.object({}), execute }),
+          },
+          outputProcessors: [
+            {
+              id: 'memory-mode-terminal-observer',
+              processOutputResult({ result, messageList }) {
+                results.push({ finishReason: result.finishReason, totalTokens: result.usage.totalTokens });
+                return messageList;
+              },
+            },
+          ],
+        }),
+      });
+      const mastra = new Mastra({ agents: { agent }, storage, pubsub, workers: false, logger: false });
+      return { agent, mastra, pubsub };
+    };
+    const original = createHost();
+    let restored: ReturnType<typeof createHost> | undefined;
+    let parked: Awaited<ReturnType<typeof original.agent.stream>> | undefined;
+    const memoryStore = (await storage.getStore('memory'))!;
+    const workflows = (await storage.getStore('workflows'))!;
+    const saveMessages = vi.spyOn(memoryStore, 'saveMessages');
+    try {
+      parked = await original.agent.stream('Request action approval.', {
+        memory: {
+          thread: threadId,
+          resource: resourceId,
+          options: mode === 'readOnly Memory' ? { readOnly: true } : undefined,
+        },
+        requireToolApproval: true,
+      });
+      void parked.output.consumeStream().catch(() => undefined);
+      const runId = parked.runId;
+      await expect
+        .poll(async () => (await original.agent.listSuspendedRuns({ threadId, resourceId })).runs.map(run => run.runId))
+        .toContain(runId);
+      const savedBefore = await workflows.listWorkflowRuns({});
+      expect(savedBefore.runs.length).toBeGreaterThan(0);
+      expect(modelCalls).toBe(1);
+      const writesBeforeStop = saveMessages.mock.calls.length;
+
+      restored = createHost();
+      restored.agent.abortRunStream(runId);
+      await expect(restored.mastra.shutdown()).resolves.toBeUndefined();
+
+      expect(results).toEqual([{ finishReason: 'abort', totalTokens: 15 }]);
+      expect(modelCalls).toBe(1);
+      expect(execute).not.toHaveBeenCalled();
+      expect(saveMessages).toHaveBeenCalledTimes(writesBeforeStop);
+      expect((await workflows.listWorkflowRuns({})).runs).toEqual([]);
+      expect(network).not.toHaveBeenCalled();
+    } finally {
+      parked?.cleanup();
+      await original.mastra.stopWorkers();
+      await restored?.mastra.stopWorkers();
+      await original.pubsub.close();
+      await restored?.pubsub.close();
+      saveMessages.mockRestore();
+      network.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/agent/durable/__tests__/durable-agent-memory.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-memory.test.ts
@@ -7,11 +7,13 @@
 
 import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { z } from 'zod';
 import { EventEmitterPubSub } from '../../../events/event-emitter';
+import { Mastra } from '../../../mastra';
 import { MockMemory } from '../../../memory/mock';
 import type { InputProcessor } from '../../../processors';
+import { InMemoryStore } from '../../../storage';
 import { createTool } from '../../../tools';
 import { Agent } from '../../agent';
 import { createDurableAgent } from '../create-durable-agent';
@@ -675,6 +677,127 @@ describe('DurableAgent memory edge cases', () => {
   // title-generation branch, so `memory.options.generateTitle` silently never fired for
   // durable/evented agents (and Inngest). See create-durable-agentic-workflow.ts.
   describe('generateTitle', () => {
+    it.each(['same wrapper', 'restored wrapper'] as const)(
+      'does not call the title model when a saved approval is canceled through the %s',
+      async wrapper => {
+        const storage = new InMemoryStore();
+        const memory = new MockMemory({ storage, options: { generateTitle: true } });
+        const restoredPubsub = new EventEmitterPubSub();
+        const network = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('No network in this test'));
+        const execute = vi.fn(async () => 'done');
+        const results: Array<{ finishReason: string; totalTokens: number | undefined }> = [];
+        let modelCalls = 0;
+        const makeAgent = (events: EventEmitterPubSub) =>
+          createDurableAgent({
+            pubsub: events,
+            agent: new Agent({
+              id: 'canceled-title-agent',
+              name: 'Canceled Title',
+              instructions: 'Request approval for action.',
+              memory,
+              model: new MockLanguageModelV2({
+                doGenerate: async options => {
+                  modelCalls++;
+                  return createTextModel('Unexpected title after cancellation').doGenerate(options);
+                },
+                doStream: async options => {
+                  modelCalls++;
+                  return modelCalls === 1
+                    ? createToolCallModel('action', {}).doStream(options)
+                    : createTextModel('Unexpected title after cancellation').doStream(options);
+                },
+              }),
+              tools: {
+                action: createTool({
+                  id: 'action',
+                  description: 'Local action',
+                  inputSchema: z.object({}),
+                  execute,
+                }),
+              },
+              outputProcessors: [
+                {
+                  id: 'canceled-title-output',
+                  processOutputResult({ result, messageList }) {
+                    results.push({ finishReason: result.finishReason, totalTokens: result.usage.totalTokens });
+                    return messageList;
+                  },
+                },
+              ],
+            }),
+          });
+        const firstAgent = makeAgent(pubsub);
+        const firstMastra = new Mastra({
+          agents: { agent: firstAgent },
+          storage,
+          pubsub,
+          workers: false,
+          logger: false,
+        });
+        let restoredMastra: Mastra | undefined;
+        let first: Awaited<ReturnType<typeof firstAgent.stream>> | undefined;
+        let resumed: Awaited<ReturnType<typeof firstAgent.resume>> | undefined;
+        const threadId = 'canceled-title-thread';
+        const resourceId = 'canceled-title-owner';
+        try {
+          first = await firstAgent.stream('Request action approval.', {
+            memory: { thread: threadId, resource: resourceId },
+            requireToolApproval: true,
+          });
+          void first.output.consumeStream().catch(() => undefined);
+          const runId = first.runId;
+          await expect
+            .poll(async () => (await firstAgent.listSuspendedRuns({ threadId, resourceId })).runs.map(run => run.runId))
+            .toContain(runId);
+          expect(modelCalls).toBe(1);
+          expect((await memory.getThreadById({ threadId }))?.title).toBeFalsy();
+
+          const owner = wrapper === 'same wrapper' ? firstAgent : makeAgent(restoredPubsub);
+          if (owner !== firstAgent) {
+            restoredMastra = new Mastra({
+              agents: { agent: owner },
+              storage,
+              pubsub: restoredPubsub,
+              workers: false,
+              logger: false,
+            });
+          }
+          resumed = await owner.resume(
+            runId,
+            { approved: false, reason: 'Aborted by user' },
+            { toolCallId: 'call-1', abortSignal: AbortSignal.abort() },
+          );
+          await resumed.output.consumeStream();
+
+          expect(results).toEqual([{ finishReason: 'abort', totalTokens: 30 }]);
+          expect(execute).not.toHaveBeenCalled();
+          const recalled = await memory.recall({ threadId, resourceId });
+          const toolStates = recalled.messages.flatMap(message =>
+            message.content.parts.flatMap(part =>
+              part.type === 'tool-invocation' && part.toolInvocation.toolCallId === 'call-1'
+                ? [part.toolInvocation.state]
+                : [],
+            ),
+          );
+          expect(toolStates).toEqual(['output-denied']);
+          for (const message of recalled.messages) {
+            expect(message.content.metadata?.pendingToolApprovals ?? {}).not.toHaveProperty('call-1');
+          }
+          expect(network).not.toHaveBeenCalled();
+          expect(modelCalls).toBe(1);
+          expect((await memory.getThreadById({ threadId }))?.title).toBeFalsy();
+        } finally {
+          resumed?.cleanup();
+          first?.cleanup();
+          await firstMastra.stopWorkers();
+          await restoredMastra?.stopWorkers();
+          await restoredPubsub.close();
+          network.mockRestore();
+        }
+      },
+      15000,
+    );
+
     it('generates a thread title from the first message after a completed durable stream', async () => {
       const mockMemory = new MockMemory();
       // Mirror the non-durable title-generation test: a dedicated title model so we can

--- a/packages/core/src/agent/durable/__tests__/durable-agent-stop-after-response.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-stop-after-response.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { AgentController } from '../../../agent-controller';
+import { createMockWorkspace } from '../../../agent-controller/test-utils';
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import { Mastra } from '../../../mastra';
+import { MockMemory } from '../../../memory/mock';
+import type { Processor } from '../../../processors';
+import { RequestContext } from '../../../request-context';
+import { InMemoryStore } from '../../../storage';
+import { MastraLanguageModelV2Mock } from '../../../test-utils/llm-mock';
+import { createTool } from '../../../tools';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../create-durable-agent';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('durable cancellation between model completion and tool execution', () => {
+  it.each(['decline', 'approve', 'suspension'] as const)(
+    'closes a persisted $0 through a fresh wrapper without further execution',
+    async resumeKind => {
+      const storage = new InMemoryStore();
+      const firstPubsub = new EventEmitterPubSub();
+      const resumedPubsub = new EventEmitterPubSub();
+      const suspended = deferred();
+      const network = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('No network in this test'));
+      let modelCalls = 0;
+      const memory = new MockMemory({ storage });
+      const execute = vi.fn(async () => 'done');
+      const settlements: Array<{ completedSteps: unknown; totalTokens: number | undefined; finishReason: string }> = [];
+      const makeAgent = (isResuming: boolean) =>
+        new Agent({
+          id: 'persisted-stop-agent',
+          name: 'Persisted Stop',
+          instructions: 'Call action.',
+          memory,
+          model: new MastraLanguageModelV2Mock({
+            doStream: async () => {
+              if (isResuming) throw new Error('Closing a persisted approval must not call a model');
+              modelCalls++;
+              return {
+                stream: new ReadableStream({
+                  start(controller) {
+                    controller.enqueue({ type: 'stream-start', warnings: [] });
+                    controller.enqueue({
+                      type: 'tool-call',
+                      toolCallId: `call-${modelCalls}`,
+                      toolName: 'action',
+                      input: '{}',
+                    });
+                    controller.enqueue({
+                      type: 'finish',
+                      finishReason: 'tool-calls',
+                      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+                    });
+                    controller.close();
+                  },
+                }),
+              };
+            },
+          }),
+          tools: {
+            action: createTool({
+              id: 'action',
+              description: 'Local action',
+              inputSchema: z.object({}),
+              suspendSchema: z.object({ reason: z.string() }),
+              resumeSchema: z.object({ answer: z.string() }),
+              execute: async (_input, context) => {
+                const result = await execute();
+                if (resumeKind === 'suspension' && modelCalls === 5) return context.agent?.suspend({ reason: 'Wait' });
+                return result;
+              },
+            }),
+          },
+          outputProcessors: [
+            {
+              id: 'saved-observation',
+              async processOutputStep({ requestContext, messageList }) {
+                requestContext?.set('completedSteps', Number(requestContext.get('completedSteps') ?? 0) + 1);
+                return messageList;
+              },
+              async processOutputResult({ requestContext, result, messageList }) {
+                settlements.push({
+                  completedSteps: requestContext?.get('completedSteps'),
+                  totalTokens: result.usage.totalTokens,
+                  finishReason: result.finishReason,
+                });
+                return messageList;
+              },
+            },
+          ],
+        });
+      const firstAgent = createDurableAgent({ agent: makeAgent(false), pubsub: firstPubsub });
+      const firstMastra = new Mastra({
+        agents: { agent: firstAgent },
+        storage,
+        pubsub: firstPubsub,
+        logger: false,
+        workers: false,
+      });
+      const first = await firstAgent.stream('Call action.', {
+        requestContext: new RequestContext(),
+        memory: { thread: 'persisted-stop-thread', resource: 'persisted-stop-owner' },
+        requireToolApproval: () => resumeKind !== 'suspension' && modelCalls === 5,
+        onSuspended: () => {
+          suspended.resolve();
+        },
+      });
+      void first.output.consumeStream().catch(() => undefined);
+      await suspended.promise;
+      const workflows = await storage.getStore('workflows');
+      await expect
+        .poll(
+          async () =>
+            (await workflows!.getWorkflowRunById({ runId: first.runId, workflowName: 'durable-agentic-loop' }))
+              ?.snapshot?.status,
+        )
+        .toBe('suspended');
+      const secondAgent = createDurableAgent({ agent: makeAgent(true), pubsub: resumedPubsub });
+      const secondMastra = new Mastra({
+        agents: { agent: secondAgent },
+        storage,
+        pubsub: resumedPubsub,
+        logger: false,
+        workers: false,
+      });
+      const readSnapshot = vi.spyOn(workflows!, 'getWorkflowRunById');
+      let resumed: Awaited<ReturnType<typeof secondAgent.resume>> | undefined;
+      try {
+        resumed = await secondAgent.resume(
+          first.runId,
+          resumeKind === 'suspension'
+            ? { answer: 'unused' }
+            : { approved: resumeKind === 'approve', reason: 'Aborted by user' },
+          {
+            toolCallId: 'call-5',
+            abortSignal: AbortSignal.abort(),
+          },
+        );
+        await resumed.output.consumeStream().catch(() => undefined);
+        expect(readSnapshot).toHaveBeenCalledWith({ runId: first.runId, workflowName: 'durable-agentic-loop' });
+        expect(settlements).toEqual([{ completedSteps: 5, totalTokens: 75, finishReason: 'abort' }]);
+        expect(modelCalls).toBe(5);
+        expect(execute).toHaveBeenCalledTimes(resumeKind === 'suspension' ? 5 : 4);
+        const recalled = await memory.recall({ threadId: 'persisted-stop-thread', resourceId: 'persisted-stop-owner' });
+        for (const message of recalled.messages) {
+          expect(message.content.metadata?.pendingToolApprovals).toBeUndefined();
+          expect(message.content.metadata?.suspendedTools).toBeUndefined();
+        }
+        const toolStates = recalled.messages.flatMap(message =>
+          message.content.parts.flatMap(part =>
+            part.type === 'tool-invocation' && part.toolInvocation.toolCallId === 'call-5'
+              ? [part.toolInvocation.state]
+              : [],
+          ),
+        );
+        expect(toolStates).toEqual([resumeKind === 'decline' ? 'output-denied' : 'call']);
+        await expect.poll(async () => (await workflows!.listWorkflowRuns({})).runs).toEqual([]);
+        expect(network).not.toHaveBeenCalled();
+      } finally {
+        readSnapshot.mockRestore();
+        resumed?.cleanup();
+        first.cleanup();
+        await firstMastra.stopWorkers();
+        await secondMastra.stopWorkers();
+        await firstPubsub.close();
+        await resumedPubsub.close();
+        network.mockRestore();
+      }
+    },
+    15000,
+  );
+
+  it.each([
+    { boundary: 'response', requireApproval: true },
+    { boundary: 'step', requireApproval: true },
+    { boundary: 'response', requireApproval: false },
+    { boundary: 'step', requireApproval: false },
+    { boundary: 'stream', requireApproval: true },
+    { boundary: 'approval', requireApproval: true },
+    { boundary: 'input', requireApproval: false },
+  ])(
+    'finishes after Stop at $boundary with approval $requireApproval',
+    async ({ boundary, requireApproval }) => {
+      const network = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('This test must not use the network'));
+      const atBoundary = deferred();
+      const releaseBoundary = deferred();
+      const finalResults: Array<{
+        finishReason: string;
+        totalTokens: number | undefined;
+        lastToolStates: string[];
+        lastToolResults: unknown[];
+      }> = [];
+      const onAbort = vi.fn();
+      let modelCalls = 0;
+      let responseCalls = 0;
+      let stepCalls = 0;
+      let stopped = false;
+      let approvalsAfterStop = 0;
+      const execute = vi.fn(async () => 'done');
+      const processor: Processor = {
+        id: 'completed-response-observer',
+        async processLLMResponse() {
+          responseCalls++;
+          if (boundary === 'response' && modelCalls === 5) {
+            atBoundary.resolve();
+            await releaseBoundary.promise;
+          }
+        },
+        async processOutputStep({ messageList }) {
+          stepCalls++;
+          if (boundary === 'step' && modelCalls === 5) {
+            atBoundary.resolve();
+            await releaseBoundary.promise;
+          }
+          return messageList;
+        },
+        async processOutputResult({ result, messageList }) {
+          const lastToolStates = messageList.get.all
+            .db()
+            .flatMap(message =>
+              message.content.parts.flatMap(part =>
+                part.type === 'tool-invocation' && part.toolInvocation.toolCallId === 'call-5'
+                  ? [part.toolInvocation.state]
+                  : [],
+              ),
+            );
+          finalResults.push({
+            finishReason: result.finishReason,
+            totalTokens: result.usage.totalTokens,
+            lastToolStates,
+            lastToolResults: result.steps.at(-1)?.toolResults ?? [],
+          });
+          return messageList;
+        },
+      };
+      const model = new MastraLanguageModelV2Mock({
+        doStream: async ({ abortSignal }) => {
+          modelCalls++;
+          if (modelCalls > 5) throw new Error('Stop must not call another model');
+          const call = modelCalls;
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+                if (boundary === 'stream' && call === 5) {
+                  abortSignal?.addEventListener(
+                    'abort',
+                    () => controller.error(new DOMException('Aborted', 'AbortError')),
+                    { once: true },
+                  );
+                  atBoundary.resolve();
+                  return;
+                }
+                controller.enqueue({ type: 'tool-call', toolCallId: `call-${call}`, toolName: 'action', input: '{}' });
+                controller.enqueue({
+                  type: 'finish',
+                  finishReason: 'tool-calls',
+                  usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+                });
+                controller.close();
+              },
+            }),
+          };
+        },
+      });
+      const base = new Agent({
+        id: crypto.randomUUID(),
+        name: 'Stop test',
+        instructions: 'Call action.',
+        model,
+        tools: {
+          action: createTool({
+            id: 'action',
+            description: 'Local action',
+            inputSchema: z.object({}),
+            execute,
+            onInputAvailable: async () => {
+              if (boundary === 'input' && modelCalls === 5) {
+                atBoundary.resolve();
+                await releaseBoundary.promise;
+              }
+            },
+          }),
+        },
+        inputProcessors: [processor],
+        outputProcessors: [processor],
+        defaultOptions: { onAbort },
+      });
+      const pubsub = new EventEmitterPubSub();
+      const agent = createDurableAgent({ agent: base, pubsub });
+      const storage = new InMemoryStore();
+      const mastra = new Mastra({
+        agents: { agent },
+        storage,
+        pubsub,
+        logger: false,
+        workers: false,
+        scheduler: { enabled: false },
+      });
+      await mastra.startWorkers();
+      const controller = new AgentController({
+        id: crypto.randomUUID(),
+        storage,
+        workspace: createMockWorkspace(),
+        agent: agent as unknown as Agent,
+        modes: [{ id: 'chat', name: 'Chat', default: true }],
+        disableBuiltinTools: [
+          'ask_user',
+          'submit_plan',
+          'task_write',
+          'task_update',
+          'task_complete',
+          'task_check',
+          'subagent',
+        ],
+      });
+      await controller.init();
+      const session = await controller.createSession({ ownerId: 'local-test-owner' });
+      await session.thread.create();
+      if (!requireApproval) await session.state.set({ yolo: true });
+      const unsubscribe = session.subscribe(event => {
+        if (event.type !== 'tool_approval_required') return;
+        if (stopped && event.toolCallId === 'call-5') approvalsAfterStop++;
+        if (modelCalls < 5) session.respondToToolApproval({ decision: 'approve', toolCallId: event.toolCallId });
+        else if (boundary === 'approval') atBoundary.resolve();
+      });
+      const send = session.sendMessage({ content: 'Call action.' });
+      void send.catch(() => undefined);
+      try {
+        await atBoundary.promise;
+        expect(modelCalls).toBe(5);
+        expect(execute).toHaveBeenCalledTimes(4);
+        stopped = true;
+        session.abort();
+        releaseBoundary.resolve();
+        await expect.poll(() => finalResults.length, { timeout: 2000 }).toBe(1);
+        await expect.poll(() => onAbort.mock.calls.length, { timeout: 2000 }).toBe(1);
+        const workflows = await storage.getStore('workflows');
+        await expect.poll(async () => (await workflows!.listWorkflowRuns({})).runs, { timeout: 2000 }).toEqual([]);
+        expect(execute).toHaveBeenCalledTimes(4);
+        expect(modelCalls).toBe(5);
+        expect(finalResults[0]).toMatchObject({ finishReason: 'abort', totalTokens: boundary === 'stream' ? 60 : 75 });
+        expect(responseCalls).toBe(boundary === 'stream' ? 4 : 5);
+        expect(stepCalls).toBe(boundary === 'stream' ? 4 : 5);
+        if (['response', 'step', 'input'].includes(boundary)) {
+          expect(finalResults[0]!.lastToolStates).toEqual(['call']);
+          expect(finalResults[0]!.lastToolResults).toEqual([]);
+          expect(onAbort.mock.calls[0]![0].steps.at(-1)?.toolResults).toEqual([]);
+        }
+        if (boundary !== 'approval') expect(approvalsAfterStop).toBe(0);
+        expect(network).not.toHaveBeenCalled();
+      } finally {
+        releaseBoundary.resolve();
+        session.abort();
+        unsubscribe();
+        controller.stopIntervals();
+        await mastra.stopWorkers();
+        await pubsub.close();
+        network.mockRestore();
+      }
+    },
+    15000,
+  );
+});

--- a/packages/core/src/agent/durable/__tests__/processor-tool-reconstruction.test.ts
+++ b/packages/core/src/agent/durable/__tests__/processor-tool-reconstruction.test.ts
@@ -1,0 +1,241 @@
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { Mastra } from '../../../mastra';
+import { SkillSearchProcessor, ToolSearchProcessor } from '../../../processors';
+import type { ProcessInputStepArgs } from '../../../processors';
+import { RequestContext, MASTRA_THREAD_ID_KEY } from '../../../request-context';
+import { InMemoryStore } from '../../../storage';
+import { createTool } from '../../../tools';
+import { noopObserve } from '../../../tools/types';
+import { LocalFilesystem, Workspace } from '../../../workspace';
+import { Agent } from '../../agent';
+import { MessageList } from '../../message-list';
+import { createDurableAgent } from '../create-durable-agent';
+
+const cleanups: Array<() => Promise<void> | void> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+function context(tenant = 'a') {
+  const result = new RequestContext();
+  result.set('tenant', tenant);
+  result.set(MASTRA_THREAD_ID_KEY, `thread-${tenant}`);
+  return result;
+}
+
+function step(requestContext: RequestContext, tools: Record<string, unknown>): ProcessInputStepArgs {
+  const model = new MockLanguageModelV2();
+  return {
+    tools,
+    requestContext,
+    messageList: new MessageList({}),
+    messages: [],
+    systemMessages: [],
+    state: {},
+    stepNumber: 1,
+    steps: [],
+    retryCount: 0,
+    model: { ...model, supportedUrls: model.supportedUrls, doGenerate: model.doStream, doStream: model.doStream },
+    abort: () => {
+      throw new Error('Unexpected processor abort');
+    },
+  };
+}
+
+function fixtureTool(id: string) {
+  return createTool({ id, description: `Find ${id} invoices`, inputSchema: z.object({}), execute: async () => id });
+}
+
+async function workspace() {
+  const prefix = path.join(os.tmpdir(), 'mastra-processor-reconstruction-');
+  const root = await mkdtemp(prefix);
+  cleanups.push(async () => {
+    if (!path.resolve(root).startsWith(path.resolve(prefix))) throw new Error('Unexpected fixture path');
+    await rm(root, { recursive: true, force: true });
+  });
+  for (const tenant of ['a', 'b']) {
+    const dir = path.join(root, 'skills', tenant, `fixture-${tenant}`);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      path.join(dir, 'SKILL.md'),
+      `---\nname: fixture-${tenant}\ndescription: Invoice fixture for tenant ${tenant}\n---\nUse invoice handling instructions for tenant ${tenant}.\n`,
+    );
+  }
+  const result = new Workspace({
+    filesystem: new LocalFilesystem({ basePath: root }),
+    skills: ({ requestContext }) => [`skills/${requestContext?.get('tenant') ?? 'a'}`],
+    bm25: true,
+  });
+  await result.init();
+  cleanups.push(() => result.destroy());
+  return result;
+}
+
+describe('processor tools reconstructed before a saved approval executes', () => {
+  it.each([false, true])(
+    'assembles both native processor tool sets without replaying a step (autoLoad=%s)',
+    async autoLoad => {
+      const skills = new SkillSearchProcessor({ workspace: await workspace(), ttl: 0 });
+      const search = new ToolSearchProcessor({
+        tools: { invoice: fixtureTool('invoice') },
+        search: { autoLoad },
+        storage: 'context',
+        ttl: 0,
+      });
+      cleanups.push(
+        () => skills.dispose(),
+        () => search.clearAllState(),
+      );
+      const base = new Agent({
+        id: 'reconstruction',
+        name: 'Reconstruction',
+        instructions: 'Use the fixture.',
+        model: new MockLanguageModelV2(),
+        inputProcessors: async () => [search, skills],
+      });
+      const agent = createDurableAgent({ agent: base });
+      const mastra = new Mastra({ storage: new InMemoryStore(), agents: { agent }, logger: false });
+      cleanups.push(() => mastra.shutdown());
+      expect(mastra.getAgentById(agent.id)).toBe(agent);
+      const tools = await agent.getToolsForExecution({ runId: 'saved-approval', requestContext: context() });
+      expect(Object.keys(tools)).toEqual(expect.arrayContaining(['search_tools', 'search_skills', 'load_skill']));
+      expect('load_tool' in tools).toBe(!autoLoad);
+      expect('invoice' in tools).toBe(false);
+      expect('unknown_tool' in tools).toBe(false);
+      expect(
+        await tools.search_skills!.execute!({ query: 'invoice' }, { toolCallId: 'search', messages: [] }),
+      ).toMatchObject({ results: [{ name: 'fixture-a' }] });
+      expect(
+        await tools.load_skill!.execute!({ skillName: 'fixture-a' }, { toolCallId: 'load', messages: [] }),
+      ).toMatchObject({ success: true, skillName: 'fixture-a' });
+    },
+  );
+
+  it('rebuilds skills using the current tenant and native thread scope', async () => {
+    const skills = new SkillSearchProcessor({ workspace: await workspace(), ttl: 0 });
+    cleanups.push(() => skills.dispose());
+    const agent = new Agent({
+      id: 'scoped-reconstruction',
+      name: 'Scoped reconstruction',
+      instructions: 'Use the fixture.',
+      model: new MockLanguageModelV2(),
+      inputProcessors: [skills],
+    });
+    const a = await agent.getToolsForExecution({ requestContext: context('a') });
+    expect(a.load_skill).toBeDefined();
+    await a.load_skill!.execute!({ skillName: 'fixture-a' }, { toolCallId: 'a', messages: [] });
+    const b = await agent.getToolsForExecution({ requestContext: context('b') });
+    expect(await b.load_skill!.execute!({ skillName: 'fixture-a' }, { toolCallId: 'b', messages: [] })).toMatchObject({
+      success: false,
+    });
+    expect(
+      await b.load_skill!.execute!({ skillName: 'fixture-b' }, { toolCallId: 'b-own', messages: [] }),
+    ).toMatchObject({ success: true });
+    const aStep = await skills.processInputStep(step(context('a'), a));
+    expect(aStep.tools).toHaveProperty('load_skill');
+  });
+
+  it('uses the current step catalog and filter instead of an earlier reconstructed meta-tool closure', async () => {
+    const search = new ToolSearchProcessor({
+      tools: {},
+      includeResolvedTools: true,
+      storage: 'context',
+      ttl: 0,
+      filter: ({ requestContext }) => requestContext?.get('tenant') === 'b',
+    });
+    cleanups.push(() => search.clearAllState());
+    const oldTools = { old_invoice: fixtureTool('old_invoice') };
+    expect(await search.getLoadedToolsForRequestContext({ requestContext: context('a'), tools: oldTools })).toEqual({});
+    const agent = new Agent({
+      id: 'current-step',
+      name: 'Current step',
+      instructions: 'Use the fixture.',
+      model: new MockLanguageModelV2(),
+      tools: oldTools,
+      inputProcessors: [search],
+    });
+    const rebuilt = await agent.getToolsForExecution({ requestContext: context('a') });
+    expect(rebuilt.search_tools).toBeDefined();
+    const fresh = await search.processInputStep(
+      step(context('b'), {
+        search_tools: rebuilt.search_tools,
+        load_tool: rebuilt.load_tool,
+        new_invoice: fixtureTool('new_invoice'),
+      }),
+    );
+    const result = await fresh.tools.search_tools.execute!(
+      { query: 'invoice' },
+      { requestContext: context('b'), observe: noopObserve },
+    );
+    expect(result).toMatchObject({ results: [{ name: 'new_invoice' }] });
+    expect(Object.keys(fresh.tools).slice(0, 2)).toEqual(['search_tools', 'load_tool']);
+    expect('new_invoice' in fresh.tools).toBe(false);
+    expect(JSON.stringify(fresh.tools)).not.toContain('processorToolOwner');
+    expect(
+      await fresh.tools.search_tools.execute!(
+        { query: 'search_tools load_tool' },
+        { requestContext: context('b'), observe: noopObserve },
+      ),
+    ).toMatchObject({ results: [] });
+  });
+
+  it('preserves explicit user overrides of tool search meta-tool names', async () => {
+    const search = new ToolSearchProcessor({ tools: {}, ttl: 0 });
+    const overrides = { search_tools: fixtureTool('search_tools'), load_tool: fixtureTool('load_tool') };
+    const agent = new Agent({
+      id: 'overrides',
+      name: 'Overrides',
+      instructions: 'Use the fixture.',
+      model: new MockLanguageModelV2(),
+      tools: overrides,
+      inputProcessors: [search],
+    });
+    const assembled = await agent.getToolsForExecution({ requestContext: context() });
+    const result = await search.processInputStep(step(context(), assembled));
+    expect(result.tools.search_tools).toBe(assembled.search_tools);
+    expect(result.tools.load_tool).toBe(assembled.load_tool);
+    expect(await assembled.search_tools!.execute!({}, { toolCallId: 'user-search', messages: [] })).toBe(
+      'search_tools',
+    );
+    expect(await assembled.load_tool!.execute!({}, { toolCallId: 'user-load', messages: [] })).toBe('load_tool');
+  });
+
+  it('warns for actual skill name collisions but not its own converted tools', async () => {
+    const skills = new SkillSearchProcessor({ workspace: await workspace(), ttl: 0 });
+    cleanups.push(() => skills.dispose());
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    cleanups.push(() => {
+      warn.mockRestore();
+    });
+    const agent = new Agent({
+      id: 'skill-warning',
+      name: 'Skill warning',
+      instructions: 'Use the fixture.',
+      model: new MockLanguageModelV2(),
+      inputProcessors: [skills],
+    });
+    const assembled = await agent.getToolsForExecution({ requestContext: context() });
+    await skills.processInputStep(step(context(), assembled));
+    expect(warn).not.toHaveBeenCalled();
+    await skills.processInputStep(step(context(), { load_skill: fixtureTool('load_skill') }));
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      '[SkillSearchProcessor] User tool "load_skill" conflicts with meta-tool and will be shadowed.',
+    );
+  });
+
+  it('does not expose processor tools when the processors are disabled', async () => {
+    const agent = new Agent({
+      id: 'plain',
+      name: 'Plain',
+      instructions: 'Use the fixture.',
+      model: new MockLanguageModelV2(),
+      tools: { invoice: fixtureTool('invoice') },
+    });
+    expect(Object.keys(await agent.getToolsForExecution({ requestContext: context() }))).toEqual(['invoice']);
+  });
+});

--- a/packages/core/src/agent/durable/__tests__/recover-run.test.ts
+++ b/packages/core/src/agent/durable/__tests__/recover-run.test.ts
@@ -87,12 +87,12 @@ function createDurableWithStore(agentId: string, store = new InMemoryStore(), pu
     model: makeMockModel(),
   });
   const agent = createDurableAgent({ agent: baseAgent, pubsub, ...(pubsub ? { cache: false } : {}) });
-  void new Mastra({
+  const mastra = new Mastra({
     agents: { [agentId]: agent as any },
     storage: store,
     ...(pubsub ? { pubsub } : {}),
   });
-  return { agent, store };
+  return { agent, store, mastra };
 }
 
 /** Persists matching outer and inner workflow snapshots for a recoverable run. */
@@ -152,6 +152,75 @@ async function readThreadRun(stream: AsyncIterable<any>) {
 }
 
 describe('DurableAgent.recover(runId)', () => {
+  it.each(['snapshot', 'lease', 'registration', 'createRun'] as const)(
+    'preserves snapshots and releases ownership when shutdown starts during %s',
+    async boundary => {
+      const runId = `shutdown-${boundary}`;
+      const pubsub = new EventEmitterPubSub();
+      const { agent, store, mastra } = createDurableWithStore(runId, new InMemoryStore(), pubsub);
+      await seed(store, runId, 'running', runId);
+      const workflow = stubWorkflow(agent, 'success');
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const workflows = (await store.getStore('workflows'))!;
+      const releaseLease = vi.spyOn(pubsub, 'releaseLease');
+      const publish = vi.spyOn(pubsub, 'publish');
+      const gate = async () => {
+        entered.resolve();
+        await release.promise;
+      };
+      const receiver =
+        boundary === 'snapshot'
+          ? workflows
+          : boundary === 'lease'
+            ? pubsub
+            : boundary === 'registration'
+              ? agentThreadStreamRuntime
+              : workflow;
+      const method =
+        boundary === 'snapshot'
+          ? 'getWorkflowRunById'
+          : boundary === 'lease'
+            ? 'acquireLease'
+            : boundary === 'registration'
+              ? 'registerRun'
+              : 'createRun';
+      const actual = (receiver as any)[method].bind(receiver);
+      const intercept = vi.spyOn(receiver as any, method);
+      intercept.mockImplementationOnce(async (...args: any[]) => {
+        const result = await actual(...args);
+        await gate();
+        return result;
+      });
+      const recovery = mastra.recoverAllDurableAgents();
+      void recovery.then(result =>
+        entered.reject(new Error(`Recovery ended before ${boundary}: ${JSON.stringify(result)}`)),
+      );
+      await entered.promise;
+      const shutdown = mastra.shutdown();
+      try {
+        release.resolve();
+        expect(await recovery).toEqual({ agents: 1, recovered: 0, succeeded: 0, failed: 0 });
+        await shutdown;
+        expect(workflow.restart).not.toHaveBeenCalled();
+        expect(globalRunRegistry.get(runId)).toBeUndefined();
+        expect((await readSnapshot(store, DurableStepIds.AGENTIC_LOOP, runId))?.snapshot.status).toBe('running');
+        expect(
+          publish.mock.calls.filter(
+            ([topic, event]) => topic === AGENT_STREAM_TOPIC(runId) && event.type === AgentStreamEventTypes.ERROR,
+          ),
+        ).toHaveLength(0);
+        if (boundary !== 'snapshot')
+          expect(releaseLease.mock.calls.some(([key]) => key.startsWith('mastra:durable-agent-recovery:'))).toBe(true);
+      } finally {
+        release.resolve();
+        await recovery;
+        await shutdown;
+        intercept.mockRestore();
+      }
+    },
+  );
+
   let agent: DurableAgent;
   let store: InMemoryStore;
 

--- a/packages/core/src/agent/durable/__tests__/stream-error-ordering.test.ts
+++ b/packages/core/src/agent/durable/__tests__/stream-error-ordering.test.ts
@@ -1,0 +1,92 @@
+import { setImmediate } from 'node:timers/promises';
+import { expect, it, vi } from 'vitest';
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import { noopLogger } from '../../../logger/noop-logger';
+import { ChunkFrom } from '../../../stream/types';
+import type { ChunkType } from '../../../stream/types';
+import {
+  createDurableAgentStream,
+  emitAbortEvent,
+  emitChunkEvent,
+  emitErrorEvent,
+  emitFinishEvent,
+} from '../stream-adapter';
+
+it.each(['finish', 'throwing-callback', 'error', 'abort'] as const)(
+  'preserves the terminal error contract: %s',
+  async ending => {
+    const pubsub = new EventEmitterPubSub();
+    const onChunk = vi.fn(async () => {
+      if (ending === 'throwing-callback') throw new Error('Callback failed');
+    });
+    const onError = vi.fn();
+    const onAbort = vi.fn();
+    const onFinish = vi.fn();
+    const { output, ready, cleanup } = createDurableAgentStream({
+      pubsub,
+      runId: 'error-order',
+      messageId: 'message',
+      model: { modelId: 'mock', provider: 'mock', version: 'v2' },
+      logger: noopLogger,
+      onChunk,
+      onError,
+      onAbort,
+      onFinish,
+    });
+    const chunks: ChunkType[] = [];
+    const consuming = (async () => {
+      for await (const chunk of output.fullStream) chunks.push(chunk);
+    })();
+    const original = { message: 'Original provider error', name: 'ProviderError', stack: 'original stack' };
+    const chunk: ChunkType = {
+      type: 'error',
+      runId: 'error-order',
+      from: ChunkFrom.AGENT,
+      payload: { error: original },
+    };
+    try {
+      await ready;
+      await emitChunkEvent(pubsub, 'error-order', chunk);
+      await setImmediate();
+      expect(onChunk).not.toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+      expect(chunks).toEqual([]);
+      if (ending === 'abort') {
+        await emitAbortEvent(pubsub, 'error-order', { text: '', steps: [] });
+      } else if (ending === 'error') {
+        const fatal = new Error('Workflow failed');
+        fatal.name = 'WorkflowError';
+        await emitErrorEvent(pubsub, 'error-order', fatal);
+      } else {
+        await emitFinishEvent(pubsub, 'error-order', {
+          output: { text: '', usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 }, steps: [] },
+          stepResult: { reason: 'error', isContinued: false, warnings: [] },
+        });
+      }
+      await consuming;
+      await pubsub.flush();
+      const errors = chunks.filter(chunk => chunk.type === 'error');
+      if (ending === 'abort') {
+        expect(errors).toHaveLength(0);
+        expect(onError).not.toHaveBeenCalled();
+        expect(onChunk).not.toHaveBeenCalled();
+        expect(onAbort).toHaveBeenCalledTimes(1);
+      } else if (ending === 'error') {
+        expect(errors).toHaveLength(1);
+        expect(errors[0]?.payload.error).toMatchObject({ message: 'Workflow failed', name: 'WorkflowError' });
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onChunk).not.toHaveBeenCalled();
+        expect(onFinish).not.toHaveBeenCalled();
+      } else {
+        expect(errors).toEqual([chunk]);
+        expect(onChunk).toHaveBeenCalledExactlyOnceWith(chunk);
+        expect(onError).toHaveBeenCalledExactlyOnceWith({
+          error: expect.objectContaining({ ...original, cause: original }),
+        });
+        expect(onFinish).toHaveBeenCalledTimes(1);
+      }
+    } finally {
+      cleanup();
+    }
+  },
+);

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -1742,6 +1742,27 @@ export class DurableAgent<
    * happens to know about the run.
    */
   #abortDurableRun(runId: string): void {
+    this.#signalDurableRun(runId);
+    const cancellation = this.#mastra
+      ? this.#mastra.__runDurableAgentCancellation(() => this.cancelStoredRun(runId))
+      : this.cancelStoredRun(runId);
+    void cancellation.catch(async error => {
+      try {
+        await this.emitError(runId, error);
+      } catch (publishError) {
+        this.#mastra?.getLogger()?.error('Failed to report durable cancellation error', { runId, error, publishError });
+      }
+    });
+  }
+
+  /** Complete cancellation inside an already admitted native lifecycle operation. @internal */
+  async __abortRunStreamAndWait(runId: string): Promise<void> {
+    super.abortRunStream(runId);
+    this.#signalDurableRun(runId);
+    await this.cancelStoredRun(runId);
+  }
+
+  #signalDurableRun(runId: string): void {
     const controller = (this.#runRegistry.get(runId) ?? globalRunRegistry.get(runId))?.abortController;
     if (controller && !controller.signal.aborted) {
       controller.abort(new Error('Aborted'));
@@ -1749,13 +1770,6 @@ export class DurableAgent<
     // Best-effort, like `requestRemoteAbort` itself: the caller gets the local
     // abort synchronously and a failed publish is logged, not thrown.
     void this.requestRemoteAbort(runId);
-    void this.cancelStoredRun(runId).catch(async error => {
-      try {
-        await this.emitError(runId, error);
-      } catch (publishError) {
-        this.#mastra?.getLogger()?.error('Failed to report durable cancellation error', { runId, error, publishError });
-      }
-    });
   }
 
   /** Close stored work after execution stops; no model is resumed. */

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -16,6 +16,7 @@ import type { ChunkType, MastraOnFinishCallback, MastraStreamTransformOptions } 
 import { ChunkFrom } from '../../stream/types';
 import { deepMerge } from '../../utils';
 import type { WorkflowRunState, WorkflowRunStatus } from '../../workflows/types';
+import { Workflow } from '../../workflows/workflow';
 import { Agent } from '../agent';
 import type { AgentExecutionOptions } from '../agent.types';
 import { beginGoalActivity, stopGoalActivity } from '../goal';
@@ -1748,6 +1749,75 @@ export class DurableAgent<
     // Best-effort, like `requestRemoteAbort` itself: the caller gets the local
     // abort synchronously and a failed publish is logged, not thrown.
     void this.requestRemoteAbort(runId);
+    void this.cancelStoredRun(runId).catch(async error => {
+      try {
+        await this.emitError(runId, error);
+      } catch (publishError) {
+        this.#mastra?.getLogger()?.error('Failed to report durable cancellation error', { runId, error, publishError });
+      }
+    });
+  }
+
+  /** Close stored work after execution stops; no model is resumed. */
+  private async cancelStoredRun(runId: string): Promise<void> {
+    const entry = this.#runRegistry.get(runId) ?? globalRunRegistry.get(runId);
+    // Execution reports its own failure. A rejected executor must not prevent
+    // cancellation from closing the exact stored run it was executing.
+    await entry?.workflowExecution?.catch(() => {});
+    const store = await this.#mastra?.getStorage()?.getStore('workflows');
+    const snapshot = await store?.loadWorkflowSnapshot({ workflowName: DurableStepIds.AGENTIC_LOOP, runId });
+    if (
+      !snapshot ||
+      !['suspended', 'running', 'waiting', 'pending'].includes(snapshot.status) ||
+      snapshot.context?.input?.agentId !== this.id
+    )
+      return;
+    const resourceId = snapshot.context.input.messageListState?.memoryInfo?.resourceId;
+
+    const execution = await store?.loadWorkflowSnapshot({ workflowName: DurableStepIds.AGENTIC_EXECUTION, runId });
+    const toolStep = execution?.context?.[DurableStepIds.TOOL_CALL];
+    const suspendedTools = toolStep?.suspendPayload?.__workflow_meta?.foreachOutput ?? [toolStep];
+    const requestContext = entry?.requestContext ?? new RequestContext(Object.entries(snapshot.requestContext ?? {}));
+    const workflows = await this.listWorkflows({ requestContext });
+    for (const tool of suspendedTools) {
+      const payload = tool?.suspendPayload;
+      const delegatedRunId = payload?.suspendedToolRunId;
+      const toolName = payload?.toolName;
+      if (
+        tool?.status !== 'suspended' ||
+        typeof delegatedRunId !== 'string' ||
+        delegatedRunId === runId ||
+        typeof toolName !== 'string' ||
+        !toolName.startsWith('workflow-')
+      )
+        continue;
+      const child = workflows[toolName.slice('workflow-'.length)];
+      if (!child) throw new Error('Cannot cancel a delegated workflow that is no longer registered');
+      const childRecord = await store?.getWorkflowRunById({ workflowName: child.id, runId: delegatedRunId });
+      const childSnapshot = await store?.loadWorkflowSnapshot({ workflowName: child.id, runId: delegatedRunId });
+      if (
+        !childRecord ||
+        !childSnapshot ||
+        !['suspended', 'running', 'waiting', 'pending'].includes(childSnapshot.status)
+      )
+        continue;
+      if ((childRecord.resourceId ?? undefined) !== (resourceId ?? undefined)) {
+        throw new Error('Cannot cancel a delegated workflow whose resource does not match its parent');
+      }
+      const childRun = await child.createRun({ runId: delegatedRunId, resourceId });
+      await childRun.cancel();
+    }
+    const workflow = this.getWorkflow();
+    const nested = workflow.steps[DurableStepIds.AGENTIC_EXECUTION];
+    if (nested instanceof Workflow) {
+      // A restored agent has not executed this nested workflow yet, so bind
+      // the same native storage authority without starting its steps.
+      if (this.#mastra) nested.__registerMastra(this.#mastra);
+      const executionRun = await nested.createRun({ runId, resourceId });
+      await executionRun.cancel();
+    }
+    const run = await workflow.createRun({ runId, resourceId });
+    await run.cancel();
   }
 
   /**

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -831,6 +831,7 @@ export class DurableAgent<
     options,
     scheduleAutoCleanup,
     recoveryLease,
+    assertAdmission,
   }: {
     runId: string;
     workflowInput: DurableAgenticWorkflowInput;
@@ -842,6 +843,7 @@ export class DurableAgent<
     options?: DurableAgentRecoverOptions<TOutput>;
     scheduleAutoCleanup: () => void;
     recoveryLease: RecoveryLease;
+    assertAdmission: () => void;
   }): Promise<{
     stream: DurableStreamAdapterResult<TOutput>;
     threadRegistration?: AgentThreadRunRegistration;
@@ -849,6 +851,7 @@ export class DurableAgent<
     let streamCleanup: (() => void) | undefined;
     let threadRegistration: AgentThreadRunRegistration | undefined;
     try {
+      assertAdmission();
       recoveryLease.assertOwned();
       registryEntry.messageList = messageList;
       this.#runRegistry.registerWithMessageList(runId, registryEntry, messageList, { threadId, resourceId });
@@ -856,6 +859,7 @@ export class DurableAgent<
 
       // Persistent backends may retain chunks from the pre-crash segment.
       const recoverOffset = await this.#getPubsubOffset(runId);
+      assertAdmission();
       recoveryLease.assertOwned();
       const stream = createDurableAgentStream<TOutput>({
         pubsub: this.pubsub,
@@ -886,6 +890,7 @@ export class DurableAgent<
       });
       streamCleanup = stream.cleanup;
       await this.#raceRecoveryLease(stream.ready, recoveryLease);
+      assertAdmission();
       recoveryLease.assertOwned();
 
       const recoverStreamOptions: AgentExecutionOptions<TOutput> = {
@@ -908,9 +913,13 @@ export class DurableAgent<
         this.getPubSub(),
         {
           strict: true,
-          validate: () => recoveryLease.assertOwned(),
+          validate: () => {
+            assertAdmission();
+            recoveryLease.assertOwned();
+          },
         },
       );
+      assertAdmission();
       recoveryLease.assertOwned();
       return { stream, threadRegistration };
     } catch (error) {
@@ -928,7 +937,9 @@ export class DurableAgent<
       if (globalRunRegistry.get(runId) === registryEntry) {
         globalRunRegistry.delete(runId);
       }
-      await this.#reportRecoveryFailure(runId, recoveryLease.getLossError() ?? error);
+      if (!(error instanceof MastraError && error.id === 'DURABLE_AGENT_RECOVER_SHUTDOWN')) {
+        await this.#reportRecoveryFailure(runId, recoveryLease.getLossError() ?? error);
+      }
       await recoveryLease.release();
       throw error;
     }
@@ -2490,7 +2501,21 @@ export class DurableAgent<
       });
     }
 
+    const assertAdmission = () => {
+      if (this.#mastra?.isShuttingDown) {
+        throw new MastraError({
+          id: 'DURABLE_AGENT_RECOVER_SHUTDOWN',
+          domain: ErrorDomain.AGENT,
+          category: ErrorCategory.USER,
+          text: 'Cannot recover a durable agent after Mastra shutdown has started.',
+          details: { agentName: this.name, runId },
+        });
+      }
+    };
+    assertAdmission();
+
     const workflowsStore = await this.#mastra.getStorage()?.getStore('workflows');
+    assertAdmission();
     if (!workflowsStore) {
       throw new MastraError({
         id: 'DURABLE_AGENT_RECOVER_NO_STORAGE',
@@ -2506,6 +2531,7 @@ export class DurableAgent<
     // 1. Validate the persisted durable-agent input before claiming ownership
     //    so obvious caller errors fail fast.
     let workflowInput = await this.#loadRecoverableWorkflowInput(workflowsStore, runId);
+    assertAdmission();
 
     // 2. Claim recovery ownership before resolving any live dependencies so a
     //    concurrent caller cannot finish first and leave this attempt using a
@@ -2526,10 +2552,12 @@ export class DurableAgent<
 
     let recoveryState: RehydratedRecoveryState;
     try {
+      assertAdmission();
       // The lease RPC itself may have waited while an earlier owner completed.
       // Re-read after acquisition and recover from that authoritative snapshot,
       // never from the pre-claim copy.
       workflowInput = await this.#loadRecoverableWorkflowInput(workflowsStore, runId);
+      assertAdmission();
       recoveryLease.assertOwned();
       recoveryState = await this.#rehydrateRecoveryState({
         runId,
@@ -2567,9 +2595,11 @@ export class DurableAgent<
 
     let workflow: ReturnType<DurableAgent<TAgentId, TTools, TOutput>['getWorkflow']>;
     try {
+      assertAdmission();
       workflow = this.getWorkflow();
       recoveryLease.assertOwned();
     } catch (error) {
+      cleanupOwnedRegistryState();
       await recoveryLease.release();
       throw error;
     }
@@ -2587,6 +2617,7 @@ export class DurableAgent<
       options,
       scheduleAutoCleanup,
       recoveryLease,
+      assertAdmission,
     });
     const { output, cleanup: streamCleanup, ready } = stream;
     const recoveryPubsub = this.#createRecoveryFencedPubSub(recoveryLease);
@@ -2599,11 +2630,13 @@ export class DurableAgent<
     //     the raw rejection so they can classify the run as failed.
     const workflowExecution = this.#raceRecoveryLease(ready, recoveryLease)
       .then(async () => {
+        assertAdmission();
         recoveryLease.assertOwned();
         const run = await this.#raceRecoveryLease(
           workflow.createRun({ runId, resourceId, pubsub: recoveryPubsub }),
           recoveryLease,
         );
+        assertAdmission();
         recoveryLease.assertOwned();
         const result = await this.#raceRecoveryLease(
           run.restart({
@@ -2625,6 +2658,12 @@ export class DurableAgent<
         }
       })
       .catch(async error => {
+        if (error instanceof MastraError && error.id === 'DURABLE_AGENT_RECOVER_SHUTDOWN') {
+          await threadRegistration?.rollback();
+          streamCleanup();
+          cleanupOwnedRegistryState();
+          throw error;
+        }
         const leaseLossError = recoveryLease.getLossError();
         if (leaseLossError) {
           await threadRegistration?.rollback({ releaseLease: false });
@@ -3207,6 +3246,7 @@ export class DurableAgent<
     let failed = 0;
 
     for (const targetRunId of targetRunIds) {
+      if (this.#mastra?.isShuttingDown) break;
       let runError: Error | undefined;
       try {
         // Delegate to the single-run streamable recover path so each run
@@ -3235,6 +3275,7 @@ export class DurableAgent<
         recovered.push({ runId: targetRunId, status: 'success' });
         succeeded++;
       } catch (error) {
+        if (error instanceof MastraError && error.id === 'DURABLE_AGENT_RECOVER_SHUTDOWN') break;
         const err = runError ?? (error instanceof Error ? error : new Error(String(error)));
         recovered.push({ runId: targetRunId, status: 'failed', error: err });
         failed++;

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -833,6 +833,7 @@ export class DurableAgent<
     scheduleAutoCleanup,
     recoveryLease,
     assertAdmission,
+    cancellation,
   }: {
     runId: string;
     workflowInput: DurableAgenticWorkflowInput;
@@ -845,6 +846,7 @@ export class DurableAgent<
     scheduleAutoCleanup: () => void;
     recoveryLease: RecoveryLease;
     assertAdmission: () => void;
+    cancellation?: { toolCallId: string };
   }): Promise<{
     stream: DurableStreamAdapterResult<TOutput>;
     threadRegistration?: AgentThreadRunRegistration;
@@ -907,19 +909,22 @@ export class DurableAgent<
           : {}),
       } as AgentExecutionOptions<TOutput>;
       recoveryLease.assertOwned();
-      threadRegistration = await agentThreadStreamRuntime.registerRun(
-        this as unknown as Agent<any, any, any, any>,
-        stream.output,
-        recoverStreamOptions,
-        this.getPubSub(),
-        {
-          strict: true,
-          validate: () => {
-            assertAdmission();
-            recoveryLease.assertOwned();
+      // Closing a saved run must not replace a newer execution on its thread.
+      // The abort result still uses this run's native stream and saved memory.
+      if (!cancellation)
+        threadRegistration = await agentThreadStreamRuntime.registerRun(
+          this as unknown as Agent<any, any, any, any>,
+          stream.output,
+          recoverStreamOptions,
+          this.getPubSub(),
+          {
+            strict: true,
+            validate: () => {
+              assertAdmission();
+              recoveryLease.assertOwned();
+            },
           },
-        },
-      );
+        );
       assertAdmission();
       recoveryLease.assertOwned();
       return { stream, threadRegistration };
@@ -1747,6 +1752,15 @@ export class DurableAgent<
       ? this.#mastra.__runDurableAgentCancellation(() => this.cancelStoredRun(runId))
       : this.cancelStoredRun(runId);
     void cancellation.catch(async error => {
+      // A competing restoration owns this run's stream. Keep the rejection
+      // on this cancellation's lifecycle; do not terminate the winner's stream.
+      if (
+        error instanceof MastraError &&
+        ['DURABLE_AGENT_RECOVER_ALREADY_IN_PROGRESS', 'DURABLE_AGENT_RECOVER_LEASE_LOST'].includes(error.id)
+      ) {
+        this.#mastra?.getLogger()?.debug('Durable cancellation could not claim the run', { runId, error });
+        return;
+      }
       try {
         await this.emitError(runId, error);
       } catch (publishError) {
@@ -1774,6 +1788,7 @@ export class DurableAgent<
 
   /** Close stored work after execution stops; no model is resumed. */
   private async cancelStoredRun(runId: string): Promise<void> {
+    const needsRestoration = !this.#runRegistry.get(runId);
     const entry = this.#runRegistry.get(runId) ?? globalRunRegistry.get(runId);
     // Execution reports its own failure. A rejected executor must not prevent
     // cancellation from closing the exact stored run it was executing.
@@ -1793,8 +1808,12 @@ export class DurableAgent<
     const suspendedTools = toolStep?.suspendPayload?.__workflow_meta?.foreachOutput ?? [toolStep];
     const requestContext = entry?.requestContext ?? new RequestContext(Object.entries(snapshot.requestContext ?? {}));
     const workflows = await this.listWorkflows({ requestContext });
+    let pendingToolCallId: string | undefined;
     for (const tool of suspendedTools) {
       const payload = tool?.suspendPayload;
+      if (tool?.status === 'suspended' && typeof payload?.toolCallId === 'string') {
+        pendingToolCallId ??= payload.toolCallId;
+      }
       const delegatedRunId = payload?.suspendedToolRunId;
       const toolName = payload?.toolName;
       if (
@@ -1820,6 +1839,21 @@ export class DurableAgent<
       }
       const childRun = await child.createRun({ runId: delegatedRunId, resourceId });
       await childRun.cancel();
+    }
+    if (needsRestoration && snapshot.status === 'suspended' && pendingToolCallId) {
+      // A restarted owner has no live executor to publish the abort result.
+      // The existing canceled-resume path maps closed waits, runs output
+      // processors and persists memory without executing another model or tool.
+      const resumed = await this.#recoverStoredRun(
+        runId,
+        { abortSignal: AbortSignal.abort() },
+        { toolCallId: pendingToolCallId },
+      );
+      const resumedExecution = globalRunRegistry.get(runId)?.workflowExecution;
+      await resumed.output.consumeStream();
+      await resumedExecution;
+      resumed.cleanup();
+      return;
     }
     const workflow = this.getWorkflow();
     const nested = workflow.steps[DurableStepIds.AGENTIC_EXECUTION];
@@ -2575,6 +2609,14 @@ export class DurableAgent<
     runId: string,
     options?: DurableAgentRecoverOptions<TOutput>,
   ): Promise<DurableAgentStreamResult<TOutput>> {
+    return this.#recoverStoredRun(runId, options);
+  }
+
+  async #recoverStoredRun(
+    runId: string,
+    options?: DurableAgentRecoverOptions<TOutput>,
+    cancellation?: { toolCallId: string },
+  ): Promise<DurableAgentStreamResult<TOutput>> {
     if (!this.#mastra) {
       throw new MastraError({
         id: 'DURABLE_AGENT_RECOVER_NO_MASTRA',
@@ -2586,7 +2628,7 @@ export class DurableAgent<
     }
 
     const assertAdmission = () => {
-      if (this.#mastra?.isShuttingDown) {
+      if (!cancellation && this.#mastra?.isShuttingDown) {
         throw new MastraError({
           id: 'DURABLE_AGENT_RECOVER_SHUTDOWN',
           domain: ErrorDomain.AGENT,
@@ -2649,6 +2691,17 @@ export class DurableAgent<
         abortController,
         recoveryLease,
       });
+      if (cancellation) {
+        await this.requireAgentExecutionFGA({
+          requestContext: recoveryState.requestContext,
+          memory: recoveryState.threadId
+            ? { thread: recoveryState.threadId, resource: recoveryState.resourceId }
+            : undefined,
+          runId,
+          snapshotMemoryInfo: { threadId: recoveryState.threadId, resourceId: recoveryState.resourceId },
+        });
+        recoveryLease.assertOwned();
+      }
     } catch (error) {
       await recoveryLease.release();
       throw error;
@@ -2702,6 +2755,7 @@ export class DurableAgent<
       scheduleAutoCleanup,
       recoveryLease,
       assertAdmission,
+      cancellation,
     });
     const { output, cleanup: streamCleanup, ready } = stream;
     const recoveryPubsub = this.#createRecoveryFencedPubSub(recoveryLease);
@@ -2723,10 +2777,17 @@ export class DurableAgent<
         assertAdmission();
         recoveryLease.assertOwned();
         const result = await this.#raceRecoveryLease(
-          run.restart({
-            requestContext,
-            ...createObservabilityContext({ currentSpan: recoverAgentSpan }),
-          } as any),
+          cancellation
+            ? run.resume({
+                resumeData: { approved: false, reason: 'Aborted by user' },
+                label: cancellation.toolCallId,
+                requestContext,
+                ...createObservabilityContext({ currentSpan: recoverAgentSpan }),
+              })
+            : run.restart({
+                requestContext,
+                ...createObservabilityContext({ currentSpan: recoverAgentSpan }),
+              } as any),
           recoveryLease,
         );
         recoveryLease.assertOwned();

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -21,7 +21,7 @@ import { Agent } from '../agent';
 import type { AgentExecutionOptions } from '../agent.types';
 import { beginGoalActivity, stopGoalActivity } from '../goal';
 import { MessageList } from '../message-list';
-import type { MessageListInput } from '../message-list';
+import type { MastraDBMessage, MessageListInput } from '../message-list';
 import { SaveQueueManager } from '../save-queue';
 import { AgentThreadLeaseConflictError, agentThreadStreamRuntime } from '../thread-stream-runtime';
 import type { AgentThreadRunRegistration } from '../thread-stream-runtime';
@@ -1749,7 +1749,9 @@ export class DurableAgent<
   #abortDurableRun(runId: string): void {
     this.#signalDurableRun(runId);
     const cancellation = this.#mastra
-      ? this.#mastra.__runDurableAgentCancellation(() => this.cancelStoredRun(runId))
+      ? this.#mastra.__runDurableAgentCancellation(async () => {
+          await this.cancelStoredRun(runId);
+        })
       : this.cancelStoredRun(runId);
     void cancellation.catch(async error => {
       // A competing restoration owns this run's stream. Keep the rejection
@@ -1770,10 +1772,10 @@ export class DurableAgent<
   }
 
   /** Complete cancellation inside an already admitted native lifecycle operation. @internal */
-  async __abortRunStreamAndWait(runId: string): Promise<void> {
+  async __abortRunStreamAndWait(runId: string): Promise<{ messages: MastraDBMessage[] } | void> {
     super.abortRunStream(runId);
     this.#signalDurableRun(runId);
-    await this.cancelStoredRun(runId);
+    return this.cancelStoredRun(runId);
   }
 
   #signalDurableRun(runId: string): void {
@@ -1787,7 +1789,7 @@ export class DurableAgent<
   }
 
   /** Close stored work after execution stops; no model is resumed. */
-  private async cancelStoredRun(runId: string): Promise<void> {
+  private async cancelStoredRun(runId: string): Promise<{ messages: MastraDBMessage[] } | void> {
     const needsRestoration = !this.#runRegistry.get(runId);
     const entry = this.#runRegistry.get(runId) ?? globalRunRegistry.get(runId);
     // Execution reports its own failure. A rejected executor must not prevent
@@ -1849,11 +1851,55 @@ export class DurableAgent<
         { abortSignal: AbortSignal.abort() },
         { toolCallId: pendingToolCallId },
       );
-      const resumedExecution = globalRunRegistry.get(runId)?.workflowExecution;
-      await resumed.output.consumeStream();
-      await resumedExecution;
-      resumed.cleanup();
-      return;
+      const resumedEntry = globalRunRegistry.get(runId);
+      const resumedExecution = resumedEntry?.workflowExecution;
+      try {
+        await resumed.output.consumeStream();
+        await resumedExecution;
+        // Cold cancellation owns no thread stream. Give its awaiting Session
+        // the actual finalized messages without acquiring a newer run's lease.
+        const durableState = snapshot.context.input.state;
+        if (
+          !durableState?.threadId ||
+          !durableState.resourceId ||
+          durableState.observationalMemory ||
+          durableState.memoryConfig?.readOnly
+        ) {
+          return { messages: [] };
+        }
+        const finalMessages = resumedEntry?.messageList?.getPersisted.response.db() ?? [];
+        if (!finalMessages.length) return { messages: [] };
+        const memory = resumedEntry?.memory ?? (await this.getMemory({ requestContext }));
+        if (!memory) return { messages: [] };
+        const memoryStore = await memory.storage.getStore('memory');
+        if (!memoryStore) throw new Error('Cannot read back cancelled durable messages');
+        const { messages } = await memoryStore.listMessagesById({
+          messageIds: finalMessages.map(message => message.id),
+        });
+        const byId = new Map(messages.map(message => [message.id, message]));
+        const savedMessages = finalMessages.map(finalMessage => {
+          const saved = byId.get(finalMessage.id);
+          if (!saved || saved.threadId !== finalMessage.threadId || saved.resourceId !== finalMessage.resourceId) {
+            throw new Error('Cancelled durable message was not retained in its original scope');
+          }
+          for (const tool of suspendedTools) {
+            const toolCallId = tool?.suspendPayload?.toolCallId;
+            if (typeof toolCallId !== 'string') continue;
+            for (const waits of [
+              saved.content.metadata?.pendingToolApprovals,
+              saved.content.metadata?.suspendedTools,
+            ]) {
+              if (waits && typeof waits === 'object' && toolCallId in waits) {
+                throw new Error('Cancelled durable message still contains a saved tool wait');
+              }
+            }
+          }
+          return saved;
+        });
+        return { messages: savedMessages };
+      } finally {
+        resumed.cleanup();
+      }
     }
     const workflow = this.getWorkflow();
     const nested = workflow.steps[DurableStepIds.AGENTIC_EXECUTION];

--- a/packages/core/src/agent/durable/run-registry.ts
+++ b/packages/core/src/agent/durable/run-registry.ts
@@ -111,7 +111,7 @@ export function __resetRunRegistryActivityForTests(): void {
 
 export function getActiveDurableAgentWorkflowExecutions(mastra: Mastra): Promise<unknown>[] {
   return Array.from(globalRunRegistry.values()).flatMap(entry =>
-    entry.mastra === mastra && entry.workflowExecution ? [entry.workflowExecution] : [],
+    entry?.mastra === mastra && entry.workflowExecution ? [entry.workflowExecution] : [],
   );
 }
 

--- a/packages/core/src/agent/durable/stream-adapter.ts
+++ b/packages/core/src/agent/durable/stream-adapter.ts
@@ -240,6 +240,7 @@ export function createDurableAgentStream<OUTPUT = undefined>(
   let lastErrorStack: string | undefined;
   let lastErrorName: string | undefined;
   let lastErrorCause: unknown;
+  let deferredErrorChunk: ChunkType<OUTPUT> | undefined;
 
   // Idle/liveness watchdog. A durable run whose driving process crashed stops
   // emitting chunks but never publishes a terminal FINISH/ERROR/ABORT event, so
@@ -347,6 +348,11 @@ export function createDurableAgentStream<OUTPUT = undefined>(
             lastErrorStack = typeof errPayload?.error?.stack === 'string' ? errPayload.error.stack : undefined;
             lastErrorName = typeof errPayload?.error?.name === 'string' ? errPayload.error.name : undefined;
             lastErrorCause = errPayload?.error ?? errPayload;
+            // A handled model error still runs final output processors and saves
+            // history. Consumers treat this chunk as terminal, so deliver it only
+            // when the workflow publishes FINISH after those side effects.
+            deferredErrorChunk = chunk as ChunkType<OUTPUT>;
+            break;
           }
           safeEnqueue(controller, chunk as ChunkType<OUTPUT>);
           await onChunk?.(chunk as ChunkType<OUTPUT>);
@@ -370,6 +376,9 @@ export function createDurableAgentStream<OUTPUT = undefined>(
 
         case AgentStreamEventTypes.FINISH: {
           const data = streamEvent.data as AgentFinishEventData;
+          const errorChunk = deferredErrorChunk;
+          deferredErrorChunk = undefined;
+          if (errorChunk) safeEnqueue(controller, errorChunk);
           // Enqueue finish chunk and close stream even if callback throws
           const finishChunk = {
             type: 'finish' as const,
@@ -381,6 +390,14 @@ export function createDurableAgentStream<OUTPUT = undefined>(
           safeEnqueue(controller, finishChunk);
           safeClose(controller);
           markTerminated();
+
+          if (errorChunk) {
+            try {
+              await onChunk?.(errorChunk);
+            } catch (callbackError) {
+              logError(`[DurableAgentStream] onChunk callback error:`, callbackError);
+            }
+          }
 
           // Build rich onFinish payload from finish event data.
           // The pubsub FINISH event carries output.text, output.steps, and

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -359,6 +359,8 @@ export interface DurableToolCallInput {
  * Output from a single tool call step
  */
 export interface DurableToolCallOutput extends DurableToolCallInput {
+  /** Canceled before execution; no tool result should be recorded. */
+  aborted?: boolean;
   /** Result from tool execution */
   result?: unknown;
   /** Whether toModelOutput was evaluated before the result crossed the durable boundary */

--- a/packages/core/src/agent/durable/workflows/__tests__/finalize-run.test.ts
+++ b/packages/core/src/agent/durable/workflows/__tests__/finalize-run.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import type { OutputResult, ProcessOutputResultArgs } from '../../../../processors';
 import { MessageList } from '../../../message-list';
 import { globalRunRegistry } from '../../run-registry';
 import type { DurableAgenticWorkflowInput, RunRegistryEntry } from '../../types';
@@ -109,6 +110,42 @@ describe('runDurableFinishSideEffects', () => {
 
     expect(generateThreadTitle).toHaveBeenCalledTimes(1);
   });
+
+  it.each(['abort', 'aborted'])(
+    'preserves final output and persistence without titling a %s result',
+    async finishReason => {
+      const generateThreadTitle = vi.fn().mockResolvedValue(undefined);
+      const flushMessages = vi.fn().mockResolvedValue(undefined);
+      const outputResult: OutputResult = {
+        text: 'hi there',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        finishReason,
+        steps: [],
+      };
+      const processOutputResult = vi.fn(({ messageList }: ProcessOutputResultArgs) => messageList);
+      globalRunRegistry.set('run-1', {
+        isPlaceholder: false,
+        outputProcessors: [{ id: 'final-observer', processOutputResult }],
+        generateThreadTitle,
+        saveQueueManager: { flushMessages },
+        memory: { createThread: vi.fn() },
+      } as unknown as RunRegistryEntry);
+
+      const result = await runDurableFinishSideEffects({
+        runId: 'run-1',
+        initData: makeInitData({ threadId: 'thread-1', resourceId: 'resource-1', threadExists: true }),
+        messageListState: makeMessageListState(),
+        outputResult,
+      });
+
+      expect(processOutputResult).toHaveBeenCalledTimes(1);
+      expect(processOutputResult.mock.calls[0]?.[0].result).toBe(outputResult);
+      expect(flushMessages).toHaveBeenCalledTimes(1);
+      expect(flushMessages.mock.calls[0]?.[0]).toBe(processOutputResult.mock.calls[0]?.[0].messageList);
+      expect(result.outputText).toBe('hi there');
+      expect(generateThreadTitle).not.toHaveBeenCalled();
+    },
+  );
 
   it('deserializes into the run MessageList the stream is already holding', async () => {
     const existing = new MessageList({ threadId: 'thread-1', resourceId: 'resource-1' });

--- a/packages/core/src/agent/durable/workflows/finalize-run.ts
+++ b/packages/core/src/agent/durable/workflows/finalize-run.ts
@@ -200,7 +200,10 @@ export async function runDurableFinishSideEffects({
 
   // Same exclusions as the persistence block above: an observational-memory run writes no
   // messages here, and titling it would create a thread row holding a title and nothing else.
+  // Cancellation still finalizes output and memory, but must not start another model call.
   if (
+    outputResult?.finishReason !== 'abort' &&
+    outputResult?.finishReason !== 'aborted' &&
     durableState?.threadId &&
     durableState?.resourceId &&
     !durableState.observationalMemory &&

--- a/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
@@ -70,7 +70,7 @@ export function createDurableLLMMappingStep() {
       const { inputData, mastra, requestContext } = params;
       const {
         llmOutput,
-        toolResults,
+        toolResults: rawToolResults,
         runId: _runId,
         agentId: _agentId,
         messageId,
@@ -83,6 +83,9 @@ export function createDurableLLMMappingStep() {
         messageId: string;
         state: SerializableDurableState;
       };
+      // Match the regular agent: canceled calls stay incomplete and are not results
+      // in memory, step events, final processors or completion callbacks.
+      const toolResults = rawToolResults.filter(toolResult => !toolResult.aborted);
 
       // 1. Deserialize message list
       const messageList = new MessageList({
@@ -90,6 +93,31 @@ export function createDurableLLMMappingStep() {
         resourceId: state.resourceId,
       });
       messageList.deserialize(llmOutput.messageListState);
+
+      // This serialized LLM state predates resume-time metadata cleanup. Clear only
+      // calls that reached mapping so recall cannot restore an already closed wait.
+      for (const toolResult of rawToolResults) {
+        const message = messageList.get.all
+          .db()
+          .findLast(message =>
+            message.content.parts.some(
+              part => part.type === 'tool-invocation' && part.toolInvocation.toolCallId === toolResult.toolCallId,
+            ),
+          );
+        for (const key of ['pendingToolApprovals', 'suspendedTools']) {
+          const entries = message?.content.metadata?.[key] as Record<string, { toolCallId?: string }> | undefined;
+          if (!entries) continue;
+          const remaining = Object.fromEntries(
+            Object.entries(entries).filter(
+              ([id, entry]) => id !== toolResult.toolCallId && entry?.toolCallId !== toolResult.toolCallId,
+            ),
+          );
+          if (Object.keys(remaining).length === Object.keys(entries).length) continue;
+          messageList.updateMessageMetadataByToolCallId(toolResult.toolCallId, {
+            [key]: Object.keys(remaining).length ? remaining : undefined,
+          });
+        }
+      }
 
       // A declined approval has no `result` but is fully resolved: persist it as `output-denied`
       // with the approval decision (rather than as a successful `result`) so it round-trips on

--- a/packages/core/src/agent/durable/workflows/steps/tool-approval-recall.test.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-approval-recall.test.ts
@@ -103,12 +103,12 @@ function seedMessageListState() {
   return messageList.serialize();
 }
 
-async function runMappingStep(toolResults: unknown[]) {
+async function runMappingStep(toolResults: unknown[], messageListState = seedMessageListState()) {
   const step = createDurableLLMMappingStep();
   const output = await (step as any).execute({
     inputData: {
       llmOutput: {
-        messageListState: seedMessageListState(),
+        messageListState,
         stepResult: {
           isContinued: true,
           reason: 'tool-calls',
@@ -142,7 +142,7 @@ async function runMappingStep(toolResults: unknown[]) {
     .flatMap(m => m.parts)
     .find((p: any) => 'toolCallId' in p && p.toolCallId === TOOL_CALL_ID) as Record<string, any> | undefined;
 
-  return { stored, v6 };
+  return { stored, v6, recalled, output };
 }
 
 afterEach(() => {
@@ -204,6 +204,29 @@ describe('issue #17218 (durable engine): tool-call step records the approval dec
 });
 
 describe('issue #17218 (durable engine): mapping step round-trips approvals on recall', () => {
+  it('clears only the canceled call wait metadata and keeps a same-name sibling wait', async () => {
+    const messages = new MessageList({ threadId: THREAD_ID, resourceId: RESOURCE_ID }).deserialize(
+      seedMessageListState(),
+    );
+    const sibling = { toolCallId: 'sibling-call', toolName: TOOL_NAME };
+    messages.updateMessageMetadataByToolCallId(TOOL_CALL_ID, {
+      customProductData: 'keep',
+      pendingToolApprovals: { [TOOL_CALL_ID]: { toolCallId: TOOL_CALL_ID }, sibling },
+      suspendedTools: { [TOOL_CALL_ID]: { toolCallId: TOOL_CALL_ID }, sibling },
+    });
+    const { recalled, output, stored } = await runMappingStep(
+      [{ toolCallId: TOOL_CALL_ID, toolName: TOOL_NAME, args: TOOL_ARGS, aborted: true }],
+      messages.serialize(),
+    );
+    expect(recalled.get.all.db()[0]?.content.metadata).toEqual({
+      customProductData: 'keep',
+      pendingToolApprovals: { sibling },
+      suspendedTools: { sibling },
+    });
+    expect(stored?.state).toBe('call');
+    expect(output.toolResults).toEqual([]);
+  });
+
   it('a declined tool result persists as output-denied + approval and recalls as a v6 output-denied part', async () => {
     const { stored, v6 } = await runMappingStep([
       {

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -59,6 +59,7 @@ const durableToolCallInputSchema = z.object({
  * Output schema for the durable tool call step
  */
 const durableToolCallOutputSchema = durableToolCallInputSchema.extend({
+  aborted: z.boolean().optional(),
   result: z.any().optional(),
   modelOutputComputed: z.boolean().optional(),
   error: z
@@ -288,6 +289,7 @@ export function createDurableToolCallStep() {
 
       const { runId, options: agentOptions, state } = initData;
       const logger = (mastra as any)?.getLogger?.();
+      const isAborted = () => (globalRunRegistry.get(runId)?.abortSignal ?? params.abortSignal)?.aborted === true;
 
       // End the open MODEL_STEP + MODEL_GENERATION + AGENT_RUN as `suspended` before
       // pausing — stores persist only span-end events, so an un-ended root is dropped if
@@ -669,6 +671,13 @@ export function createDurableToolCallStep() {
         (suspendData as { type?: unknown }).type === 'approval';
       const approvalGated = suspendedForApproval || (requiresApproval && suspendData === undefined);
 
+      // A completed response can still be running async processors when Stop arrives.
+      // Do not enter a new approval wait or execute its tools after cancellation.
+      // Existing resumes still need their normal approval/suspension metadata cleanup.
+      if (isAborted() && resumeData === undefined) {
+        return { ...typedInput, aborted: true };
+      }
+
       if (approvalGated && !approvalDecision) {
         const resumeSchema = JSON.stringify({
           type: 'object',
@@ -681,6 +690,8 @@ export function createDurableToolCallStep() {
 
         // Persist active goal time before exposing the approval wait.
         await stopGoalActivity({ agentId: initData.agentId, runId });
+
+        if (isAborted()) return { ...typedInput, aborted: true };
 
         // Emit approval chunk via PubSub (mirrors base agent's controller.enqueue)
         if (pubsub) {
@@ -708,6 +719,11 @@ export function createDurableToolCallStep() {
 
         // Flush messages before suspension
         await doFlush();
+
+        if (isAborted()) {
+          await removeToolMetadata('approval');
+          return { ...typedInput, aborted: true };
+        }
 
         // End the trace's open spans as suspended before pausing.
         endSpansAsSuspended({ toolCallId, toolName, reason: 'approval' });
@@ -800,6 +816,8 @@ export function createDurableToolCallStep() {
         await removeToolMetadata('suspension');
       }
 
+      if (isAborted()) return { ...typedInput, aborted: true };
+
       // 3. Check for background task execution
       const bgManager = registryEntry?.backgroundTaskManager;
       const bgConfig = registryEntry?.backgroundTasksConfig;
@@ -849,6 +867,8 @@ export function createDurableToolCallStep() {
       }
 
       // Execute the tool
+      if (isAborted()) return { ...typedInput, aborted: true };
+
       if (!tool.execute) {
         return {
           ...typedInput,

--- a/packages/core/src/agent/message-list/adapters/AIV6Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV6Adapter.ts
@@ -362,7 +362,8 @@ export class AIV6Adapter {
     const hasTextParts = dbParts.some(part => part.type === 'text');
 
     for (const part of dbParts) {
-      parts.push(AIV6Adapter.toUIPart(part));
+      const uiPart = AIV6Adapter.toUIPart(part);
+      if (uiPart) parts.push(uiPart);
     }
 
     if (!hasToolInvocationParts || !hasReasoningParts || !hasFileParts || !hasTextParts) {
@@ -564,7 +565,7 @@ export class AIV6Adapter {
     };
   }
 
-  private static toUIPart(part: MastraMessagePart): AIV6Type.UIMessage['parts'][number] {
+  private static toUIPart(part: MastraMessagePart): AIV6Type.UIMessage['parts'][number] | undefined {
     if (part.type === 'tool-invocation') {
       const base = withOptionalFields(
         {
@@ -697,17 +698,17 @@ export class AIV6Adapter {
       ) as AIV6Type.UIMessage['parts'][number];
     }
 
-    return AIV6Adapter.toUIPartFromV5(
-      AIV5Adapter.toUIMessage({
-        id: 'tmp',
-        role: 'assistant',
-        createdAt: new Date(),
-        content: {
-          format: 2,
-          parts: [part],
-        },
-      }).parts[0]!,
-    );
+    const v5Part = AIV5Adapter.toUIMessage({
+      id: 'tmp',
+      role: 'assistant',
+      createdAt: new Date(),
+      content: {
+        format: 2,
+        parts: [part],
+      },
+    }).parts[0];
+    // V5 intentionally omits some parts, such as an opening empty reasoning part.
+    return v5Part ? AIV6Adapter.toUIPartFromV5(v5Part) : undefined;
   }
 
   private static toUIPartFromV5(part: AIV5Type.UIMessage['parts'][number]): AIV6Type.UIMessage['parts'][number] {

--- a/packages/core/src/agent/message-list/tests/message-list-v6-empty-reasoning.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-v6-empty-reasoning.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { MessageList } from '../message-list';
+import type { MastraDBMessage, MastraMessagePart } from '../state/types';
+
+const emptyReasoning: MastraMessagePart = { type: 'reasoning', reasoning: '', details: [] };
+
+function project(parts: MastraMessagePart[]) {
+  const message: MastraDBMessage = {
+    id: 'assistant-message',
+    role: 'assistant',
+    createdAt: new Date('2026-09-06T00:00:00.000Z'),
+    content: { format: 2, parts },
+  };
+  return new MessageList().add([message], 'memory').get.all.aiV6.ui();
+}
+
+describe('MessageList V6 empty reasoning', () => {
+  it('keeps an assistant message whose empty reasoning part is omitted by V5', () => {
+    expect(project([emptyReasoning])).toMatchObject([{ id: 'assistant-message', role: 'assistant', parts: [] }]);
+  });
+
+  it('keeps text and tool results in order around omitted reasoning parts', () => {
+    const result = project([
+      emptyReasoning,
+      { type: 'text', text: 'Before' },
+      emptyReasoning,
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'result',
+          toolCallId: 'search-1',
+          toolName: 'search',
+          args: { query: 'example' },
+          result: { found: true },
+        },
+      },
+      { type: 'text', text: 'After' },
+      emptyReasoning,
+    ]);
+
+    expect(result[0]?.parts).toEqual([
+      { type: 'text', text: 'Before' },
+      {
+        type: 'tool-search',
+        toolCallId: 'search-1',
+        providerExecuted: undefined,
+        state: 'output-available',
+        input: { query: 'example' },
+        output: { found: true },
+      },
+      { type: 'text', text: 'After' },
+    ]);
+  });
+
+  it('preserves native tool approval state next to empty reasoning', () => {
+    const result = project([
+      emptyReasoning,
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'approval-requested',
+          toolCallId: 'search-2',
+          toolName: 'search',
+          args: { query: 'example' },
+          approval: { id: 'approval-2' },
+        },
+      },
+    ]);
+
+    expect(result[0]?.parts).toEqual([
+      {
+        type: 'tool-search',
+        toolCallId: 'search-2',
+        providerExecuted: undefined,
+        state: 'approval-requested',
+        input: { query: 'example' },
+        approval: { id: 'approval-2' },
+      },
+    ]);
+  });
+
+  it('preserves nonempty reasoning and its metadata', () => {
+    const result = project([
+      emptyReasoning,
+      {
+        type: 'reasoning',
+        reasoning: 'Keep this reasoning',
+        details: [{ type: 'text', text: 'Keep this reasoning' }],
+        providerMetadata: { example: { signature: 'signature-1' } },
+        createdAt: 123,
+      },
+    ]);
+
+    expect(result[0]?.parts).toEqual([
+      {
+        type: 'reasoning',
+        text: 'Keep this reasoning',
+        state: 'done',
+        providerMetadata: { example: { signature: 'signature-1' }, mastra: { createdAt: 123 } },
+      },
+    ]);
+  });
+
+  it('preserves reasoning that has details but no summary text', () => {
+    const result = project([
+      { type: 'reasoning', reasoning: '', details: [{ type: 'text', text: 'From details' }] },
+      { type: 'reasoning', reasoning: '', details: [{ type: 'redacted', data: 'opaque-data' }] },
+    ]);
+
+    expect(result[0]?.parts).toEqual([
+      { type: 'reasoning', text: 'From details', state: 'done' },
+      { type: 'reasoning', text: '', state: 'done' },
+    ]);
+  });
+});

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -2578,12 +2578,21 @@ export class AgentThreadStreamRuntime {
                     : typedPart;
                 yield partWithRunId;
                 if (done) break;
-                const finishReason = typedPart.finishReason ?? typedPart.payload?.finishReason;
+                const finishReason =
+                  typedPart.payload?.stepResult?.reason ?? typedPart.finishReason ?? typedPart.payload?.finishReason;
                 const terminalBoundary =
                   typedPart.type === 'error' ||
                   typedPart.type === 'abort' ||
                   (typedPart.type === 'finish' && finishReason !== 'tool-calls');
                 if (terminalBoundary) {
+                  // A durable subscriber can consume the whole run while each
+                  // approval resume registers another stream for that same run.
+                  // Those queued streams are already covered by this terminal
+                  // boundary; replaying them would reopen resolved approvals.
+                  // Keep other runs, including follow-ups queued during finish.
+                  for (let index = pendingRuns.length - 1; index >= 0; index--) {
+                    if (pendingRuns[index]?.runId === run.runId) pendingRuns.splice(index, 1);
+                  }
                   // After a final terminal chunk, drain any non-visible trailing
                   // data in the background to prevent upstream backpressure while
                   // allowing the generator to immediately serve subsequent runs.

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1204,6 +1204,13 @@ export type AgentMethodType = 'generate' | 'stream' | 'generateLegacy' | 'stream
  * to maintain compatibility with the server handlers.
  */
 export interface DurableAgentLike {
+  /**
+   * Complete Stop within an already admitted native Mastra cancellation operation.
+   * Optional for compatibility with other durable wrappers; only implementations
+   * providing this method guarantee stored cancellation completion to Session.
+   * @internal
+   */
+  __abortRunStreamAndWait?(runId: string): Promise<void>;
   /** Agent ID */
   readonly id: string;
   /** Agent name */

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -66,7 +66,7 @@ import type { AnyWorkspace } from '../workspace';
 import type { SkillFormat } from '../workspace/skills';
 import type { Agent } from './agent';
 import type { AgentExecutionOptions, NetworkOptions } from './agent.types';
-import type { MessageList } from './message-list/index';
+import type { MastraDBMessage, MessageList } from './message-list/index';
 import type { AgentSignalAttributes, CreatedAgentSignal } from './signals';
 import type { SubAgent } from './subagent';
 export type {
@@ -1210,7 +1210,7 @@ export interface DurableAgentLike {
    * providing this method guarantee stored cancellation completion to Session.
    * @internal
    */
-  __abortRunStreamAndWait?(runId: string): Promise<void>;
+  __abortRunStreamAndWait?(runId: string): Promise<{ messages: MastraDBMessage[] } | void>;
   /** Agent ID */
   readonly id: string;
   /** Agent name */

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -1249,226 +1249,234 @@ export async function createNetworkLoop({
       const run = await wf.createRun({ runId });
 
       // listen for the network-level abort signal
-      const networkAbortCb = async () => {
-        await run.cancel();
-        await onAbort?.({
-          primitiveType: 'workflow',
-          primitiveId: inputData.primitiveId,
-          iteration: inputData.iteration,
+      let cancellation: Promise<void> | undefined;
+      const networkAbortCb = () => {
+        cancellation ??= run.cancel().then(async () => {
+          await onAbort?.({
+            primitiveType: 'workflow',
+            primitiveId: inputData.primitiveId,
+            iteration: inputData.iteration,
+          });
         });
+        void cancellation.catch(() => {});
       };
       if (abortSignal) {
         abortSignal.addEventListener('abort', networkAbortCb);
       }
 
-      const toolData = {
-        workflowId: wf.id,
-        args: inputData,
-        runId: stepId,
-      };
-
-      await writer?.write({
-        type: 'workflow-execution-start',
-        payload: toolData,
-        from: ChunkFrom.NETWORK,
-        runId,
-      });
-
-      const stream = resumeData
-        ? run.resumeStream({
-            resumeData,
-            requestContext: requestContext,
-          })
-        : run.stream({
-            inputData: input,
-            requestContext: requestContext,
-          });
-
-      // const wflowAbortCb = () => {
-      //   abort();
-      // };
-      // run.abortController.signal.addEventListener('abort', wflowAbortCb);
-      // wflowAbortSignal.addEventListener('abort', async () => {
-      //   run.abortController.signal.removeEventListener('abort', wflowAbortCb);
-      //   await run.cancel();
-      // });
-
-      // let result: any;
-      // let stepResults: Record<string, any> = {};
-      let workflowCancelled = false;
-      let chunks: ChunkType[] = [];
-      for await (const chunk of stream.fullStream) {
-        chunks.push(chunk);
-        await writer?.write({
-          type: `workflow-execution-event-${chunk.type}`,
-          payload: {
-            ...chunk,
-            runId: stepId,
-          },
-          from: ChunkFrom.NETWORK,
-          runId,
-        });
-        if (chunk.type === 'workflow-canceled') {
-          workflowCancelled = true;
-        }
-      }
-
-      let runSuccess = true;
-
-      const workflowState = await stream.result;
-
-      if (!workflowState?.status || workflowState?.status === 'failed') {
-        runSuccess = false;
-      }
-
-      let resumeSchema;
-      let suspendPayload;
-      if (workflowState?.status === 'suspended') {
-        const suspendedStep = workflowState?.suspended?.[0]?.[0]!;
-        suspendPayload = workflowState?.steps?.[suspendedStep]?.suspendPayload;
-        if (suspendPayload?.__workflow_meta) {
-          delete suspendPayload.__workflow_meta;
-        }
-        const firstSuspendedStepPath = [...(workflowState?.suspended?.[0] ?? [])];
-        let wflowStep = wf;
-        while (firstSuspendedStepPath.length > 0) {
-          const key = firstSuspendedStepPath.shift();
-          if (key) {
-            if (!wflowStep.steps[key]) {
-              mastra?.getLogger()?.warn(`Suspended step '${key}' not found in workflow '${workflowId}'`);
-              break;
-            }
-            wflowStep = wflowStep.steps[key] as any;
-          }
-        }
-        const wflowStepSchema = (wflowStep as Step<any, any, any, any, any, any>)?.resumeSchema;
-        if (wflowStepSchema) {
-          resumeSchema = JSON.stringify(schemaToJsonSchema(wflowStepSchema));
-        } else {
-          resumeSchema = '';
-        }
-      }
-
-      const finalResult = JSON.stringify({
-        isNetwork: true,
-        primitiveType: inputData.primitiveType,
-        primitiveId: inputData.primitiveId,
-        selectionReason: inputData.selectionReason,
-        input,
-        finalResult: {
-          runId: run.runId,
-          runResult: workflowState,
-          chunks,
-          runSuccess,
-        },
-      });
-
-      const memory = await agent.getMemory({ requestContext: requestContext });
-      const initData = await getInitData<{ threadId: string; threadResourceId: string }>();
-
-      // When the workflow was cancelled due to abort, skip saving results to memory
-      if (workflowCancelled && abortSignal?.aborted) {
-        return handleAbort({
-          writer,
-          eventType: 'workflow-execution-abort',
-          primitiveType: 'workflow',
-          primitiveId: inputData.primitiveId,
-          iteration: inputData.iteration,
-          task: inputData.task,
-        });
-      }
-
-      await saveMessagesWithProcessors(
-        memory,
-        [
-          {
-            id: generateId({
-              idType: 'message',
-              source: 'workflow',
-              entityId: wf.id,
-              threadId: initData?.threadId || runId,
-              resourceId: initData?.threadResourceId || networkName,
-              role: 'assistant',
-            }),
-            type: 'text',
-            role: 'assistant',
-            content: {
-              parts: [{ type: 'text', text: finalResult }],
-              format: 2,
-              metadata: {
-                mode: 'network',
-                ...(suspendPayload
-                  ? {
-                      suspendedTools: {
-                        [inputData.primitiveId]: {
-                          args: input,
-                          suspendPayload,
-                          runId,
-                          type: 'suspension',
-                          resumeSchema,
-                          workflowId,
-                          primitiveType: 'workflow',
-                          primitiveId: inputData.primitiveId,
-                          toolName: inputData.primitiveId,
-                          toolCallId: inputData.primitiveId,
-                        },
-                      },
-                    }
-                  : {}),
-              },
-            },
-            createdAt: new Date(),
-            threadId: initData?.threadId || runId,
-            resourceId: initData?.threadResourceId || networkName,
-          },
-        ] as MastraDBMessage[],
-        processorRunner,
-        { requestContext },
-      );
-
-      if (suspendPayload) {
-        await writer?.write({
-          type: 'workflow-execution-suspended',
-          payload: {
-            args: input,
-            workflowId,
-            suspendPayload,
-            resumeSchema,
-            name: wf.name,
-            runId: stepId,
-            usage: await stream.usage,
-            selectionReason: inputData.selectionReason,
-            toolName: inputData.primitiveId,
-            toolCallId: inputData.primitiveId,
-          },
-          from: ChunkFrom.NETWORK,
-          runId,
-        });
-        return suspend({ ...toolData, workflowSuspended: suspendPayload });
-      } else {
-        const endPayload = {
-          task: inputData.task,
-          primitiveId: inputData.primitiveId,
-          primitiveType: inputData.primitiveType,
-          result: finalResult,
-          isComplete: false,
-          iteration: inputData.iteration,
+      try {
+        const toolData = {
+          workflowId: wf.id,
+          args: inputData,
+          runId: stepId,
         };
 
         await writer?.write({
-          type: 'workflow-execution-end',
-          payload: {
-            ...endPayload,
-            result: workflowState,
-            name: wf.name,
-            runId: stepId,
-            usage: await stream.usage,
-          },
+          type: 'workflow-execution-start',
+          payload: toolData,
           from: ChunkFrom.NETWORK,
           runId,
         });
 
-        return endPayload;
+        const stream = resumeData
+          ? run.resumeStream({
+              resumeData,
+              requestContext: requestContext,
+            })
+          : run.stream({
+              inputData: input,
+              requestContext: requestContext,
+            });
+
+        // const wflowAbortCb = () => {
+        //   abort();
+        // };
+        // run.abortController.signal.addEventListener('abort', wflowAbortCb);
+        // wflowAbortSignal.addEventListener('abort', async () => {
+        //   run.abortController.signal.removeEventListener('abort', wflowAbortCb);
+        //   await run.cancel();
+        // });
+
+        // let result: any;
+        // let stepResults: Record<string, any> = {};
+        let workflowCancelled = false;
+        let chunks: ChunkType[] = [];
+        for await (const chunk of stream.fullStream) {
+          chunks.push(chunk);
+          await writer?.write({
+            type: `workflow-execution-event-${chunk.type}`,
+            payload: {
+              ...chunk,
+              runId: stepId,
+            },
+            from: ChunkFrom.NETWORK,
+            runId,
+          });
+          if (chunk.type === 'workflow-canceled') {
+            workflowCancelled = true;
+          }
+        }
+
+        let runSuccess = true;
+
+        const workflowState = await stream.result;
+
+        if (!workflowState?.status || workflowState?.status === 'failed') {
+          runSuccess = false;
+        }
+
+        let resumeSchema;
+        let suspendPayload;
+        if (workflowState?.status === 'suspended') {
+          const suspendedStep = workflowState?.suspended?.[0]?.[0]!;
+          suspendPayload = workflowState?.steps?.[suspendedStep]?.suspendPayload;
+          if (suspendPayload?.__workflow_meta) {
+            delete suspendPayload.__workflow_meta;
+          }
+          const firstSuspendedStepPath = [...(workflowState?.suspended?.[0] ?? [])];
+          let wflowStep = wf;
+          while (firstSuspendedStepPath.length > 0) {
+            const key = firstSuspendedStepPath.shift();
+            if (key) {
+              if (!wflowStep.steps[key]) {
+                mastra?.getLogger()?.warn(`Suspended step '${key}' not found in workflow '${workflowId}'`);
+                break;
+              }
+              wflowStep = wflowStep.steps[key] as any;
+            }
+          }
+          const wflowStepSchema = (wflowStep as Step<any, any, any, any, any, any>)?.resumeSchema;
+          if (wflowStepSchema) {
+            resumeSchema = JSON.stringify(schemaToJsonSchema(wflowStepSchema));
+          } else {
+            resumeSchema = '';
+          }
+        }
+
+        const finalResult = JSON.stringify({
+          isNetwork: true,
+          primitiveType: inputData.primitiveType,
+          primitiveId: inputData.primitiveId,
+          selectionReason: inputData.selectionReason,
+          input,
+          finalResult: {
+            runId: run.runId,
+            runResult: workflowState,
+            chunks,
+            runSuccess,
+          },
+        });
+
+        const memory = await agent.getMemory({ requestContext: requestContext });
+        const initData = await getInitData<{ threadId: string; threadResourceId: string }>();
+
+        // When the workflow was cancelled due to abort, skip saving results to memory
+        if (workflowCancelled && abortSignal?.aborted) {
+          return handleAbort({
+            writer,
+            eventType: 'workflow-execution-abort',
+            primitiveType: 'workflow',
+            primitiveId: inputData.primitiveId,
+            iteration: inputData.iteration,
+            task: inputData.task,
+          });
+        }
+
+        await saveMessagesWithProcessors(
+          memory,
+          [
+            {
+              id: generateId({
+                idType: 'message',
+                source: 'workflow',
+                entityId: wf.id,
+                threadId: initData?.threadId || runId,
+                resourceId: initData?.threadResourceId || networkName,
+                role: 'assistant',
+              }),
+              type: 'text',
+              role: 'assistant',
+              content: {
+                parts: [{ type: 'text', text: finalResult }],
+                format: 2,
+                metadata: {
+                  mode: 'network',
+                  ...(suspendPayload
+                    ? {
+                        suspendedTools: {
+                          [inputData.primitiveId]: {
+                            args: input,
+                            suspendPayload,
+                            runId,
+                            type: 'suspension',
+                            resumeSchema,
+                            workflowId,
+                            primitiveType: 'workflow',
+                            primitiveId: inputData.primitiveId,
+                            toolName: inputData.primitiveId,
+                            toolCallId: inputData.primitiveId,
+                          },
+                        },
+                      }
+                    : {}),
+                },
+              },
+              createdAt: new Date(),
+              threadId: initData?.threadId || runId,
+              resourceId: initData?.threadResourceId || networkName,
+            },
+          ] as MastraDBMessage[],
+          processorRunner,
+          { requestContext },
+        );
+
+        if (suspendPayload) {
+          await writer?.write({
+            type: 'workflow-execution-suspended',
+            payload: {
+              args: input,
+              workflowId,
+              suspendPayload,
+              resumeSchema,
+              name: wf.name,
+              runId: stepId,
+              usage: await stream.usage,
+              selectionReason: inputData.selectionReason,
+              toolName: inputData.primitiveId,
+              toolCallId: inputData.primitiveId,
+            },
+            from: ChunkFrom.NETWORK,
+            runId,
+          });
+          return suspend({ ...toolData, workflowSuspended: suspendPayload });
+        } else {
+          const endPayload = {
+            task: inputData.task,
+            primitiveId: inputData.primitiveId,
+            primitiveType: inputData.primitiveType,
+            result: finalResult,
+            isComplete: false,
+            iteration: inputData.iteration,
+          };
+
+          await writer?.write({
+            type: 'workflow-execution-end',
+            payload: {
+              ...endPayload,
+              result: workflowState,
+              name: wf.name,
+              runId: stepId,
+              usage: await stream.usage,
+            },
+            from: ChunkFrom.NETWORK,
+            runId,
+          });
+
+          return endPayload;
+        }
+      } finally {
+        abortSignal?.removeEventListener('abort', networkAbortCb);
+        await cancellation;
       }
     },
   });

--- a/packages/core/src/loop/network/workflow-cancellation.test.ts
+++ b/packages/core/src/loop/network/workflow-cancellation.test.ts
@@ -1,0 +1,105 @@
+import { getEventListeners } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import z from 'zod';
+import { Memory } from '../../../../memory/src';
+import { Agent } from '../../agent';
+import { Mastra } from '../../mastra';
+import { RequestContext } from '../../request-context';
+import { InMemoryStore } from '../../storage';
+import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
+import { createStep, createWorkflow } from '../../workflows';
+import { createNetworkLoop } from './index';
+
+describe('network workflow cancellation ownership', () => {
+  it.each(['complete', 'abort', 'write failure'] as const)(
+    '%s observes cancellation and removes its listener',
+    async mode => {
+      const network = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('External network forbidden'));
+      const storage = new InMemoryStore();
+      const memory = new Memory({ storage });
+      await memory.saveThread({
+        thread: { id: 'thread', resourceId: 'resource', title: 'Local', createdAt: new Date(), updatedAt: new Date() },
+      });
+      const signal = new AbortController();
+      const entered = Promise.withResolvers<void>();
+      const child = createWorkflow({ id: 'child', inputSchema: z.object({}), outputSchema: z.object({}) })
+        .then(
+          createStep({
+            id: 'local',
+            inputSchema: z.object({}),
+            outputSchema: z.object({}),
+            execute: async ({ abortSignal }) => {
+              entered.resolve();
+              if (mode !== 'complete')
+                await new Promise<void>(resolve =>
+                  abortSignal.addEventListener('abort', () => resolve(), { once: true }),
+                );
+              return {};
+            },
+          }),
+        )
+        .commit();
+      const model = new MastraLanguageModelV2Mock({
+        doStream: async () => {
+          throw new Error('No model should run');
+        },
+      });
+      const agent = new Agent({
+        id: 'network-owner',
+        name: 'Owner',
+        instructions: 'Use child.',
+        model,
+        memory,
+        workflows: { child },
+      });
+      const mastra = new Mastra({
+        agents: { agent },
+        workflows: { child },
+        storage,
+        logger: false,
+        workers: false,
+        scheduler: { enabled: false },
+      });
+      const requestContext = new RequestContext();
+      const { networkWorkflow } = await createNetworkLoop({
+        networkName: 'local-network',
+        requestContext,
+        runId: 'local-network-run',
+        agent,
+        generateId: () => 'local-id',
+        abortSignal: signal.signal,
+      });
+      const step = networkWorkflow.steps['workflow-execution-step'];
+      const failure = new Error('Cancellation storage unavailable');
+      const workflows = (await storage.getStore('workflows'))!;
+      let write: ReturnType<typeof vi.spyOn> | undefined;
+      const execution = step.execute!({
+        inputData: {
+          task: 'Local',
+          primitiveType: 'workflow',
+          primitiveId: 'child',
+          prompt: '{}',
+          selectionReason: 'Local',
+          iteration: 1,
+        },
+        requestContext,
+        mastra,
+        writer: { write: async () => {} },
+        getInitData: () => ({ threadId: 'thread', threadResourceId: 'resource' }),
+      } as any);
+      try {
+        await entered.promise;
+        if (mode === 'write failure') write = vi.spyOn(workflows, 'updateWorkflowState').mockRejectedValueOnce(failure);
+        const result = Promise.resolve(execution);
+        if (mode !== 'complete') signal.abort();
+        if (mode === 'write failure') await expect(result).rejects.toBe(failure);
+        else await expect(result).resolves.toBeDefined();
+        expect(getEventListeners(signal.signal, 'abort')).toHaveLength(0);
+        expect(network).not.toHaveBeenCalled();
+      } finally {
+        write?.mockRestore();
+        network.mockRestore();
+      }
+    },
+  );
+});

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -746,6 +746,8 @@ export class Mastra<
   #storageExplicit = false;
   #storageFallbackWarningPending = false;
   #recoveryConfig: MastraRecoveryConfig = { durableAgents: 'off' };
+  #durableAgentRecoveries = new Set<Promise<unknown>>();
+  #shutdownStarted = false;
   #scorers?: TScorers;
   #tools?: TTools;
   #processors?: TProcessors;
@@ -3898,6 +3900,11 @@ export class Mastra<
     return this.#recoveryConfig;
   }
 
+  /** Whether shutdown has closed admission for new durable-agent recovery. */
+  get isShuttingDown(): boolean {
+    return this.#shutdownStarted;
+  }
+
   /**
    * Re-drive every orphaned RUNNING durable-agent run across every registered
    * `DurableAgent`. Delegates to `DurableAgent.recoverActiveRuns()` on each
@@ -3915,6 +3922,29 @@ export class Mastra<
    * counts.
    */
   public async recoverAllDurableAgents(): Promise<{
+    agents: number;
+    recovered: number;
+    succeeded: number;
+    failed: number;
+  }> {
+    if (this.#shutdownStarted) {
+      throw new MastraError({
+        id: 'MASTRA_DURABLE_RECOVERY_SHUTDOWN',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        text: 'Cannot recover durable agents after Mastra shutdown has started.',
+      });
+    }
+    const recovery = this.#recoverAllDurableAgents();
+    this.#durableAgentRecoveries.add(recovery);
+    try {
+      return await recovery;
+    } finally {
+      this.#durableAgentRecoveries.delete(recovery);
+    }
+  }
+
+  async #recoverAllDurableAgents(): Promise<{
     agents: number;
     recovered: number;
     succeeded: number;
@@ -3945,6 +3975,7 @@ export class Mastra<
     let failed = 0;
 
     for (const agent of durableAgents) {
+      if (this.#shutdownStarted) break;
       try {
         const result = await agent.recoverActiveRuns();
         recovered += result.recovered.length;
@@ -6901,6 +6932,7 @@ export class Mastra<
    * ```
    */
   async shutdown(): Promise<void> {
+    this.#shutdownStarted = true;
     // The scorer hook lives on a process-global emitter. Release it before any
     // awaited teardown so even a later cleanup failure cannot retain this
     // Mastra instance and its full component graph.
@@ -6916,6 +6948,10 @@ export class Mastra<
 
     // SchedulerWorker is stopped as part of stopWorkers().
     await this.stopWorkers();
+
+    // Discovery can still be reading storage before a run enters the registry.
+    // Admission is closed; keep storage open until these reads settle.
+    await Promise.allSettled(this.#durableAgentRecoveries);
 
     // Durable workflows may still be persisting their next terminal or suspended
     // snapshot. Keep storage and other shared resources alive until they settle.

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -747,7 +747,10 @@ export class Mastra<
   #storageFallbackWarningPending = false;
   #recoveryConfig: MastraRecoveryConfig = { durableAgents: 'off' };
   #durableAgentRecoveries = new Set<Promise<unknown>>();
+  #durableAgentCancellations = new Set<Promise<void>>();
+  #durableAgentCancellationErrors: unknown[] = [];
   #shutdownStarted = false;
+  #shutdownPromise?: Promise<void>;
   #scorers?: TScorers;
   #tools?: TTools;
   #processors?: TProcessors;
@@ -6931,8 +6934,34 @@ export class Mastra<
    * });
    * ```
    */
-  async shutdown(): Promise<void> {
+  shutdown(): Promise<void> {
+    if (this.#shutdownPromise) return this.#shutdownPromise;
     this.#shutdownStarted = true;
+    this.#shutdownPromise = Promise.resolve().then(() => this.#shutdown());
+    return this.#shutdownPromise;
+  }
+
+  /**
+   * Admit a native Stop before its first storage read. The operation must await
+   * all discovered cancellation writes; it must not dispatch detached cleanup.
+   * @internal
+   */
+  __runDurableAgentCancellation(operation: () => Promise<void>): Promise<void> {
+    if (this.#shutdownStarted)
+      return Promise.reject(new Error('Mastra is shutting down; cancellation admission is closed'));
+    const cancellation = Promise.resolve().then(operation);
+    this.#durableAgentCancellations.add(cancellation);
+    void cancellation.then(
+      () => this.#durableAgentCancellations.delete(cancellation),
+      error => {
+        this.#durableAgentCancellationErrors.push(error);
+        this.#durableAgentCancellations.delete(cancellation);
+      },
+    );
+    return cancellation;
+  }
+
+  async #shutdown(): Promise<void> {
     // The scorer hook lives on a process-global emitter. Release it before any
     // awaited teardown so even a later cleanup failure cannot retain this
     // Mastra instance and its full component graph.
@@ -6963,6 +6992,11 @@ export class Mastra<
         });
       }
     });
+
+    // Accepted cold Stop discovery is not an executing workflow. Its promise
+    // includes every discovered cancellation, so no child write can outlive it.
+    // New admission closed synchronously in shutdown(), before teardown began.
+    await Promise.allSettled(this.#durableAgentCancellations);
 
     // Stop — don't destroy — registered workspaces. Remote sandboxes
     // suspend/pause and stay resumable across process restarts, and
@@ -7008,6 +7042,12 @@ export class Mastra<
     // Shutdown observability registry, exporters, etc...
     await this.#observability.shutdown();
 
+    if (this.#durableAgentCancellationErrors.length) {
+      throw new AggregateError(
+        this.#durableAgentCancellationErrors,
+        'Durable agent cancellation failed during shutdown',
+      );
+    }
     this.#logger?.info('Mastra shutdown completed');
   }
 

--- a/packages/core/src/mastra/recover-all-durable-agents.test.ts
+++ b/packages/core/src/mastra/recover-all-durable-agents.test.ts
@@ -164,4 +164,61 @@ describe('Mastra.recoverAllDurableAgents', () => {
     await Promise.resolve();
     expect(spy).not.toHaveBeenCalled();
   });
+
+  it.each([false, true])('keeps storage open while discovery is pending (rejects=%s)', async rejects => {
+    const durable = makeDurable('pending-discovery');
+    const mastra = new Mastra({ agents: { durable }, storage: store, logger: false });
+    const workflows = (await store.getStore('workflows'))!;
+    await workflows.persistWorkflowSnapshot({
+      workflowName: 'durable-agentic-loop',
+      runId: 'held-discovery-run',
+      snapshot: {
+        runId: 'held-discovery-run',
+        status: 'running',
+        context: { input: { __workflowKind: 'durable-agent', agentId: durable.id } },
+      } as any,
+    });
+    const recoverRun = vi.spyOn(durable, 'recover');
+    const read = workflows.listWorkflowRuns.bind(workflows);
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const order: string[] = [];
+    vi.spyOn(workflows, 'listWorkflowRuns').mockImplementation(async input => {
+      const rows = await read(input);
+      expect(rows.runs).toHaveLength(1);
+      entered.resolve();
+      await release.promise;
+      order.push('discovery-finished');
+      if (rejects) throw new Error('discovery failed');
+      return rows;
+    });
+    const stopWorkers = vi.spyOn(mastra, 'stopWorkers');
+    const close = vi.spyOn(store, 'close');
+    const recovery = mastra.recoverAllDurableAgents();
+    await entered.promise;
+    const shutdown = mastra.shutdown().then(() => order.push('shutdown-finished'));
+    try {
+      await new Promise(resolve => setImmediate(resolve));
+      expect(stopWorkers).toHaveBeenCalledOnce();
+      expect(close).not.toHaveBeenCalled();
+    } finally {
+      release.resolve();
+      await recovery;
+      await shutdown;
+    }
+    expect(order).toEqual(['discovery-finished', 'shutdown-finished']);
+    expect(close).toHaveBeenCalledOnce();
+    expect(recoverRun).not.toHaveBeenCalled();
+  });
+
+  it('refuses a new recovery scan once shutdown has started', async () => {
+    const durable = makeDurable('closing');
+    const mastra = new Mastra({ agents: { durable }, storage: store, logger: false });
+    const spy = vi.spyOn(durable, 'recoverActiveRuns');
+    const shutdown = mastra.shutdown();
+    await expect(mastra.recoverAllDurableAgents()).rejects.toThrow('shutdown');
+    await shutdown;
+    await expect(mastra.recoverAllDurableAgents()).rejects.toThrow('shutdown');
+    expect(spy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/mastra/shutdown.test.ts
+++ b/packages/core/src/mastra/shutdown.test.ts
@@ -15,6 +15,53 @@ function deferred<T = void>() {
 }
 
 describe('Mastra shutdown lifecycle', () => {
+  it('drains accepted cancellation, refuses new work and shares repeated shutdown', async () => {
+    const storage = new MockStore();
+    const close = vi.spyOn(storage, 'close');
+    const mastra = new Mastra({ logger: false, workers: false, storage });
+    const started = deferred();
+    const release = deferred();
+    const operation = mastra.__runDurableAgentCancellation(async () => {
+      started.resolve();
+      await release.promise;
+    });
+    await started.promise;
+    const shutdown = mastra.shutdown();
+    expect(mastra.shutdown()).toBe(shutdown);
+    const late = vi.fn(async () => {});
+    await expect(mastra.__runDurableAgentCancellation(late)).rejects.toThrow('admission is closed');
+    expect(late).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+    release.resolve();
+    await operation;
+    await shutdown;
+    expect(close).toHaveBeenCalledTimes(1);
+    await expect(mastra.__runDurableAgentCancellation(late)).rejects.toThrow('admission is closed');
+  });
+
+  it('waits every accepted Stop even when another fails and another instance shuts down', async () => {
+    const storage = new MockStore();
+    const close = vi.spyOn(storage, 'close');
+    const mastra = new Mastra({ logger: false, workers: false, storage });
+    const other = new Mastra({ logger: false, workers: false });
+    const release = deferred();
+    const failure = new Error('Cancellation write failed');
+    const failed = mastra.__runDurableAgentCancellation(async () => {
+      throw failure;
+    });
+    const pending = mastra.__runDurableAgentCancellation(() => release.promise);
+    await expect(failed).rejects.toBe(failure);
+    const shutdown = mastra.shutdown();
+    const rejection = expect(shutdown).rejects.toMatchObject({ errors: [failure] });
+    await other.shutdown();
+    expect(close).not.toHaveBeenCalled();
+    release.resolve();
+    await pending;
+    await rejection;
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(mastra.shutdown()).toBe(shutdown);
+  });
+
   it('ignores a removed cache entry refreshed by its disposal callback', async () => {
     const mastra = new Mastra({ logger: false, workers: false });
     const runId = 'removed-during-cleanup';

--- a/packages/core/src/mastra/shutdown.test.ts
+++ b/packages/core/src/mastra/shutdown.test.ts
@@ -15,6 +15,19 @@ function deferred<T = void>() {
 }
 
 describe('Mastra shutdown lifecycle', () => {
+  it('ignores a removed cache entry refreshed by its disposal callback', async () => {
+    const mastra = new Mastra({ logger: false, workers: false });
+    const runId = 'removed-during-cleanup';
+    globalRunRegistry.set(runId, { mastra, cleanup: () => globalRunRegistry.get(runId) } as any);
+    globalRunRegistry.delete(runId);
+    expect(Array.from(globalRunRegistry.values())).toContain(undefined);
+    try {
+      await expect(mastra.shutdown()).resolves.toBeUndefined();
+    } finally {
+      globalRunRegistry.clear();
+    }
+  });
+
   it('releases the process-global scorer hook', async () => {
     const baseline = __hookHandlerCount(AvailableHooks.ON_SCORER_RUN);
     const mastra = new Mastra({ logger: false, workers: false });

--- a/packages/core/src/processors/processors/skill-search.ts
+++ b/packages/core/src/processors/processors/skill-search.ts
@@ -26,10 +26,13 @@ import type { IMastraLogger } from '../../logger';
 import type { Mastra } from '../../mastra';
 import { parseMemoryRequestContext } from '../../memory/types';
 import { MASTRA_THREAD_ID_KEY } from '../../request-context';
+import type { RequestContext } from '../../request-context';
 import { createTool } from '../../tools';
+import type { Tool } from '../../tools';
 import type { WorkspaceSkills } from '../../workspace/skills';
 import type { Workspace } from '../../workspace/workspace';
 import type { ProcessInputStepArgs, Processor } from '../index';
+import { getProcessorToolOwner, markProcessorTools } from '../tool-provenance';
 
 /**
  * Thread state with timestamp for TTL management
@@ -168,7 +171,7 @@ export class SkillSearchProcessor implements Processor<'skill-search'> {
    * resolving the thread (covers HTTP calls that pass the thread via
    * `memory.thread`).
    */
-  private getThreadId(args: ProcessInputStepArgs): string {
+  private getThreadId(args: Pick<ProcessInputStepArgs, 'requestContext'>): string {
     return (
       (args.requestContext?.get(MASTRA_THREAD_ID_KEY) as string | undefined) ||
       parseMemoryRequestContext(args.requestContext)?.thread?.id ||
@@ -269,42 +272,32 @@ export class SkillSearchProcessor implements Processor<'skill-search'> {
     return this.cleanupStaleState();
   }
 
-  async processInputStep(args: ProcessInputStepArgs) {
-    const { tools, messageList } = args;
-    const threadId = this.getThreadId(args);
-    const threadState = this.getThreadState(threadId);
+  /** Rebuild native discovery tools before a saved approval enters tool execution. */
+  public async getLoadedToolsForRequestContext(args?: {
+    requestContext?: RequestContext;
+    tools?: Record<string, unknown>;
+    includeMetaTools?: boolean;
+  }): Promise<Record<string, Tool<any, any>>> {
+    if (!args?.includeMetaTools) return {};
     const configuredSkills = this.skills;
-
-    if (!configuredSkills) {
-      return { tools };
-    }
-
+    if (!configuredSkills) return {};
     const skills = configuredSkills.getScoped
-      ? await configuredSkills.getScoped({ requestContext: args.requestContext })
+      ? await configuredSkills.getScoped({ requestContext: args?.requestContext })
       : configuredSkills;
+    const metaTools = this.createMetaTools(skills, this.getThreadState(this.getThreadId(args)));
+    this.warnMetaToolConflicts(args.tools, metaTools);
+    return metaTools;
+  }
 
-    // Revalidate skills on first step only. Fire-and-forget by default: the
-    // staleness walk can cost seconds of filesystem I/O over remote sandboxes,
-    // so the turn proceeds on the cached catalog while the walk runs in the
-    // background. Rejections are contained (an unhandled rejection in a
-    // processor can kill the process) but logged so sandbox outages stay
-    // visible. With blockingRefresh the walk is awaited so search results
-    // reflect disk.
-    if (args.stepNumber === 0) {
-      if (this.blockingRefresh) {
-        await skills.maybeRefresh({ requestContext: args.requestContext })?.catch(this.warnRefreshFailed);
-      } else {
-        void skills.maybeRefresh({ requestContext: args.requestContext })?.catch(this.warnRefreshFailed);
+  private warnMetaToolConflicts(tools: Record<string, unknown> | undefined, metaTools: Record<string, unknown>) {
+    for (const key of Object.keys(tools ?? {})) {
+      if (key in metaTools && getProcessorToolOwner(tools?.[key]) !== this.id) {
+        console.warn(`[SkillSearchProcessor] User tool "${key}" conflicts with meta-tool and will be shadowed.`);
       }
     }
+  }
 
-    // Add system instruction about the meta-tools
-    messageList.addSystem(
-      'To discover available skills, call search_skills with a keyword query. ' +
-        "To load a skill's instructions, call load_skill with the skill name. " +
-        'Loaded skills provide context and instructions for the conversation.',
-    );
-
+  private createMetaTools(skills: WorkspaceSkills, threadState: ThreadState) {
     // Create the search_skills meta-tool
     const searchSkillTool = createTool({
       id: 'search_skills',
@@ -430,19 +423,53 @@ export class SkillSearchProcessor implements Processor<'skill-search'> {
       },
     });
 
+    return markProcessorTools({ search_skills: searchSkillTool, load_skill: loadSkillTool }, this.id);
+  }
+
+  async processInputStep(args: ProcessInputStepArgs) {
+    const { tools, messageList } = args;
+    const threadId = this.getThreadId(args);
+    const threadState = this.getThreadState(threadId);
+    const configuredSkills = this.skills;
+
+    if (!configuredSkills) {
+      return { tools };
+    }
+
+    const skills = configuredSkills.getScoped
+      ? await configuredSkills.getScoped({ requestContext: args.requestContext })
+      : configuredSkills;
+
+    // Revalidate skills on first step only. Fire-and-forget by default: the
+    // staleness walk can cost seconds of filesystem I/O over remote sandboxes,
+    // so the turn proceeds on the cached catalog while the walk runs in the
+    // background. Rejections are contained (an unhandled rejection in a
+    // processor can kill the process) but logged so sandbox outages stay
+    // visible. With blockingRefresh the walk is awaited so search results
+    // reflect disk.
+    if (args.stepNumber === 0) {
+      if (this.blockingRefresh) {
+        await skills.maybeRefresh({ requestContext: args.requestContext })?.catch(this.warnRefreshFailed);
+      } else {
+        void skills.maybeRefresh({ requestContext: args.requestContext })?.catch(this.warnRefreshFailed);
+      }
+    }
+
+    // Add system instruction about the meta-tools
+    messageList.addSystem(
+      'To discover available skills, call search_skills with a keyword query. ' +
+        "To load a skill's instructions, call load_skill with the skill name. " +
+        'Loaded skills provide context and instructions for the conversation.',
+    );
+
+    const metaTools = this.createMetaTools(skills, threadState);
+
     // Build system messages for loaded skills
     for (const [skillName, instructions] of threadState.skills) {
       messageList.addSystem(`[Skill: ${skillName}]\n\n${instructions}`);
     }
 
-    const metaTools = { search_skills: searchSkillTool, load_skill: loadSkillTool };
-    if (tools) {
-      for (const key of Object.keys(tools)) {
-        if (key in metaTools) {
-          console.warn(`[SkillSearchProcessor] User tool "${key}" conflicts with meta-tool and will be shadowed.`);
-        }
-      }
-    }
+    this.warnMetaToolConflicts(tools, metaTools);
 
     return {
       tools: {

--- a/packages/core/src/processors/processors/tool-search.ts
+++ b/packages/core/src/processors/processors/tool-search.ts
@@ -7,6 +7,7 @@ import type { Tool } from '../../tools';
 import { BM25Index } from '../../workspace/search/bm25';
 import type { TokenizeOptions } from '../../workspace/search/bm25';
 import type { ProcessInputStepArgs, Processor } from '../index';
+import { getProcessorToolOwner, markProcessorTools } from '../tool-provenance';
 import type { LoadedToolStore, LoadedToolStoreContext } from './tool-search-stores';
 import { LegacyMapLoadedToolStore, ContextLoadedToolStore } from './tool-search-stores';
 
@@ -378,21 +379,27 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
     requestContext?: RequestContext;
     stepArgs?: ProcessInputStepArgs;
     tools?: Record<string, unknown>;
+    /** Include native discovery tools when rebuilding an agent's executors. */
+    includeMetaTools?: boolean;
   }): Promise<Record<string, Tool<any, any>>> {
-    if (args?.stepArgs) {
-      const loadedNames = await this.store.getLoadedNames(this.makeStoreContext(args.stepArgs));
-      // Fall back to the step's own request context so active-phase filtering still
-      // runs when the caller only supplies stepArgs.
-      return this.getLoadedTools(
-        this.catalogForStep(args.stepArgs.tools),
-        loadedNames,
-        args.requestContext ?? args.stepArgs.requestContext,
-      );
-    }
-
-    const threadId = this.resolveThreadId(args?.requestContext);
-    const loadedNames = await this.store.getLoadedNames({ threadId, args: undefined });
-    return this.getLoadedTools(this.catalogForStep(args?.tools), loadedNames, args?.requestContext);
+    const requestContext = args?.requestContext ?? args?.stepArgs?.requestContext;
+    const resolvedTools = args?.stepArgs ? args.stepArgs.tools : args?.tools;
+    const catalog = this.catalogForStep(resolvedTools);
+    const storeContext = args?.stepArgs
+      ? this.makeStoreContext(args.stepArgs)
+      : { threadId: this.resolveThreadId(requestContext), args: undefined };
+    const loadedNames = await this.store.getLoadedNames(storeContext);
+    const loadedTools = await this.getLoadedTools(catalog, loadedNames, requestContext);
+    if (!args?.includeMetaTools) return loadedTools;
+    const metaTools = this.createMetaTools(catalog, storeContext, loadedNames, requestContext);
+    return {
+      ...Object.fromEntries(
+        Object.entries(metaTools).filter(
+          ([name]) => !resolvedTools?.[name] || getProcessorToolOwner(resolvedTools[name]) === this.id,
+        ),
+      ),
+      ...loadedTools,
+    };
   }
 
   /**
@@ -508,27 +515,13 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
     });
   }
 
-  async processInputStep(args: ProcessInputStepArgs) {
-    const { tools, messageList } = args;
-    const catalog = this.catalogForStep(tools);
-    const storeContext = this.makeStoreContext(args);
-    // Snapshot of names already loaded as of this step. Newly activated tools are
-    // recorded via the store and become available on the model's next turn.
-    const loadedToolNames = await this.store.getLoadedNames(storeContext);
-
+  private createMetaTools(
+    catalog: ToolCatalog,
+    storeContext: LoadedToolStoreContext,
+    loadedToolNames: Set<string>,
+    requestContext?: RequestContext,
+  ) {
     const autoLoad = this.searchConfig.autoLoad;
-
-    // Add system instruction about the meta-tools
-    messageList.addSystem(
-      autoLoad
-        ? 'To discover available tools, call search_tools with a keyword query. ' +
-            'Matching tools are loaded automatically and become available on your next turn — ' +
-            'there is no separate load step. After searching, use the tool directly.'
-        : 'To discover available tools, call search_tools with a keyword query. ' +
-            'To add one or more tools to the conversation, call load_tool with a toolName or toolNames array. ' +
-            'Tools must be loaded before they can be used.',
-    );
-
     // Create the search tool with BM25 ranking
     const searchTool = createTool({
       id: 'search_tools',
@@ -556,7 +549,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
       }),
       execute: async ({ query }) => {
         // Use BM25 search for relevance-ranked results
-        const results = await this.searchTools(catalog, query, args.requestContext);
+        const results = await this.searchTools(catalog, query, requestContext);
 
         if (results.length === 0) {
           return {
@@ -656,7 +649,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
             continue;
           }
 
-          const isAllowed = await this.isToolAllowed(matchingTool, args.requestContext, 'load');
+          const isAllowed = await this.isToolAllowed(matchingTool, requestContext, 'load');
           if (!isAllowed) {
             notFound.push(name);
             continue;
@@ -682,7 +675,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
           // Single-tool response (backward compatible shape)
           if (notFound.length > 0) {
             const name = toLoad[0]!;
-            const suggestions = await this.getSuggestedToolNames(catalog, name, args.requestContext);
+            const suggestions = await this.getSuggestedToolNames(catalog, name, requestContext);
             let message = `Tool "${name}" not found.`;
             if (suggestions.length > 0) {
               message += ` Did you mean: ${suggestions.slice(0, 3).join(', ')}?`;
@@ -722,8 +715,41 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
       },
     });
 
+    return markProcessorTools({ search_tools: searchTool, ...(autoLoad ? {} : { load_tool: loadTool }) }, this.id);
+  }
+
+  async processInputStep(args: ProcessInputStepArgs) {
+    const { tools, messageList } = args;
+    const catalog = this.catalogForStep(tools);
+    const storeContext = this.makeStoreContext(args);
+    // Snapshot of names already loaded as of this step. Newly activated tools are
+    // recorded via the store and become available on the model's next turn.
+    const loadedToolNames = await this.store.getLoadedNames(storeContext);
+
+    const autoLoad = this.searchConfig.autoLoad;
+
+    // Add system instruction about the meta-tools
+    messageList.addSystem(
+      autoLoad
+        ? 'To discover available tools, call search_tools with a keyword query. ' +
+            'Matching tools are loaded automatically and become available on your next turn — ' +
+            'there is no separate load step. After searching, use the tool directly.'
+        : 'To discover available tools, call search_tools with a keyword query. ' +
+            'To add one or more tools to the conversation, call load_tool with a toolName or toolNames array. ' +
+            'Tools must be loaded before they can be used.',
+    );
+
+    const metaTools = this.createMetaTools(catalog, storeContext, loadedToolNames, args.requestContext);
+
     // Get loaded tools as of this step's snapshot.
     const loadedTools = await this.getLoadedTools(catalog, loadedToolNames, args.requestContext);
+    // Replace only our own earlier meta-tool closures. Explicit user overrides
+    // retain their existing precedence over the processor's generated tools.
+    const existingTools = Object.fromEntries(
+      Object.entries(tools ?? {}).filter(
+        ([name, tool]) => !META_TOOL_NAMES.has(name) || getProcessorToolOwner(tool) !== this.id,
+      ),
+    );
 
     // Return merged tools, ordered to keep the cacheable prefix stable:
     // meta-tool(s) first (always present, fixed position), then existing tools,
@@ -732,13 +758,11 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
     // not invalidated when a tool is loaded mid-conversation.
     return {
       tools: {
-        search_tools: searchTool,
-        // load_tool is omitted in auto-load mode — search_tools activates matches directly.
-        ...(autoLoad ? {} : { load_tool: loadTool }),
+        ...metaTools,
         // When request-resolved tools are searchable they are withheld here:
         // leaving them in would defeat the point, since they would still occupy
         // prompt space. They come back through `loadedTools` once loaded.
-        ...(this.includeResolvedTools ? unsearchableResolvedTools(tools) : (tools ?? {})),
+        ...(this.includeResolvedTools ? unsearchableResolvedTools(existingTools) : existingTools),
         ...loadedTools,
       },
     };

--- a/packages/core/src/processors/tool-provenance.ts
+++ b/packages/core/src/processors/tool-provenance.ts
@@ -1,0 +1,15 @@
+/** In-process provenance only. Symbols are omitted from persisted tool schemas. */
+export const PROCESSOR_TOOL_OWNER = Symbol('mastra.processorToolOwner');
+
+export function getProcessorToolOwner(tool: unknown): string | undefined {
+  return typeof tool === 'object' && tool !== null
+    ? (tool as { [PROCESSOR_TOOL_OWNER]?: string })[PROCESSOR_TOOL_OWNER]
+    : undefined;
+}
+
+export function markProcessorTools<T extends Record<string, object>>(tools: T, processorId: string): T {
+  for (const tool of Object.values(tools)) {
+    Object.defineProperty(tool, PROCESSOR_TOOL_OWNER, { value: processorId, enumerable: true });
+  }
+  return tools;
+}

--- a/packages/core/src/tools/builtin/web-fetch.test.ts
+++ b/packages/core/src/tools/builtin/web-fetch.test.ts
@@ -1,7 +1,10 @@
-import { EventEmitter } from 'node:events';
-import { Readable } from 'node:stream';
+import { EventEmitter, getEventListeners } from 'node:events';
+import type { ClientRequest } from 'node:http';
+import net from 'node:net';
+import { Duplex, Readable } from 'node:stream';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
 
 const mocks = vi.hoisted(() => ({
   dnsLookup: vi.fn(),
@@ -35,6 +38,7 @@ vi.mock('node:https', async () => {
   };
 });
 
+import { createStep, createWorkflow } from '../../workflows';
 import { webFetchTool as exportedWebFetchTool } from '../index';
 import { webFetchTool } from './web-fetch';
 
@@ -101,6 +105,7 @@ function createResponse(
 describe('webFetchTool', () => {
   afterEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it('fetches a URL and returns response metadata', async () => {
@@ -245,12 +250,11 @@ describe('webFetchTool', () => {
       statusMessage: 'Found',
       headers: { location: 'http://169.254.169.254/latest/meta-data' },
     });
-    response.resume = vi.fn();
     mockRequest(response);
 
     const result = await (webFetchTool as any).execute({ url: 'https://example.com/redirect' }, {});
 
-    expect(response.resume).toHaveBeenCalled();
+    expect(response.destroy).toHaveBeenCalled();
     expect(result).toEqual({
       content: 'Failed to fetch URL: URL resolves to a private or reserved address.',
       isError: true,
@@ -274,5 +278,224 @@ describe('webFetchTool', () => {
 
   it('is exported from the tools index', () => {
     expect(exportedWebFetchTool).toBe(webFetchTool);
+  });
+});
+
+describe('webFetchTool cancellation and deadline', () => {
+  const sockets: Duplex[] = [];
+  const requests: ClientRequest[] = [];
+  const flush = () => new Promise(resolve => setImmediate(resolve));
+
+  // Keep Node's real ClientRequest, HTTP parser, IncomingMessage and signal handling.
+  // Only socket creation is replaced, so these cases cannot connect to a network.
+  async function useLocalSockets(pendingDns = false) {
+    const actualHttp = await vi.importActual<typeof import('node:http')>('node:http');
+    vi.spyOn(net.Socket.prototype, 'connect').mockImplementation(() => {
+      throw new Error('Real network connections are forbidden in this test');
+    });
+    mocks.httpRequest.mockImplementation((url, options, callback) => {
+      const socket = Object.assign(
+        new Duplex({
+          read() {},
+          write(_chunk, _encoding, done) {
+            done();
+          },
+        }),
+        { setTimeout: vi.fn(), setNoDelay: vi.fn(), setKeepAlive: vi.fn() },
+      );
+      sockets.push(socket);
+      const agent = new actualHttp.Agent({ keepAlive: false });
+      agent.createConnection = connectionOptions => {
+        if (pendingDns) {
+          Object.assign(socket, { connecting: true });
+          mocks.dnsLookup.mockImplementation(() => {});
+          connectionOptions.lookup!('example.com', {}, () => {});
+        }
+        return socket as unknown as net.Socket;
+      };
+      const request = actualHttp.request(url, { ...options, agent }, callback);
+      requests.push(request);
+      return request;
+    });
+    mocks.httpsRequest.mockImplementation(() => {
+      throw new Error('Unexpected HTTPS request in a socket-only test');
+    });
+  }
+
+  afterEach(async () => {
+    for (const request of requests) request.destroy();
+    for (const socket of sockets) socket.destroy();
+    await flush();
+    sockets.length = 0;
+    requests.length = 0;
+    expect(net.Socket.prototype.connect).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+    vi.resetAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('does not start a request when native cancellation already happened', async () => {
+    await useLocalSockets();
+    const reason = new Error('Owner stopped the run');
+    const promise = (webFetchTool as any).execute(
+      { url: 'http://example.com' },
+      { abortSignal: AbortSignal.abort(reason) },
+    );
+    let outcome: unknown;
+    promise.then(
+      (value: unknown) => {
+        outcome = value;
+      },
+      (error: unknown) => {
+        outcome = error;
+      },
+    );
+    await flush();
+    expect(outcome).toBe(reason);
+    expect(mocks.httpRequest).not.toHaveBeenCalled();
+  });
+
+  it.each(['dns', 'headers', 'body', 'redirect'] as const)('cancels the live Node request during %s', async stage => {
+    await useLocalSockets(stage === 'dns');
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    const controller = new AbortController();
+    const reason = new Error('Owner stopped the run');
+    let outcome: unknown;
+    const promise = (webFetchTool as any).execute({ url: 'http://example.com' }, { abortSignal: controller.signal });
+    promise.then(
+      (value: unknown) => {
+        outcome = value;
+      },
+      (error: unknown) => {
+        outcome = error;
+      },
+    );
+    await flush();
+    if (stage === 'body') {
+      sockets[0]!.push('HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\npartial');
+      await flush();
+    }
+    if (stage === 'redirect') {
+      sockets[0]!.push('HTTP/1.1 302 Found\r\nLocation: /next\r\nContent-Length: 0\r\n\r\n');
+      await flush();
+      expect(requests).toHaveLength(2);
+    }
+    controller.abort(reason);
+    await flush();
+    await flush();
+    expect(outcome).toBe(reason);
+    expect(requests.every(request => request.destroyed)).toBe(true);
+    expect(sockets.every(socket => socket.destroyed)).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+    if (stage === 'dns') expect(mocks.dnsLookup).toHaveBeenCalledOnce();
+  });
+
+  it.each(['dns', 'headers', 'body', 'redirect'] as const)('applies one 15-second deadline through %s', async stage => {
+    await useLocalSockets(stage === 'dns');
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    let outcome: any;
+    const promise = (webFetchTool as any).execute({ url: 'http://example.com' }, {});
+    promise.then((value: unknown) => {
+      outcome = value;
+    });
+    await flush();
+    if (stage === 'body') {
+      sockets[0]!.push('HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n');
+      await flush();
+    }
+    await vi.advanceTimersByTimeAsync(10_000);
+    if (stage === 'body') sockets[0]!.push('still sending');
+    if (stage === 'redirect') {
+      // An unread redirect body must not outlive the final request.
+      sockets[0]!.push('HTTP/1.1 302 Found\r\nLocation: /next\r\nContent-Length: 100\r\n\r\n');
+      await flush();
+      expect(requests).toHaveLength(2);
+    }
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(outcome).toBeUndefined();
+    await vi.advanceTimersByTimeAsync(1);
+    await flush();
+    expect(outcome).toEqual({ content: 'Failed to fetch URL: Request timed out after 15000ms.', isError: true });
+    expect(requests.every(request => request.destroyed)).toBe(true);
+    expect(sockets.every(socket => socket.destroyed)).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+    if (stage === 'dns') expect(mocks.dnsLookup).toHaveBeenCalledOnce();
+  });
+
+  it('clears the deadline after a successful redirect and stops reading its unused body', async () => {
+    await useLocalSockets();
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    const controller = new AbortController();
+    const promise = (webFetchTool as any).execute({ url: 'http://example.com' }, { abortSignal: controller.signal });
+    await flush();
+    sockets[0]!.push('HTTP/1.1 302 Found\r\nLocation: /next\r\nContent-Length: 100\r\n\r\n');
+    await flush();
+    sockets[1]!.push('HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nHello');
+    expect(await promise).toMatchObject({ content: 'Hello', url: 'http://example.com/next', ok: true });
+    await flush();
+    expect(sockets[0]!.destroyed).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
+  });
+
+  it('keeps truncation working with the real Node response stream and clears its deadline', async () => {
+    await useLocalSockets();
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    const promise = (webFetchTool as any).execute({ url: 'http://example.com' }, {});
+    await flush();
+    sockets[0]!.push(`HTTP/1.1 200 OK\r\nContent-Length: 100001\r\n\r\n${'x'.repeat(100_001)}`);
+    const result = await promise;
+    expect(result.content).toHaveLength(100_000);
+    expect(result).toMatchObject({ truncated: true, ok: true });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('keeps private redirect targets blocked and clears the deadline', async () => {
+    await useLocalSockets();
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    const promise = (webFetchTool as any).execute({ url: 'http://example.com' }, {});
+    await flush();
+    sockets[0]!.push('HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1\r\nContent-Length: 100\r\n\r\n');
+    expect(await promise).toEqual({
+      content: 'Failed to fetch URL: URL resolves to a private or reserved address.',
+      isError: true,
+    });
+    expect(requests).toHaveLength(1);
+    expect(sockets[0]!.destroyed).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('cleans up the deadline after a network error', async () => {
+    await useLocalSockets();
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    const promise = (webFetchTool as any).execute({ url: 'http://example.com' }, {});
+    await flush();
+    requests[0]!.destroy(new Error('Connection lost'));
+    expect(await promise).toEqual({ content: 'Failed to fetch URL: Connection lost', isError: true });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('stops the request through native workflow cancellation without running the next step', async () => {
+    await useLocalSockets();
+    const next = vi.fn(async () => ({ content: 'next step' }));
+    const resultSchema = z.object({ content: z.string() });
+    const workflow = createWorkflow({
+      id: 'web-fetch-cancellation',
+      inputSchema: z.object({ url: z.string() }),
+      outputSchema: resultSchema,
+      options: { shouldPersistSnapshot: () => false },
+    })
+      .then(createStep(webFetchTool))
+      .then(createStep({ id: 'after-fetch', inputSchema: resultSchema, outputSchema: resultSchema, execute: next }))
+      .commit();
+    const run = await workflow.createRun();
+    const completion = run.start({ inputData: { url: 'http://example.com' } });
+    await flush();
+    expect(requests).toHaveLength(1);
+    await run.cancel();
+    expect((await completion).status).toBe('canceled');
+    expect(requests[0]!.destroyed).toBe(true);
+    expect(sockets[0]!.destroyed).toBe(true);
+    expect(next).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/tools/builtin/web-fetch.ts
+++ b/packages/core/src/tools/builtin/web-fetch.ts
@@ -183,6 +183,7 @@ async function readBody(response: http.IncomingMessage): Promise<{ content: stri
 
 async function requestUrl(
   url: URL,
+  signal: AbortSignal,
   redirectsRemaining = MAX_REDIRECTS,
 ): Promise<{
   content: string;
@@ -193,6 +194,7 @@ async function requestUrl(
   url?: string;
   ok?: boolean;
 }> {
+  signal.throwIfAborted();
   assertAllowedUrl(url);
 
   return new Promise((resolve, reject) => {
@@ -205,6 +207,7 @@ async function requestUrl(
           accept: 'text/html,text/plain,application/json,application/xml;q=0.9,*/*;q=0.8',
         },
         lookup: createLookup(),
+        signal,
         timeout: TIMEOUT_MS,
       },
       response => {
@@ -212,7 +215,7 @@ async function requestUrl(
           const location = response.headers.location;
 
           if (location && response.statusCode && response.statusCode >= 300 && response.statusCode < 400) {
-            response.resume();
+            response.destroy();
 
             if (redirectsRemaining <= 0) {
               throw new WebFetchError(`Too many redirects. Maximum is ${MAX_REDIRECTS}.`);
@@ -223,7 +226,7 @@ async function requestUrl(
               throw new WebFetchError('Redirect target must use HTTP or HTTPS.');
             }
 
-            resolve(await requestUrl(nextUrl, redirectsRemaining - 1));
+            resolve(await requestUrl(nextUrl, signal, redirectsRemaining - 1));
             return;
           }
 
@@ -276,7 +279,8 @@ export const webFetchTool = createTool({
     ok: z.boolean().optional(),
     isError: z.boolean().optional(),
   }),
-  execute: async ({ url }: { url: string }) => {
+  execute: async ({ url }: { url: string }, context) => {
+    context?.abortSignal?.throwIfAborted();
     const parsedUrl = parseHttpUrl(url);
 
     if (!parsedUrl) {
@@ -286,13 +290,23 @@ export const webFetchTool = createTool({
       };
     }
 
+    const deadline = new AbortController();
+    const timeout = setTimeout(() => {
+      deadline.abort(new WebFetchError(`Request timed out after ${TIMEOUT_MS}ms.`));
+    }, TIMEOUT_MS);
+    timeout.unref();
+    const signal = context?.abortSignal ? AbortSignal.any([context.abortSignal, deadline.signal]) : deadline.signal;
+
     try {
-      return await requestUrl(parsedUrl);
+      return await requestUrl(parsedUrl, signal);
     } catch (error) {
+      context?.abortSignal?.throwIfAborted();
       return {
-        content: `Failed to fetch URL: ${getErrorMessage(error)}`,
+        content: `Failed to fetch URL: ${getErrorMessage(signal.aborted ? signal.reason : error)}`,
         isError: true,
       };
+    } finally {
+      clearTimeout(timeout);
     }
   },
 });

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -26,6 +26,7 @@ import type { Mastra } from '../../mastra';
 import { SpanType, wrapMastra, EntityType, getOrCreateSpan, createObservabilityContext } from '../../observability';
 import type { AnySpan } from '../../observability';
 import { executeWithContext } from '../../observability/utils';
+import { PROCESSOR_TOOL_OWNER, getProcessorToolOwner } from '../../processors/tool-provenance';
 import { RequestContext } from '../../request-context';
 import { isStandardSchemaWithJSON, toStandardSchema, standardSchemaToJSONSchema } from '../../schema';
 import type { StandardSchemaWithJSON } from '../../schema';
@@ -1133,8 +1134,10 @@ export class CoreToolBuilder extends MastraBase {
         : undefined,
     };
 
+    const processorToolOwner = getProcessorToolOwner(this.originalTool);
     return {
       ...definition,
+      ...(processorToolOwner === undefined ? {} : { [PROCESSOR_TOOL_OWNER]: processorToolOwner }),
       id: 'id' in this.originalTool ? this.originalTool.id : undefined,
       parameters: processedInputSchema ?? z.object({}),
       outputSchema: processedOutputSchema,

--- a/packages/core/src/workflows/__tests__/cancel-storage-failure.test.ts
+++ b/packages/core/src/workflows/__tests__/cancel-storage-failure.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+import z from 'zod';
+import { createStep, createWorkflow } from '..';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage';
+
+describe('Run.cancel durable write failures', () => {
+  it('preserves completion racing the cancellation write from another run instance', async () => {
+    const storage = new InMemoryStore();
+    const makeWorkflow = () =>
+      createWorkflow({ id: 'racing', inputSchema: z.object({}), outputSchema: z.object({}) })
+        .then(
+          createStep({ id: 'done', inputSchema: z.object({}), outputSchema: z.object({}), execute: async () => ({}) }),
+        )
+        .commit();
+    const workflow = makeWorkflow();
+    const other = makeWorkflow();
+    const mastra = new Mastra({
+      workflows: { workflow },
+      storage,
+      logger: false,
+      workers: false,
+      scheduler: { enabled: false },
+    });
+    other.__registerMastra(mastra);
+    const active = await workflow.createRun();
+    const stale = await other.createRun({ runId: active.runId });
+    const store = (await storage.getStore('workflows'))!;
+    const update = store.updateWorkflowState.bind(store);
+    vi.spyOn(store, 'updateWorkflowState').mockImplementationOnce(async options => {
+      expect((await active.start({ inputData: {} })).status).toBe('success');
+      return update(options);
+    });
+    await stale.cancel();
+    expect((await store.loadWorkflowSnapshot({ workflowName: workflow.id, runId: active.runId }))?.status).toBe(
+      'success',
+    );
+    expect(stale.workflowRunStatus).not.toBe('canceled');
+  });
+
+  it('does not replace a completed result when cancellation arrives late', async () => {
+    const storage = new InMemoryStore();
+    const workflow = createWorkflow({ id: 'finished', inputSchema: z.object({}), outputSchema: z.object({}) })
+      .then(
+        createStep({ id: 'done', inputSchema: z.object({}), outputSchema: z.object({}), execute: async () => ({}) }),
+      )
+      .commit();
+    new Mastra({ workflows: { workflow }, storage, logger: false, workers: false, scheduler: { enabled: false } });
+    const run = await workflow.createRun();
+    expect((await run.start({ inputData: {} })).status).toBe('success');
+    const completed = await workflow.createRun({ runId: run.runId });
+    expect(completed.workflowRunStatus).toBe('success');
+    await completed.cancel();
+    expect(completed.workflowRunStatus).toBe('success');
+    expect(completed.abortController.signal.aborted).toBe(false);
+    const workflows = (await storage.getStore('workflows'))!;
+    expect((await workflows.loadWorkflowSnapshot({ workflowName: workflow.id, runId: run.runId }))?.status).toBe(
+      'success',
+    );
+  });
+
+  it('repeated and concurrent cancellations retain one canceled result', async () => {
+    const storage = new InMemoryStore();
+    const workflow = createWorkflow({ id: 'repeat', inputSchema: z.object({}), outputSchema: z.object({}) })
+      .then(
+        createStep({
+          id: 'wait',
+          inputSchema: z.object({}),
+          outputSchema: z.object({}),
+          execute: async ({ suspend }) => suspend({}),
+        }),
+      )
+      .commit();
+    new Mastra({ workflows: { workflow }, storage, logger: false, workers: false, scheduler: { enabled: false } });
+    const run = await workflow.createRun();
+    await run.start({ inputData: {} });
+    await Promise.all([run.cancel(), run.cancel()]);
+    await run.cancel();
+    const workflows = (await storage.getStore('workflows'))!;
+    expect((await workflows.loadWorkflowSnapshot({ workflowName: workflow.id, runId: run.runId }))?.status).toBe(
+      'canceled',
+    );
+    expect(run.abortController.signal.aborted).toBe(true);
+  });
+
+  it('delivers abort but rejects a failed stored cancellation without replacing the saved suspended state', async () => {
+    const storage = new InMemoryStore();
+    const workflow = createWorkflow({ id: 'parked', inputSchema: z.object({}), outputSchema: z.object({}) })
+      .then(
+        createStep({
+          id: 'wait',
+          inputSchema: z.object({}),
+          outputSchema: z.object({}),
+          execute: async ({ suspend }) => suspend({ prompt: 'Wait.' }),
+        }),
+      )
+      .commit();
+    new Mastra({ workflows: { workflow }, storage, logger: false, workers: false, scheduler: { enabled: false } });
+    const run = await workflow.createRun();
+    expect((await run.start({ inputData: {} })).status).toBe('suspended');
+    const workflows = (await storage.getStore('workflows'))!;
+    const failure = new Error('Local cancellation write rejected');
+    const write = vi.spyOn(workflows, 'updateWorkflowState').mockRejectedValueOnce(failure);
+    await expect(run.cancel()).rejects.toBe(failure);
+    expect(run.abortController.signal.aborted).toBe(true);
+    expect((await workflows.loadWorkflowSnapshot({ workflowName: workflow.id, runId: run.runId }))?.status).toBe(
+      'suspended',
+    );
+    expect(write).toHaveBeenCalledTimes(1);
+    write.mockRestore();
+  });
+});

--- a/packages/core/src/workflows/handlers/entry.ts
+++ b/packages/core/src/workflows/handlers/entry.ts
@@ -308,7 +308,9 @@ export async function executeEntry(
       executionContext.stepExecutionPath?.push(stepId);
     }
     const stepPrevOutput = getResumeStepPrevOutput({
-      isResumedStep,
+      // A restart must also use the active step's saved input: earlier outputs
+      // may have been pruned after this payload was persisted.
+      isResumedStep: isResumedStep || !!restart?.activeStepsPath?.[stepId],
       stepId,
       stepResults,
       prevOutput,

--- a/packages/core/src/workflows/restart-step-input.test.ts
+++ b/packages/core/src/workflows/restart-step-input.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { Mastra } from '../mastra';
+import { MockStore } from '../storage/mock';
+import { createWorkflow } from './create';
+import { createStep } from './workflow';
+
+describe('restart active step input', () => {
+  it.each([
+    { name: 'saved object', payload: { messages: ['retained'] }, saved: true },
+    { name: 'explicit null', payload: null, saved: true },
+    { name: 'explicit undefined', payload: undefined, saved: true },
+    { name: 'missing payload', payload: 'previous output', saved: false },
+  ])('uses $name without replaying completed steps', async ({ payload, saved }) => {
+    const storage = new MockStore();
+    const mastra = new Mastra({ logger: false, storage });
+    const previous = vi.fn();
+    const active = vi.fn(async ({ inputData }) => ({ received: inputData }));
+    const following = vi.fn(async ({ inputData }) => inputData);
+    const makeStep = (id: string, execute: typeof active) =>
+      createStep({ id, inputSchema: z.any(), outputSchema: z.any(), execute });
+    const workflow = createWorkflow({ id: 'restart-input', inputSchema: z.any(), outputSchema: z.any() })
+      .then(makeStep('previous', previous))
+      .then(makeStep('active', active))
+      .then(makeStep('following', following))
+      .commit();
+    workflow.__registerMastra(mastra);
+    const workflows = await storage.getStore('workflows');
+    await workflows!.persistWorkflowSnapshot({
+      workflowName: workflow.id,
+      runId: 'disposable-restart',
+      snapshot: {
+        runId: 'disposable-restart',
+        status: 'running',
+        value: {},
+        activePaths: [1],
+        activeStepsPath: { active: [1] },
+        context: {
+          input: 'initial',
+          previous: { status: 'success', output: 'previous output', startedAt: 1, endedAt: 2 },
+          active: { status: 'running', startedAt: 3, ...(saved ? { payload } : {}) },
+          following: { status: 'pending', payload: 'stale unrelated input' },
+        },
+        serializedStepGraph: (workflow as any).serializedStepGraph,
+        suspendedPaths: {},
+        waitingPaths: {},
+        resumeLabels: {},
+        timestamp: Date.now(),
+      },
+    });
+    try {
+      const run = await workflow.createRun({ runId: 'disposable-restart' });
+      const result = await run.restart();
+      expect(result.status).toBe('success');
+      expect(active).toHaveBeenCalledOnce();
+      expect(active.mock.calls[0]![0].inputData).toEqual(payload);
+      expect(following.mock.calls[0]![0].inputData).toEqual({ received: payload });
+      expect(previous).not.toHaveBeenCalled();
+    } finally {
+      await mastra.shutdown();
+    }
+  });
+});

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2834,9 +2834,11 @@ export class Workflow<
     const nestedAbortCb = () => {
       abort();
     };
-    const parentAbortCb = async () => {
+    let parentCancellation: Promise<void> | undefined;
+    const parentAbortCb = () => {
       run.abortController.signal.removeEventListener('abort', nestedAbortCb);
-      await run.cancel();
+      parentCancellation ??= run.cancel();
+      void parentCancellation.catch(() => {});
     };
     run.abortController.signal.addEventListener('abort', nestedAbortCb);
     abortSignal.addEventListener('abort', parentAbortCb);
@@ -2903,6 +2905,7 @@ export class Workflow<
       run.abortController.signal.removeEventListener('abort', nestedAbortCb);
       abortSignal.removeEventListener('abort', parentAbortCb);
       unwatch();
+      await parentCancellation;
     }
 
     const suspendedSteps = Object.entries(res.steps).filter(([_stepName, stepResult]) => {
@@ -3452,29 +3455,27 @@ export class Run<
    * This aborts any running execution and updates the workflow status to 'canceled' in storage.
    */
   async cancel() {
-    // Abort any running execution and update in-memory status
-    this.abortController.abort();
-    this.workflowRunStatus = 'canceled';
+    if (['success', 'failed', 'canceled'].includes(this.workflowRunStatus)) return;
 
-    // End the whole span tree now: a step that ignores abortSignal keeps running, so the
-    // execution engine may never unwind and no span in the tree would otherwise be ended.
-    this.workflowRunSpan?.endTree({ attributes: { status: 'canceled' } });
+    // Deliver cancellation immediately, even if persisting it later fails.
+    this.abortController.abort();
 
     // Update workflow status in storage to 'canceled'
     // This is necessary for suspended/waiting workflows where the abort signal won't be checked
-    try {
-      const workflowsStore = await this.mastra?.getStorage()?.getStore('workflows');
-      await workflowsStore?.updateWorkflowState({
-        workflowName: this.workflowId,
-        runId: this.runId,
-        opts: {
-          status: 'canceled',
-        },
-      });
-    } catch {
-      // Storage errors should not prevent cancellation from succeeding
-      // The abort signal and in-memory status are already updated
-    }
+    const workflowsStore = await this.mastra?.getStorage()?.getStore('workflows');
+    const canceled = await workflowsStore?.updateWorkflowState({
+      workflowName: this.workflowId,
+      runId: this.runId,
+      opts: {
+        status: 'canceled',
+        expectedStatus: ['pending', 'running', 'waiting', 'suspended'],
+      },
+    });
+    // A concurrent completion or prior cancellation wins the storage condition.
+    // Do not relabel its in-memory status or completed span as canceled.
+    if (workflowsStore && !canceled) return;
+    this.workflowRunStatus = 'canceled';
+    this.workflowRunSpan?.endTree({ attributes: { status: 'canceled' } });
   }
 
   async #validateSchema<TInput>(schema: StandardSchemaWithJSON<TInput>, data: TInput, type: string) {

--- a/packages/deployer/src/server/__tests__/startup-recovery.test.ts
+++ b/packages/deployer/src/server/__tests__/startup-recovery.test.ts
@@ -1,0 +1,164 @@
+import type { Server } from 'node:http';
+import { Agent } from '@mastra/core/agent';
+import { createDurableAgent } from '@mastra/core/agent/durable';
+import { Mastra } from '@mastra/core/mastra';
+import { InMemoryStore } from '@mastra/core/storage';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createNodeServer } from '../index';
+
+describe('production startup durable-agent recovery', () => {
+  let mastra: Mastra;
+  let server: Server | undefined;
+  let listeners: Map<NodeJS.Signals, Function[]>;
+
+  beforeEach(() => {
+    vi.stubEnv('MASTRA_TELEMETRY_DISABLED', 'true');
+    vi.stubEnv('MASTRA_HTTPS_KEY', '');
+    vi.stubEnv('MASTRA_HTTPS_CERT', '');
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('No outbound requests are permitted'));
+    listeners = new Map((['SIGINT', 'SIGTERM'] as const).map(signal => [signal, process.listeners(signal)]));
+  });
+
+  afterEach(async () => {
+    if (server) {
+      server.closeAllConnections();
+      await new Promise<void>(resolve => server!.close(() => resolve()));
+      server = undefined;
+    }
+    await mastra?.shutdown();
+    for (const [signal, previous] of listeners) {
+      for (const listener of process.listeners(signal)) {
+        if (!previous.includes(listener)) process.removeListener(signal, listener);
+      }
+    }
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  function fixture(mode?: 'auto' | 'off') {
+    const modelCall = vi.fn(async () => {
+      throw new Error('No model execution is permitted');
+    });
+    const agent = createDurableAgent({
+      agent: new Agent({
+        id: 'startup-proof',
+        name: 'Startup proof',
+        instructions: 'No task is sent.',
+        model: {
+          specificationVersion: 'v2',
+          provider: 'unpaid-fixture',
+          modelId: 'never-run',
+          supportedUrls: {},
+          doGenerate: modelCall,
+          doStream: modelCall,
+        },
+      }),
+    });
+    mastra = new Mastra({
+      agents: { agent },
+      storage: new InMemoryStore({ id: 'startup-proof' }),
+      ...(mode ? { recovery: { durableAgents: mode } } : {}),
+      logger: false,
+      server: { host: '127.0.0.1', port: 0 },
+    });
+    return {
+      modelCall,
+      recovery: vi.spyOn(mastra, 'recoverAllDurableAgents'),
+      agentRecovery: vi.spyOn(agent, 'recoverActiveRuns'),
+      workers: vi.spyOn(mastra, 'startWorkers'),
+    };
+  }
+
+  async function start(isDev = false) {
+    server = (await createNodeServer(mastra, { tools: {}, studio: false, isDev })) as Server;
+  }
+
+  it.each(['auto', 'off', undefined] as const)('honors production recovery=%s with real native methods', async mode => {
+    const proof = fixture(mode);
+    await start();
+
+    expect(proof.workers).toHaveBeenCalledOnce();
+    if (mode === 'auto') {
+      await vi.waitFor(() => expect(proof.agentRecovery).toHaveBeenCalledOnce());
+      expect(proof.recovery).toHaveBeenCalledOnce();
+      expect(proof.workers.mock.invocationCallOrder[0]).toBeLessThan(proof.recovery.mock.invocationCallOrder[0]!);
+      await expect(proof.recovery.mock.results[0]!.value).resolves.toEqual({
+        agents: 1,
+        recovered: 0,
+        succeeded: 0,
+        failed: 0,
+      });
+    } else {
+      expect(proof.recovery).not.toHaveBeenCalled();
+      expect(proof.agentRecovery).not.toHaveBeenCalled();
+    }
+    expect(proof.modelCall).not.toHaveBeenCalled();
+  });
+
+  it('leaves dev recovery to its existing restart endpoint', async () => {
+    const proof = fixture('auto');
+    await start(true);
+    expect(proof.recovery).not.toHaveBeenCalled();
+
+    const app = mastra.getServerApp<{ request: (path: string, init: RequestInit) => Promise<Response> }>();
+    const response = await app!.request('/__restart-active-workflow-runs', { method: 'POST' });
+    expect(response.status).toBe(200);
+    await vi.waitFor(() => expect(proof.agentRecovery).toHaveBeenCalledOnce());
+    expect(proof.recovery).toHaveBeenCalledOnce();
+    expect(proof.modelCall).not.toHaveBeenCalled();
+  });
+
+  it('logs rejected recovery without rejecting server startup', async () => {
+    const proof = fixture('auto');
+    const error = new Error('recovery storage unavailable');
+    const logged = vi.spyOn(mastra.getLogger(), 'error');
+    proof.recovery.mockRejectedValue(error);
+
+    await start();
+
+    await vi.waitFor(() => {
+      expect(logged).toHaveBeenCalledWith('Failed to recover durable agent runs during server startup', { error });
+    });
+    expect(proof.recovery).toHaveBeenCalledOnce();
+  });
+
+  it('returns the server while recovery is still running', async () => {
+    const proof = fixture('auto');
+    let finishRecovery!: (value: { agents: number; recovered: number; succeeded: number; failed: number }) => void;
+    const recoveryResult = new Promise<Awaited<ReturnType<Mastra['recoverAllDurableAgents']>>>(resolve => {
+      finishRecovery = resolve;
+    });
+    proof.recovery.mockReturnValue(recoveryResult);
+    const startup = start();
+    let returned = false;
+    void startup.then(() => {
+      returned = true;
+    });
+
+    try {
+      await vi.waitFor(() => expect(returned).toBe(true));
+      expect(server).toBeDefined();
+      expect(proof.recovery).toHaveBeenCalledOnce();
+    } finally {
+      finishRecovery({ agents: 1, recovered: 0, succeeded: 0, failed: 0 });
+      await startup;
+    }
+  });
+
+  it('installs native shutdown handlers before starting recovery', async () => {
+    const proof = fixture('auto');
+    const order: string[] = [];
+    const nativeRecovery = Mastra.prototype.recoverAllDurableAgents;
+    proof.recovery.mockImplementation(() => {
+      for (const [signal, previous] of listeners) {
+        expect(process.listeners(signal).length).toBeGreaterThan(previous.length);
+      }
+      order.push('recovery');
+      return nativeRecovery.call(mastra);
+    });
+
+    await start();
+    expect(order).toEqual(['recovery']);
+  });
+});

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -757,5 +757,13 @@ export async function createNodeServer(mastra: Mastra, options: ServerBundleOpti
     process.on('SIGTERM', () => void shutdown('SIGTERM'));
   }
 
+  if (!options.isDev && mastra.recoveryConfig?.durableAgents === 'auto') {
+    // Recovery is admitted and drained by Core shutdown, including storage
+    // discovery. Do not delay normal server startup until turns finish.
+    void mastra.recoverAllDurableAgents().catch(error => {
+      mastra.getLogger().error('Failed to recover durable agent runs during server startup', { error });
+    });
+  }
+
   return server;
 }


### PR DESCRIPTION
Durable sessions can leave saved work suspended after Stop, replay resolved approvals, or lose a workflow guardrail failure. This change keeps cancellation attached to the agent and run that owned it when Stop was accepted, including after navigation or reopening, and makes shutdown wait for accepted cancellation work. Later runs keep their own approvals.

Saved skill and tool discovery executors are restored through the existing processor path before approval resumes after a process restart. Cold Stop uses the existing native recovery ownership and lease fencing, then resumes the actual saved suspension with cancellation. It produces the native abort result and usage, closes pending Memory approvals, and waits for saved workflow cleanup. A competing restoration reports the existing typed ownership conflict; losing that ownership does not publish a terminal error into the winning run's stream. Explicit user tool overrides remain intact.

The same Controller, Session, processor, workflow, storage and deployer paths retain ownership. The contribution also preserves workflow tripwire results, carries cancellation through web fetch, wires recovery into generated server startup and shutdown, and omits empty reasoning content during message conversion.

Validation at source 9b601c94 (Core 1.64.0): 93 focused Stop, shutdown, recovery and concurrency tests pass, along with Core types, strict fixture types and scoped lint. The prior 127 processor/reconstruction tests passed at parent ed7ca86e. The separate 1.63.2 contribution at 5f2dd577 passes 86 focused tests and produces byte-identical complete Windows/Linux Core and deployer packages. Its Linux installed package passes two real-process PostgreSQL cases: selected skill decline (6 assertions) and cold Session Stop (8 assertions), with no further inference or tool execution. These package results are not archive proof for this 1.64.0 branch.

This remains draft. Hosted billing and full app journeys are unproven. Duplicate Stop is not claimed to be idempotent, the default in-process PubSub is not a distributed lock, and these tests do not establish universal Stop-versus-approval serialization. The local review service was unavailable under the account's free plan; no clean automated review is claimed.
