### PR TITLE
fix(mcp): keep mimeType and _meta on readResource

### DIFF
--- a/.changeset/mcp-read-resource-metadata.md
+++ b/.changeset/mcp-read-resource-metadata.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+'@mastra/mcp': patch
+'@mastra/server': patch
+---
+
+Fixed `readResource()` dropping a resource's `mimeType` and `_meta`, which stripped MCP App `ui://` resources of their CSP settings before they reached the renderer. Native and proxied MCP servers now both return the same metadata their resource listing reports. Fixes #23068

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -314,9 +314,15 @@ export abstract class MCPServerBase<TId extends string = string> extends MastraB
    * @param uri The resource URI to read (e.g. `ui://weather/dashboard`).
    * @returns A promise resolving to the resource content.
    */
-  public abstract readResource(
-    uri: string,
-  ): Promise<{ contents: Array<{ uri: string; text?: string; blob?: string }> }>;
+  public abstract readResource(uri: string): Promise<{
+    contents: Array<{
+      uri: string;
+      mimeType?: string;
+      _meta?: Record<string, unknown>;
+      text?: string;
+      blob?: string;
+    }>;
+  }>;
 
   /**
    * Lists all resources available on this MCP server.

--- a/packages/mcp/src/client/server-proxy.test.ts
+++ b/packages/mcp/src/client/server-proxy.test.ts
@@ -1,0 +1,124 @@
+import http from 'node:http';
+import type { Resource } from '@modelcontextprotocol/sdk/types.js';
+import getPort from 'get-port';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { MCPServer } from '../server/server';
+import { InternalMastraMCPClient } from './client';
+import { MCPClientServerProxy } from './server-proxy';
+
+vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 });
+
+const listenOnFreePort = async (server: http.Server): Promise<number> => {
+  const port = await getPort();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, () => resolve());
+  });
+  return port;
+};
+
+const UI_RESOURCE_URI = 'ui://weather/widget';
+const UI_META = { ui: { csp: { connectDomains: ['https://api.example.com'] } } };
+
+const resources: Resource[] = [
+  {
+    uri: UI_RESOURCE_URI,
+    name: 'Weather UI Widget',
+    mimeType: 'text/html',
+    _meta: UI_META,
+  },
+  {
+    uri: 'weather://current',
+    name: 'Current Weather Data',
+    mimeType: 'application/json',
+  },
+];
+
+const resourceContents: Record<string, { text: string }> = {
+  [UI_RESOURCE_URI]: { text: '<html><body>widget</body></html>' },
+  'weather://current': { text: JSON.stringify({ temp: 20 }) },
+};
+
+describe('MCPClientServerProxy', () => {
+  let upstreamServer: MCPServer;
+  let httpServer: http.Server;
+  let client: InternalMastraMCPClient;
+  let proxy: MCPClientServerProxy;
+
+  beforeAll(async () => {
+    upstreamServer = new MCPServer({
+      name: 'UpstreamResourceServer',
+      version: '1.0.0',
+      tools: {},
+      resources: {
+        listResources: async () => resources,
+        getResourceContent: async ({ uri }) => {
+          const content = resourceContents[uri];
+          if (!content) throw new Error(`No content for ${uri}`);
+          return content;
+        },
+      },
+    });
+
+    httpServer = http.createServer(async (req, res) => {
+      const url = new URL(req.url || '', `http://localhost`);
+      await upstreamServer.startHTTP({
+        url,
+        httpPath: '/http',
+        req,
+        res,
+        options: { sessionIdGenerator: undefined },
+      });
+    });
+    const port = await listenOnFreePort(httpServer);
+
+    client = new InternalMastraMCPClient({
+      name: 'proxy-test-client',
+      server: { url: new URL(`http://localhost:${port}/http`) },
+    });
+    await client.connect();
+
+    proxy = new MCPClientServerProxy({ name: 'proxied-server' }, async () => client);
+  });
+
+  afterAll(async () => {
+    await client.disconnect();
+    httpServer.closeAllConnections?.();
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close(err => (err ? reject(err) : resolve()));
+    });
+    await upstreamServer.close();
+  });
+
+  describe('readResource', () => {
+    it('preserves mimeType and _meta from the upstream server', async () => {
+      const result = await proxy.readResource(UI_RESOURCE_URI);
+
+      expect(result.contents).toHaveLength(1);
+      expect(result.contents[0]).toEqual(
+        expect.objectContaining({
+          uri: UI_RESOURCE_URI,
+          mimeType: 'text/html',
+          _meta: UI_META,
+          text: '<html><body>widget</body></html>',
+        }),
+      );
+    });
+
+    it('reports the same metadata listResources() does for the same resource', async () => {
+      const listed = (await proxy.listResources()).resources.find(r => r.uri === UI_RESOURCE_URI);
+      const [read] = (await proxy.readResource(UI_RESOURCE_URI)).contents;
+
+      expect(read!.mimeType).toBe(listed!.mimeType);
+      expect(read!._meta).toEqual(listed!._meta);
+    });
+
+    it('omits _meta for a resource that declares none', async () => {
+      const [content] = (await proxy.readResource('weather://current')).contents;
+
+      expect(content).not.toHaveProperty('_meta');
+      expect(content!.mimeType).toBe('application/json');
+    });
+  });
+});

--- a/packages/mcp/src/client/server-proxy.ts
+++ b/packages/mcp/src/client/server-proxy.ts
@@ -177,12 +177,25 @@ export class MCPClientServerProxy extends MCPServerBase {
     };
   }
 
-  public async readResource(uri: string): Promise<{ contents: Array<{ uri: string; text?: string; blob?: string }> }> {
+  public async readResource(uri: string): Promise<{
+    contents: Array<{
+      uri: string;
+      mimeType?: string;
+      _meta?: Record<string, unknown>;
+      text?: string;
+      blob?: string;
+    }>;
+  }> {
     const client = await this.getClient();
     const result = await client.resources.read(uri);
+
+    // MCP Apps hosts read the UI CSP from `contents[]._meta.ui.csp`, so dropping
+    // `mimeType` and `_meta` here silently breaks proxied `ui://` resources.
     return {
       contents: (result.contents ?? []).map((c: any) => ({
         uri: c.uri ?? uri,
+        ...(c.mimeType !== undefined ? { mimeType: c.mimeType } : {}),
+        ...(c._meta !== undefined ? { _meta: c._meta } : {}),
         ...(c.text !== undefined ? { text: c.text } : {}),
         ...(c.blob !== undefined ? { blob: c.blob } : {}),
       })),

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -573,6 +573,46 @@ describe('MCPServer', () => {
       const content = resourceContentResult.contents[0] as { _meta?: Record<string, unknown> };
       expect(content._meta).toEqual({ ui: { csp: { connectDomains: ['https://api.example.com'] } } });
     });
+
+    it('should preserve `mimeType` and `_meta` on the public readResource() method', async () => {
+      // The `resources/read` protocol handler preserves these, but Studio reads
+      // `ui://` resources through the public method, which dropped both.
+      const result = await resourceTestServerInstance.readResource('weather://ui');
+
+      expect(result.contents.length).toBe(1);
+      expect(result.contents[0]).toEqual({
+        uri: 'weather://ui',
+        mimeType: 'text/html',
+        _meta: { ui: { csp: { connectDomains: ['https://api.example.com'] } } },
+        text: '<html><body>widget</body></html>',
+      });
+    });
+
+    it('should omit `_meta` on readResource() when the resource declares none', async () => {
+      const result = await resourceTestServerInstance.readResource('weather://historical');
+
+      expect(result.contents[0]).not.toHaveProperty('_meta');
+      expect(result.contents[0]?.mimeType).toBe('application/json');
+    });
+
+    it('should still return content from readResource() when the resource list provider throws', async () => {
+      const server = new MCPServer({
+        name: 'ThrowingListResourcesServer',
+        version: '1.0.0',
+        tools: minimalTestTool,
+        resources: {
+          listResources: async () => {
+            throw new Error('list provider unavailable');
+          },
+          getResourceContent: async () => ({ text: 'content' }),
+        },
+      });
+
+      const result = await server.readResource('weather://ui');
+
+      expect(result.contents[0]).toEqual({ uri: 'weather://ui', text: 'content' });
+      await server.close();
+    });
   });
 
   describe('MCPServer Resource Handling with Notifications and Templates', () => {

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -3047,7 +3047,15 @@ export class MCPServer extends MCPServerBase {
    * @param uri - The resource URI to read (e.g. `ui://weather/dashboard`)
    * @returns Promise resolving to the resource content
    */
