### PR TITLE
feat(factory): expose durable automation run ingress

### DIFF
--- a/.changeset/factory-automation-run-ingress.md
+++ b/.changeset/factory-automation-run-ingress.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+---
+
+Added a durable automation-run ingress for trusted external orchestrators.
+
+External controllers can now enqueue one revision-checked, idempotent Factory skill invocation for an existing work item without pre-creating a source-control session. Factory's existing decision dispatcher remains responsible for approval policy, binding, delivery, retries, and restart recovery.

--- a/mastracode/factory/src/routes/automation-runs.test.ts
+++ b/mastracode/factory/src/routes/automation-runs.test.ts
@@ -68,7 +68,7 @@ beforeEach(async () => {
   const project = await seed.projects.create({
     orgId: 'org1',
     userId: 'u1',
-    input: { name: 'modelspend', autoRunEnabled: true },
+    input: { name: 'modelspend' },
   });
   projectId = project.id;
   const result = await seed.workItems.upsert({

--- a/mastracode/factory/src/routes/automation-runs.test.ts
+++ b/mastracode/factory/src/routes/automation-runs.test.ts
@@ -7,6 +7,7 @@ import { createFactoryStorageForTests } from '../storage/test-utils.js';
 import type { FactoryStorageTestSeed } from '../storage/test-utils.js';
 import { buildAutomationRunRoutes } from './automation-runs.js';
 import { fakeRouteAuth, mountApiRoutes } from './test-utils.js';
+import type { RouteAuth } from './route.js';
 
 const orgUser = { workosId: 'u1', organizationId: 'org1' };
 const REQUEST_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
@@ -24,16 +25,18 @@ const audit: AuditEmitter = {
   },
 };
 
-function app() {
+function app(options: { auth?: RouteAuth; user?: typeof orgUser | null } = {}) {
   const hono = new Hono();
-  hono.use('*', async (c, next) => {
-    c.set('factoryAuthUser' as never, orgUser as never);
-    await next();
-  });
+  if (options.user !== null) {
+    hono.use('*', async (c, next) => {
+      c.set('factoryAuthUser' as never, (options.user ?? orgUser) as never);
+      await next();
+    });
+  }
   mountApiRoutes(
     hono as never,
     buildAutomationRunRoutes({
-      auth: fakeRouteAuth(),
+      auth: options.auth ?? fakeRouteAuth(),
       audit,
       projects: seed.projects,
       workItems: seed.workItems,
@@ -43,8 +46,8 @@ function app() {
   return hono;
 }
 
-function request(body: Record<string, unknown>) {
-  return app().request(`/web/factory/projects/${projectId}/work-items/${workItemId}/automation-runs`, {
+function request(body: Record<string, unknown>, options: { auth?: RouteAuth; user?: typeof orgUser | null } = {}) {
+  return app(options).request(`/web/factory/projects/${projectId}/work-items/${workItemId}/automation-runs`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
@@ -115,6 +118,54 @@ describe('POST automation-runs', () => {
       },
     });
     expect(auditEvents.at(-1)).toMatchObject({ action: 'factory.automation_run.queued' });
+  });
+
+  it('rejects tenant callers who are not organization administrators', async () => {
+    const response = await request(body(), {
+      auth: fakeRouteAuth({ isOrganizationAdmin: async () => false }),
+    });
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ error: 'forbidden' });
+    expect(await seed.workItems.listDeferredDecisions('org1', projectId)).toHaveLength(0);
+  });
+
+  it('supports the trusted local no-auth storage scope without inventing a tenant user', async () => {
+    const localProject = await seed.projects.create({
+      orgId: 'local',
+      userId: 'local',
+      input: { name: 'local-modelspend' },
+    });
+    const localItem = await seed.workItems.upsert({
+      orgId: 'local',
+      userId: 'local',
+      factoryProjectId: localProject.id,
+      input: {
+        board: 'work',
+        title: 'Local automation ingress',
+        stages: ['intake'],
+        externalSource: {
+          integrationId: 'github',
+          type: 'issue',
+          externalId: 'github-issue:802',
+          url: 'https://github.com/TheTekTeam/modelspend/issues/802',
+        },
+      },
+    });
+    projectId = localProject.id;
+    workItemId = localItem.item.id;
+    workItemRevision = localItem.item.revision;
+
+    const response = await request(body({ arguments: '{"issue":802}' }), {
+      auth: fakeRouteAuth({ enabled: false }),
+      user: null,
+    });
+    expect(response.status).toBe(202);
+    const decisions = await seed.workItems.listDeferredDecisions('local', localProject.id);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({
+      workItemId: localItem.item.id,
+      actor: { type: 'system', id: 'factory-external-orchestrator' },
+    });
   });
 
   it('replays the same request id without inserting a second decision', async () => {

--- a/mastracode/factory/src/routes/automation-runs.test.ts
+++ b/mastracode/factory/src/routes/automation-runs.test.ts
@@ -1,0 +1,153 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { builtInFactoryRules } from '../rules/defaults.js';
+import type { AuditEmitter } from '../storage/domains/audit/domain.js';
+import { createFactoryStorageForTests } from '../storage/test-utils.js';
+import type { FactoryStorageTestSeed } from '../storage/test-utils.js';
+import { buildAutomationRunRoutes } from './automation-runs.js';
+import { fakeRouteAuth, mountApiRoutes } from './test-utils.js';
+
+const orgUser = { workosId: 'u1', organizationId: 'org1' };
+const REQUEST_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+const SECOND_REQUEST_ID = '11111111-2222-4333-8444-555555555555';
+
+let seed: FactoryStorageTestSeed;
+let projectId = '';
+let workItemId = '';
+let workItemRevision = 0;
+let auditEvents: Array<Record<string, unknown>> = [];
+
+const audit: AuditEmitter = {
+  async emit({ input }) {
+    auditEvents.push(input as unknown as Record<string, unknown>);
+  },
+};
+
+function app() {
+  const hono = new Hono();
+  hono.use('*', async (c, next) => {
+    c.set('factoryAuthUser' as never, orgUser as never);
+    await next();
+  });
+  mountApiRoutes(
+    hono as never,
+    buildAutomationRunRoutes({
+      auth: fakeRouteAuth(),
+      audit,
+      projects: seed.projects,
+      workItems: seed.workItems,
+      rules: builtInFactoryRules(),
+    }),
+  );
+  return hono;
+}
+
+function request(body: Record<string, unknown>) {
+  return app().request(`/web/factory/projects/${projectId}/work-items/${workItemId}/automation-runs`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function body(overrides: Record<string, unknown> = {}) {
+  return {
+    requestId: REQUEST_ID,
+    expectedRevision: workItemRevision,
+    role: 'work',
+    skillName: 'modelspend-implementation',
+    arguments: '{"issue":801}',
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  seed = await createFactoryStorageForTests();
+  auditEvents = [];
+  const project = await seed.projects.create({
+    orgId: 'org1',
+    userId: 'u1',
+    input: { name: 'modelspend', autoRunEnabled: true },
+  });
+  projectId = project.id;
+  const result = await seed.workItems.upsert({
+    orgId: 'org1',
+    userId: 'u1',
+    factoryProjectId: projectId,
+    input: {
+      board: 'work',
+      title: 'EXECUTION.BRIDGE.REQUEST.ENVELOPE.1',
+      stages: ['intake'],
+      externalSource: {
+        integrationId: 'github',
+        type: 'issue',
+        externalId: 'github-issue:801',
+        url: 'https://github.com/TheTekTeam/modelspend/issues/801',
+      },
+      metadata: { githubIssueNumber: 801, authorTrusted: true },
+    },
+  });
+  workItemId = result.item.id;
+  workItemRevision = result.item.revision;
+});
+
+describe('POST automation-runs', () => {
+  it('commits one bounded invokeSkill decision and stores a system actor', async () => {
+    const response = await request(body());
+    expect(response.status).toBe(202);
+    expect(await response.json()).toMatchObject({
+      status: 'committed',
+      result: { status: 'accepted', itemId: workItemId },
+    });
+
+    const decisions = await seed.workItems.listDeferredDecisions('org1', projectId);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({
+      workItemId,
+      status: 'pending',
+      actor: { type: 'system', id: 'factory-external-orchestrator' },
+      decision: {
+        type: 'invokeSkill',
+        role: 'work',
+        skillName: 'modelspend-implementation',
+        arguments: '{"issue":801}',
+      },
+    });
+    expect(auditEvents.at(-1)).toMatchObject({ action: 'factory.automation_run.queued' });
+  });
+
+  it('replays the same request id without inserting a second decision', async () => {
+    expect((await request(body())).status).toBe(202);
+    const replay = await request(body());
+    expect(replay.status).toBe(200);
+    expect(await replay.json()).toMatchObject({ status: 'replayed', result: { status: 'accepted' } });
+
+    const decisions = await seed.workItems.listDeferredDecisions('org1', projectId);
+    expect(decisions).toHaveLength(1);
+  });
+
+  it('rejects a stale expected revision without creating a runnable decision', async () => {
+    const response = await request(body({ requestId: SECOND_REQUEST_ID, expectedRevision: workItemRevision + 1 }));
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      status: 'committed',
+      result: { status: 'rejected', code: 'stale' },
+    });
+    expect(await seed.workItems.listDeferredDecisions('org1', projectId)).toHaveLength(0);
+    expect(auditEvents.at(-1)).toMatchObject({ action: 'factory.automation_run.rejected' });
+  });
+
+  it('rejects unsupported request fields at the HTTP boundary', async () => {
+    const response = await request(body({ effect: { type: 'transition', stage: 'done' } }));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: 'invalid_automation_run_request' });
+    expect(await seed.workItems.listDeferredDecisions('org1', projectId)).toHaveLength(0);
+  });
+
+  it('rejects unknown roles before a deferred failure can be queued', async () => {
+    const response = await request(body({ role: 'release-manager' }));
+    expect(response.status).toBe(400);
+    expect(await seed.workItems.listDeferredDecisions('org1', projectId)).toHaveLength(0);
+  });
+});

--- a/mastracode/factory/src/routes/automation-runs.ts
+++ b/mastracode/factory/src/routes/automation-runs.ts
@@ -61,28 +61,51 @@ async function resolveProject(
   c: Context,
   deps: Pick<AutomationRunRoutesDeps, 'auth' | 'projects'>,
 ): Promise<{ orgId: string; userId: string; factoryProjectId: string } | { response: Response }> {
-  await deps.auth.ensureUser(c);
-  const tenant = deps.auth.tenant(c);
-  if (!tenant) return { response: c.json({ error: 'unauthorized' }, 401) };
-  if (!tenant.orgId) {
-    return {
-      response: c.json(
-        { error: 'organization_required', message: 'The Factory board requires an organization.' },
-        403,
-      ),
-    };
+  let orgId: string;
+  let userId: string;
+
+  if (deps.auth.enabled()) {
+    await deps.auth.ensureUser(c);
+    const tenant = deps.auth.tenant(c);
+    if (!tenant) return { response: c.json({ error: 'unauthorized' }, 401) };
+    if (!tenant.orgId) {
+      return {
+        response: c.json(
+          { error: 'organization_required', message: 'The Factory board requires an organization.' },
+          403,
+        ),
+      };
+    }
+    if (!(await deps.auth.isOrganizationAdmin(c, tenant.orgId))) {
+      return {
+        response: c.json(
+          { error: 'forbidden', message: 'Organization administrator access is required for automation ingress.' },
+          403,
+        ),
+      };
+    }
+    orgId = tenant.orgId;
+    userId = tenant.userId;
+  } else {
+    // Match Factory's existing no-auth storage scope. This keeps the trusted
+    // loopback/self-hosted controller path usable without inventing a fake user.
+    orgId = 'local';
+    userId = 'local';
   }
+
   const projectId = c.req.param('id');
   if (!projectId || !UUID_RE.test(projectId)) return { response: c.json({ error: 'Project not found' }, 404) };
   await deps.projects.ensureReady();
-  const project = await deps.projects.get({ orgId: tenant.orgId, id: projectId });
+  const project = await deps.projects.get({ orgId, id: projectId });
   if (!project) return { response: c.json({ error: 'Project not found' }, 404) };
-  return { orgId: tenant.orgId, userId: tenant.userId, factoryProjectId: projectId };
+  return { orgId, userId, factoryProjectId: projectId };
 }
 
 /**
  * Constrained durable ingress for a trusted external orchestrator.
  *
+ * Local/no-auth deployments may call this through their trusted loopback
+ * boundary. In tenant mode the caller must be an organization administrator.
  * The caller may enqueue exactly one validated invokeSkill decision for an
  * existing work item. It cannot move the board, send arbitrary messages, stamp
  * human consent, or create a source-control session. Those responsibilities stay

--- a/mastracode/factory/src/routes/automation-runs.ts
+++ b/mastracode/factory/src/routes/automation-runs.ts
@@ -1,0 +1,171 @@
+import type { ApiRoute } from '@mastra/core/server';
+import { registerApiRoute } from '@mastra/core/server';
+import type { Context } from 'hono';
+
+import type { FactoryRules } from '../rules/types.js';
+import { isFactoryRole } from '../rules/types.js';
+import { FactoryRuleValidationError, validateFactoryRuleDecision } from '../rules/validation.js';
+import type { AuditEmitter } from '../storage/domains/audit/domain.js';
+import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
+import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import type { RouteAuth } from './route.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const ALLOWED_KEYS = new Set(['requestId', 'expectedRevision', 'role', 'skillName', 'arguments']);
+
+interface AutomationRunRequest {
+  requestId: string;
+  expectedRevision: number;
+  role: string;
+  skillName: string;
+  arguments?: string;
+}
+
+export interface AutomationRunRoutesDeps {
+  auth: RouteAuth;
+  audit: AuditEmitter;
+  projects: FactoryProjectsStorage;
+  workItems: WorkItemsStorage;
+  rules: FactoryRules;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseAutomationRunRequest(body: unknown): AutomationRunRequest | null {
+  if (!isRecord(body) || Object.keys(body).some(key => !ALLOWED_KEYS.has(key))) return null;
+  if (typeof body.requestId !== 'string' || !UUID_RE.test(body.requestId)) return null;
+  if (!Number.isSafeInteger(body.expectedRevision) || Number(body.expectedRevision) < 1) return null;
+  if (typeof body.role !== 'string' || !isFactoryRole(body.role)) return null;
+  if (typeof body.skillName !== 'string' || body.skillName.trim().length === 0) return null;
+  if (body.arguments !== undefined && typeof body.arguments !== 'string') return null;
+  return {
+    requestId: body.requestId,
+    expectedRevision: Number(body.expectedRevision),
+    role: body.role,
+    skillName: body.skillName.trim(),
+    ...(body.arguments !== undefined ? { arguments: body.arguments } : {}),
+  };
+}
+
+async function readJson(c: Context): Promise<unknown | undefined> {
+  try {
+    return await c.req.json();
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveProject(
+  c: Context,
+  deps: Pick<AutomationRunRoutesDeps, 'auth' | 'projects'>,
+): Promise<{ orgId: string; userId: string; factoryProjectId: string } | { response: Response }> {
+  await deps.auth.ensureUser(c);
+  const tenant = deps.auth.tenant(c);
+  if (!tenant) return { response: c.json({ error: 'unauthorized' }, 401) };
+  if (!tenant.orgId) {
+    return {
+      response: c.json(
+        { error: 'organization_required', message: 'The Factory board requires an organization.' },
+        403,
+      ),
+    };
+  }
+  const projectId = c.req.param('id');
+  if (!projectId || !UUID_RE.test(projectId)) return { response: c.json({ error: 'Project not found' }, 404) };
+  await deps.projects.ensureReady();
+  const project = await deps.projects.get({ orgId: tenant.orgId, id: projectId });
+  if (!project) return { response: c.json({ error: 'Project not found' }, 404) };
+  return { orgId: tenant.orgId, userId: tenant.userId, factoryProjectId: projectId };
+}
+
+/**
+ * Constrained durable ingress for a trusted external orchestrator.
+ *
+ * The caller may enqueue exactly one validated invokeSkill decision for an
+ * existing work item. It cannot move the board, send arbitrary messages, stamp
+ * human consent, or create a source-control session. Those responsibilities stay
+ * with Factory's rule store and FactoryDecisionDispatcher.
+ */
+export function buildAutomationRunRoutes(deps: AutomationRunRoutesDeps): ApiRoute[] {
+  return [
+    registerApiRoute('/web/factory/projects/:id/work-items/:workItemId/automation-runs', {
+      method: 'POST',
+      requiresAuth: false,
+      handler: async c => {
+        const context = c as Context;
+        const resolved = await resolveProject(context, deps);
+        if ('response' in resolved) return resolved.response;
+
+        const workItemId = context.req.param('workItemId');
+        if (!workItemId || !UUID_RE.test(workItemId)) return c.json({ error: 'Work item not found' }, 404);
+
+        const parsed = parseAutomationRunRequest(await readJson(context));
+        if (!parsed) return c.json({ error: 'invalid_automation_run_request' }, 400);
+
+        await deps.workItems.ensureReady();
+        const item = await deps.workItems.getForProject(resolved.orgId, resolved.factoryProjectId, workItemId);
+        if (!item) return c.json({ error: 'Work item not found' }, 404);
+
+        const ingressIdentity = `external-orchestrator:${parsed.requestId}`;
+        let decision: Record<string, unknown>;
+        try {
+          decision = {
+            ...validateFactoryRuleDecision({
+              type: 'invokeSkill',
+              idempotencyKey: `${ingressIdentity}:invoke-skill`,
+              role: parsed.role,
+              skillName: parsed.skillName,
+              ...(parsed.arguments !== undefined ? { arguments: parsed.arguments } : {}),
+            }),
+          };
+        } catch (error) {
+          if (error instanceof FactoryRuleValidationError) {
+            return c.json({ error: error.code, message: error.message }, 400);
+          }
+          throw error;
+        }
+        if (decision.type !== 'invokeSkill') return c.json({ error: 'invalid_automation_run_request' }, 400);
+
+        const committed = await deps.workItems.commitRuleEvaluation({
+          orgId: resolved.orgId,
+          factoryProjectId: resolved.factoryProjectId,
+          workItemId,
+          ingress: { identity: ingressIdentity, triggerType: 'external-orchestrator.invoke-skill' },
+          ruleSetVersion: deps.rules.version,
+          expectedRevision: parsed.expectedRevision,
+          actor: { type: 'system', id: 'factory-external-orchestrator' },
+          outcome: { status: 'accepted' },
+          decisions: [decision],
+          causalChain: [],
+          now: new Date(),
+        });
+
+        if (committed.status === 'missing') return c.json({ error: 'Work item not found' }, 404);
+        const result = committed.result;
+        const rejected = result.status === 'rejected';
+
+        await deps.audit.emit({
+          context,
+          input: {
+            action: rejected ? 'factory.automation_run.rejected' : 'factory.automation_run.queued',
+            factoryProjectId: resolved.factoryProjectId,
+            targets: [{ type: 'work_item', id: workItemId, name: item.title }],
+            metadata: {
+              requestId: parsed.requestId,
+              role: parsed.role,
+              skillName: parsed.skillName,
+              commitStatus: committed.status,
+              resultStatus: result.status,
+              ...(typeof result.code === 'string' ? { code: result.code } : {}),
+            },
+          },
+        });
+
+        if (rejected) return c.json({ status: committed.status, result }, result.code === 'stale' ? 409 : 422);
+        return c.json({ status: committed.status, result }, committed.status === 'replayed' ? 200 : 202);
+      },
+    }),
+  ];
+}

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -49,6 +49,7 @@ import {
   type WorkItemsStorage,
 } from '../storage/domains/work-items/base.js';
 import { workItemBranch, workItemBranchSource, workItemThreadTitle } from '../work-item-branch.js';
+import { buildAutomationRunRoutes } from './automation-runs.js';
 import { ConfigRoutes } from './config.js';
 import { invalidateCustomProvidersSnapshots } from './custom-provider-source.js';
 import { buildFsRoutes } from './fs.js';
@@ -546,6 +547,15 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
           projects: deps.domains.projects,
           knowledge: async () => deps.factoryStorage?.getMastraStorage().getStore('knowledge'),
         }).routes()
+      : []),
+    ...(deps.factoryReady
+      ? buildAutomationRunRoutes({
+          auth: deps.auth,
+          audit: deps.audit,
+          projects: deps.domains.projects,
+          workItems: deps.domains.workItems,
+          rules: deps.rules,
+        })
       : []),
     ...(deps.factoryReady
       ? new WorkItemRoutes({


### PR DESCRIPTION
Closes #23185.

## Summary

Adds a constrained Factory HTTP ingress for trusted external orchestrators to enqueue one durable `invokeSkill` decision against an existing work item without pre-creating a source-control session.

`POST /web/factory/projects/:id/work-items/:workItemId/automation-runs`

The route:
- accepts only `requestId`, exact `expectedRevision`, a built-in Factory role, `skillName`, and optional bounded arguments;
- validates the constructed effect through the existing Factory rule validator;
- stamps a non-human system actor server-side;
- commits through `WorkItemsStorage.commitRuleEvaluation()` so ingress replay and decision persistence are atomic;
- returns stale revision as 409 and never queues a runnable decision for stale state;
- leaves approval/auto-run policy, source-control session creation/reuse, delivery, retries, and restart recovery to `FactoryDecisionDispatcher`;
- supports the existing local/no-auth Factory storage scope (`orgId=userId=local`) used by trusted self-hosted loopback controllers;
- in tenant mode, requires a signed-in organisation administrator before accepting a system-actor automation decision;
- emits bounded audit events for queued/rejected automation runs.

## Regression coverage

Focused route tests cover:
- one request -> one pending `invokeSkill` decision;
- same request id -> replay with no duplicate decision;
- stale expected revision -> 409 and zero runnable decisions;
- unsupported request fields -> 400;
- unknown role -> 400;
- server-stamped system actor on the deferred decision;
- tenant non-admin -> 403 and no deferred decision;
- local/no-auth self-hosted scope -> accepted without inventing a tenant user.

## Field motivation

This is required by the live ModelSpend event-driven Factory qualification. A signed GitHub wake completed exactly once but could not dispatch a ready Intake work item because the current `/runs/start` endpoint requires an already-created source-control session and is a binding/preparation endpoint rather than a durable autonomous skill-dispatch ingress.

The implementation reuses Factory's existing durable rule/deferred-decision store and dispatcher instead of adding another queue or delivery mechanism.

Exact ready-for-review head: `200dcf19ebe900059227b2779ac25de685d37b91`.