### PR TITLE
fix(cli): detect package manager from ancestor locks

### DIFF
--- a/.changeset/detect-workspace-package-manager.md
+++ b/.changeset/detect-workspace-package-manager.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed peer dependency update hints to use the package manager from the nearest ancestor lockfile.

--- a/packages/cli/src/utils/check-peer-deps.test.ts
+++ b/packages/cli/src/utils/check-peer-deps.test.ts
@@ -1,7 +1,11 @@
-import { getPackageInfo } from 'local-pkg';
-import { describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
-import { checkMastraPeerDeps, logPeerDepWarnings } from './check-peer-deps.js';
+import { getPackageInfo } from 'local-pkg';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { checkMastraPeerDeps, detectPackageManager, logPeerDepWarnings } from './check-peer-deps.js';
 import type { MastraPackageInfo } from './mastra-packages.js';
 
 // Mock local-pkg
@@ -202,5 +206,51 @@ describe('logPeerDepWarnings', () => {
     expect(consoleSpy).toHaveBeenCalled();
 
     consoleSpy.mockRestore();
+  });
+});
+
+describe('detectPackageManager', () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, { recursive: true, force: true })));
+  });
+
+  async function createNestedProject(lockfile?: string) {
+    const workspace = await mkdtemp(join(tmpdir(), 'mastra-package-manager-'));
+    const project = join(workspace, 'apps', 'api');
+    temporaryDirectories.push(workspace);
+    await mkdir(project, { recursive: true });
+
+    if (lockfile) {
+      await writeFile(join(workspace, lockfile), '');
+    }
+
+    return { project, workspace };
+  }
+
+  it('detects pnpm from an ancestor workspace lockfile', async () => {
+    const { project } = await createNestedProject('pnpm-lock.yaml');
+
+    expect(detectPackageManager(project)).toBe('pnpm');
+  });
+
+  it('detects yarn from an ancestor workspace lockfile', async () => {
+    const { project } = await createNestedProject('yarn.lock');
+
+    expect(detectPackageManager(project)).toBe('yarn');
+  });
+
+  it('uses the closest lockfile when workspaces are nested', async () => {
+    const { project, workspace } = await createNestedProject('pnpm-lock.yaml');
+    await writeFile(join(workspace, 'apps', 'yarn.lock'), '');
+
+    expect(detectPackageManager(project)).toBe('yarn');
+  });
+
+  it('falls back to npm when no lockfile is found', async () => {
+    const { project } = await createNestedProject();
+
+    expect(detectPackageManager(project)).toBe('npm');
   });
 });

--- a/packages/cli/src/utils/check-peer-deps.ts
+++ b/packages/cli/src/utils/check-peer-deps.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 
 import { getPackageInfo } from 'local-pkg';
 import pc from 'picocolors';
@@ -85,9 +86,21 @@ export async function checkMastraPeerDeps(packages: MastraPackageInfo[]): Promis
 /**
  * Detects the package manager being used in the project.
  */
-export function detectPackageManager(): 'pnpm' | 'npm' | 'yarn' {
-  if (existsSync('pnpm-lock.yaml')) return 'pnpm';
-  if (existsSync('yarn.lock')) return 'yarn';
+export function detectPackageManager(startDirectory = process.cwd()): 'pnpm' | 'npm' | 'yarn' {
+  let directory = resolve(startDirectory);
+
+  while (true) {
+    if (existsSync(join(directory, 'pnpm-lock.yaml'))) return 'pnpm';
+    if (existsSync(join(directory, 'yarn.lock'))) return 'yarn';
+    if (existsSync(join(directory, 'package-lock.json')) || existsSync(join(directory, 'npm-shrinkwrap.json'))) {
+      return 'npm';
+    }
+
+    const parentDirectory = dirname(directory);
+    if (parentDirectory === directory) break;
+    directory = parentDirectory;
+  }
+
   return 'npm';
 }
 


### PR DESCRIPTION
## Description

Walk upward from the project directory when detecting the package manager used in peer dependency repair hints. This keeps nested applications aligned with the nearest workspace lockfile instead of defaulting to npm.

The detector now recognizes pnpm, Yarn, npm lockfiles, and npm shrinkwrap files at each ancestor. It retains the npm fallback when no lockfile exists. Regression tests cover nested pnpm and Yarn workspaces, nearest-lockfile precedence, and the fallback.

Validation:

- Targeted `check-peer-deps.test.ts`: 12 tests passed
- Isolated package-manager reproduction harness: 4 cases passed
- Formatter check passed
- `git diff --check` passed
- Package-wide typecheck was attempted but could not run cleanly in this partial dependency checkout because unrelated CLI dependencies and built workspace packages are unavailable

## Related issue(s)

Fixes #23193

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (not applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an app is inside a larger project, the CLI now finds the correct package manager by checking nearby parent folders. This prevents it from suggesting npm commands when the project uses pnpm or Yarn.

## Changes

- Updated `detectPackageManager` to:
  - Walk from the start directory toward the filesystem root.
  - Use the nearest supported lockfile.
  - Support pnpm, Yarn, npm, and npm shrinkwrap lockfiles.
  - Preserve npm as the fallback.
  - Accept an optional `startDirectory` for deterministic tests.
- Added regression tests for nested workspaces, lockfile precedence, and npm fallback.
- Added a patch changeset for `mastra`.

## Verification

- Targeted tests passed.
- Reproduction cases passed.
- Formatter checks passed.
- `git diff --check` passed.
- Package-wide typechecking could not run because dependencies were unavailable in the partial checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->