### PR TITLE
fix(cli): include optional Mastra packages

### DIFF
--- a/.changeset/include-optional-mastra-packages.md
+++ b/.changeset/include-optional-mastra-packages.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed CLI package discovery to include optional Mastra dependencies.

--- a/packages/cli/src/utils/mastra-packages.test.ts
+++ b/packages/cli/src/utils/mastra-packages.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getPackageInfo } from 'local-pkg';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getMastraPackages } from './mastra-packages.js';
+
+vi.mock('local-pkg', () => ({
+  getPackageInfo: vi.fn(),
+}));
+
+const mockGetPackageInfo = vi.mocked(getPackageInfo);
+
+describe('getMastraPackages', () => {
+  let rootDir: string;
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'mastra-packages-'));
+    mockGetPackageInfo.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('includes optional Mastra dependencies and filters unrelated packages', async () => {
+    writeFileSync(
+      join(rootDir, 'package.json'),
+      JSON.stringify({
+        optionalDependencies: {
+          '@mastra/optional': '^1.0.0',
+          mastra: '^1.0.0',
+          unrelated: '^1.0.0',
+        },
+      }),
+    );
+
+    await expect(getMastraPackages(rootDir)).resolves.toEqual([
+      { name: '@mastra/optional', version: '^1.0.0' },
+      { name: 'mastra', version: '^1.0.0' },
+    ]);
+  });
+
+  it('uses the optional dependency specification when package sections overlap', async () => {
+    writeFileSync(
+      join(rootDir, 'package.json'),
+      JSON.stringify({
+        dependencies: { '@mastra/core': '^1.0.0' },
+        devDependencies: { '@mastra/core': '^2.0.0' },
+        optionalDependencies: { '@mastra/core': '^3.0.0' },
+      }),
+    );
+
+    await expect(getMastraPackages(rootDir)).resolves.toEqual([{ name: '@mastra/core', version: '^3.0.0' }]);
+  });
+});

--- a/packages/cli/src/utils/mastra-packages.ts
+++ b/packages/cli/src/utils/mastra-packages.ts
@@ -5,6 +5,7 @@ import { getPackageInfo } from 'local-pkg';
 interface PackageJson {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
 }
 
 export interface MastraPackageInfo {
@@ -31,6 +32,7 @@ export async function getMastraPackages(rootDir: string): Promise<MastraPackageI
     const allDependencies = {
       ...(packageJson.dependencies ?? {}),
       ...(packageJson.devDependencies ?? {}),
+      ...(packageJson.optionalDependencies ?? {}),
     };
 
     const mastraDeps = Object.entries(allDependencies).filter(


### PR DESCRIPTION
## Description

Include optional Mastra dependencies in the CLI package inventory. Merge `optionalDependencies` last so duplicate entries follow npm's documented precedence, and add regression coverage for optional-only discovery, filtering, and overlapping dependency sections.

## Related issue(s)

Fixes #23191

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Validation

- Isolated package-inventory assertions for optional discovery, precedence, and filtering (3/3)
- `git diff --check`

The package test and typecheck could not run because workspace dependencies are not installed in this checkout.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The CLI now finds Mastra packages listed as optional dependencies. It also uses the optional version when a package appears in multiple dependency sections and ignores unrelated packages.

## Changes

- Added `optionalDependencies` to CLI package discovery.
- Applied npm precedence by merging optional dependencies last.
- Added regression tests for:
  - Optional-only package discovery.
  - Dependency precedence.
  - Filtering unrelated optional packages.
- Added a patch changeset for `mastra`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->