### PR TITLE
fix(memory): recover observation indexing and avoid PostgreSQL pool timeouts

### DIFF
--- a/.changeset/full-states-move.md
+++ b/.changeset/full-states-move.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'mastracode': patch
+---
+
+Fixed observation indexing retries so temporary connection errors recover without duplicating stored observations.

--- a/.changeset/full-states-move.md
+++ b/.changeset/full-states-move.md
@@ -1,6 +1,5 @@
 ---
 '@mastra/memory': patch
-'mastracode': patch
 ---
 
 Fixed observation indexing retries so temporary connection errors recover without duplicating stored observations.

--- a/.changeset/tough-eyes-relate.md
+++ b/.changeset/tough-eyes-relate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed vector operations timing out with small PostgreSQL connection pools when index metadata is not cached.

--- a/packages/memory/src/embedding-cache.test.ts
+++ b/packages/memory/src/embedding-cache.test.ts
@@ -1,3 +1,4 @@
+import { embedMany as embedManyV6 } from '@internal/ai-v6';
 import { InMemoryStore } from '@mastra/core/storage';
 import { describe, it, expect, vi } from 'vitest';
 import { Memory } from './index';
@@ -31,6 +32,65 @@ function createMemory() {
     options: { semanticRecall: true },
   });
 }
