### PR TITLE
fix(mastracode): render output after starting plan as goal

### DIFF
--- a/.changeset/lovely-waves-pump.md
+++ b/.changeset/lovely-waves-pump.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed output rendering after starting an approved plan as a goal.

--- a/mastracode/tui/e2e/fixtures/plan-approval-goal-handoff.json
+++ b/mastracode/tui/e2e/fixtures/plan-approval-goal-handoff.json
@@ -4,6 +4,17 @@
       "match": {
         "model": "gpt-5.4-mini",
         "endpoint": "chat",
+        "userMessage": "Goal: # E2E Goal Plan",
+        "sequenceIndex": 0
+      },
+      "response": {
+        "content": "{\"decision\":\"done\",\"reason\":\"The plan goal handoff is verified.\"}"
+      }
+    },
+    {
+      "match": {
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat",
         "userMessage": "Create a concise goal implementation plan for the plan approval e2e test.",
         "hasToolResult": false
       },
@@ -46,6 +57,18 @@
       "streamingProfile": {
         "ttft": 200,
         "tps": 30
+      }
+    },
+    {
+      "match": {
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat",
+        "userMessage": "Create a concise goal implementation plan for the plan approval e2e test.",
+        "hasToolResult": true,
+        "toolCallId": "call_plan_goal_e2e_submit"
+      },
+      "response": {
+        "content": "Resumed plan output before goal startup."
       }
     },
     {

--- a/mastracode/tui/e2e/tui/plan-approval-goal-handoff.ts
+++ b/mastracode/tui/e2e/tui/plan-approval-goal-handoff.ts
@@ -1,13 +1,28 @@
+import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { expect } from './expect.js';
+import { createGlobalPatchScope } from './global-patches.js';
 import type { McE2eScenario } from './types.js';
+
+let holdNextResponse = false;
+let releaseResume: () => void;
+
+function readGoalObjective(dbPath: string): string {
+  return execFileSync(
+    'sqlite3',
+    [
+      dbPath,
+      "select json_extract(value, '$.objective') from mastra_thread_state where type = 'goal' order by updatedAt desc limit 1;",
+    ],
+    { encoding: 'utf8' },
+  ).trim();
+}
 
 export const planApprovalGoalHandoffScenario: McE2eScenario = {
   name: 'plan-approval-goal-handoff',
   description: 'Use AIMock submit_plan and select Use as /goal through the real TUI.',
-  testName: 'sets an AIMock-driven submitted plan as a persistent goal',
-  skipReason: 'current main goal judge returns invalid structured scorer output after plan goal handoff',
+  testName: 'renders resumed plan output before starting the approved plan as a goal',
   useOpenAIModel: true,
   aimockFixture: 'plan-approval-goal-handoff.json',
   prepare({ appDataDir }) {
@@ -20,7 +35,47 @@ export const planApprovalGoalHandoffScenario: McE2eScenario = {
     };
     writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
   },
-  async run({ terminal, runtime }) {
+  async inProcessApp({ startMastraCodeApp }) {
+    holdNextResponse = false;
+    const resumeGate = new Promise<void>(resolve => {
+      releaseResume = resolve;
+    });
+    const patches = createGlobalPatchScope();
+    const originalFetch = globalThis.fetch.bind(globalThis);
+    patches.setProperty(globalThis, 'fetch', async (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (!url.includes('/chat/completions') && !url.includes('/responses')) return originalFetch(input, init);
+      const hold = holdNextResponse;
+      if (hold) holdNextResponse = false;
+      const response = await originalFetch(input, init);
+      if (!hold || !response.body) return response;
+      // Deliver text deltas but keep the resumed run open until the screen assertion.
+      return new Response(
+        response.body.pipeThrough(
+          new TransformStream({
+            async flush() {
+              await resumeGate;
+            },
+          }),
+        ),
+        { status: response.status, headers: response.headers },
+      );
+    });
+    try {
+      const app = await startMastraCodeApp();
+      return {
+        stop: () => {
+          releaseResume();
+          return patches.stopApp(app.stop);
+        },
+      };
+    } catch (error) {
+      releaseResume();
+      patches.restore();
+      throw error;
+    }
+  },
+  async run({ terminal, runtime, dbPath }) {
     runtime.startLiveOutput(terminal);
     await (expect(terminal.getByText(/Project:|Resource ID:|>/gi, { full: true, strict: false })) as any).toBeVisible();
 
@@ -32,15 +87,27 @@ export const planApprovalGoalHandoffScenario: McE2eScenario = {
     await runtime.waitForScreenText(/Use as \/goal\s+— switch to Build mode and pursue this plan/i, terminal, 10_000);
     await runtime.waitForScreenText(/Confirm the goal handoff starts the canonical goal run/i, terminal, 10_000);
 
+    holdNextResponse = true;
     terminal.write('\x1b[B');
     terminal.write('\r');
+
+    await runtime.waitForScreenText(/Resumed plan output before goal startup\./i, terminal, 10_000);
+    if (readGoalObjective(dbPath) || /Goal \(judge:/.test(terminal.serialize().view)) {
+      throw new Error('Goal started before the resumed plan run finished');
+    }
+    releaseResume();
 
     await runtime.waitForScreenText(/✓\s+Set as goal/i, terminal, 10_000);
     await runtime.waitForScreenText(/Goal \(judge: openai\/gpt-5\.4-mini\)/i, terminal, 10_000);
     await runtime.waitForScreenText(/# E2E Goal Plan/i, terminal, 10_000);
-    await runtime.waitForScreenText(/▐[^\r\n▌]+▌[^\r\n]*\bgoal\b(?:[ \t]+<1m)?/i, terminal, 10_000);
     await runtime.waitForScreenText(/Plan goal handoff e2e goal run started\./i, terminal, 15_000);
+    const expectedObjective =
+      '# E2E Goal Plan\n\n## Overview\nUse this plan as a persistent goal from the real TUI.\n\n## Steps\n1. Render the submitted plan.\n2. Select Use as /goal.\n3. Start the goal handoff.\n\n## Verification\nConfirm the goal handoff starts the canonical goal run.';
+    if (readGoalObjective(dbPath) !== expectedObjective) {
+      throw new Error('The started goal did not preserve the complete approved plan');
+    }
 
+    await runtime.waitForScreenText(/Goal\s+●\s+done/i, terminal, 15_000);
     terminal.keyCtrlC();
   },
   verifyAimockRequests(requests) {

--- a/mastracode/tui/src/tui/handlers/__tests__/prompts.test.ts
+++ b/mastracode/tui/src/tui/handlers/__tests__/prompts.test.ts
@@ -225,6 +225,35 @@ describe('handlePlanApproval goal mode', () => {
     expect(state.planStartedGoalId).toBe('goal-123');
   });
 
+  it('releases the event queue while waiting for the plan resume before starting the goal', async () => {
+    const projectPath = createTmpProjectWithPlan(PLAN_TITLE, 'Build the feature');
+    const { state, ctx } = createPlanApprovalCtx(projectPath);
+    let releaseResume!: () => void;
+    const resume = new Promise<void>(resolve => {
+      releaseResume = resolve;
+    });
+    state.session.respondToToolSuspension = vi.fn().mockReturnValue(resume);
+
+    const { promise, component } = await renderPlanApproval(ctx, state, PLAN_PATH);
+    const approval = (component as any).onGoal();
+
+    await vi.waitFor(() => expect(state.session.respondToToolSuspension).toHaveBeenCalledTimes(1));
+    let handlerResolved = false;
+    void promise.then(() => {
+      handlerResolved = true;
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(handlerResolved).toBe(true);
+    expect(ctx.startGoal).not.toHaveBeenCalled();
+
+    releaseResume();
+    await approval;
+    await promise;
+
+    expect(ctx.startGoal).toHaveBeenCalledWith('# Test Plan\n\nBuild the feature', 'Goal cancelled.');
+    expect(state.planStartedGoalId).toBe('goal-123');
+  });
+
   it('does not set planStartedGoalId if startGoal does not set a goal', async () => {
     const projectPath = createTmpProjectWithPlan(PLAN_TITLE, 'Build the feature');
     const { state, ctx } = createPlanApprovalCtx(projectPath);

--- a/mastracode/tui/src/tui/handlers/prompts.ts
+++ b/mastracode/tui/src/tui/handlers/prompts.ts
@@ -419,7 +419,13 @@ export async function handlePlanApproval(
         releaseApprovalFocus();
         firePermissionResult('approved');
         await prepareApprovedPlan(ctx, resolvedTitle, plan, planPath);
-        await resumeApprovedPlan(ctx, toolCallId, resolvedTitle, plan, snapshotKey);
+        const resumed = resumeApprovedPlan(ctx, toolCallId, resolvedTitle, plan, snapshotKey);
+        // The controller emits the resumed tool's terminal events while this
+        // handler owns its serialized event queue. Let those events reach their
+        // render boundaries immediately, but wait for the plan-mode run to
+        // finish before starting the fresh goal run below.
+        resolve();
+        await resumed;
 
         // The plan-mode resume reaches its idle boundary before `startGoal` sends
         // the canonical goal reminder, so this starts a fresh build-mode run.
@@ -430,8 +436,6 @@ export async function handlePlanApproval(
         if (goal?.id) {
           state.planStartedGoalId = goal.id;
         }
-
-        resolve();
       },
       onReject: () => {
         releaseApprovalFocus();


### PR DESCRIPTION
Fixes the TUI path for selecting **Use as /goal** after a plan is approved.

Before: `await resumeApprovedPlan(...); await startGoal(...)` kept controller events queued until the resumed plan run finished.

After: `const resumed = resumeApprovedPlan(...); resolve(); await resumed; await startGoal(...)` lets resumed output render immediately while still waiting for the plan run before goal startup.

Added regression coverage for that ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

After you approve a plan and choose “Use as /goal,” the TUI now shows the resumed plan output immediately. It waits for the plan to finish before starting the goal.

## Changes

- Resolve the approval event before waiting for the resumed plan run.
- Start the goal only after the resumed plan run completes.
- Add unit and end-to-end regression coverage for this ordering.
- Add a patch changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->