### PR TITLE
fix(langfuse): promote root metadata and span type to trace metadata

### DIFF
--- a/.changeset/sparkly-apes-work.md
+++ b/.changeset/sparkly-apes-work.md
@@ -1,0 +1,5 @@
+---
+'@mastra/langfuse': patch
+---
+
+Map the root span's metadata and span type to `langfuse.trace.metadata.*` so keys like `runId` and `threadId` are filterable trace metadata again, matching the legacy exporter. fixes #23187

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -394,6 +394,134 @@ describe('LangfuseExporter', () => {
       expect(attrs['langfuse.trace.metadata.customerId']).toBe('abc');
     });
 
+    it('promotes root span metadata keys to langfuse.trace.metadata.*', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: SpanType.AGENT_RUN,
+          isRootSpan: true,
+          metadata: { runId: 'run-1', threadId: 'thread-1', sampleKey: 'sample-value' },
+        }),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.metadata.runId']).toBe('run-1');
+      // threadId still maps to session.id AND lands on the trace metadata,
+      // matching the legacy exporter that only pulled sessionId out
+      expect(attrs['langfuse.trace.metadata.threadId']).toBe('thread-1');
+      expect(attrs['session.id']).toBe('thread-1');
+      expect(attrs['langfuse.trace.metadata.sampleKey']).toBe('sample-value');
+    });
+
+    it('promotes the span type to langfuse.trace.metadata.spanType on the root span', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: SpanType.WORKFLOW_RUN,
+          isRootSpan: true,
+          entityId: 'my-workflow',
+          entityName: 'My Workflow',
+        }),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.metadata.spanType']).toBe('workflow_run');
+      expect(attrs['langfuse.trace.metadata.workflowId']).toBe('my-workflow');
+      // observation level mapping is unchanged
+      expect(attrs['langfuse.observation.metadata.spanType']).toBe('workflow_run');
+    });
+
+    it('lets a user metadata key named spanType win over the span type', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: SpanType.AGENT_RUN,
+          isRootSpan: true,
+          metadata: { spanType: 'user-supplied' },
+        }),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.metadata.spanType']).toBe('user-supplied');
+    });
+
+    it('does not promote metadata keys on non-root spans', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(exporter, makeSpan({ metadata: { runId: 'run-1' } }));
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.metadata.runId']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.spanType']).toBeUndefined();
+    });
+
+    it('skips metadata keys with dedicated trace targets when promoting', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          isRootSpan: true,
+          metadata: { userId: 'user-1', sessionId: 'session-1', traceName: 'my-trace', version: 'v2', runId: 'run-1' },
+        }),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['user.id']).toBe('user-1');
+      expect(attrs['session.id']).toBe('session-1');
+      expect(attrs['langfuse.trace.name']).toBe('my-trace');
+      expect(attrs['langfuse.trace.version']).toBe('v2');
+      // dedicated targets are not duplicated as trace metadata
+      expect(attrs['langfuse.trace.metadata.userId']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.sessionId']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.traceName']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.version']).toBeUndefined();
+      // everything else is still promoted
+      expect(attrs['langfuse.trace.metadata.runId']).toBe('run-1');
+    });
+
+    it('serializes promoted non-string metadata values as JSON', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          isRootSpan: true,
+          metadata: { seats: 42, isVip: true, nested: { plan: 'pro' }, nothing: undefined, blank: null },
+        }),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.metadata.seats']).toBe('42');
+      expect(attrs['langfuse.trace.metadata.isVip']).toBe('true');
+      expect(attrs['langfuse.trace.metadata.nested']).toBe(JSON.stringify({ plan: 'pro' }));
+      expect(attrs['langfuse.trace.metadata.nothing']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.blank']).toBeUndefined();
+    });
+
+    it('lets root span metadata win over a colliding custom langfuse metadata key but not over identity', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: SpanType.AGENT_RUN,
+          isRootSpan: true,
+          entityId: 'weather-agent',
+          metadata: {
+            langfuse: { customerId: 'abc' },
+            customerId: 'from-metadata',
+            agentId: 'from-metadata',
+          },
+        }),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      // the langfuse object is mapped first, root metadata never overwrites it
+      expect(attrs['langfuse.trace.metadata.customerId']).toBe('abc');
+      // root-span identity wins over promoted metadata
+      expect(attrs['langfuse.trace.metadata.agentId']).toBe('weather-agent');
+    });
+
     it('maps completionStartTime to langfuse.observation.completion_start_time', async () => {
       exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
       const ttftTime = new Date('2025-01-01T00:00:00.500Z');

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -405,6 +405,38 @@ function mapMastraToLangfuseAttributes(
         attributes['langfuse.trace.metadata.workflowName'] = span.entityName;
       }
     }
+
+    // Trace metadata: the legacy exporter built the trace payload with the
+    // span type and the root span's metadata (minus the keys that map to
+    // their own trace fields), so keys like runId, threadId, or custom
+    // fields landed on the
+    // trace record as filterable langfuse.trace.metadata.* entries. The
+    // rewrite only forwards the langfuse-specific metadata object and the
+    // entity identity above, silently dropping every other root metadata key.
+    // Promote them again: the metadata keys first, without overwriting the
+    // reserved mappings above, then the span type as the lowest precedence
+    // fallback so a user metadata key named spanType still wins over it.
+    for (const [key, value] of Object.entries(span.metadata ?? {})) {
+      // userId, sessionId, traceName, and version already have their own
+      // trace targets (user.id, session.id, langfuse.trace.name/version),
+      // and langfuse has its own object handling above.
+      if (key === 'userId' || key === 'sessionId' || key === 'traceName' || key === 'version' || key === 'langfuse') {
+        continue;
+      }
+      if (value === null || value === undefined) {
+        continue;
+      }
+      const traceKey = `langfuse.trace.metadata.${key}`;
+      if (attributes[traceKey] === undefined) {
+        // Langfuse maps langfuse.trace.metadata.* as string attributes, so
+        // serialize non-strings with JSON, same convention as the
+        // mastra.metadata.langfuse keys above.
+        attributes[traceKey] = typeof value === 'string' ? value : JSON.stringify(value);
+      }
+    }
+    if (attributes['langfuse.trace.metadata.spanType'] === undefined) {
+      attributes['langfuse.trace.metadata.spanType'] = span.type;
+    }
   }
 
   // Observation metadata: map semantic attributes to langfuse.observation.metadata.*


