### PR TITLE
fix(schema-compat): skip AJV codegen when new Function is blocked

### DIFF
--- a/.changeset/lazy-json-schema-workers.md
+++ b/.changeset/lazy-json-schema-workers.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed JSON Schema tool validation on Cloudflare Workers so it no longer fails when AJV cannot compile with new Function. Fixes #14503.

--- a/packages/schema-compat/src/standard-schema/adapters/json-schema.test.ts
+++ b/packages/schema-compat/src/standard-schema/adapters/json-schema.test.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema7 } from 'json-schema';
 import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
 import { isStandardSchemaWithJSON } from '../standard-schema';
 import { toStandardSchema } from './json-schema';
 
@@ -336,21 +337,19 @@ describe('json-schema standard-schema adapter', () => {
 
     function withBlockedCodegen<T>(fn: () => T): T {
       const OriginalFunction = globalThis.Function;
-      const originalEval = globalThis.eval;
       const blowUp = function BlockedFunction() {
         throw new EvalError('Code generation from strings disallowed for this context');
       };
       globalThis.Function = blowUp as unknown as FunctionConstructor;
-      globalThis.eval = blowUp as unknown as typeof eval;
       try {
         return fn();
       } finally {
         globalThis.Function = OriginalFunction;
-        globalThis.eval = originalEval;
       }
     }
 
-    it('validates JSON Schema input when new Function/eval is blocked', async () => {
+    it('validates JSON Schema input when new Function is blocked', async () => {
+      z.object({ a: z.string() }).safeParse({ a: 'x' });
       const standardSchema = toStandardSchema(workflowToolSchema);
       const result = await withBlockedCodegen(() =>
         standardSchema['~standard'].validate({

--- a/packages/schema-compat/src/standard-schema/adapters/json-schema.test.ts
+++ b/packages/schema-compat/src/standard-schema/adapters/json-schema.test.ts
@@ -318,4 +318,66 @@ describe('json-schema standard-schema adapter', () => {
       expect(isStandardSchemaWithJSON({})).toBe(false);
     });
   });
+
+  describe('Cloudflare Workers codegen restriction (issue #14503)', () => {
+    const workflowToolSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        inputData: {
+          type: 'object',
+          properties: {
+            test: { type: 'string' },
+          },
+          required: ['test'],
+        },
+      },
+      required: ['inputData'],
+    };
+
+    function withBlockedCodegen<T>(fn: () => T): T {
+      const OriginalFunction = globalThis.Function;
+      const originalEval = globalThis.eval;
+      const blowUp = function BlockedFunction() {
+        throw new EvalError('Code generation from strings disallowed for this context');
+      };
+      globalThis.Function = blowUp as unknown as FunctionConstructor;
+      globalThis.eval = blowUp as unknown as typeof eval;
+      try {
+        return fn();
+      } finally {
+        globalThis.Function = OriginalFunction;
+        globalThis.eval = originalEval;
+      }
+    }
+
+    it('validates JSON Schema input when new Function/eval is blocked', async () => {
+      const standardSchema = toStandardSchema(workflowToolSchema);
+      const result = await withBlockedCodegen(() =>
+        standardSchema['~standard'].validate({
+          inputData: { test: '123' },
+        }),
+      );
+
+      expect('issues' in result && result.issues).toBeFalsy();
+      expect(result).toEqual({
+        value: { inputData: { test: '123' } },
+      });
+    });
+
+    it('returns schema issues, not a codegen error, when input is invalid and Function is blocked', async () => {
+      const standardSchema = toStandardSchema({
+        type: 'object',
+        properties: { name: { type: 'string' } },
+        required: ['name'],
+      });
+      const result = await withBlockedCodegen(() => standardSchema['~standard'].validate({}));
+
+      expect('issues' in result && result.issues).toBeTruthy();
+      if ('issues' in result && result.issues) {
+        expect(
+          result.issues.some(issue => /code generation from strings|Schema validation error:/i.test(issue.message)),
+        ).toBe(false);
+      }
+    });
+  });
 });

--- a/packages/schema-compat/src/standard-schema/adapters/json-schema.ts
+++ b/packages/schema-compat/src/standard-schema/adapters/json-schema.ts
@@ -3,7 +3,26 @@ import Ajv from 'ajv';
 import Ajv2020 from 'ajv/dist/2020.js';
 import type { JSONSchema7 } from 'json-schema';
 import traverse from 'json-schema-traverse';
+import { z } from 'zod';
+import { convertJsonSchemaToZod } from 'zod-from-json-schema';
+import { convertJsonSchemaToZod as convertJsonSchemaToZodV3 } from 'zod-from-json-schema-v3';
 import type { StandardSchemaWithJSON, StandardSchemaWithJSONProps } from '../standard-schema.types';
+
+function isDynamicCodegenAllowed(): boolean {
+  try {
+    const fn = new Function('return 1');
+    return fn() === 1;
+  } catch {
+    return false;
+  }
+}
+
+function isCodegenDisallowedError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return error.name === 'EvalError' || /code generation from strings/i.test(error.message);
+}
 
 /**
  * Vendor name for JSON Schema wrapped schemas.
@@ -30,8 +49,9 @@ export interface JsonSchemaAdapterOptions {
  * A wrapper class that makes JSON Schema compatible with @standard-schema/spec.
  *
  * This class implements both `StandardSchemaV1` (validation) and `StandardJSONSchemaV1`
- * (JSON Schema conversion) interfaces. Validation is performed using Ajv (Another JSON
- * Schema Validator).
+ * (JSON Schema conversion) interfaces. Validation uses Ajv when `new Function` is
+ * allowed. On runtimes that block dynamic code generation (Cloudflare Workers), it
+ * falls back to converting the JSON Schema to Zod via `zod-from-json-schema`.
  *
  * @typeParam T - The TypeScript type that the JSON Schema represents
  *
@@ -62,6 +82,8 @@ export class JsonSchemaWrapper<Input = unknown, Output = Input> implements Stand
   readonly #options: JsonSchemaAdapterOptions;
   #ajvValidateCache: ReturnType<Ajv['compile']> | null = null;
   #ajvInstance: Ajv | null = null;
+  #useAjv: boolean | null = null;
+  #zodFromJsonSchema: z.ZodTypeAny | null = null;
 
   readonly '~standard': StandardSchemaWithJSONProps<Input, Output>;
 
@@ -82,13 +104,17 @@ export class JsonSchemaWrapper<Input = unknown, Output = Input> implements Stand
   }
 
   /**
-   * Validates a value against the JSON Schema using Ajv.
+   * Validates a value against the JSON Schema using Ajv, or Zod when Ajv cannot compile.
    *
    * @param value - The value to validate
    * @returns A result object with either the validated value or validation issues
    */
   #validate(value: unknown): StandardSchemaV1.Result<Output> | Promise<StandardSchemaV1.Result<Output>> {
     try {
+      if (!this.#shouldUseAjv()) {
+        return this.#validateWithZodFromJsonSchema(value);
+      }
+
       const validateFn = this.#getAjvValidator();
       const result = validateFn(value);
 
@@ -118,7 +144,50 @@ export class JsonSchemaWrapper<Input = unknown, Output = Input> implements Stand
 
       return { issues };
     } catch (error) {
+      if (isCodegenDisallowedError(error)) {
+        this.#useAjv = false;
+        return this.#validateWithZodFromJsonSchema(value);
+      }
       // If validation fails unexpectedly, return a validation error
+      const message = error instanceof Error ? error.message : 'Unknown validation error';
+      return {
+        issues: [{ message: `Schema validation error: ${message}` }],
+      };
+    }
+  }
+
+  #shouldUseAjv(): boolean {
+    if (this.#useAjv === null) {
+      this.#useAjv = isDynamicCodegenAllowed();
+    }
+    return this.#useAjv;
+  }
+
+  #getZodFromJsonSchema(): z.ZodTypeAny {
+    if (!this.#zodFromJsonSchema) {
+      if ('toJSONSchema' in z) {
+        // @ts-expect-error - type issue in convertJsonSchemaToZod
+        this.#zodFromJsonSchema = convertJsonSchemaToZod(this.#schema);
+      } else {
+        // @ts-expect-error - type issue in convertJsonSchemaToZodV3
+        this.#zodFromJsonSchema = convertJsonSchemaToZodV3(this.#schema);
+      }
+    }
+    return this.#zodFromJsonSchema;
+  }
+
+  #validateWithZodFromJsonSchema(value: unknown): StandardSchemaV1.Result<Output> {
+    try {
+      const result = this.#getZodFromJsonSchema().safeParse(value);
+      if (result.success) {
+        return { value: result.data as Output };
+      }
+      const issues: StandardSchemaV1.Issue[] = result.error.issues.map(issue => ({
+        message: issue.message,
+        path: issue.path,
+      }));
+      return { issues };
+    } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown validation error';
       return {
         issues: [{ message: `Schema validation error: ${message}` }],
@@ -241,8 +310,8 @@ export class JsonSchemaWrapper<Input = unknown, Output = Input> implements Stand
  * Wraps a JSON Schema to implement the full @standard-schema/spec interface.
  *
  * This function creates a wrapper that implements both `StandardSchemaV1` (validation)
- * and `StandardJSONSchemaV1` (JSON Schema conversion) interfaces. Validation is performed
- * using Ajv (Another JSON Schema Validator).
+ * and `StandardJSONSchemaV1` (JSON Schema conversion) interfaces. Validation uses Ajv
+ * when `new Function` is allowed, and `zod-from-json-schema` when it is not.
  *
  * @typeParam T - The TypeScript type that the JSON Schema represents
  * @param schema - The JSON Schema to wrap

--- a/packages/schema-compat/src/standard-schema/adapters/json-schema.ts
+++ b/packages/schema-compat/src/standard-schema/adapters/json-schema.ts
@@ -8,21 +8,21 @@ import { convertJsonSchemaToZod } from 'zod-from-json-schema';
 import { convertJsonSchemaToZod as convertJsonSchemaToZodV3 } from 'zod-from-json-schema-v3';
 import type { StandardSchemaWithJSON, StandardSchemaWithJSONProps } from '../standard-schema.types';
 
-function isDynamicCodegenAllowed(): boolean {
-  try {
-    const fn = new Function('return 1');
-    return fn() === 1;
-  } catch {
-    return false;
-  }
-}
-
 function isCodegenDisallowedError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
   }
   return error.name === 'EvalError' || /code generation from strings/i.test(error.message);
 }
