### PR TITLE
fix(cli): require source entry files

### DIFF
--- a/.changeset/entry-files-only.md
+++ b/.changeset/entry-files-only.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed CLI entry discovery so directories are not selected as source files.

--- a/packages/cli/src/services/service.file.test.ts
+++ b/packages/cli/src/services/service.file.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -11,6 +11,31 @@ afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
     rmSync(directory, { recursive: true, force: true });
   }
+});
+
+describe('FileService.getFirstExistingFile', () => {
+  it('skips directories and returns the first regular file', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'mastra-file-service-'));
+    temporaryDirectories.push(directory);
+    const directoryCandidate = join(directory, 'index.ts');
+    const fileCandidate = join(directory, 'index.js');
+    mkdirSync(directoryCandidate);
+    writeFileSync(fileCandidate, 'export {};');
+
+    expect(new FileService().getFirstExistingFile([directoryCandidate, fileCandidate])).toBe(fileCandidate);
+  });
+
+  it('throws when none of the candidates are regular files', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'mastra-file-service-'));
+    temporaryDirectories.push(directory);
+    const directoryCandidate = join(directory, 'index.ts');
+    const missingCandidate = join(directory, 'index.js');
+    mkdirSync(directoryCandidate);
+
+    expect(() => new FileService().getFirstExistingFile([directoryCandidate, missingCandidate])).toThrow(
+      `Missing required file, checked the following paths: ${directoryCandidate}, ${missingCandidate}`,
+    );
+  });
 });
 
 describe('FileService.replaceValuesInFile', () => {

--- a/packages/cli/src/services/service.file.ts
+++ b/packages/cli/src/services/service.file.ts
@@ -41,8 +41,12 @@ export class FileService {
 
   public getFirstExistingFile(files: string[]): string {
     for (const f of files) {
-      if (fs.existsSync(f)) {
-        return f;
+      try {
+        if (fs.statSync(f).isFile()) {
+          return f;
+        }
+      } catch {
+        // Missing or inaccessible paths are not valid file candidates.
       }
     }
 


### PR DESCRIPTION
## Description

Require CLI source-entry candidates to resolve to regular files. Directory and inaccessible candidates are skipped so a later valid entry can be selected, while the existing missing-file error remains unchanged when none qualify.

Add regression coverage for directory fallback and directory-only candidate lists.

## Related issue(s)

Fixes #23174

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Validation

- Bounded filesystem assertions for directory fallback and missing-file behavior (2/2)
- `git diff --check`

The package test and typecheck could not run because workspace dependencies are not installed in this checkout.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The CLI now ignores folders and invalid paths when looking for a source file. It continues searching until it finds a real file, or reports the existing error if none exists.

## Changes

- Updated `FileService.getFirstExistingFile()` to accept only regular files.
- Skips directories, missing paths, broken paths, and filesystem errors.
- Added regression tests for fallback selection and directory-only candidates.
- Added a patch changeset for the `mastra` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->