### PR TITLE
feat(studio): add inline tag editor to dataset detail page

### DIFF
--- a/.changeset/crisp-cats-learn.md
+++ b/.changeset/crisp-cats-learn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added an `onInputValueChange` callback to the `Combobox` component so consumers can react to the search text (for example to offer a "Create ..." option built from what the user typed).

--- a/.changeset/tricky-states-count.md
+++ b/.changeset/tricky-states-count.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added an inline tag editor on the dataset detail page. Existing tags show as removable badges under the actions row, and an "Add tag" combobox lists all tags used across datasets or lets you create a new one by typing its name. Changes are saved immediately.

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.test.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.test.tsx
@@ -144,6 +144,56 @@ describe('Combobox', () => {
     });
   });
 
+  it('reports the search text through onInputValueChange and resets it after a selection', async () => {
+    const onInputValueChange = vi.fn();
+    render(<Combobox options={options} onInputValueChange={onInputValueChange} searchPlaceholder="Search providers" />);
+
+    fireEvent.click(screen.getByRole('combobox'));
+
+    const search = await screen.findByPlaceholderText('Search providers');
+    fireEvent.input(search, { target: { value: 'goo' }, inputType: 'insertText' });
+
+    await waitFor(() => {
+      expect(onInputValueChange).toHaveBeenCalledWith('goo');
+    });
+
+    const google = await screen.findByRole('option', { name: 'Google' });
+    fireEvent.pointerDown(google, { pointerType: 'mouse' });
+    fireEvent.click(google, { detail: 1 });
+
+    await waitFor(() => {
+      expect(onInputValueChange).toHaveBeenLastCalledWith('');
+    });
+  });
+
+  it('keeps a consumer-injected option whose label contains the search text as the first option', async () => {
+    const onValueChange = vi.fn();
+    render(
+      <Combobox
+        options={[{ label: 'Create "goo"', value: '__create__' }, ...options]}
+        onValueChange={onValueChange}
+        searchPlaceholder="Search providers"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('combobox'));
+
+    const search = await screen.findByPlaceholderText('Search providers');
+    fireEvent.input(search, { target: { value: 'goo' }, inputType: 'insertText' });
+
+    await screen.findByRole('option', { name: 'Google' });
+    const visible = screen.getAllByRole('option');
+    expect(visible.map(o => o.textContent)).toEqual(['Create "goo"', 'Google']);
+
+    const createOption = screen.getByRole('option', { name: 'Create "goo"' });
+    fireEvent.pointerDown(createOption, { pointerType: 'mouse' });
+    fireEvent.click(createOption, { detail: 1 });
+
+    await waitFor(() => {
+      expect(onValueChange).toHaveBeenCalledWith('__create__');
+    });
+  });
+
   it('does not offer a custom value unless custom values are allowed', async () => {
     renderCombobox();
 

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
@@ -20,7 +20,7 @@ export type ComboboxOption = {
 
 type ComboboxSharedProps = {
   options: ComboboxOption[];
-  placeholder?: string;
+  placeholder?: React.ReactNode;
   searchPlaceholder?: string;
   emptyText?: string;
   className?: string;
@@ -32,6 +32,8 @@ type ComboboxSharedProps = {
   container?: HTMLElement | ShadowRoot | null | React.RefObject<HTMLElement | ShadowRoot | null>;
   error?: string;
   allowCustomValue?: boolean;
+  /** Called with the search input text as it changes (and with `''` after a single-mode selection resets it). */
+  onInputValueChange?: (value: string) => void;
 };
 
 export type ComboboxSingleProps = ComboboxSharedProps & {
@@ -79,9 +81,14 @@ export function Combobox(props: ComboboxProps) {
     container,
     error,
     allowCustomValue = false,
+    onInputValueChange,
   } = props;
   const multiple = isMultipleCombobox(props);
-  const [inputValue, setInputValue] = React.useState('');
+  const [inputValue, setInputValueState] = React.useState('');
+  const setInputValue = (value: string) => {
+    setInputValueState(value);
+    onInputValueChange?.(value);
+  };
   const customValue = inputValue.trim();
   const customOption =
     !multiple && allowCustomValue && customValue && !options.some(option => option.value === customValue)

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
@@ -84,11 +84,7 @@ export function Combobox(props: ComboboxProps) {
     onInputValueChange,
   } = props;
   const multiple = isMultipleCombobox(props);
-  const [inputValue, setInputValueState] = React.useState('');
-  const setInputValue = (value: string) => {
-    setInputValueState(value);
-    onInputValueChange?.(value);
-  };
+  const [inputValue, setInputValue] = React.useState('');
   const customValue = inputValue.trim();
   const customOption =
     !multiple && allowCustomValue && customValue && !options.some(option => option.value === customValue)
@@ -208,11 +204,15 @@ export function Combobox(props: ComboboxProps) {
         items={displayedOptions}
         value={selectedOption}
         inputValue={inputValue}
-        onInputValueChange={setInputValue}
+        onInputValueChange={value => {
+          setInputValue(value);
+          onInputValueChange?.(value);
+        }}
         onValueChange={item => {
           if (item) {
             props.onValueChange?.(item.value);
             setInputValue('');
+            onInputValueChange?.('');
           }
         }}
         disabled={disabled}

--- a/packages/playground/src/domains/datasets/components/dataset-detail/__tests__/dataset-items-view.msw.test.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/__tests__/dataset-items-view.msw.test.tsx
@@ -32,6 +32,7 @@ function renderView() {
           datasetId={DATASET_ID}
           leftSlot={<span>left slot</span>}
           rightSlot={<span>right slot</span>}
+          belowToolbarSlot={<span>below toolbar slot</span>}
         />
       </DatasetItemPanelProvider>
     </TestLinkProvider>,
@@ -63,6 +64,17 @@ describe('DatasetItemsView', () => {
     const left = within(toolbar).getByText('left slot');
     const addItem = within(toolbar).getByRole('button', { name: /add item/i });
     expect(left.compareDocumentPosition(addItem) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('renders the below-toolbar slot on its own row, after the toolbar and before the items', async () => {
+    renderView();
+    const firstItem = await screen.findByText('item-a');
+
+    const toolbar = screen.getByTestId('dataset-items-toolbar');
+    const below = screen.getByText('below toolbar slot');
+    expect(toolbar.contains(below)).toBe(false);
+    expect(toolbar.compareDocumentPosition(below) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(below.compareDocumentPosition(firstItem) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('does not own the "View experiments" action (it lives in the page header)', async () => {

--- a/packages/playground/src/domains/datasets/components/dataset-detail/__tests__/dataset-tags-editor.msw.test.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/__tests__/dataset-tags-editor.msw.test.tsx
@@ -1,0 +1,155 @@
+import type { DatasetRecord, UpdateDatasetParams } from '@mastra/client-js';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { DatasetTagsEditor } from '../dataset-tags-editor';
+import { buildDataset, buildListDatasetsResponse } from '@/domains/datasets/components/__tests__/fixtures/datasets';
+import { server } from '@/test/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '@/test/render';
+
+const DATASET_ID = 'ds-tags';
+
+let current: DatasetRecord;
+let patchBodies: Array<Omit<UpdateDatasetParams, 'datasetId'>>;
+
+beforeAll(() => {
+  if (typeof window.PointerEvent === 'undefined') {
+    window.PointerEvent = window.MouseEvent as unknown as typeof PointerEvent;
+  }
+});
+
+beforeEach(() => {
+  current = buildDataset({ id: DATASET_ID, name: 'Tagged', tags: ['alpha'] });
+  patchBodies = [];
+
+  server.use(
+    http.get(`${TEST_BASE_URL}/api/datasets`, () =>
+      HttpResponse.json(
+        buildListDatasetsResponse([
+          current,
+          buildDataset({ id: 'ds-other-1', name: 'Other 1', tags: ['beta', 'gamma'] }),
+          buildDataset({ id: 'ds-other-2', name: 'Other 2', tags: ['beta'] }),
+        ]),
+      ),
+    ),
+    http.get(`${TEST_BASE_URL}/api/datasets/${DATASET_ID}`, () => HttpResponse.json(current)),
+    http.patch(`${TEST_BASE_URL}/api/datasets/${DATASET_ID}`, async ({ request }) => {
+      const body = (await request.json()) as Omit<UpdateDatasetParams, 'datasetId'>;
+      patchBodies.push(body);
+      current = { ...current, ...body };
+      return HttpResponse.json(current);
+    }),
+  );
+});
+
+function renderEditor() {
+  return renderWithProviders(<DatasetTagsEditor datasetId={DATASET_ID} />);
+}
+
+async function openCombobox() {
+  const trigger = await screen.findByRole('combobox');
+  expect(trigger.textContent).toContain('Add tag');
+  fireEvent.click(trigger);
+  return screen.findByPlaceholderText('Search or create tag...');
+}
+
+function selectOption(option: HTMLElement) {
+  fireEvent.pointerDown(option, { pointerType: 'mouse' });
+  fireEvent.click(option, { detail: 1 });
+}
+
+describe('DatasetTagsEditor', () => {
+  describe('given a dataset tagged "alpha" among datasets tagged "beta" and "gamma"', () => {
+    it('renders the current tags as removable badges', async () => {
+      renderEditor();
+
+      const remove = await screen.findByRole('button', { name: 'Remove tag alpha' });
+      const editor = screen.getByTestId('dataset-tags-editor');
+      expect(editor.contains(remove)).toBe(true);
+      expect(editor.textContent).toContain('alpha');
+    });
+
+    it('lists every known tag and marks the ones already on the dataset', async () => {
+      renderEditor();
+      await screen.findByRole('button', { name: 'Remove tag alpha' });
+
+      await openCombobox();
+
+      await screen.findByRole('option', { name: 'beta' });
+      const options = screen.getAllByRole('option');
+      expect(options.map(o => o.textContent)).toEqual(['alpha', 'beta', 'gamma']);
+      expect(within(options[0]).queryByTestId('tag-applied')).not.toBeNull();
+      expect(within(options[1]).queryByTestId('tag-applied')).toBeNull();
+    });
+
+    it('does nothing when a tag already on the dataset is selected', async () => {
+      renderEditor();
+      await screen.findByRole('button', { name: 'Remove tag alpha' });
+
+      await openCombobox();
+      selectOption(await screen.findByRole('option', { name: 'alpha' }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('option')).toBeNull();
+      });
+      expect(patchBodies).toEqual([]);
+      expect(screen.getByRole('button', { name: 'Remove tag alpha' })).toBeDefined();
+    });
+
+    it('offers to create an unknown tag as the first option and persists it on select', async () => {
+      renderEditor();
+      await screen.findByRole('button', { name: 'Remove tag alpha' });
+
+      const search = await openCombobox();
+      fireEvent.input(search, { target: { value: 'new-tag' }, inputType: 'insertText' });
+
+      const create = await screen.findByRole('option', { name: 'Create "new-tag"' });
+      expect(screen.getAllByRole('option')[0]).toBe(create);
+
+      selectOption(create);
+
+      await waitFor(() => {
+        expect(patchBodies).toEqual([{ tags: ['alpha', 'new-tag'] }]);
+      });
+      await screen.findByRole('button', { name: 'Remove tag new-tag' });
+    });
+
+    it('adds an existing tag on select', async () => {
+      renderEditor();
+      await screen.findByRole('button', { name: 'Remove tag alpha' });
+
+      await openCombobox();
+      selectOption(await screen.findByRole('option', { name: 'beta' }));
+
+      await waitFor(() => {
+        expect(patchBodies).toEqual([{ tags: ['alpha', 'beta'] }]);
+      });
+      await screen.findByRole('button', { name: 'Remove tag beta' });
+    });
+
+    it('removes a tag when its remove button is clicked', async () => {
+      renderEditor();
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Remove tag alpha' }));
+
+      await waitFor(() => {
+        expect(patchBodies).toEqual([{ tags: [] }]);
+      });
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: 'Remove tag alpha' })).toBeNull();
+      });
+    });
+
+    it('does not offer to create a tag that already exists', async () => {
+      renderEditor();
+      await screen.findByRole('button', { name: 'Remove tag alpha' });
+
+      const search = await openCombobox();
+      fireEvent.input(search, { target: { value: 'beta' }, inputType: 'insertText' });
+
+      await screen.findByRole('option', { name: 'beta' });
+      expect(screen.queryByRole('option', { name: /Create/ })).toBeNull();
+    });
+  });
+});

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-items-view.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-items-view.tsx
@@ -21,6 +21,7 @@ export interface DatasetItemsViewProps {
   onNavigateToDataset?: (datasetId: string) => void;
   leftSlot?: React.ReactNode;
   rightSlot?: React.ReactNode;
+  belowToolbarSlot?: React.ReactNode;
 }
 
 export function DatasetItemsView({
@@ -29,6 +30,7 @@ export function DatasetItemsView({
   onNavigateToDataset,
   leftSlot,
   rightSlot,
+  belowToolbarSlot,
 }: DatasetItemsViewProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const { activeVersion: activeDatasetVersion } = useDatasetItemsUrlState(searchParams, setSearchParams);
@@ -117,6 +119,7 @@ export function DatasetItemsView({
           items={items}
           leftSlot={leftSlot}
           rightSlot={rightSlot}
+          belowToolbarSlot={belowToolbarSlot}
           isLoading={isItemsLoading}
           onItemClick={handleItemClick}
           featuredItemId={currentItemId}

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-tags-editor.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-tags-editor.tsx
@@ -1,0 +1,94 @@
+import { Badge } from '@mastra/playground-ui/components/Badge';
+import { Combobox } from '@mastra/playground-ui/components/Combobox';
+import type { ComboboxOption } from '@mastra/playground-ui/components/Combobox';
+import { toast } from '@mastra/playground-ui/utils/toast';
+import { Check, Tag, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { getAllDatasetTags } from '../datasets-list/helpers';
+import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
+import { useDataset, useDatasets } from '@/domains/datasets/hooks/use-datasets';
+
+const CREATE_TAG_VALUE = '__create_tag__';
+
+export interface DatasetTagsEditorProps {
+  datasetId: string;
+}
+
+/**
+ * Inline tag editor for a dataset: current tags as removable badges plus an
+ * "Add tag" combobox listing every tag known across datasets (applied ones are
+ * checked), with a first-row `Create "<input>"` option for new ones. Every
+ * change persists immediately; removal is via the badge only.
+ */
+export function DatasetTagsEditor({ datasetId }: DatasetTagsEditorProps) {
+  const { data: dataset } = useDataset(datasetId);
+  const { data: datasetsData } = useDatasets();
+  const { updateDataset } = useDatasetMutations();
+  const [search, setSearch] = useState('');
+
+  const currentTags = useMemo(() => (Array.isArray(dataset?.tags) ? dataset.tags : []), [dataset?.tags]);
+  const allTags = useMemo(() => getAllDatasetTags(datasetsData?.datasets ?? []), [datasetsData?.datasets]);
+
+  const options = useMemo<ComboboxOption[]>(() => {
+    const existing = allTags.map(tag => ({
+      label: tag,
+      value: tag,
+      end: currentTags.includes(tag) ? <Check data-testid="tag-applied" className="size-3.5" /> : undefined,
+    }));
+    const trimmed = search.trim();
+    const canCreate = trimmed.length > 0 && !allTags.includes(trimmed) && !currentTags.includes(trimmed);
+    return canCreate ? [{ label: `Create "${trimmed}"`, value: CREATE_TAG_VALUE }, ...existing] : existing;
+  }, [allTags, currentTags, search]);
+
+  const persistTags = (tags: string[]) => {
+    updateDataset.mutate({ datasetId, tags }, { onError: () => toast.error('Failed to update tags') });
+  };
+
+  const handleAdd = (value: string) => {
+    const tag = value === CREATE_TAG_VALUE ? search.trim() : value;
+    if (!tag || currentTags.includes(tag)) return;
+    persistTags([...currentTags, tag]);
+  };
+
+  const handleRemove = (tag: string) => {
+    persistTags(currentTags.filter(t => t !== tag));
+  };
+
+  return (
+    <div data-testid="dataset-tags-editor" className="flex flex-wrap items-center gap-2 px-4 py-2">
+      {currentTags.map(tag => (
+        <Badge key={tag} size="md" className="gap-1 pr-1">
+          {tag}
+          <button
+            type="button"
+            aria-label={`Remove tag ${tag}`}
+            disabled={updateDataset.isPending}
+            onClick={() => handleRemove(tag)}
+            className="text-neutral3 hover:text-neutral6 rounded-sm disabled:opacity-50"
+          >
+            <X className="size-3" />
+          </button>
+        </Badge>
+      ))}
+      <Combobox
+        options={options}
+        value={undefined}
+        onValueChange={handleAdd}
+        onInputValueChange={setSearch}
+        placeholder={
+          <span className="flex items-center gap-1.5">
+            <Tag className="size-3.5" />
+            Add tag
+          </span>
+        }
+        searchPlaceholder="Search or create tag..."
+        emptyText="Type to create a tag"
+        variant="ghost"
+        size="xs"
+        className="w-auto min-w-0"
+        disabled={updateDataset.isPending}
+      />
+    </div>
+  );
+}

--- a/packages/playground/src/domains/datasets/components/datasets-list/helpers.ts
+++ b/packages/playground/src/domains/datasets/components/datasets-list/helpers.ts
@@ -6,7 +6,8 @@ export const DATASET_EXPERIMENT_OPTIONS = [
   { value: 'without', label: 'Without experiments' },
 ] as const;
 
-export function getDatasetTagOptions(datasets: DatasetRecord[]) {
+/** Distinct tags across all datasets, sorted alphabetically. */
+export function getAllDatasetTags(datasets: DatasetRecord[]): string[] {
   const tagSet = new Set<string>();
 
   for (const dataset of datasets) {
@@ -17,10 +18,9 @@ export function getDatasetTagOptions(datasets: DatasetRecord[]) {
     }
   }
 
-  return [
-    { value: 'all', label: 'All tags' },
-    ...Array.from(tagSet)
-      .sort()
-      .map(tag => ({ value: tag, label: tag })),
-  ];
+  return Array.from(tagSet).sort();
+}
+
+export function getDatasetTagOptions(datasets: DatasetRecord[]) {
+  return [{ value: 'all', label: 'All tags' }, ...getAllDatasetTags(datasets).map(tag => ({ value: tag, label: tag }))];
 }

--- a/packages/playground/src/domains/datasets/components/items/dataset-items.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-items.tsx
@@ -18,6 +18,8 @@ export interface DatasetItemsProps {
   leftSlot?: React.ReactNode;
   /** Page-level actions rendered at the end of the toolbar row. */
   rightSlot?: React.ReactNode;
+  /** Page-level content rendered on its own row, between the toolbar and the list. */
+  belowToolbarSlot?: React.ReactNode;
   isLoading: boolean;
   onItemClick: (itemId: string) => void;
   /** Id of the item currently open in the URL-driven item panel, if any. */
@@ -57,6 +59,7 @@ export function DatasetItems({
   items,
   leftSlot,
   rightSlot,
+  belowToolbarSlot,
   isLoading,
   onItemClick,
   featuredItemId,
@@ -153,6 +156,8 @@ export function DatasetItems({
         activeDatasetVersion={activeDatasetVersion}
         onReturnToLatestVersion={() => handleVersionChange(null)}
       />
+
+      {belowToolbarSlot}
 
       <DatasetItemsList
         items={items}

--- a/packages/playground/src/domains/datasets/index.ts
+++ b/packages/playground/src/domains/datasets/index.ts
@@ -46,6 +46,7 @@ export type { DatasetVersionsProps } from './components/dataset-versions';
 export { DatasetHeader } from './components/dataset-detail/dataset-header';
 export type { DatasetHeaderProps } from './components/dataset-detail/dataset-header';
 export { DatasetItemsView } from './components/dataset-detail/dataset-items-view';
+export { DatasetTagsEditor } from './components/dataset-detail/dataset-tags-editor';
 export { DatasetItemsList } from './components/items/dataset-items-list';
 export { ActionsMenu } from './components/dataset-detail/items-list-actions';
 export { AddItemDialog } from './components/add-item-dialog';

--- a/packages/playground/src/pages/datasets/dataset/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/index.tsx
@@ -15,6 +15,7 @@ import { useState } from 'react';
 import { Link, Outlet, useParams, useNavigate, useSearchParams } from 'react-router';
 import {
   DatasetItemsView,
+  DatasetTagsEditor,
   DatasetVersions,
   DuplicateDatasetDialog,
   ExperimentTriggerDialog,
@@ -124,6 +125,7 @@ function DatasetPage() {
             <DatasetItemsView
               datasetId={datasetId}
               onAddItemClick={() => setAddItemDialogOpen(true)}
+              belowToolbarSlot={<DatasetTagsEditor datasetId={datasetId} />}
               leftSlot={
                 <span className="text-ui-sm text-neutral3 mr-3 whitespace-nowrap">
                   {dataset?.createdAt ? `Created ${format(new Date(dataset.createdAt), 'MMM d')}` : ''}


### PR DESCRIPTION
Datasets can carry tags, but Studio had no way to manage them from the dataset page — you could only see them on the list. This adds a small tag row under the items toolbar on `/datasets/:id`.

Current tags show as badges with a remove button. An \`Add tag\` combobox lists every tag known across datasets, with a check mark on the ones already applied; picking an applied tag removes it, picking another adds it. Typing something new puts \`Create "<input>"\` as the first option. Every change persists right away through the existing \`updateDataset\` mutation, so the list page and its tag filter pick it up after invalidation.

To make the create row possible without baking any label into the design system, \`Combobox\` gets an optional \`onInputValueChange\` callback so consumers can see the search text:

\`\`\`tsx
<Combobox
  options={[{ label: \`Create "\${search}"\`, value: '__create__' }, ...existing]}
  onInputValueChange={setSearch}
  onValueChange={value => addTag(value === '__create__' ? search : value)}
/>
\`\`\`

Covered by MSW tests for the editor (render, add existing, create new, remove, no create for existing tags), a slot-ordering test for \`DatasetItemsView\`, and a Combobox test for the consumer-injected first option. Changesets included for both packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Users can add, remove, and create dataset tags directly from the dataset page. Changes save immediately.

## Changes

- Added `DatasetTagsEditor` below the dataset items toolbar.
- Displayed current tags as removable badges.
- Added a combobox for selecting existing tags or creating new tags.
- Saved tag changes through `updateDataset`.
- Added shared tag discovery with `getAllDatasetTags`.
- Added optional `belowToolbarSlot` support to dataset item components.
- Extended `Combobox` with `onInputValueChange` and React node placeholders.
- Exported `DatasetTagsEditor` from the datasets domain.
- Added changesets for `@mastra/playground` and `@mastra/playground-ui`.

## Tests

- Added MSW coverage for rendering, adding, creating, removing, and duplicate prevention.
- Added slot-ordering tests.
- Added `Combobox` input-change and option-selection tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->