### PR TITLE
fix(schema-compat): let optional enum and const accept null

### DIFF
--- a/.changeset/quiet-doors-listen.md
+++ b/.changeset/quiet-doors-listen.md
@@ -1,0 +1,6 @@
+---
+
+'@mastra/schema-compat': patch
+---
+
+Fixed optional enum and const properties in OpenAI strict schemas so they accept null like every other optional property. Optional enum or const values no longer fail tool calls when the model sends null for the omitted value.

--- a/packages/schema-compat/src/provider-compats/openai-optional-scalar-null.test.ts
+++ b/packages/schema-compat/src/provider-compats/openai-optional-scalar-null.test.ts
@@ -1,0 +1,67 @@
+import Ajv from 'ajv';
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import type { ModelInformation } from '../types';
+import { OpenAISchemaCompatLayer } from './openai';
+
+/**
+ * OpenAI strict mode turns every optional property into a required-and-nullable one.
+ * For scalar enum/const properties the compat layer copied the constraint into the
+ * non-null anyOf branch but left it on the outer property node as well. JSON Schema
+ * evaluates sibling keywords together, so the outer enum/const still rejected null
+ * and the generated schema was not actually nullable.
+ * https://github.com/mastra-ai/mastra/issues/23173
+ */
+describe('OpenAISchemaCompatLayer - optional scalar enum/const nullability', () => {
+  const modelInfo: ModelInformation = {
+    provider: 'openai',
+    modelId: 'gpt-4o',
+    supportsStructuredOutputs: false,
+  };
+
+  const compat = new OpenAISchemaCompatLayer(modelInfo);
+
+  const expectWireAccepts = (schema: unknown, value: unknown) => {
+    const ajv = new Ajv({ strict: false, allErrors: true });
+    const validate = ajv.compile(schema as object);
+    expect(validate(value)).toBe(true);
+  };
+
+  it('accepts null for an optional enum property in strict mode', () => {
+    const schema = z.object({
+      encoding: z.enum(['utf8', 'base64']).optional(),
+    });
+
+    const wireSchema = compat.processToJSONSchema(schema) as Record<string, any>;
+    const encoding = wireSchema.properties.encoding;
+
+    // null may only be validated by the dedicated null branch
+    expect(encoding.anyOf.map((b: any) => b.type)).toEqual(['string', 'null']);
+    expect(encoding).not.toHaveProperty('enum');
+    expect(encoding).not.toHaveProperty('const');
+
+    // the non-null branch keeps the original constraint
+    expect(encoding.anyOf[0].enum).toEqual(['utf8', 'base64']);
+
+    expectWireAccepts(wireSchema, { encoding: null });
+    expectWireAccepts(wireSchema, { encoding: 'base64' });
+  });
+
+  it('accepts null for an optional const property in strict mode', () => {
+    const schema = z.object({
+      kind: z.literal('fixed').optional(),
+    });
+
+    const wireSchema = compat.processToJSONSchema(schema) as Record<string, any>;
+    const kind = wireSchema.properties.kind;
+
+    expect(kind.anyOf.map((b: any) => b.type)).toEqual(['string', 'null']);
+    expect(kind).not.toHaveProperty('const');
+    expect(kind).not.toHaveProperty('enum');
+
+    expect(kind.anyOf[0].const).toBe('fixed');
+
+    expectWireAccepts(wireSchema, { kind: null });
+    expectWireAccepts(wireSchema, { kind: 'fixed' });
+  });
+});

--- a/packages/schema-compat/src/provider-compats/openai.ts
+++ b/packages/schema-compat/src/provider-compats/openai.ts
@@ -308,6 +308,11 @@ export class OpenAISchemaCompatLayer extends SchemaCompatLayer {
               delete propSchema.anyOf;
               delete propSchema.type;
               delete prop.type;
+              // enum/const must live only inside the non-null branch: JSON Schema
+              // applies sibling keywords together, so keeping them on the outer
+              // property would still reject null after the nullable anyOf is built
+              delete prop.const;
+              delete prop.enum;
               prop.anyOf = [
                 {
                   ...propSchema,


### PR DESCRIPTION
## Description

OpenAI strict mode turns every optional property into a required and nullable one, but optional scalar enum and const properties end up not nullable at all

the nullable anyOf conversion in OpenAISchemaCompatLayer copies the enum or const constraint into the non-null branch but leaves it on the outer property node too, and JSON Schema evaluates sibling keywords together, so the outer constraint still rejects null even though the anyOf carries a null branch, an optional encoding: z.enum(['utf8', 'base64']) for example cannot receive null on the wire, which is how native image content fell back to raw text in Mastra Code subagents (#23173)

the fix keeps enum and const only inside the non-null branch of the generated anyOf, the same place every other scalar constraint already lives after the nullable conversion, the multi-type arm is untouched since it already handles null by appending it to the outer enum

- optional scalar enum properties validate null through the null branch
- same for optional scalar const properties
- real values validate exactly like before since the non-null branch keeps the original constraint

## Related issue(s)

Fixes #23173

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Optional values can be `null`. This fix makes OpenAI strict schemas accept `null` while still checking non-null `enum` and `const` values.

## Changes

- Removed outer `enum` and `const` constraints when creating nullable `anyOf` schemas.
- Preserved those constraints in the non-null `anyOf` branch.
- Added Ajv regression tests for valid `null` and non-null values.
- Added a patch changeset for `@mastra/schema-compat`.

This restores the intended omitted/null encoding behavior for native image delivery without changing explicit encodings or text-file behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->