### PR TITLE
docs(editor): agent.update() creates an inactive draft, it does not activate it

### DIFF
--- a/docs/src/content/en/reference/editor/versioning.mdx
+++ b/docs/src/content/en/reference/editor/versioning.mdx
@@ -28,7 +28,7 @@ Saving changed snapshot fields creates a new latest version. Saving identical sn
 
 If an active version exists, creating a draft doesn't change the version handling published requests. Publishing updates `activeVersionId`. Restoring a historical version copies its configuration into a new inactive draft.
 
-The direct namespace methods and REST APIs differ in one important way. `editor.prompt.update()` creates an inactive draft. `editor.agent.update()` creates a version and immediately assigns it to `activeVersionId`. The stored-agent REST `PATCH` route creates an inactive draft unless `autoPublish` is enabled.
+The direct namespace methods and the REST APIs agree on this. `editor.prompt.update()` and `editor.agent.update()` both create an inactive draft; neither assigns the new version to `activeVersionId`. To publish a version from the SDK, pass it explicitly: `editor.agent.update({ id, status: 'published', activeVersionId: version.id })`. The stored-agent REST `PATCH` route also creates an inactive draft unless `autoPublish` is enabled, and `POST /stored/agents/:id/versions/:versionId/activate` publishes it.
 
 When a generic stored resource has no active version, published resolution can fall back to the latest snapshot. For a code-defined agent override, requesting `status: 'published'` without an active override returns the original code agent.
 

--- a/docs/src/content/en/reference/editor/versioning.mdx
+++ b/docs/src/content/en/reference/editor/versioning.mdx
@@ -28,7 +28,7 @@ Saving changed snapshot fields creates a new latest version. Saving identical sn
 
 If an active version exists, creating a draft doesn't change the version handling published requests. Publishing updates `activeVersionId`. Restoring a historical version copies its configuration into a new inactive draft.
 
-The direct namespace methods and the REST APIs agree on this. `editor.prompt.update()` and `editor.agent.update()` both create an inactive draft; neither assigns the new version to `activeVersionId`. To publish a version from the SDK, pass it explicitly: `editor.agent.update({ id, status: 'published', activeVersionId: version.id })`. The stored-agent REST `PATCH` route also creates an inactive draft unless `autoPublish` is enabled, and `POST /stored/agents/:id/versions/:versionId/activate` publishes it.
+The direct namespace methods and the REST APIs agree on this. `editor.prompt.update()` and `editor.agent.update()` both create an inactive draft. Neither assigns the new version to `activeVersionId`. To publish a version from the SDK, pass it explicitly: `editor.agent.update({ id, status: 'published', activeVersionId: version.id })`. The stored-agent REST `PATCH` route also creates an inactive draft unless `autoPublish` is enabled, and `POST /stored/agents/:id/versions/:versionId/activate` publishes it.
 
 When a generic stored resource has no active version, published resolution can fall back to the latest snapshot. For a code-defined agent override, requesting `status: 'published'` without an active override returns the original code agent.
 


### PR DESCRIPTION
## Description

Corrects one sentence in the Editor versioning reference (`docs/src/content/en/reference/editor/versioning.mdx`) that still describes the pre-#21528 behavior.

The page said `editor.agent.update()` "creates a version and immediately assigns it to `activeVersionId`". Since #21528 (fix(editor): keep SDK agent updates as drafts) `EditorAgentNamespace.update()` creates the version but never activates it — `activeVersionId` only moves when the caller passes it. The doc now says that the namespace methods and the REST routes agree (both keep drafts), shows the explicit publish call `editor.agent.update({ id, status: 'published', activeVersionId })`, and names the REST activate route.

Verified against `@mastra/editor` 0.14.3 and `packages/editor/src/namespaces/agent.ts` on `main` (`createVersionFromSnapshotUpdate` + `getProvidedAgentRecordFields`); repro in the linked issue.

## Related issue(s)

Fixes #23180

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The documentation now explains that updates create drafts instead of publishing changes automatically. It also explains how SDK and REST users can publish those drafts.

## Changes

- Updated the versioning reference to state that `editor.prompt.update()` and `editor.agent.update()` create inactive drafts.
- Documented that SDK callers must provide `activeVersionId` and `status: 'published'` to publish an agent version.
- Documented that REST `PATCH` updates remain drafts unless `autoPublish` is enabled.
- Added the REST activation route: `POST /stored/agents/:id/versions/:versionId/activate`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->