### PR TITLE
fix(core): lazy-load tokenx so CJS does not require it

### DIFF
--- a/.changeset/lazy-tokenx-cjs.md
+++ b/.changeset/lazy-tokenx-cjs.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed CommonJS and Jest loading of token counting so the ESM-only tokenx package is imported only when a count runs. Fixes #22609.

--- a/e2e-tests/pkg-outputs/bundle.test.ts
+++ b/e2e-tests/pkg-outputs/bundle.test.ts
@@ -150,7 +150,7 @@ describe('@mastra/core runtime-only dependencies', () => {
   if (!corePkg) throw new Error('@mastra/core not found in workspace packages');
   const coreDistDir = join(corePkg.dir, 'dist');
 
-  const runtimeOnlyDeps = ['execa', '@ast-grep/napi'];
+  const runtimeOnlyDeps = ['execa', '@ast-grep/napi', 'tokenx'];
 
   // Read dist once, shared by the per-dependency test cases below.
   let distFiles: { file: string; content: string }[] = [];

--- a/packages/core/src/processors/processors/token-limiter.ts
+++ b/packages/core/src/processors/processors/token-limiter.ts
@@ -1,9 +1,9 @@
 import type { CoreMessage as CoreMessageV4 } from '@internal/ai-sdk-v4';
-import { estimateTokenCount, sliceByTokens } from 'tokenx';
 import type { MastraDBMessage } from '../../agent/message-list';
 import { parseDataUri, resolveFilePartMediaTypeAndData } from '../../agent/message-list/prompt/image-utils';
 import { TripWire } from '../../agent/trip-wire';
 import type { ChunkType } from '../../stream';
+import { getTokenx } from '../../utils/tokenx';
 import type { ProcessInputStepArgs, ProcessOutputStreamArgs, Processor } from '../index';
 
 /**
@@ -132,8 +132,8 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
     }
   }
 
-  private countTokens(text: string): number {
-    return estimateTokenCount(text);
+  private async countTokens(text: string): Promise<number> {
+    return (await getTokenx()).estimateTokenCount(text);
   }
 
   /**
@@ -237,7 +237,7 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
 
     const tokenString = message.role + message.content;
 
-    return this.countTokens(tokenString) + TokenLimiterProcessor.TOKENS_PER_MESSAGE;
+    return (await this.countTokens(tokenString)) + TokenLimiterProcessor.TOKENS_PER_MESSAGE;
   }
 
   /**
@@ -328,7 +328,7 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
       overhead += toolResultCount * TokenLimiterProcessor.TOKENS_PER_MESSAGE;
     }
 
-    const tokenCount = this.countTokens(tokenString);
+    const tokenCount = await this.countTokens(tokenString);
     const total = tokenCount + overhead + mediaTokens;
     return total;
   }
@@ -393,12 +393,12 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
   private async countTokensInChunk(part: ChunkType): Promise<number> {
     if (part.type === 'text-delta') {
       // For text chunks, count the text content directly
-      return this.countTokens(part.payload.text);
+      return await this.countTokens(part.payload.text);
     } else if (part.type === 'object') {
       // For object chunks, count the JSON representation
       // This is similar to how the memory processor handles object content
       const objectString = JSON.stringify(part.object);
-      return this.countTokens(objectString);
+      return await this.countTokens(objectString);
     }
 
     // Anything else carries no generated output and is not counted
@@ -416,6 +416,7 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
     // Always process output results (this is the main/original functionality)
     const { messages, abort } = args;
     const limit = this.maxTokens;
+    const tokenx = await getTokenx();
 
     // Use a local variable to track tokens within this single result processing
     let cumulativeTokens = 0;
@@ -428,7 +429,7 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
       const processedParts = message.content.parts.map(part => {
         if (part.type === 'text') {
           const textContent = part.text;
-          const tokens = this.countTokens(textContent);
+          const tokens = tokenx.estimateTokenCount(textContent);
 
           // Check if adding this part's tokens would exceed the cumulative limit
           if (cumulativeTokens + tokens <= limit) {
@@ -440,8 +441,8 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
             } else {
               // Truncate the text to fit within the remaining token limit
               const remainingTokens = Math.max(0, limit - cumulativeTokens);
-              const truncatedText = remainingTokens > 0 ? sliceByTokens(textContent, 0, remainingTokens) : '';
-              cumulativeTokens += this.countTokens(truncatedText);
+              const truncatedText = remainingTokens > 0 ? tokenx.sliceByTokens(textContent, 0, remainingTokens) : '';
+              cumulativeTokens += tokenx.estimateTokenCount(truncatedText);
 
               return {
                 ...part,

--- a/packages/core/src/processors/tool-result-reminder.ts
+++ b/packages/core/src/processors/tool-result-reminder.ts
@@ -1,8 +1,8 @@
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { isAbsolute, normalize, posix, resolve, win32 } from 'node:path';
-import { estimateTokenCount } from 'tokenx';
 import type { MessageList, MastraDBMessage } from '../agent/message-list';
 import { signalToXmlMarkup } from '../agent/signals';
+import { estimateTokenCount } from '../utils/tokenx';
 import type { ProcessInputStepArgs, Processor, ToolCallInfo } from './index';
 
 const INSTRUCTION_FILE_NAMES = ['AGENTS.md', 'CLAUDE.md', 'CONTEXT.md'] as const;
@@ -219,8 +219,8 @@ function getReminderMarkup(reminderText: string, instructionPath: string): strin
   });
 }
 
-function truncateToTokenLimit(content: string, maxTokens: number): string {
-  const estimatedTokens = estimateTokenCount(content);
+async function truncateToTokenLimit(content: string, maxTokens: number): Promise<string> {
+  const estimatedTokens = await estimateTokenCount(content);
   if (estimatedTokens <= maxTokens) {
     return content;
   }
@@ -229,7 +229,7 @@ function truncateToTokenLimit(content: string, maxTokens: number): string {
   const sliceEnd = Math.min(content.length, approximateCharLimit);
   const newlineIndex = content.lastIndexOf('\n', sliceEnd);
   const truncatedContent = content.slice(0, newlineIndex > 0 ? newlineIndex : sliceEnd).trimEnd();
-  const shownTokens = estimateTokenCount(truncatedContent);
+  const shownTokens = await estimateTokenCount(truncatedContent);
 
   return `${truncatedContent}\n\n[truncated — showing first ~${shownTokens} of ~${estimatedTokens} estimated tokens]`;
 }
@@ -343,7 +343,7 @@ export class AgentsMDInjector implements Processor<'agents-md-injector'> {
       return messageList;
     }
 
-    const reminderText = this.getReminderText(instructionPath, reader);
+    const reminderText = await this.getReminderText(instructionPath, reader);
     if (!reminderText) {
       return messageList;
     }
@@ -364,11 +364,11 @@ export class AgentsMDInjector implements Processor<'agents-md-injector'> {
     return messageList;
   }
 
-  private getReminderText(instructionPath: string, reader: ReminderFileReader): string | undefined {
+  private async getReminderText(instructionPath: string, reader: ReminderFileReader): Promise<string | undefined> {
     try {
       const content = reader.readFile(instructionPath).trim();
       if (content.length > 0) {
-        return truncateToTokenLimit(content, this.maxTokens);
+        return await truncateToTokenLimit(content, this.maxTokens);
       }
     } catch {
       // Fall back to configured reminder text if file cannot be read.

--- a/packages/core/src/utils/tokenx.test.ts
+++ b/packages/core/src/utils/tokenx.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { estimateTokenCount as tokenxEstimate, sliceByTokens as tokenxSlice } from 'tokenx';
+import { describe, expect, it } from 'vitest';
+import { estimateTokenCount, getTokenx, sliceByTokens } from './tokenx';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function sourceWithoutTypeImports(relativePath: string): string {
+  return readFileSync(join(here, relativePath), 'utf8')
+    .split('\n')
+    .filter(line => !/^\s*import type\b/.test(line))
+    .join('\n');
+}
+
+function assertNoStaticTokenx(relativePath: string): void {
+  const src = sourceWithoutTypeImports(relativePath);
+  expect(src, relativePath).not.toMatch(/from\s+['"]tokenx['"]/);
+  expect(src, relativePath).not.toMatch(/import\s*\(\s*['"]tokenx['"]\s*\)/);
+  expect(src, relativePath).not.toMatch(/(?<![.\w])require\s*\(\s*['"]tokenx['"]\s*\)/);
+}
+
+describe('lazy tokenx loader', () => {
+  it('does not statically import tokenx from the loader or its core callers', () => {
+    assertNoStaticTokenx('./tokenx.ts');
+    assertNoStaticTokenx('../processors/processors/token-limiter.ts');
+    assertNoStaticTokenx('../processors/tool-result-reminder.ts');
+    assertNoStaticTokenx('../workspace/tools/output-helpers.ts');
+  });
+
+  it('keeps the tokenx specifier behind importModule so the bundler cannot emit require("tokenx")', () => {
+    const src = readFileSync(join(here, './tokenx.ts'), 'utf8');
+    expect(src).toMatch(/const importModule = \(moduleName: string\) => import\(/);
+    expect(src).toMatch(/importModule\('tokenx'\)/);
+  });
+
+  it('returns the same estimates as tokenx', async () => {
+    const samples = ['', 'hello world', 'function foo() { return 1; }\n', '你好世界'];
+    for (const sample of samples) {
+      await expect(estimateTokenCount(sample)).resolves.toBe(tokenxEstimate(sample));
+    }
+  });
+
+  it('returns the same slices as tokenx', async () => {
+    const text = 'one two three four five six seven eight nine ten';
+    await expect(sliceByTokens(text, 0, 4)).resolves.toBe(tokenxSlice(text, 0, 4));
+    await expect(sliceByTokens(text, -3)).resolves.toBe(tokenxSlice(text, -3));
+  });
+
+  it('caches the loaded module', async () => {
+    const first = await getTokenx();
+    const second = await getTokenx();
+    expect(first).toBe(second);
+    expect(typeof first.estimateTokenCount).toBe('function');
+    expect(typeof first.sliceByTokens).toBe('function');
+  });
+});

--- a/packages/core/src/utils/tokenx.ts
+++ b/packages/core/src/utils/tokenx.ts
@@ -1,0 +1,48 @@
+import type { estimateTokenCount as EstimateTokenCount, sliceByTokens as SliceByTokens } from 'tokenx';
+
+type TokenxApi = {
+  estimateTokenCount: typeof EstimateTokenCount;
+  sliceByTokens: typeof SliceByTokens;
+};
+
+let cached: TokenxApi | undefined;
+let loading: Promise<TokenxApi> | undefined;
+
+// Keep the specifier as a parameter so tsdown cannot fold it into a literal dynamic import.
+const importModule = (moduleName: string) => import(/* @vite-ignore */ /* webpackIgnore: true */ moduleName);
+
+/**
+ * Lazily imports tokenx using a runtime-constructed module specifier.
+ * tokenx is ESM-only. A static import becomes a CommonJS require of that
+ * package, which Jest's default runtime cannot load.
+ */
+export async function getTokenx(): Promise<TokenxApi> {
+  if (cached) {
+    return cached;
+  }
+  if (!loading) {
+    loading = (async () => {
+      try {
+        const loaded = (await importModule('tokenx')) as TokenxApi;
+        cached = {
+          estimateTokenCount: loaded.estimateTokenCount,
+          sliceByTokens: loaded.sliceByTokens,
+        };
+        return cached;
+      } catch (err) {
+        throw new Error('tokenx is required for token estimation but could not be loaded in this environment.', {
+          cause: err,
+        });
+      }
+    })();
+  }
+  return loading;
+}
+
+export async function estimateTokenCount(text?: string): Promise<number> {
+  return (await getTokenx()).estimateTokenCount(text);
+}
+
+export async function sliceByTokens(text: string, start?: number, end?: number): Promise<string> {
+  return (await getTokenx()).sliceByTokens(text, start, end);
+}

--- a/packages/core/src/workspace/tools/output-helpers.ts
+++ b/packages/core/src/workspace/tools/output-helpers.ts
@@ -1,6 +1,5 @@
-import { estimateTokenCount, sliceByTokens } from 'tokenx';
-
 import { isValidationError } from '../../tools/validation';
+import { estimateTokenCount, sliceByTokens } from '../../utils/tokenx';
 
 /** Default number of lines to return (tail). */
 export const DEFAULT_TAIL_LINES = 200;
@@ -93,10 +92,10 @@ export async function applyTokenLimit(
 ): Promise<string> {
   if (!output) return output;
 
-  const totalTokens = estimateTokenCount(output);
+  const totalTokens = await estimateTokenCount(output);
   if (totalTokens <= limit) return output;
 
-  const kept = from === 'start' ? sliceByTokens(output, -limit) : sliceByTokens(output, 0, limit);
+  const kept = from === 'start' ? await sliceByTokens(output, -limit) : await sliceByTokens(output, 0, limit);
 
   const position = from === 'start' ? 'last' : 'first';
   return from === 'start'
@@ -120,13 +119,13 @@ export async function applyTokenLimitSandwich(
 ): Promise<string> {
   if (!output) return output;
 
-  const totalTokens = estimateTokenCount(output);
+  const totalTokens = await estimateTokenCount(output);
   if (totalTokens <= limit) return output;
   const headBudget = Math.floor(limit * headRatio);
   const tailBudget = limit - headBudget;
 
-  const head = headBudget > 0 ? sliceByTokens(output, 0, headBudget) : '';
-  const tail = tailBudget > 0 ? sliceByTokens(output, -tailBudget) : '';
+  const head = headBudget > 0 ? await sliceByTokens(output, 0, headBudget) : '';
+  const tail = tailBudget > 0 ? await sliceByTokens(output, -tailBudget) : '';
 
   const notice = `[...output truncated — showing first ~${headBudget} + last ~${tailBudget} of ~${totalTokens} tokens...]`;
   return [head, notice, tail].filter(Boolean).join('\n');


### PR DESCRIPTION
## Description

`@mastra/core` imported `tokenx` statically. The CJS build emits `require("tokenx")` (`dist/agent-*.cjs`), and tokenx resolves to `dist/index.mjs`, so under Jest 30 `require('tokenx')` from the core package throws `Must use import to load ES Module`. Node 22 handles it, Jest does not.

This adds `src/utils/tokenx.ts` using the same `importModule(name)` pattern the core already uses for execa, and points `TokenLimiterProcessor`, the tool-result reminder, and the workspace output helpers at it. All three call sites were already async, so the await is added there. tokenx is added to the pkg-outputs `runtimeOnlyDeps` guard. I did not add it to `deps.alwaysBundle`; #23030 did that and wardpeet closed it asking for a different import instead.

Verified: `vitest run src/utils/tokenx.test.ts src/processors/processors/token-limiter.test.ts src/workspace/tools/output-helpers.test.ts src/processors/tool-result-reminder.test.ts` (116 tests pass), oxlint on the touched files, and after `pnpm turbo build --filter ./packages/core` the CJS dist has `await importModule("tokenx")` and no `require("tokenx")`.

Requiring `Agent` under Jest still dies earlier on `@sindresorhus/slugify` (same ESM-only class). That is out of scope for this PR and needs its own follow-up.

## Related issue(s)

Fixes #22609

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR stops CommonJS and Jest users from loading the ESM-only `tokenx` package too early. It loads `tokenx` only when token counting runs, so `@mastra/core` can load correctly in CommonJS environments.

## Changes

- Added a cached lazy loader for `tokenx`.
- Updated token counting, slicing, tool-result reminders, and workspace output helpers to use asynchronous loading.
- Added tests for lazy loading, caching, dynamic imports, and behavior parity.
- Added `tokenx` to the runtime-only dependency bundle checks.
- Added a patch changeset for `@mastra/core`.
- Verified that built CommonJS output uses `await importModule("tokenx")` and does not call `require("tokenx")`.

This resolves issue `#22609`. Compatibility issues with `@sindresorhus/slugify` remain out of scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->