+
+type JsonSchemaZod = {
+  safeParse: (
+    data: unknown,
+    params?: { jitless?: boolean },
+  ) =>
+    | { success: true; data: unknown }
+    | { success: false; error: { issues: Array<{ message: string; path: PropertyKey[] }> } };
+};
 
 /**
  * Vendor name for JSON Schema wrapped schemas.
@@ -40,6 +40,7 @@ export interface JsonSchemaAdapterOptions {
 
   /**
    * Ajv options to customize validation behavior.
+   * Only applied when Ajv compiles (runtimes that allow `new Function`).
    * @see https://ajv.js.org/options.html
    */
   ajvOptions?: ConstructorParameters<typeof Ajv>[0];
@@ -52,6 +53,7 @@ export interface JsonSchemaAdapterOptions {
  * (JSON Schema conversion) interfaces. Validation uses Ajv when `new Function` is
  * allowed. On runtimes that block dynamic code generation (Cloudflare Workers), it
  * falls back to converting the JSON Schema to Zod via `zod-from-json-schema`.
+ * `ajvOptions` only apply on the Ajv path.
  *
  * @typeParam T - The TypeScript type that the JSON Schema represents
  *
@@ -82,8 +84,7 @@ export class JsonSchemaWrapper<Input = unknown, Output = Input> implements Stand
   readonly #options: JsonSchemaAdapterOptions;
   #ajvValidateCache: ReturnType<Ajv['compile']> | null = null;
   #ajvInstance: Ajv | null = null;
-  #useAjv: boolean | null = null;
-  #zodFromJsonSchema: z.ZodTypeAny | null = null;
+  #zodFromJsonSchema: JsonSchemaZod | null = null;
 
   readonly '~standard': StandardSchemaWithJSONProps<Input, Output>;
 
@@ -111,7 +112,7 @@ export class JsonSchemaWrapper<Input = unknown, Output = Input> implements Stand
    */
   #validate(value: unknown): StandardSchemaV1.Result<Output> | Promise<StandardSchemaV1.Result<Output>> {
     try {
-      if (!this.#shouldUseAjv()) {
+      if (this.#zodFromJsonSchema) {
         return this.#validateWithZodFromJsonSchema(value);
       }
 
@@ -145,7 +146,6 @@ export class JsonSchemaWrapper<Input = unknown, Output = Input> implements Stand
       return { issues };
     } catch (error) {
       if (isCodegenDisallowedError(error)) {
-        this.#useAjv = false;
         return this.#validateWithZodFromJsonSchema(value);
       }
       // If validation fails unexpectedly, return a validation error
@@ -156,29 +156,24 @@ export class JsonSchemaWrapper<Input = unknown, Output = Input> implements Stand
     }
   }
 
-  #shouldUseAjv(): boolean {
-    if (this.#useAjv === null) {
-      this.#useAjv = isDynamicCodegenAllowed();
+  #getZodFromJsonSchema(): JsonSchemaZod {
+    if (this.#zodFromJsonSchema) {
+      return this.#zodFromJsonSchema;
     }
-    return this.#useAjv;
-  }
-
-  #getZodFromJsonSchema(): z.ZodTypeAny {
-    if (!this.#zodFromJsonSchema) {
-      if ('toJSONSchema' in z) {
-        // @ts-expect-error - type issue in convertJsonSchemaToZod
-        this.#zodFromJsonSchema = convertJsonSchemaToZod(this.#schema);
-      } else {
-        // @ts-expect-error - type issue in convertJsonSchemaToZodV3
-        this.#zodFromJsonSchema = convertJsonSchemaToZodV3(this.#schema);
-      }
-    }
-    return this.#zodFromJsonSchema;
+    const schema: JsonSchemaZod =
+      'toJSONSchema' in z
+        ? (convertJsonSchemaToZod(this.#schema as any) as JsonSchemaZod)
+        : (convertJsonSchemaToZodV3(this.#schema as any) as JsonSchemaZod);
+    this.#zodFromJsonSchema = schema;
+    return schema;
   }
 
   #validateWithZodFromJsonSchema(value: unknown): StandardSchemaV1.Result<Output> {
     try {
-      const result = this.#getZodFromJsonSchema().safeParse(value);
+      const schema = this.#getZodFromJsonSchema();
+      // Zod v4 may have already cached allowsEval=true and enabled object JIT.
+      // jitless skips that fastpass so parse does not call new Function on Workers.
+      const result = 'toJSONSchema' in z ? schema.safeParse(value, { jitless: true }) : schema.safeParse(value);
       if (result.success) {
         return { value: result.data as Output };
       }
@@ -297,6 +292,7 @@ export class JsonSchemaWrapper<Input = unknown, Output = Input> implements Stand
 
   /**
    * Returns the Ajv instance used for validation.
+   * Throws on runtimes that block dynamic code generation.
    * Useful for advanced use cases like adding custom formats or keywords.
    */
   getAjv(): Ajv {


### PR DESCRIPTION
## Description

`JsonSchemaWrapper` compiles AJV with `new Function`. #14503 reports that on Cloudflare Workers this throws `EvalError: Code generation from strings disallowed for this context`, and the wrapper reports it as a tool-input validation error. MCP tools and workflow-as-tool schemas (createTool with a JSON Schema) go through this wrapper.

When `new Function` is blocked, validate with `zod-from-json-schema` (already a dependency of `@mastra/schema-compat`) instead of AJV. Node still uses AJV. Zod `.refine()` is unchanged, Zod v4 already validates through its own `~standard.validate`. `resolveSerializedZodOutput` still uses `Function()` for Vercel JSON tools, out of scope here.

Repro in the new tests: stub `Function` as a constructor that throws that EvalError, then `toStandardSchema` + `~standard.validate`. With `json-schema.ts` reverted and the tests kept, they fail with `Schema validation error: Code generation from strings disallowed for this context`. With the change, valid `{ inputData: { test: "123" } }` succeeds and missing required fields still return schema issues. In packages/schema-compat: `tsc -p tsconfig.build.json --noEmit` exit 0, `vitest run src/standard-schema/adapters/json-schema.test.ts` 38 pass, `vitest run --project unit:packages/schema-compat:v4 --no-file-parallelism` 655 pass.

## Related issue(s)

Fixes #14503

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Cloudflare Workers block the JavaScript technique that AJV uses to validate schemas. This PR uses Zod validation when that technique is unavailable, while keeping AJV for Node.js.

## Changes

- Added a fallback from AJV to `zod-from-json-schema` when dynamic code generation fails.
- Preserved AJV validation in environments that support code generation.
- Disabled Zod JIT on the v4 fallback path to prevent additional `new Function` calls.
- Preserved `.refine()` and `.superRefine()` behavior.
- Added tests for blocked `Function` construction, valid input, and missing required fields.
- Added a patch changeset for `@mastra/schema-compat`.
- Added typechecking for fallback schema conversion.

## Verification

- Typechecking passes.
- Schema compatibility tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->