### PR DESCRIPTION
## Description

the legacy exporter built the trace payload with the span type and the root span's metadata, so keys like runId, threadId or custom fields landed on the trace record as filterable langfuse.trace.metadata.* entries. the otel rewrite only forwards the mastra.metadata.langfuse object and the entity identity keys (agentId, agentName) now, every other root metadata key stays observation level only, so langfuse queries and integrations that match on those trace metadata fields stop matching

this promotes the root span's metadata back to langfuse.trace.metadata.* and fills langfuse.trace.metadata.spanType as the lowest precedence fallback, a user metadata key named spanType still wins over it, mirroring the legacy payload order

- userId, sessionId, traceName and version keep their own trace targets (user.id, session.id, langfuse.trace.name, langfuse.trace.version) and are not duplicated as trace metadata
- existing trace metadata keys are never overwritten, so the langfuse object keys and the root span identity keep precedence
- non string values are serialized with JSON, same convention as the langfuse metadata object keys, and langfuse restores the original types on ingestion
- behavior on non root spans is unchanged

## Related issue(s)

Fixes #23187

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Root span details were not reaching Langfuse trace metadata after the OTEL migration. This PR restores that mapping while protecting existing trace fields and nested span behavior.

## Changes

- Promotes root-span metadata to `langfuse.trace.metadata.*`.
- Promotes `spanType` as a lowest-precedence fallback.
- Preserves precedence for:
  - User-provided `spanType`
  - Explicit Langfuse metadata
  - Root span identity metadata
- Keeps `userId`, `sessionId`, `traceName`, and `version` on their dedicated trace targets.
- JSON-serializes non-string metadata values.
- Preserves non-root span behavior.
- Adds coverage for promotion, precedence, dedicated targets, serialization, and collisions.
- Adds a patch changeset for `@mastra/langfuse`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->