-  public async readResource(uri: string): Promise<{ contents: Array<{ uri: string; text?: string; blob?: string }> }> {
+  public async readResource(uri: string): Promise<{
+    contents: Array<{
+      uri: string;
+      mimeType?: string;
+      _meta?: Record<string, unknown>;
+      text?: string;
+      blob?: string;
+    }>;
+  }> {
     if (!this.resourceOptions?.getResourceContent) {
       throw new MastraError({
         id: 'MCP_SERVER_RESOURCES_NOT_CONFIGURED',
@@ -3058,12 +3066,29 @@ export class MCPServer extends MCPServerBase {
     }
 
     const extra = {} as any;
+
+    // Carry the resource's `mimeType` and `_meta` onto the contents, matching the
+    // `resources/read` handler. MCP Apps hosts read the UI CSP from
+    // `contents[]._meta.ui.csp`, and Studio reads `ui://` resources through here.
+    // Metadata is best-effort: unlike the protocol handler this must not turn a
+    // readable resource into a failed read, so a throwing provider is not fatal.
+    let resource: Resource | undefined;
+    try {
+      const resources = await this.resourceOptions.listResources?.({ extra });
+      resource = resources?.find(r => r.uri === uri);
+    } catch (error) {
+      this.logger.warn(`Could not resolve metadata for resource '${uri}'`, { error });
+    }
+    const resourceMeta = resource?._meta ? { _meta: resource._meta } : {};
+
     const result = await this.resourceOptions.getResourceContent({ uri, extra });
     const contents = Array.isArray(result) ? result : [result];
 
     return {
       contents: contents.map(c => ({
         uri,
+        ...(resource?.mimeType !== undefined ? { mimeType: resource.mimeType } : {}),
+        ...resourceMeta,
         ...('text' in c && c.text !== undefined ? { text: c.text } : {}),
         ...('blob' in c && c.blob !== undefined ? { blob: c.blob } : {}),
       })),

--- a/packages/server/src/server/schemas/mcp.ts
+++ b/packages/server/src/server/schemas/mcp.ts
@@ -85,6 +85,8 @@ export const readResourceBodySchema = z.object({
 
 export const resourceContentSchema = z.object({
   uri: z.string(),
+  mimeType: z.string().optional(),
+  _meta: z.record(z.string(), z.unknown()).optional(),
   text: z.string().optional(),
   blob: z.string().optional(),
 });


### PR DESCRIPTION
`MCPClientServerProxy.readResource()` rebuilt each content block as `{ uri, text?, blob? }`, so `mimeType` and `_meta` were dropped on the way out. MCP Apps hosts read the UI CSP from `contents[]._meta.ui.csp`, so every `ui://` resource served through a proxied server reached the renderer without its `connectDomains` and widget fetches failed.

```js
// before
{ uri: 'ui://weather/widget', text: '<html>…</html>' }
// after
{ uri: 'ui://weather/widget', mimeType: 'text/html', _meta: { ui: { csp: {…} } }, text: '<html>…</html>' }
```

The same gap exists on the native path. #19163 fixed the `resources/read` protocol handler, but `MCPServer.readResource()` is a separate method ~2000 lines further down, and it's the one `@mastra/server`'s `POST /api/mcp/:serverId/resources/read` route calls for Studio. It now resolves the resource and carries `mimeType`/`_meta` the same way the handler does. The lookup is best-effort and wrapped, so a list provider that throws degrades to today's behaviour instead of turning a readable resource into a failed read. It deliberately doesn't throw `Resource not found` the way the protocol handler does, since that would change behaviour for existing callers. It also doesn't cache the listing, per the invariant in #17609.

The reason neither path was caught earlier is that `MCPServerBase.readResource()` declared `{ uri, text?, blob? }`, so `tsc` couldn't see the loss. That's widened to include the two optional fields both implementations already return — it describes existing behaviour rather than changing a contract, so it's a patch like the optional-method addition in #22286. `resourceContentSchema` in `@mastra/server` had the same narrowing while its sibling `resourceInfoSchema` already carried both fields, so Studio's generated client types stayed blind to them; that's widened to match.

Happy to split the `server.ts` change into its own PR if you'd rather keep this to the reported bug.

Fixes #23068

Tests: `packages/mcp/src/client/server-proxy.test.ts` is new and drives a real `MCPServer` over `node:http` with a real `InternalMastraMCPClient`, so it also covers `_meta` surviving JSON-RPC serialization. Reverting the proxy change fails all three. `server.test.ts` gains three cases next to the existing #19163 one, including the throwing-provider guard; reverting the `server.ts` change fails two of them.

---

*Disclosure: this patch was authored with AI assistance (Claude Code). I've reviewed it, I understand it, and I'll be the one responding to review feedback.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

MCP resources can include format details and display settings. This PR keeps those details when resources pass through proxy or native server paths.

## Changes

- Preserve `mimeType` and `_meta` in `MCPClientServerProxy.readResource()`.
- Resolve and include resource metadata in `MCPServer.readResource()`.
- Keep native server reads working when resource listing fails.
- Widen MCP return types and the server resource content schema.
- Add tests for proxy serialization, metadata preservation, missing metadata, and provider failures.
- Add release notes for `@mastra/core`, `@mastra/mcp`, and `@mastra/server`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->