### PR TITLE
fix(inngest): resume nested workflows under a derivable run id

### DIFF
--- a/.changeset/tidy-lamps-resume.md
+++ b/.changeset/tidy-lamps-resume.md
@@ -1,0 +1,5 @@
+---
+'@mastra/inngest': patch
+---
+
+Fixed resuming a step that suspended inside a nested workflow. The nested run now uses the parent's run id (with a per-index suffix for foreach iterations), matching the default engine, instead of a random id that was lost when core strips `suspendPayload` from the persisted snapshot; and the delivery pass after the child finishes replays the memoized invoke instead of throwing `No suspended steps found in nested workflow`.

--- a/workflows/inngest/src/execution-engine.test.ts
+++ b/workflows/inngest/src/execution-engine.test.ts
@@ -1,5 +1,6 @@
 import { MastraNonRetryableError } from '@mastra/core/error';
 import type { Mastra } from '@mastra/core/mastra';
+import { omitPriorCompletionFields } from '@mastra/core/workflows';
 import { Inngest, NonRetriableError } from 'inngest';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
@@ -157,7 +158,19 @@ describe('InngestExecutionEngine.executeStepWithRetry', () => {
   });
 });
 
-function createNestedResumeFixture(suspendedPaths: Record<string, number[]>) {
+function createNestedResumeFixture(
+  suspendedPaths: Record<string, number[]>,
+  opts: {
+    /** Parent-side step result for the nested workflow; defaults to one with `suspendPayload` intact. */
+    parentStepResult?: Record<string, unknown>;
+    /** The only run id the (realistic) store answers for; defaults to the legacy stored child id. */
+    knownRunId?: string;
+    /** Simulate execution inside a foreach iteration. */
+    foreachIndex?: number;
+    /** Pass no `resume`, exercising the fresh-run path. */
+    withResume?: boolean;
+  } = {},
+) {
   const inngest = new Inngest({ id: 'nested-resume-test' });
   const { createWorkflow, createStep } = init(inngest);
   const suspendedStep = createStep({
@@ -175,15 +188,20 @@ function createNestedResumeFixture(suspendedPaths: Record<string, number[]>) {
     .then(suspendedStep)
     .commit();
 
-  const nestedRunId = 'nested-run';
+  const nestedRunId = opts.knownRunId ?? 'nested-run';
   const nestedStepResults = Object.fromEntries(
     Object.keys(suspendedPaths).map(stepId => [stepId, { status: 'suspended', payload: { value: 'before-suspend' } }]),
   );
-  const loadWorkflowSnapshot = vi.fn().mockResolvedValue({
-    value: { count: 1 },
-    context: nestedStepResults,
-    suspendedPaths,
-  });
+  // A realistic store answers only for run ids that actually exist.
+  const loadWorkflowSnapshot = vi.fn(async ({ runId }: { runId: string }) =>
+    runId === nestedRunId
+      ? {
+          value: { count: 1 },
+          context: nestedStepResults,
+          suspendedPaths,
+        }
+      : undefined,
+  );
   const mastra = {
     getStorage: () => ({
       getStore: async () => ({ loadWorkflowSnapshot }),
@@ -201,14 +219,15 @@ function createNestedResumeFixture(suspendedPaths: Record<string, number[]>) {
   };
   const engine = new InngestExecutionEngine(mastra, inngestStep as any, 0, {} as any);
   const resumePayload = { approved: true };
+  const parentStepResult = opts.parentStepResult ?? {
+    status: 'suspended',
+    suspendPayload: { __workflow_meta: { runId: nestedRunId } },
+  };
   const execute = () =>
     engine.executeWorkflowStep({
       step: nestedWorkflow as any,
       stepResults: {
-        [nestedWorkflow.id]: {
-          status: 'suspended',
-          suspendPayload: { __workflow_meta: { runId: nestedRunId } },
-        } as any,
+        [nestedWorkflow.id]: parentStepResult as any,
       },
       executionContext: {
         workflowId: 'parent-workflow',
@@ -216,8 +235,9 @@ function createNestedResumeFixture(suspendedPaths: Record<string, number[]>) {
         executionPath: [0],
         suspendedPaths: {},
         state: {},
+        ...(opts.foreachIndex !== undefined ? { foreachIndex: opts.foreachIndex } : {}),
       } as any,
-      resume: { steps: [nestedWorkflow.id], resumePayload },
+      ...(opts.withResume === false ? {} : { resume: { steps: [nestedWorkflow.id], resumePayload } }),
       prevOutput: {},
       inputData: { value: 'start' },
       pubsub: { publish: vi.fn().mockResolvedValue(undefined) } as any,
@@ -257,27 +277,105 @@ describe('InngestExecutionEngine.executeWorkflowStep', () => {
     });
   });
 
-  it.each<{ name: string; suspendedPaths: Record<string, number[]>; message: string }>([
-    {
-      name: 'no suspended child',
-      suspendedPaths: {},
-      message: 'No suspended steps found in nested workflow: nested-resume-workflow',
-    },
-    {
-      name: 'multiple suspended children',
-      suspendedPaths: { 'first-child': [1, 0], 'second-child': [1, 1] },
-      message:
-        'Multiple suspended steps found: [first-child], [second-child]. Please specify which step to resume using the "step" parameter.',
-    },
-  ])('does not guess a resume target with $name', async ({ suspendedPaths, message }) => {
-    const { execute, invoke } = createNestedResumeFixture(suspendedPaths);
+  it('does not guess a resume target with multiple suspended children', async () => {
+    const { execute, invoke } = createNestedResumeFixture({ 'first-child': [1, 0], 'second-child': [1, 1] });
 
     const result = await execute();
 
     expect(invoke).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       status: 'failed',
-      error: expect.objectContaining({ message }),
+      error: expect.objectContaining({
+        message:
+          'Multiple suspended steps found: [first-child], [second-child]. Please specify which step to resume using the "step" parameter.',
+      }),
     });
+  });
+
+  it('replays the memoized invoke when the child is no longer suspended (delivery pass)', async () => {
+    // `step.invoke` parks the parent until the child finishes, so Inngest re-executes
+    // this block with `resume` still on the event — by which point the child snapshot
+    // has no suspended paths. That pass must replay, not throw.
+    const { execute, invoke } = createNestedResumeFixture({});
+
+    const result = await execute();
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke.mock.calls[0]?.[1].data).not.toHaveProperty('resume');
+    expect(invoke.mock.calls[0]?.[1].data).toHaveProperty('initialState');
+    expect(result?.status).toBe('success');
+  });
+});
+
+describe('InngestExecutionEngine.executeWorkflowStep — derivable nested run ids (#23182)', () => {
+  /** Exactly what core hands the nested branch after re-entry (handlers/step.ts). */
+  function afterCoreReEntry(stepResult: Record<string, unknown>) {
+    return {
+      ...omitPriorCompletionFields(stepResult),
+      status: 'running',
+      resumePayload: { approved: true },
+      resumedAt: Date.now(),
+    };
+  }
+
+  const parkedStepResult = {
+    status: 'suspended',
+    payload: { value: 'before-suspend' },
+    suspendPayload: { __workflow_meta: { runId: 'parent-run', path: ['suspended-child-step'] } },
+  };
+
+  it('resumes under the parent run id after core strips suspendPayload on re-entry', async () => {
+    // Core persists the omitPriorCompletionFields-stripped step result before the
+    // nested branch runs, and Inngest re-hydrates the parent from that snapshot —
+    // so nothing stored on the step result survives to the resume pass.
+    const parentStepResult = afterCoreReEntry(parkedStepResult);
+    expect(parentStepResult.suspendPayload).toBeUndefined();
+
+    const { execute, invoke, loadWorkflowSnapshot } = createNestedResumeFixture(
+      { 'suspended-child-step': [1, 0] },
+      { parentStepResult, knownRunId: 'parent-run' },
+    );
+
+    const result = await execute();
+
+    expect(loadWorkflowSnapshot).toHaveBeenCalledWith({ workflowName: 'nested-resume-workflow', runId: 'parent-run' });
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke.mock.calls[0]?.[1].data.resume).toMatchObject({
+      runId: 'parent-run',
+      steps: ['suspended-child-step'],
+      resumePath: [1, 0],
+    });
+    expect(result?.status).toBe('success');
+  });
+
+  it('starts a fresh nested run under the parent run id', async () => {
+    const { execute, invoke } = createNestedResumeFixture({}, { knownRunId: 'parent-run', withResume: false });
+
+    await execute();
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke.mock.calls[0]?.[1].data.runId).toBe('parent-run');
+    expect(invoke.mock.calls[0]?.[1].data).toHaveProperty('initialState');
+  });
+
+  it('keys foreach iterations by index so concurrent iterations do not share a snapshot row', async () => {
+    const fresh = createNestedResumeFixture(
+      {},
+      { knownRunId: 'parent-run-foreach-2', foreachIndex: 2, withResume: false },
+    );
+    await fresh.execute();
+    expect(fresh.invoke.mock.calls[0]?.[1].data.runId).toBe('parent-run-foreach-2');
+
+    // The same derivation applies on a resume whose suspendPayload was stripped.
+    const resumed = createNestedResumeFixture(
+      { 'suspended-child-step': [1, 0] },
+      { parentStepResult: afterCoreReEntry(parkedStepResult), knownRunId: 'parent-run-foreach-2', foreachIndex: 2 },
+    );
+    const result = await resumed.execute();
+    expect(resumed.loadWorkflowSnapshot).toHaveBeenCalledWith({
+      workflowName: 'nested-resume-workflow',
+      runId: 'parent-run-foreach-2',
+    });
+    expect(result?.status).toBe('success');
   });
 });

--- a/workflows/inngest/src/execution-engine.ts
+++ b/workflows/inngest/src/execution-engine.ts
@@ -527,9 +527,21 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
 
     const isTimeTravel = !!(timeTravel && timeTravel.steps?.length > 1 && timeTravel.steps[0] === step.id);
 
+    // The nested run id must be derivable on every replay pass: core strips
+    // `suspendPayload` from the persisted step result (`omitPriorCompletionFields`)
+    // before this branch runs, so nothing stored on it survives Inngest's
+    // re-execution from the snapshot. The default engine runs nested workflows
+    // under the parent's run id (`Workflow.execute` → `createRun({ runId })`), so
+    // do the same here; foreach iterations get a per-index suffix so concurrent
+    // iterations don't share a snapshot row.
+    const derivedNestedRunId =
+      executionContext.foreachIndex !== undefined
+        ? `${executionContext.runId}-foreach-${executionContext.foreachIndex}`
+        : executionContext.runId;
+
     try {
       if (isResume) {
-        runId = stepResults[resume?.steps?.[0] ?? '']?.suspendPayload?.__workflow_meta?.runId ?? randomUUID();
+        runId = stepResults[resume?.steps?.[0] ?? '']?.suspendPayload?.__workflow_meta?.runId ?? derivedNestedRunId;
         const workflowsStore = await this.mastra?.getStorage()?.getStore('workflows');
         const snapshot: any = await workflowsStore?.loadWorkflowSnapshot({
           workflowName: step.id,
@@ -537,19 +549,25 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
         });
 
         const nestedResumeSteps = resume.steps.slice(1);
+        let replayOnly = false;
         if (nestedResumeSteps.length === 0) {
           const suspendedStepIds = Object.keys(snapshot?.suspendedPaths ?? {});
           if (suspendedStepIds.length === 0) {
-            throw new Error(`No suspended steps found in nested workflow: ${step.id}`);
-          }
-          if (suspendedStepIds.length > 1) {
+            // The child is no longer suspended. `step.invoke` parks the parent until
+            // the child finishes, so Inngest re-executes this block to deliver the
+            // memoized result — by which point the resume has already happened.
+            // Replay the invoke (same durable id) instead of treating this as an
+            // error, which would discard a child run that already succeeded.
+            replayOnly = true;
+          } else if (suspendedStepIds.length > 1) {
             const pathStrings = suspendedStepIds.map(stepId => `[${stepId}]`);
             throw new Error(
               `Multiple suspended steps found: ${pathStrings.join(', ')}. ` +
                 'Please specify which step to resume using the "step" parameter.',
             );
+          } else {
+            nestedResumeSteps.push(suspendedStepIds[0]!);
           }
-          nestedResumeSteps.push(suspendedStepIds[0]!);
         }
         const nestedResumeStepId = nestedResumeSteps[0];
 
@@ -559,12 +577,18 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
             inputData,
             requestContext: forwardedRequestContext,
             runId: runId,
-            resume: {
-              runId: runId,
-              steps: nestedResumeSteps,
-              resumePayload: resume.resumePayload,
-              resumePath: nestedResumeStepId ? (snapshot?.suspendedPaths?.[nestedResumeStepId] as any) : undefined,
-            },
+            ...(replayOnly
+              ? { initialState: executionContext.state ?? {} }
+              : {
+                  resume: {
+                    runId: runId,
+                    steps: nestedResumeSteps,
+                    resumePayload: resume.resumePayload,
+                    resumePath: nestedResumeStepId
+                      ? (snapshot?.suspendedPaths?.[nestedResumeStepId] as any)
+                      : undefined,
+                  },
+                }),
             outputOptions: { includeState: true, includeResumeLabels: true },
             nestedWorkflowOutputMode: NESTED_WORKFLOW_OUTPUT_MODE.COMPACT,
             perStep,
@@ -612,7 +636,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
         // event against `data.runId` on the trigger, so a nested run invoked
         // without one cannot be cancelled by id — and it would take the
         // unnamed-run branch, warning about advice the caller cannot act on.
-        const nestedRunId = randomUUID();
+        const nestedRunId = derivedNestedRunId;
         const invokeResp = (await this.inngestStep.invoke(`workflow.${executionContext.workflowId}.step.${step.id}`, {
           function: step.getFunction(),
           data: {
@@ -641,6 +665,12 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
         result = errorCause as Extract<NestedWorkflowResult, { status: 'failed' }>;
         runId = 'runId' in errorCause && typeof errorCause.runId === 'string' ? errorCause.runId : randomUUID();
       } else {
+        // Log before flattening: the error object itself doesn't survive
+        // serialization (`JSON.stringify(new Error('x'))` is `{}`), so without
+        // this line the snapshot only ever shows "Workflow failed".
+        this.logger?.error(
+          `Nested workflow step ${step.id} failed: ` + (e instanceof Error ? (e.stack ?? e.message) : String(e)),
+        );
         // Fallback: if we can't get the result from error, construct a basic failed result
         runId = randomUUID();
         result = {

--- a/workflows/inngest/src/index.test.ts
+++ b/workflows/inngest/src/index.test.ts
@@ -10128,6 +10128,102 @@ describe('MastraInngestWorkflow', () => {
         srv.close();
       });
 
+      it('resumes a nested workflow that suspended inside a dountil loop (#23182)', async ctx => {
+        // The child's run id used to live only on `suspendPayload.__workflow_meta`,
+        // which core strips from the persisted snapshot before the nested branch
+        // runs — and Inngest re-executes the parent from that snapshot. The resume
+        // then looked up a run that never existed and failed with
+        // `No suspended steps found in nested workflow`, discarding a child run
+        // that had already succeeded on the delivery pass.
+        const inngest = new Inngest({
+          id: 'mastra',
+          baseUrl: `http://localhost:${(ctx as any).inngestPort}`,
+        });
+
+        const { createWorkflow, createStep } = init(inngest);
+
+        const increment = vi.fn().mockImplementation(async ({ inputData, resumeData, suspend }) => {
+          // Gate only the first iteration, so the loop must run again after the resume.
+          if (inputData.value === 0 && !resumeData) {
+            await suspend({});
+          }
+          return { value: inputData.value + 1 };
+        });
+        const incrementStep = createStep({
+          id: 'gated-increment',
+          inputSchema: z.object({ value: z.number() }),
+          outputSchema: z.object({ value: z.number() }),
+          resumeSchema: z.object({ approved: z.boolean() }),
+          execute: increment,
+        });
+
+        const nestedCounter = createWorkflow({
+          id: 'nested-counter-workflow',
+          inputSchema: z.object({ value: z.number() }),
+          outputSchema: z.object({ value: z.number() }),
+          options: { validateInputs: false },
+        })
+          .then(incrementStep)
+          .commit();
+
+        const parentWorkflow = createWorkflow({
+          id: 'dountil-nested-parent',
+          inputSchema: z.object({ value: z.number() }),
+          outputSchema: z.object({ value: z.number() }),
+          options: { validateInputs: false },
+        })
+          .dountil(nestedCounter, async ({ inputData }) => (inputData?.value ?? 0) >= 2)
+          .commit();
+
+        const mastra = new Mastra({
+          storage: new DefaultStorage({
+            id: 'test-storage',
+            url: ':memory:',
+          }),
+          workflows: {
+            'test-workflow': parentWorkflow,
+          },
+          server: {
+            apiRoutes: [
+              {
+                path: '/inngest/api',
+                method: 'ALL',
+                createHandler: async ({ mastra }) => inngestServe({ mastra, inngest, ...getDockerRegisterOptions() }),
+              },
+            ],
+          },
+        });
+
+        const app = await createHonoServer(mastra);
+
+        const srv = (globServer = serve({
+          fetch: app.fetch,
+          port: (ctx as any).handlerPort,
+        }));
+        await resetInngest();
+
+        const run = await parentWorkflow.createRun();
+        const result = await run.start({ inputData: { value: 0 } });
+
+        expect(increment).toHaveBeenCalledTimes(1);
+        expect(result.status).toBe('suspended');
+        expect(result.steps['nested-counter-workflow']).toMatchObject({ status: 'suspended' });
+
+        const resumedResults = await run.resume({
+          step: [nestedCounter, incrementStep],
+          resumeData: { approved: true },
+        });
+
+        // Iteration 1 finishes on resume (0 -> 1), then the loop runs a second
+        // iteration under the same derived child run id (1 -> 2) and exits.
+        expect(resumedResults.status).toBe('success');
+        // @ts-expect-error - testing dynamic workflow result
+        expect(resumedResults.result).toMatchObject({ value: 2 });
+        expect(increment).toHaveBeenCalledTimes(3);
+
+        srv.close();
+      });
+
       it('propagates a nested step resume label into the parent snapshot', async ctx => {
         // A step inside a nested workflow suspends with `resumeLabel`. That label
         // must survive the nested->parent suspend boundary, otherwise the parent


### PR DESCRIPTION
## Description

Resuming a step that suspended inside a nested workflow always failed on the Inngest engine with `No suspended steps found in nested workflow: <id>`. The full analysis is in #23182; the short version is two independent defects in `executeWorkflowStep`:

1. **The child's run id didn't survive.** It was stored only on `suspendPayload.__workflow_meta`, but core strips `suspendPayload` (`omitPriorCompletionFields`) and persists the stripped result *before* the nested branch runs — and Inngest re-executes the parent from that snapshot. The `?? randomUUID()` fallback then invented a run id that was never stored.
2. **The resume block ran twice.** `step.invoke` parks the parent until the child finishes, so Inngest replays the parent to deliver the memoized result — with `resume` still on the event. By then the child had no suspended paths, so the same throw discarded a child run that had already succeeded.

### The fix

- The nested run id is now **derived, not remembered**: a nested workflow runs under the parent's run id, which is what the default engine already does (`Workflow.execute` → `createRun({ runId })`). Snapshots are keyed by `(workflow_name, run_id)`, so parent and child can't collide. The old `suspendPayload` field is still read first, so runs parked by older builds keep resuming. This also repairs the time-travel branch and `getWorkflowRunSteps`, both of which already looked the child up under the parent's run id.
- **foreach iterations get a per-index suffix** (`{runId}-foreach-{k}`). The parent run id alone would make concurrent iterations (`concurrency > 1`) share one snapshot row; `executionContext.foreachIndex` is present on both the start and the resume re-entry, so the derivation is stable across replay passes.
- When the child is **no longer suspended on a resume pass**, that's the delivery replay, not an error: the invoke is replayed (same durable id, memoized by Inngest) instead of throwing.
- The catch block now **logs the real error** before flattening it — `JSON.stringify(new Error(...))` is `{}`, so previously every failure here surfaced only as `NonRetriableError: Workflow failed`.

### Why parent-run-id is safe for loops

- `dountil`/`dowhile`: parity with the default engine, which reuses the parent's run id every iteration. Only the child's own previous-iteration snapshot is overwritten, and no reader wants an older iteration (resume, time travel, and `getWorkflowRunSteps` all want the latest).
- Parallel/conditional siblings: different step ids → different `workflow_name` rows, no collision.
- Nothing anywhere requires the child's run id to differ from the parent's — core already ships them equal for every plain nested step, and `__workflow_meta.runId` has exactly three readers, all engine-internal.

Out of scope, worth its own issue: on resume, the step-level `__workflow_meta.runId` for a suspended foreach only describes the first suspended index (same shape in core's `handlers/step.ts`), so resuming a specific later iteration is a pre-existing gap on both engines.

### Tests

- `execution-engine.test.ts`: regression cases that run the parent step result through core's real `omitPriorCompletionFields` (the shape the old fixture couldn't produce), plus the delivery-pass replay, the fresh-run id, and the foreach-index derivation. The store mock now answers only for run ids that exist, like a real store. The old "no suspended child → throw" expectation is updated to the new replay behaviour.
- `index.test.ts`: an end-to-end case for the shape that hit this in production — a nested workflow suspending inside a `dountil`, resumed, with the loop then running a second iteration under the same derived run id. There was previously no test of a nested workflow inside a loop.

## Related issue(s)

Fixes #23182

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a nested workflow pauses, it now remembers the correct run and resumes reliably. After the child finishes, the parent reuses the completed result instead of reporting an error.

## Changes

- Derive nested workflow run IDs from the parent run ID.
- Add per-index suffixes for `foreach` iterations.
- Support older suspended runs that still store the run ID in `suspendPayload`.
- Replay memoized invocations when the child is no longer suspended.
- Log nested workflow errors before serialization.
- Add tests for stripped step results, delivery replay, fresh run IDs, `foreach`, and nested workflows inside `dountil`.
- Add a patch release changeset for `@mastra/inngest`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->