### PR TITLE
fix(factory): enforce bearer organization on custom routes

### DIFF
--- a/.changeset/wacky-beds-design.md
+++ b/.changeset/wacky-beds-design.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Factory custom API routes to honor validated bearer organization selection.

--- a/mastracode/factory/src/auth-seam.test.ts
+++ b/mastracode/factory/src/auth-seam.test.ts
@@ -3,7 +3,15 @@ import type { IMastraAuthProvider } from '@mastra/core/server';
 import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { buildAuthRoutes, getWorkOSProvider, isWorkOSAuth, mountFactoryAuth, factoryAuthTenant } from './auth.js';
+import {
+  buildAuthRoutes,
+  createFactoryRouteAuth,
+  getWorkOSProvider,
+  isWorkOSAuth,
+  mountFactoryAuth,
+  factoryAuthTenant,
+} from './auth.js';
+import { handleServerError } from './server-error.js';
 
 /**
  * Provider-seam behavior: the auth module operates on an explicitly-passed
@@ -94,6 +102,73 @@ describe('active provider resolution', () => {
 
   it('getWorkOSProvider throws when the active provider is not WorkOS', () => {
     expect(() => getWorkOSProvider(fakeProvider())).toThrow(/not WorkOS/);
+  });
+});
+
+describe('Factory route auth organization selection', () => {
+  function buildRouteApp(provider: IMastraAuthProvider) {
+    const app = new Hono();
+    const auth = createFactoryRouteAuth(provider);
+    app.onError(handleServerError);
+    app.get('/web/projects', async c => {
+      const user = await auth.ensureUser(c);
+      if (!user) return c.json({ error: 'unauthorized' }, 401);
+      return c.json(auth.tenant(c));
+    });
+    return app;
+  }
+
+  it('selects a requested bearer organization inside the custom route auth seam', async () => {
+    const provider = fakeProvider({
+      authenticateToken: vi.fn(async () => ({
+        id: 'user_123',
+        organizationId: 'org_1',
+        memberOrgIds: ['org_1', 'org_2'],
+      })),
+    });
+
+    const res = await buildRouteApp(provider).request('/web/projects', {
+      headers: {
+        Authorization: 'Bearer cli-token',
+        'X-Mastra-Organization-Id': 'org_2',
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ orgId: 'org_2', userId: 'user_123' });
+  });
+
+  it('rejects an inaccessible bearer organization inside the custom route auth seam', async () => {
+    const provider = fakeProvider({
+      authenticateToken: vi.fn(async () => ({
+        id: 'user_123',
+        organizationId: 'org_1',
+        memberOrgIds: ['org_1'],
+      })),
+    });
+
+    const res = await buildRouteApp(provider).request('/web/projects', {
+      headers: {
+        Authorization: 'Bearer cli-token',
+        'X-Mastra-Organization-Id': 'org_other',
+      },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'organization_forbidden' });
+  });
+
+  it('ignores the organization header for cookie-authenticated custom routes', async () => {
+    const provider = fakeProvider({
+      authenticateToken: vi.fn(async () => ({ id: 'user_123', organizationId: 'org_cookie' })),
+    });
+
+    const res = await buildRouteApp(provider).request('/web/projects', {
+      headers: { 'X-Mastra-Organization-Id': 'org_other' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ orgId: 'org_cookie', userId: 'user_123' });
   });
 });
 

--- a/mastracode/factory/src/auth.ts
+++ b/mastracode/factory/src/auth.ts
@@ -11,6 +11,7 @@ import {
 } from '@mastra/core/server';
 import type { ApiRoute, IMastraAuthProvider, ISessionProvider } from '@mastra/core/server';
 import type { Context, Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
 
 import type { RouteAuth } from './routes/route.js';
 import { actorFromAuthUser } from './storage/domains/comments/actor.js';
@@ -398,7 +399,14 @@ export async function ensureFactoryAuthUser(
   const user = await authenticateRequest(provider, token, c.req.raw);
   if (!user) return undefined;
 
-  await ensureUserOrg(provider, user);
+  const requestedOrganizationId = token ? c.req.header(ORGANIZATION_ID_HEADER)?.trim() : undefined;
+  if (requestedOrganizationId) {
+    if (!selectRequestedOrganization(user, requestedOrganizationId)) {
+      throw new HTTPException(403, { message: 'organization_forbidden' });
+    }
+  } else {
+    await ensureUserOrg(provider, user);
+  }
 
   c.set(FACTORY_AUTH_USER_KEY, user);
   return user;


### PR DESCRIPTION
The Factory CLI already sends both the bearer token and the deploy project's organization when it calls a hosted Factory:

```http
Authorization: Bearer <token>
X-Mastra-Organization-Id: <project organization>
```

PR #23196 added secure organization selection to the top-level Factory auth gate. However, Factory-owned `/web/factory/*` routes authenticate through `ensureFactoryAuthUser()` directly, so they bypassed that gate. The outgoing request was correct, but the custom route continued using the default organization returned by `/auth/verify` rather than the requested organization.

For example, `/auth/verify` could return `organizationId: org_default` while `memberOrgIds` includes `org_factory`, and the request selects `org_factory`. Before this change, the route queried Factory storage as `org_default`, producing an empty project list even though the caller was a valid member of `org_factory`.

This change applies the same organization selection inside the custom-route auth seam before the authenticated user is cached:

```ts
const requestedOrganizationId = token ? c.req.header(ORGANIZATION_ID_HEADER)?.trim() : undefined;
if (requestedOrganizationId && !selectRequestedOrganization(user, requestedOrganizationId)) {
  throw new HTTPException(403, { message: 'organization_forbidden' });
}
```

The token and `/auth/verify` response are not modified. Only the request-scoped authenticated user is switched after the requested organization is validated against provider-proven memberships. Cookie-authenticated browser requests continue to ignore this header and retain their session organization.

Verified with focused auth seam coverage: a valid member organization selects that tenant and exposes its Factory project, an inaccessible organization returns `403 organization_forbidden`, cookie tenancy remains unchanged, and the existing Factory auth suite continues to pass. `@mastra/factory` typecheck and build also pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory routes now honor the organization requested by signed-in API users. Users can access only organizations they belong to, while browser sessions keep using their existing organization.

## Changes

- Added bearer-request support for `X-Mastra-Organization-Id`.
- Validate organization membership before caching the authenticated user.
- Select the requested organization when the user has access.
- Return `403 organization_forbidden` for inaccessible organizations.
- Keep cookie-authenticated requests on their session organization.
- Keep tokens and `/auth/verify` responses unchanged.
- Added focused route-level tests.
- Added a patch changeset for `@mastra/factory`.

## Validation

- Focused authentication tests pass.
- Existing Factory authentication tests pass.
- `@mastra/factory` typecheck passes.
- Build passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->