### PR TITLE
fix(factory): select requested bearer organization securely

### DIFF
--- a/.changeset/cute-socks-crash.md
+++ b/.changeset/cute-socks-crash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed hosted Factory bearer requests to select only organizations proven by the authenticated user's memberships.

--- a/mastracode/factory/src/auth.test.ts
+++ b/mastracode/factory/src/auth.test.ts
@@ -374,6 +374,88 @@ describe('mountFactoryAuth gate (enabled)', () => {
       avatarUrl: 'https://avatars.example/user.png',
     });
   });
+
+  it('selects a requested bearer organization proven by provider memberships', async () => {
+    mockAuthenticate.mockResolvedValue({
+      workosId: 'user_123',
+      memberships: [
+        { id: 'membership_1', organizationId: 'org_1' },
+        { id: 'membership_2', organizationId: 'org_2' },
+      ],
+    });
+    const app = new Hono();
+    mountFactoryAuth(app, { redirectUri: 'http://localhost:4111/auth/callback' });
+    app.get('/web/whoami', c => c.json(factoryAuthTenant(c)));
+
+    const res = await app.request('/web/whoami', {
+      headers: {
+        Accept: 'application/json',
+        Authorization: 'Bearer cli-token',
+        'X-Mastra-Organization-Id': 'org_2',
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ orgId: 'org_2', userId: 'user_123' });
+    expect(mockEnsureOrganization).not.toHaveBeenCalled();
+  });
+
+  it('selects a requested bearer organization proven by Studio membership ids', async () => {
+    mockAuthenticate.mockResolvedValue({
+      id: 'user_123',
+      organizationId: 'org_1',
+      memberOrgIds: ['org_1', 'org_2'],
+    });
+    const app = new Hono();
+    mountFactoryAuth(app, { redirectUri: 'http://localhost:4111/auth/callback' });
+    app.get('/web/whoami', c => c.json(factoryAuthTenant(c)));
+
+    const res = await app.request('/web/whoami', {
+      headers: {
+        Accept: 'application/json',
+        Authorization: 'Bearer cli-token',
+        'X-Mastra-Organization-Id': 'org_2',
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ orgId: 'org_2', userId: 'user_123' });
+    expect(mockEnsureOrganization).not.toHaveBeenCalled();
+  });
+
+  it('rejects a requested bearer organization not present in provider memberships', async () => {
+    mockAuthenticate.mockResolvedValue({
+      workosId: 'user_123',
+      memberships: [{ id: 'membership_1', organizationId: 'org_1' }],
+    });
+    const { app } = buildApp();
+
+    const res = await app.request('/web/projects', {
+      headers: {
+        Accept: 'application/json',
+        Authorization: 'Bearer cli-token',
+        'X-Mastra-Organization-Id': 'org_other',
+      },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'organization_forbidden' });
+    expect(mockEnsureOrganization).not.toHaveBeenCalled();
+  });
+
+  it('does not let an organization header change cookie-authenticated tenancy', async () => {
+    mockAuthenticate.mockResolvedValue({ workosId: 'user_123', organizationId: 'org_cookie' });
+    const app = new Hono();
+    mountFactoryAuth(app, { redirectUri: 'http://localhost:4111/auth/callback' });
+    app.get('/web/whoami', c => c.json(factoryAuthTenant(c)));
+
+    const res = await app.request('/web/whoami', {
+      headers: { Accept: 'application/json', 'X-Mastra-Organization-Id': 'org_other' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ orgId: 'org_cookie', userId: 'user_123' });
+  });
 });
 
 describe('mountFactoryAuth /auth routes (enabled)', () => {

--- a/mastracode/factory/src/auth.ts
+++ b/mastracode/factory/src/auth.ts
@@ -16,6 +16,8 @@ import type { RouteAuth } from './routes/route.js';
 import { actorFromAuthUser } from './storage/domains/comments/actor.js';
 import { timedAboveThreshold } from './timing.js';
 
+const ORGANIZATION_ID_HEADER = 'X-Mastra-Organization-Id';
+
 /**
  * Provider-neutral factory auth gating for the MastraCode web server.
  *
@@ -56,6 +58,8 @@ export interface FactoryAuthUser {
    * isolated building instances. Absent for personal (no-org) accounts.
    */
   organizationId?: string;
+  /** Organization ids proven by the provider's authenticated membership response. */
+  organizationMembershipIds?: string[];
 }
 
 /**
@@ -230,10 +234,23 @@ function toFactoryAuthUser(result: unknown): FactoryAuthUser | null {
     name?: unknown;
     avatarUrl?: unknown;
     organizationId?: unknown;
+    memberships?: unknown;
+    memberOrgIds?: unknown;
   };
   const id = typeof flat.id === 'string' ? flat.id : undefined;
   const workosId = typeof flat.workosId === 'string' ? flat.workosId : undefined;
   if (!id && !workosId) return null;
+  const membershipOrganizationIds = Array.isArray(flat.memberships)
+    ? flat.memberships.flatMap(membership => {
+        if (!membership || typeof membership !== 'object') return [];
+        const organizationId = (membership as { organizationId?: unknown }).organizationId;
+        return typeof organizationId === 'string' ? [organizationId] : [];
+      })
+    : [];
+  const memberOrgIds = Array.isArray(flat.memberOrgIds)
+    ? flat.memberOrgIds.filter((organizationId): organizationId is string => typeof organizationId === 'string')
+    : [];
+  const organizationMembershipIds = [...new Set([...membershipOrganizationIds, ...memberOrgIds])];
   return {
     id,
     workosId,
@@ -241,6 +258,7 @@ function toFactoryAuthUser(result: unknown): FactoryAuthUser | null {
     name: typeof flat.name === 'string' ? flat.name : undefined,
     avatarUrl: typeof flat.avatarUrl === 'string' ? flat.avatarUrl : undefined,
     organizationId: typeof flat.organizationId === 'string' ? flat.organizationId : undefined,
+    organizationMembershipIds,
   };
 }
 
@@ -280,6 +298,13 @@ async function ensureUserOrg(provider: IMastraAuthProvider, user: FactoryAuthUse
   } catch {
     // Best-effort: the user stays no-org until a later request succeeds.
   }
+}
+
+function selectRequestedOrganization(user: FactoryAuthUser, requestedOrganizationId: string): boolean {
+  if (user.organizationId === requestedOrganizationId) return true;
+  if (!user.organizationMembershipIds?.includes(requestedOrganizationId)) return false;
+  user.organizationId = requestedOrganizationId;
+  return true;
 }
 
 /**
@@ -807,9 +832,16 @@ export function createFactoryAuthGate(provider: IMastraAuthProvider) {
     );
 
     if (user) {
-      // Bootstrap a personal org for no-org accounts so the org id resolves on
-      // this request (see ensureFactoryAuthUser for the rationale).
-      await ensureUserOrg(provider, user);
+      const requestedOrganizationId = token ? c.req.header(ORGANIZATION_ID_HEADER)?.trim() : undefined;
+      if (requestedOrganizationId) {
+        if (!selectRequestedOrganization(user, requestedOrganizationId)) {
+          return c.json({ error: 'organization_forbidden' }, 403);
+        }
+      } else {
+        // Bootstrap a personal org for no-org accounts so the org id resolves on
+        // this request (see ensureFactoryAuthUser for the rationale).
+        await ensureUserOrg(provider, user);
+      }
       c.set(FACTORY_AUTH_USER_KEY, user);
       const requestContext = c.get('requestContext');
       requestContext?.set('user', user);


### PR DESCRIPTION
## Summary

Allow authenticated Factory bearer requests to select an organization with `X-Mastra-Organization-Id` when that organization is proven by the provider's membership data.

This fixes hosted automation for users with multiple organizations, where bearer authentication could otherwise resolve no organization and fall back to a different tenant than the browser session. Invalid organization selections fail closed with `403 organization_forbidden`; cookie-authenticated browser requests keep their existing behavior.

This PR is intentionally server-only so it can be deployed before the separate Factory API CLI work. The CLI header-sending change remains in that follow-up branch.

## Test plan

- `pnpm --filter @mastra/factory exec vitest run src/auth.test.ts --reporter=dot --bail=1`
- `pnpm --filter @mastra/factory check`
- `pnpm --filter @mastra/factory build:lib`
- `pnpm exec oxfmt --check mastracode/factory/src/auth.ts mastracode/factory/src/auth.test.ts .changeset/cute-socks-crash.md`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory requests can now choose an organization only when the signed-in user belongs to it. Invalid choices are rejected, while browser cookie authentication keeps its existing behavior.

## Changes

- Added support for the `X-Mastra-Organization-Id` header for bearer authentication.
- Validated requested organizations against provider membership data.
- Return `403 organization_forbidden` for unauthorized organization selections.
- Preserved existing cookie-authenticated tenancy behavior.
- Added membership normalization from `memberships` and `memberOrgIds`.
- Added authentication tests for valid, invalid, and cookie-authenticated requests.
- Added a patch changeset for `@mastra/factory`.

## Validation

- Factory authentication tests
- Type checking
- Library build validation
- Formatting checks
- Whitespace validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->