+
+describe('observation indexing IDs', () => {
+  const observation = {
+    text: 'An observation',
+    groupId: 'group-1',
+    range: 'message-1:message-2',
+    threadId: 'thread-1',
+    resourceId: 'resource-1',
+  };
+
+  it('reuses UUIDs across retries and Memory instances', async () => {
+    const first = createMemory();
+    const second = createMemory();
+    await first.indexObservation(observation);
+    await first.indexObservation(observation);
+    await second.indexObservation(observation);
+    const calls = vi.mocked(first.vector!.upsert).mock.calls;
+    const ids = calls[0]![0].ids;
+    expect(ids).toHaveLength(1);
+    expect(ids![0]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-8[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    expect(calls[1]![0].ids).toEqual(ids);
+    expect(vi.mocked(second.vector!.upsert).mock.calls[0]![0].ids).toEqual(ids);
+  });
+
+  it('does not duplicate chunks when a successful write reports a timeout', async () => {
+    vi.mocked(embedManyV6).mockImplementationOnce(async ({ values }) => ({
+      values,
+      embeddings: values.map(() => [0.1, 0.2]),
+      usage: { tokens: 1 },
+      warnings: [],
+    }));
+    const memory = createMemory();
+    const rows = new Set<string>();
+    let attempts = 0;
+    vi.mocked(memory.vector!.upsert).mockImplementation(async ({ ids, vectors }) => {
+      const storedIds = vectors.map((_, index) => ids?.[index] ?? crypto.randomUUID());
+      storedIds.forEach(id => rows.add(id));
+      if (++attempts === 1) throw new Error('Connection terminated due to connection timeout');
+      return storedIds;
+    });
+    const input = { ...observation, text: 'observation '.repeat(5000) };
+    await expect(memory.indexObservation(input)).rejects.toThrow('connection timeout');
+    await memory.indexObservation(input);
+    const calls = vi.mocked(memory.vector!.upsert).mock.calls;
+    const ids = calls[0]![0].ids!;
+    expect(ids.length).toBeGreaterThan(1);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(calls[1]![0].ids).toEqual(ids);
+    expect(rows.size).toBe(ids.length);
+  });
+
+  it.each(['groupId', 'threadId', 'resourceId'] as const)('isolates IDs by %s', async key => {
+    const memory = createMemory();
+    await memory.indexObservation(observation);
+    await memory.indexObservation({ ...observation, [key]: 'another-value' });
+    const calls = vi.mocked(memory.vector!.upsert).mock.calls;
+    expect(calls[0]![0].ids).not.toEqual(calls[1]![0].ids);
+  });
+});
 
 describe('embedMessageContent caching', () => {
   it('reuses cached embeddings for repeated content (cache hit)', async () => {

--- a/packages/memory/src/embedding-cache.test.ts
+++ b/packages/memory/src/embedding-cache.test.ts
@@ -1,17 +1,31 @@
-import { embedMany as embedManyV6 } from '@internal/ai-v6';
 import { InMemoryStore } from '@mastra/core/storage';
 import { describe, it, expect, vi } from 'vitest';
 import { Memory } from './index';
 
 // Mock embedMany across AI SDK versions so embedMessageContent does no network I/O.
 vi.mock('@internal/ai-v6', () => ({
-  embedMany: vi.fn().mockResolvedValue({ embeddings: [[0.1, 0.2]], usage: { tokens: 1 } }),
+  embedMany: vi.fn(async ({ values }: { values: string[] }) => ({
+    values,
+    embeddings: values.map(() => [0.1, 0.2]),
+    usage: { tokens: 1 },
+    warnings: [],
+  })),
 }));
 vi.mock('@internal/ai-sdk-v5', () => ({
-  embedMany: vi.fn().mockResolvedValue({ embeddings: [[0.1, 0.2]], usage: { tokens: 1 } }),
+  embedMany: vi.fn(async ({ values }: { values: string[] }) => ({
+    values,
+    embeddings: values.map(() => [0.1, 0.2]),
+    usage: { tokens: 1 },
+    warnings: [],
+  })),
 }));
 vi.mock('@internal/ai-sdk-v4', () => ({
-  embedMany: vi.fn().mockResolvedValue({ embeddings: [[0.1, 0.2]], usage: { tokens: 1 } }),
+  embedMany: vi.fn(async ({ values }: { values: string[] }) => ({
+    values,
+    embeddings: values.map(() => [0.1, 0.2]),
+    usage: { tokens: 1 },
+    warnings: [],
+  })),
 }));
 
 function createMemory() {
@@ -57,13 +71,14 @@ describe('observation indexing IDs', () => {
   });
 
   it('does not duplicate chunks when a successful write reports a timeout', async () => {
-    vi.mocked(embedManyV6).mockImplementationOnce(async ({ values }) => ({
-      values,
-      embeddings: values.map(() => [0.1, 0.2]),
-      usage: { tokens: 1 },
-      warnings: [],
-    }));
     const memory = createMemory();
+    const chunks = ['first', 'second', 'third', 'fourth'];
+    vi.spyOn(memory as any, 'embedMessageContent').mockResolvedValue({
+      chunks,
+      embeddings: chunks.map(() => [0.1, 0.2]),
+      usage: { tokens: 1 },
+      dimension: 2,
+    });
     const rows = new Set<string>();
     let attempts = 0;
     vi.mocked(memory.vector!.upsert).mockImplementation(async ({ ids, vectors }) => {
@@ -72,9 +87,8 @@ describe('observation indexing IDs', () => {
       if (++attempts === 1) throw new Error('Connection terminated due to connection timeout');
       return storedIds;
     });
-    const input = { ...observation, text: 'observation '.repeat(5000) };
-    await expect(memory.indexObservation(input)).rejects.toThrow('connection timeout');
-    await memory.indexObservation(input);
+    await expect(memory.indexObservation(observation)).rejects.toThrow('connection timeout');
+    await memory.indexObservation(observation);
     const calls = vi.mocked(memory.vector!.upsert).mock.calls;
     const ids = calls[0]![0].ids!;
     expect(ids.length).toBeGreaterThan(1);

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { embedMany } from '@internal/ai-sdk-v4';
 import type { TextPart } from '@internal/ai-sdk-v4';
 import { embedMany as embedManyV5 } from '@internal/ai-sdk-v5';
@@ -2281,9 +2282,21 @@ Notes:
     }
 
     const { indexName } = await this.createObservationEmbeddingIndex(embedResult.dimension);
+    // Stable UUIDv8 IDs make retries safe even when a write succeeds but its acknowledgement is lost.
+    // UUID formatting also supports vector stores that reject arbitrary string IDs.
+    const ids = embedResult.chunks.map((_, chunkIndex) => {
+      const hash = createHash('sha256')
+        .update(JSON.stringify([resourceId, threadId, groupId, chunkIndex]))
+        .digest();
+      hash[6] = (hash[6]! & 0x0f) | 0x80;
+      hash[8] = (hash[8]! & 0x3f) | 0x80;
+      const hex = hash.toString('hex', 0, 16);
+      return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+    });
 
     await this.vector.upsert({
       indexName,
+      ids,
       vectors: embedResult.embeddings,
       metadata: embedResult.chunks.map(chunk => ({
         group_id: groupId,

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
@@ -927,6 +927,50 @@ describe('buffer()', () => {
     expect(status.bufferedChunkCount).toBe(1);
   });
 
+  it.each([true, false])('handles transient=%s indexing errors without regenerating observations', async transient => {
+    const resourceId = 'indexing-resource';
+    const error = new Error(transient ? 'Connection terminated due to connection timeout' : 'Invalid vector dimension');
+    const onIndexObservations = vi.fn().mockRejectedValueOnce(error).mockResolvedValue(undefined);
+    const model = createMockObserverModel();
+    const observe = vi.spyOn(model, 'doStream');
+    const persist = vi.spyOn(storage, 'updateBufferedObservations');
+    const om = new ObservationalMemory({
+      storage,
+      scope: 'thread',
+      retrieval: { vector: true },
+      onIndexObservations,
+      observation: { model, messageTokens: 500, bufferTokens: 0.2 },
+      reflection: { model: createMockReflectorModel(), observationTokens: 10000 },
+    });
+    await storage.saveThread({
+      thread: {
+        id: threadId,
+        resourceId,
+        title: 'Indexing',
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+    await storage.saveMessages({
+      messages: createBulkMessages(5, threadId).map(message => ({ ...message, resourceId })),
+    });
+
+    await om.buffer({ threadId, resourceId });
+    await om.waitForBuffering(threadId, resourceId, 5000);
+
+    expect(onIndexObservations).toHaveBeenCalledTimes(transient ? 2 : 1);
+    expect(observe).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledTimes(1);
+    const status = await om.getStatus({ threadId, resourceId });
+    expect(status.bufferedChunkCount).toBe(1);
+    expect(status.record?.isBufferingObservation).toBe(false);
+    const stored = await storage.listMessages({ threadId, perPage: false });
+    const markerTypes = stored.messages.flatMap(message => message.content.parts.map(part => part.type));
+    expect(markerTypes.includes('data-om-buffering-failed')).toBe(!transient);
+    expect(markerTypes.includes('data-om-buffering-end')).toBe(transient);
+  });
+
   it('should not buffer when no unobserved messages exist', async () => {
     const om = createOM(storage, { messageTokens: 500, bufferTokens: 0.2 });
     // No messages in storage

--- a/packages/memory/src/processors/observational-memory/observation-strategies/base.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/base.ts
@@ -9,6 +9,7 @@ import { getObservableMessages, stripThreadTags } from '../message-utils';
 import { parseObservationGroups, wrapInObservationGroup } from '../observation-groups';
 import type { ObserverRunner } from '../observer-runner';
 import type { ReflectorRunner } from '../reflector-runner';
+import { withRetry } from '../retry';
 import { stripSubconsciousSignals } from '../subconscious/origin';
 import { getMaxThreshold } from '../thresholds';
 import type { TokenCounter } from '../token-counter';
@@ -329,14 +330,18 @@ export abstract class ObservationStrategy {
 
     await Promise.all(
       groups.map(group =>
-        this.deps.onIndexObservations!({
-          text: group.content,
-          groupId: group.id,
-          range: group.range,
-          threadId,
-          resourceId,
-          observedAt,
-        }),
+        withRetry(
+          () =>
+            this.deps.onIndexObservations!({
+              text: group.content,
+              groupId: group.id,
+              range: group.range,
+              threadId,
+              resourceId,
+              observedAt,
+            }),
+          { label: 'index-observations', abortSignal: this.opts.abortSignal },
+        ),
       ),
     );
   }

--- a/stores/pg/src/vector/index.count-scan.test.ts
+++ b/stores/pg/src/vector/index.count-scan.test.ts
@@ -117,6 +117,45 @@ describe('PgVector row counts', () => {
     mockClient.query.mockReset();
   });
 
+  it.each(['upsert', 'query', 'updateVector', 'buildIndex'] as const)(
+    '%s works with a cold metadata cache and a single available connection',
+    async operation => {
+      const vectorStore = new PgVector(baseConfig);
+      await (vectorStore as any).cacheWarmupPromise;
+      clearIndexCaches(vectorStore);
+      statements = [];
+      let held = false;
+      let exhausted = false;
+      const connect = vi.spyOn(vectorStore.pool, 'connect').mockImplementation(async () => {
+        if (held) {
+          exhausted = true;
+          throw new Error('Connection pool exhausted');
+        }
+        held = true;
+        return mockClient;
+      });
+      mockClient.release.mockImplementation(() => {
+        held = false;
+      });
+      try {
+        if (operation === 'upsert') {
+          await vectorStore.upsert({ indexName, vectors: [[1, 2, 3]], ids: ['vector-1'] });
+        } else if (operation === 'query') {
+          await vectorStore.query({ indexName, queryVector: [1, 2, 3] });
+        } else if (operation === 'updateVector') {
+          await vectorStore.updateVector({ indexName, id: 'vector-1', update: { vector: [3, 2, 1] } });
+        } else {
+          await vectorStore.buildIndex({ indexName, metric: 'cosine', indexConfig: { type: 'flat' } });
+        }
+        expect(held).toBe(false);
+        expect(exhausted).toBe(false);
+        expect(statements.some(sql => sql.includes('pg_attribute'))).toBe(true);
+      } finally {
+        connect.mockRestore();
+      }
+    },
+  );
+
   it('does not count rows while warming the index cache on construction', async () => {
     const vectorStore = new PgVector(baseConfig);
     await (vectorStore as any).cacheWarmupPromise;

--- a/stores/pg/src/vector/index.pool-capacity.test.ts
+++ b/stores/pg/src/vector/index.pool-capacity.test.ts
@@ -1,0 +1,51 @@
+import { randomUUID } from 'node:crypto';
+import { expect, it, vi } from 'vitest';
+
+import { PgVector } from '.';
+
+it('supports cold-cache vector operations with a single-connection pool', async () => {
+  const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@localhost:5434/mastra';
+  const indexName = `pool_${randomUUID().replaceAll('-', '')}`;
+  const admin = new PgVector({ id: 'pool-capacity-admin', connectionString, pgPoolOptions: { max: 1 } });
+  const createClient = () => {
+    // Prevent constructor warmup from filling the metadata cache before the operation under test.
+    const listIndexes = vi.spyOn(PgVector.prototype, 'listIndexes').mockResolvedValue([]);
+    try {
+      return new PgVector({
+        id: 'pool-capacity-client',
+        connectionString,
+        disableInit: true,
+        pgPoolOptions: { max: 1, connectionTimeoutMillis: 500 },
+      });
+    } finally {
+      listIndexes.mockRestore();
+    }
+  };
+
+  try {
+    await admin.createIndex({ indexName, dimension: 3 });
+    // A fresh client for each operation ensures metadata has not been cached by a previous operation.
+    for (const operation of ['upsert', 'query', 'update', 'build'] as const) {
+      const client = createClient();
+      try {
+        if (operation === 'upsert') {
+          await client.upsert({ indexName, vectors: [[1, 0, 0]], ids: ['vector-1'] });
+        } else if (operation === 'query') {
+          const results = await client.query({ indexName, queryVector: [1, 0, 0] });
+          expect(results[0]?.id).toBe('vector-1');
+        } else if (operation === 'update') {
+          await client.updateVector({ indexName, id: 'vector-1', update: { vector: [0, 1, 0] } });
+        } else {
+          await client.buildIndex({ indexName, metric: 'cosine', indexConfig: { type: 'flat' } });
+        }
+        expect(client.pool.totalCount).toBe(1);
+        expect(client.pool.idleCount).toBe(1);
+      } finally {
+        await client.disconnect();
+      }
+    }
+  } finally {
+    await admin.deleteIndex({ indexName });
+    await admin.disconnect();
+  }
+});

--- a/stores/pg/src/vector/index.test.ts
+++ b/stores/pg/src/vector/index.test.ts
@@ -3478,6 +3478,8 @@ describe('PgVector', () => {
       const originalConnect = vectorDB.pool.connect.bind(vectorDB.pool);
       const connectSpy = vi.spyOn(vectorDB.pool, 'connect').mockImplementation(async () => {
         const client: any = await originalConnect();
+        // Metadata and data queries can reuse the same pooled client on separate checkouts.
+        if (patched.some(entry => entry.client === client)) return client;
         const originalQuery = client.query.bind(client);
         patched.push({ client, originalQuery });
         client.query = (...args: any[]) => {

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -650,6 +650,8 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       }
     }
 
+    // Load metadata before holding a connection so a cold cache cannot exhaust the pool.
+    const indexInfo = await this.getIndexMetadata({ indexName });
     // Vector similarity query
     const client = await this.pool.connect();
     try {
@@ -658,9 +660,6 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       await client.query('BEGIN');
       const translatedFilter = this.transformFilter(filter);
       const { sql: filterQuery, values: filterValues } = buildFilterQuery(translatedFilter, minScore, topK);
-
-      // Get index type and configuration
-      const indexInfo = await this.getIndexMetadata({ indexName });
 
       const metric = indexInfo.metric ?? 'cosine';
       const ops = this.getVectorOps(indexInfo.vectorType, metric);
@@ -775,6 +774,8 @@ export class PgVector extends MastraVector<PGVectorFilter> {
 
     const { tableName } = this.getTableName(indexName);
 
+    const indexInfo = await this.getIndexMetadata({ indexName });
+
     // Start a transaction
     const client = await this.pool.connect();
     try {
@@ -806,7 +807,6 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       const vectorIds = ids || vectors.map(() => crypto.randomUUID());
 
       // Get the properly qualified vector type for this index
-      const indexInfo = await this.getIndexMetadata({ indexName });
       const qualifiedVectorType = this.getVectorTypeName(indexInfo.vectorType, indexInfo.dimension);
       const ops = this.getVectorOps(indexInfo.vectorType, indexInfo.metric ?? 'cosine');
 
@@ -1253,7 +1253,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       let existingIndexInfo: PGIndexMetadata | null = null;
       let dimension = 0;
       try {
-        existingIndexInfo = await this.getIndexMetadata({ indexName });
+        existingIndexInfo = await this.describeIndexMetadata({ indexName }, client);
         dimension = existingIndexInfo.dimension;
 
         if (isConfigEmpty && existingIndexInfo.metric === metric) {
@@ -1542,8 +1542,11 @@ export class PgVector extends MastraVector<PGVectorFilter> {
    * {@link describeIndex} it issues no `COUNT(*)`, so its cost does not grow with the
    * number of rows in the table.
    */
-  private async describeIndexMetadata({ indexName }: DescribeIndexParams): Promise<PGIndexMetadata> {
-    const client = await this.pool.connect();
+  private async describeIndexMetadata(
+    { indexName }: DescribeIndexParams,
+    existingClient?: pg.PoolClient,
+  ): Promise<PGIndexMetadata> {
+    const client = existingClient ?? (await this.pool.connect());
     try {
       const { tableName, parsedIndexName } = this.getTableName(indexName);
 
@@ -1641,7 +1644,6 @@ export class PgVector extends MastraVector<PGVectorFilter> {
         config,
       };
     } catch (e: any) {
-      await client.query('ROLLBACK');
       const mastraError = new MastraError(
         {
           id: createVectorErrorId('PG', 'DESCRIBE_INDEX', 'FAILED'),
@@ -1656,7 +1658,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       this.logger?.trackException(mastraError);
       throw mastraError;
     } finally {
-      client.release();
+      if (!existingClient) client.release();
     }
   }
 
@@ -1805,6 +1807,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
         });
       }
 
+      const indexInfo = await this.getIndexMetadata({ indexName });
       client = await this.pool.connect();
       // Set search path so vector type casts (e.g. ::vector, ::halfvec) resolve correctly
       await this.ensureSearchPath(client);
@@ -1812,7 +1815,6 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       const { tableName } = this.getTableName(indexName);
 
       // Get the properly qualified vector type for this index
-      const indexInfo = await this.getIndexMetadata({ indexName });
       const qualifiedVectorType = this.getVectorTypeName(indexInfo.vectorType, indexInfo.dimension);
       const ops = this.getVectorOps(indexInfo.vectorType, indexInfo.metric ?? 'cosine');
 


### PR DESCRIPTION
Fixes cold-cache vector operations holding one PostgreSQL connection while waiting for another. Observation indexing now retries temporary failures with stable vector IDs, so a lost write acknowledgement does not create duplicate observations.

For an existing index, the same call now works with an uncached index and a single-connection pool:

```ts
const vector = new PgVector({
  id: "observations",
  connectionString,
  pgPoolOptions: { max: 1, connectionTimeoutMillis: 500 },
});

// Before: could time out waiting for a second connection.
// After: completes using the available connection.
await vector.upsert({ indexName, vectors: [[1, 0, 0]], ids: ["observation-1"] });
```

Verified with 559 passing tests (one skipped), including a real PostgreSQL regression that failed before the fix. Memory and PostgreSQL typechecks, lint, and formatting checks pass. Includes separate patch changesets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR prevents PostgreSQL vector operations from getting stuck when the connection pool is small. It also makes observation retries update the same records instead of creating duplicates.

## Changes

- Load PostgreSQL index metadata before acquiring a connection.
- Reuse caller-owned clients during index setup without rolling back or releasing them.
- Generate stable IDs for observation embedding chunks.
- Retry observation indexing with stable vector IDs.
- Add tests for retry behavior, duplicate prevention, ID isolation, and buffering.
- Add PostgreSQL regression tests for cold-cache vector operations with one connection.
- Add patch changesets for `@mastra/memory`, `mastracode`, and `@mastra/pg`.

## Validation

- 559 tests passed.
- 1 test was skipped.
- Memory and PostgreSQL typechecks passed.
- Linting and formatting checks passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->