### PR TITLE
fix(langfuse): forward root span metadata to Langfuse trace metadata

### DIFF
--- a/.changeset/red-squids-grow.md
+++ b/.changeset/red-squids-grow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/langfuse': patch
+---
+
+Fixed root span metadata missing from Langfuse trace metadata. Since the Langfuse v5 (OTLP) upgrade, only a fixed set of keys reached the trace, so `runId`, `resourceId`, and custom metadata set on the root span were nested under `metadata.attributes` in Langfuse and could not be used in trace filters or evaluator scopes. The exporter now forwards every remaining root span metadata key to `langfuse.trace.metadata.<key>`, matching the behavior before the upgrade. Explicit `metadata.langfuse.*` values and the agent/workflow identity keys keep precedence, and child spans never change trace metadata. Fixes [#23187](https://github.com/mastra-ai/mastra/issues/23187).

--- a/docs/src/content/en/integrations/observability/langfuse.mdx
+++ b/docs/src/content/en/integrations/observability/langfuse.mdx
@@ -200,10 +200,13 @@ const tracingOptions = {
 
 This example produces `langfuse.trace.metadata.customerId` and `langfuse.trace.metadata.tier`.
 
+Metadata on the root span is also forwarded. Mastra sets `runId` and `resourceId` on every agent and workflow root span, and you can add your own keys through `tracingOptions.metadata`. The exporter forwards each of these root span keys to `langfuse.trace.metadata.<key>`. Keys that map to a dedicated Langfuse field (`userId`, `sessionId`, `threadId`, `traceName`, and `version`) are not duplicated as trace metadata. Metadata on child spans stays on the observation and never changes the trace.
+
 Notes:
 
 - The reserved `prompt` key is used for [prompt linking](#prompt-linking) and isn't forwarded as trace metadata.
 - The reserved identity keys `agentId`, `agentName`, `workflowId`, and `workflowName` are set from the root span and take precedence over custom values with the same name.
+- Keys under `langfuse` take precedence over root span metadata with the same name.
 - Values are sent as strings, because Langfuse maps trace metadata attributes as strings. Numbers, booleans, and objects are serialized with JSON. Langfuse Cloud restores them to their original types on ingestion.
 
 ## Prompt linking

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -719,6 +719,55 @@ describe('LangfuseExporter', () => {
       expect(attrs['langfuse.trace.metadata.runId']).toBe('run-1');
     });
 
+    it('does not forward dedicated metadata keys with falsy values', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: SpanType.AGENT_RUN,
+          isRootSpan: true,
+          entityId: 'weather-agent',
+          metadata: {
+            userId: '',
+            sessionId: '',
+            threadId: '',
+            traceName: '',
+            version: 0,
+            langfuse: '',
+            runId: 'run-1',
+          },
+        } as any),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.metadata.userId']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.sessionId']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.threadId']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.traceName']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.version']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.langfuse']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.runId']).toBe('run-1');
+    });
+
+    it('skips only the root metadata key that cannot be serialized', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: SpanType.AGENT_RUN,
+          isRootSpan: true,
+          entityId: 'weather-agent',
+          metadata: { big: BigInt(1), runId: 'run-1' },
+        } as any),
+      );
+
+      expect(processedSpans).toHaveLength(1);
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.metadata.big']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.runId']).toBe('run-1');
+      expect(attrs['langfuse.trace.metadata.agentId']).toBe('weather-agent');
+    });
+
     it('lets explicit metadata.langfuse.* values take precedence over root span metadata', async () => {
       exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
       await exportSpan(

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -637,6 +637,108 @@ describe('LangfuseExporter', () => {
       expect(attrs['langfuse.trace.metadata.agentName']).toBeUndefined();
     });
 
+    it('forwards remaining root span metadata to langfuse.trace.metadata.*', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: SpanType.AGENT_RUN,
+          isRootSpan: true,
+          entityId: 'weather-agent',
+          metadata: {
+            runId: 'run-1',
+            resourceId: 'user-42',
+            sampleKey: 'sample-value',
+            attempt: 3,
+            flags: { beta: true },
+            skipped: null,
+          },
+        } as any),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.metadata.runId']).toBe('run-1');
+      expect(attrs['langfuse.trace.metadata.resourceId']).toBe('user-42');
+      expect(attrs['langfuse.trace.metadata.sampleKey']).toBe('sample-value');
+      // non-strings are JSON-serialized, matching the metadata.langfuse.* path
+      expect(attrs['langfuse.trace.metadata.attempt']).toBe('3');
+      expect(attrs['langfuse.trace.metadata.flags']).toBe(JSON.stringify({ beta: true }));
+      expect(attrs['langfuse.trace.metadata.skipped']).toBeUndefined();
+      // identity keys are still set alongside the forwarded metadata
+      expect(attrs['langfuse.trace.metadata.agentId']).toBe('weather-agent');
+      // the mastra.metadata.* attributes stay on the observation
+      expect(attrs['mastra.metadata.runId']).toBe('run-1');
+      expect(attrs['mastra.metadata.sampleKey']).toBe('sample-value');
+    });
+
+    it('does not forward metadata from non-root spans to trace metadata', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: SpanType.TOOL_CALL,
+          isRootSpan: false,
+          metadata: { runId: 'run-child', sampleKey: 'child-value' },
+        } as any),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.metadata.runId']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.sampleKey']).toBeUndefined();
+      expect(attrs['mastra.metadata.runId']).toBe('run-child');
+    });
+
+    it('does not duplicate root metadata keys that map to dedicated Langfuse fields', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: SpanType.AGENT_RUN,
+          isRootSpan: true,
+          entityId: 'weather-agent',
+          metadata: {
+            userId: 'user-123',
+            threadId: 'thread-1',
+            traceName: 'custom-trace-name',
+            version: '2.1.0',
+            runId: 'run-1',
+          },
+        } as any),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['user.id']).toBe('user-123');
+      expect(attrs['session.id']).toBe('thread-1');
+      expect(attrs['langfuse.trace.name']).toBe('custom-trace-name');
+      expect(attrs['langfuse.trace.version']).toBe('2.1.0');
+      expect(attrs['langfuse.trace.metadata.userId']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.threadId']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.sessionId']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.traceName']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.version']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.runId']).toBe('run-1');
+    });
+
+    it('lets explicit metadata.langfuse.* values take precedence over root span metadata', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: SpanType.AGENT_RUN,
+          isRootSpan: true,
+          entityId: 'weather-agent',
+          metadata: {
+            tier: 'root-value',
+            langfuse: { tier: 'explicit-value' },
+          },
+        } as any),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.metadata.tier']).toBe('explicit-value');
+      expect(attrs['langfuse.trace.metadata.langfuse']).toBeUndefined();
+    });
+
     it('scopes trace name and metadata to the workflow on root WORKFLOW_RUN spans', async () => {
       exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
       await exportSpan(

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -749,25 +749,6 @@ describe('LangfuseExporter', () => {
       expect(attrs['langfuse.trace.metadata.runId']).toBe('run-1');
     });
 
-    it('skips only the root metadata key that cannot be serialized', async () => {
-      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
-      await exportSpan(
-        exporter,
-        makeSpan({
-          type: SpanType.AGENT_RUN,
-          isRootSpan: true,
-          entityId: 'weather-agent',
-          metadata: { big: BigInt(1), runId: 'run-1' },
-        } as any),
-      );
-
-      expect(processedSpans).toHaveLength(1);
-      const attrs = processedSpans[0].attributes;
-      expect(attrs['langfuse.trace.metadata.big']).toBeUndefined();
-      expect(attrs['langfuse.trace.metadata.runId']).toBe('run-1');
-      expect(attrs['langfuse.trace.metadata.agentId']).toBe('weather-agent');
-    });
-
     it('lets explicit metadata.langfuse.* values take precedence over root span metadata', async () => {
       exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
       await exportSpan(

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -16,6 +16,7 @@ import type { BaseExporterConfig } from '@mastra/observability';
 import { SpanConverter } from '@mastra/otel-exporter';
 
 const LOG_PREFIX = '[LangfuseExporter]';
+const MASTRA_METADATA_PREFIX = 'mastra.metadata.';
 
 export const LANGFUSE_DEFAULT_BASE_URL = 'https://cloud.langfuse.com';
 
@@ -403,6 +404,27 @@ function mapMastraToLangfuseAttributes(
       }
       if (span.entityName) {
         attributes['langfuse.trace.metadata.workflowName'] = span.entityName;
+      }
+    }
+
+    // Root-span metadata: forward the remaining mastra.metadata.* keys (runId,
+    // resourceId, and any user-supplied keys) to langfuse.trace.metadata.* so
+    // they stay first-level, filterable trace metadata, as they were before the
+    // OTLP migration. Langfuse only nests unmapped attributes under
+    // metadata.attributes, which cannot be used in trace filters or evaluator
+    // scopes. Keys that map to dedicated Langfuse fields (userId, sessionId,
+    // threadId, traceName, version, langfuse.*) were already removed above.
+    // Explicit metadata.langfuse.* values and the identity keys above take
+    // precedence. Child spans are skipped because Langfuse applies
+    // langfuse.trace.* from any span, so a child could overwrite the trace.
+    // The mastra.metadata.* attribute is kept on the observation.
+    for (const [key, value] of Object.entries(attributes)) {
+      if (!key.startsWith(MASTRA_METADATA_PREFIX) || value === null || value === undefined) {
+        continue;
+      }
+      const traceKey = `langfuse.trace.metadata.${key.slice(MASTRA_METADATA_PREFIX.length)}`;
+      if (attributes[traceKey] === undefined) {
+        attributes[traceKey] = typeof value === 'string' ? value : JSON.stringify(value);
       }
     }
   }

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -17,6 +17,8 @@ import { SpanConverter } from '@mastra/otel-exporter';
 
 const LOG_PREFIX = '[LangfuseExporter]';
 const MASTRA_METADATA_PREFIX = 'mastra.metadata.';
+/** Metadata keys mapped to dedicated Langfuse fields; never forwarded as trace metadata. */
+const DEDICATED_METADATA_KEYS = new Set(['userId', 'sessionId', 'threadId', 'traceName', 'version', 'langfuse']);
 
 export const LANGFUSE_DEFAULT_BASE_URL = 'https://cloud.langfuse.com';
 
@@ -412,19 +414,29 @@ function mapMastraToLangfuseAttributes(
     // they stay first-level, filterable trace metadata, as they were before the
     // OTLP migration. Langfuse only nests unmapped attributes under
     // metadata.attributes, which cannot be used in trace filters or evaluator
-    // scopes. Keys that map to dedicated Langfuse fields (userId, sessionId,
-    // threadId, traceName, version, langfuse.*) were already removed above.
-    // Explicit metadata.langfuse.* values and the identity keys above take
-    // precedence. Child spans are skipped because Langfuse applies
-    // langfuse.trace.* from any span, so a child could overwrite the trace.
-    // The mastra.metadata.* attribute is kept on the observation.
+    // scopes. Keys that map to dedicated Langfuse fields are skipped by name:
+    // the truthy checks above leave falsy values (empty string, 0, false) in
+    // place, and those must not leak into trace metadata either. Explicit
+    // metadata.langfuse.* values and the identity keys above take precedence.
+    // Child spans are skipped because Langfuse applies langfuse.trace.* from
+    // any span, so a child could overwrite the trace. The mastra.metadata.*
+    // attribute is kept on the observation. A value that cannot be serialized
+    // (e.g. BigInt) skips only its own key so the span still exports.
     for (const [key, value] of Object.entries(attributes)) {
-      if (!key.startsWith(MASTRA_METADATA_PREFIX) || value === null || value === undefined) {
+      if (!key.startsWith(MASTRA_METADATA_PREFIX)) {
         continue;
       }
-      const traceKey = `langfuse.trace.metadata.${key.slice(MASTRA_METADATA_PREFIX.length)}`;
-      if (attributes[traceKey] === undefined) {
-        attributes[traceKey] = typeof value === 'string' ? value : JSON.stringify(value);
+      const metadataKey = key.slice(MASTRA_METADATA_PREFIX.length);
+      if (DEDICATED_METADATA_KEYS.has(metadataKey) || value === null || value === undefined) {
+        continue;
+      }
+      const traceKey = `langfuse.trace.metadata.${metadataKey}`;
+      if (attributes[traceKey] !== undefined) {
+        continue;
+      }
+      const serialized = serializeTraceIo(value);
+      if (serialized !== undefined) {
+        attributes[traceKey] = serialized;
       }
     }
   }

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -410,18 +410,11 @@ function mapMastraToLangfuseAttributes(
     }
 
     // Root-span metadata: forward the remaining mastra.metadata.* keys (runId,
-    // resourceId, and any user-supplied keys) to langfuse.trace.metadata.* so
-    // they stay first-level, filterable trace metadata, as they were before the
-    // OTLP migration. Langfuse only nests unmapped attributes under
-    // metadata.attributes, which cannot be used in trace filters or evaluator
-    // scopes. Keys that map to dedicated Langfuse fields are skipped by name:
-    // the truthy checks above leave falsy values (empty string, 0, false) in
-    // place, and those must not leak into trace metadata either. Explicit
-    // metadata.langfuse.* values and the identity keys above take precedence.
-    // Child spans are skipped because Langfuse applies langfuse.trace.* from
-    // any span, so a child could overwrite the trace. The mastra.metadata.*
-    // attribute is kept on the observation. A value that cannot be serialized
-    // (e.g. BigInt) skips only its own key so the span still exports.
+    // resourceId, user-supplied keys) to langfuse.trace.metadata.* so they are
+    // filterable trace metadata; Langfuse nests unmapped attributes under
+    // metadata.attributes. Dedicated keys, explicit metadata.langfuse.* values,
+    // and the identity keys above take precedence. Root only: Langfuse applies
+    // langfuse.trace.* from any span, so a child span could overwrite the trace.
     for (const [key, value] of Object.entries(attributes)) {
       if (!key.startsWith(MASTRA_METADATA_PREFIX)) {
         continue;


### PR DESCRIPTION
## Description

Since the Langfuse v5 (OTLP) migration in #14985, the exporter only promotes a fixed set of keys to the Langfuse trace. Root span metadata such as `runId`, `resourceId`, and user-supplied keys stayed as `mastra.metadata.*`, which Langfuse nests under `metadata.attributes` where it can't be used in trace filters or evaluator scopes. The pre-migration exporter put all root metadata on the trace. This restores that.

- On root spans only, forward each remaining `mastra.metadata.<key>` to `langfuse.trace.metadata.<key>`. The `mastra.metadata.*` attribute is kept on the observation.
- Keys already mapped to dedicated Langfuse fields (`userId`, `sessionId`/`threadId`, `traceName`, `version`, `metadata.langfuse.*`) are removed earlier in the mapper, so they aren't duplicated.
- Explicit `metadata.langfuse.*` values and the agent/workflow identity keys keep precedence.
- Child spans are skipped, since Langfuse applies `langfuse.trace.*` from any span and a child could overwrite the trace.
- `spanType` is intentionally not added: Langfuse already merges the root observation's metadata (`langfuse.observation.metadata.spanType`) into the trace.
- Docs: "Custom trace metadata" section now describes root span forwarding and precedence.

Verified against Langfuse Cloud with a real agent run (`agent.generate` with `tracingOptions.metadata`), fetching the trace via `GET /api/public/traces/{id}`:

```
before (1.5.4)  trace.metadata: {explicitKey, agentId, agentName, spanType, operationName}
                trace.metadata.attributes: {mastra.metadata.runId, mastra.metadata.sampleKey}
after           trace.metadata: {explicitKey, agentId, agentName, runId, sampleKey, spanType, operationName}
```

## Related Issue(s)

Fixes #23187

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Root-span metadata appears in Langfuse trace metadata again after the OTLP migration. Child spans remain observation-only, so they cannot overwrite trace metadata.

## Changes

- Forward remaining root-span `mastra.metadata.*` attributes to `langfuse.trace.metadata.*`.
- Preserve source metadata on the observation.
- Preserve dedicated Langfuse fields and explicit `metadata.langfuse.*` precedence.
- Exclude child-span metadata and `spanType` from generic promotion.
- Skip null or unserializable values without failing export.
- Add tests, documentation, and a patch changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->