### PR TITLE
fix(factory-ui): linked repositories feed Work Intake by default

### DIFF
--- a/.changeset/factory-linked-repo-feeds-intake.md
+++ b/.changeset/factory-linked-repo-feeds-intake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed linked repositories not feeding the board by default. Linking a repository to a Factory during onboarding or from Settings › Repositories now also selects it under Work Intake › GitHub issues, as the create-Factory wizard already did, so its open issues show up without a second trip to Settings. Repositories that already feed intake are left untouched.

--- a/.changeset/factory-linked-repo-feeds-intake.md
+++ b/.changeset/factory-linked-repo-feeds-intake.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed linked repositories not feeding the board by default. Linking a repository to a Factory during onboarding or from Settings › Repositories now also selects it under Work Intake › GitHub issues, as the create-Factory wizard already did, so its open issues show up without a second trip to Settings. Repositories that already feed intake are left untouched.
+Fixed a newly linked repository staying unchecked under Work Intake. Linking a repository to a Factory now selects it for GitHub issue intake, so its open issues reach the board right away. Existing intake selections are kept.

--- a/mastracode/factory-ui/src/hooks/__tests__/useFactories.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useFactories.msw.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * BDD coverage for the repository link mutation. Every place that links a
+ * repository to a Factory (onboarding, the wizard, Settings › Repositories)
+ * routes through it, so this is where "a linked repository feeds the board"
+ * is guaranteed.
+ *
+ * Drives the real services + React Query cache; only the network is mocked
+ * (MSW) on the ApiConfig base URL the test providers inject.
+ */
+import { waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../e2e/ui/msw-server';
+import { renderHookWithProviders, TEST_BASE_URL } from '../../../e2e/ui/render';
+import type { IntakeConfig } from '../../ui/domains/factory/services/intake';
+import type { GithubRepo } from '../../ui/domains/workspaces/services/github';
+import { useLinkRepositoryMutation } from '../useFactories';
+import { useIntakeConfigQuery } from '../useIntakeConfig';
+
+const CONFIG_URL = `${TEST_BASE_URL}/web/intake/config`;
+
+const repo: GithubRepo = {
+  id: 99,
+  fullName: 'octo/hello',
+  name: 'hello',
+  owner: 'octo',
+  defaultBranch: 'main',
+  private: false,
+  installationId: 7,
+  installationStorageId: 'inst-7',
+  sandboxProvider: 'local',
+  sandboxWorkdir: '/workspace/hello',
+};
+
+function stubRepositoryLink() {
+  server.use(
+    http.get(`${TEST_BASE_URL}/web/factory/projects/fp-1/source-control-connections`, () =>
+      HttpResponse.json({ connections: [{ id: 'conn-1', installationId: 'inst-7', repositories: [] }] }),
+    ),
+    http.post(`${TEST_BASE_URL}/web/factory/projects/fp-1/source-control-connections/conn-1/repositories`, () =>
+      HttpResponse.json({
+        projectRepository: {
+          id: 'ghp_1',
+          branch: 'main',
+          sandboxWorkdir: '/workspace/hello',
+          repository: { slug: 'octo/hello', defaultBranch: 'main' },
+        },
+      }),
+    ),
+  );
+}
+
+/** Stateful intake config: each PUT becomes what the next GET returns. */
+function stubIntakeConfig(initial: IntakeConfig) {
+  let config = initial;
+  const saved: IntakeConfig[] = [];
+  server.use(
+    http.get(CONFIG_URL, () => HttpResponse.json({ config })),
+    http.put<never, IntakeConfig>(CONFIG_URL, async ({ request }) => {
+      config = await request.json();
+      saved.push(config);
+      return HttpResponse.json({ config });
+    }),
+  );
+  return saved;
+}
+
+describe('useLinkRepositoryMutation', () => {
+  it('given a repository outside issue intake, when it is linked, then its issues feed the caller’s intake', async () => {
+    stubRepositoryLink();
+    const saved = stubIntakeConfig({
+      github: { enabled: true, sourceIds: null },
+      linear: { enabled: false, sourceIds: null },
+    });
+
+    const { result } = renderHookWithProviders(() => ({
+      link: useLinkRepositoryMutation(),
+      intake: useIntakeConfigQuery(),
+    }));
+    await waitFor(() => expect(result.current.intake.data).toBeDefined());
+
+    result.current.link.mutate({ factoryProjectId: 'fp-1', repo });
+
+    await waitFor(() => expect(result.current.link.isSuccess).toBe(true));
+    expect(saved).toEqual([
+      { github: { enabled: true, sourceIds: ['octo/hello'] }, linear: { enabled: false, sourceIds: null } },
+    ]);
+    expect(result.current.intake.data?.github.sourceIds).toEqual(['octo/hello']);
+  });
+
+  it('given GitHub intake switched off, when a repository is linked, then intake is switched back on for it', async () => {
+    stubRepositoryLink();
+    const saved = stubIntakeConfig({
+      github: { enabled: false, sourceIds: ['octo/other'] },
+      linear: { enabled: false, sourceIds: null },
+    });
+
+    const { result } = renderHookWithProviders(() => useLinkRepositoryMutation());
+
+    result.current.mutate({ factoryProjectId: 'fp-1', repo });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(saved).toEqual([
+      {
+        github: { enabled: true, sourceIds: ['octo/other', 'octo/hello'] },
+        linear: { enabled: false, sourceIds: null },
+      },
+    ]);
+  });
+
+  it('given a repository already feeding issue intake, when it is linked again, then the selection is left alone', async () => {
+    stubRepositoryLink();
+    const saved = stubIntakeConfig({
+      github: { enabled: true, sourceIds: ['octo/hello'] },
+      linear: { enabled: false, sourceIds: null },
+    });
+
+    const { result } = renderHookWithProviders(() => useLinkRepositoryMutation());
+
+    result.current.mutate({ factoryProjectId: 'fp-1', repo });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(saved).toEqual([]);
+  });
+
+  it('given the intake write fails, when a repository is linked, then the link surfaces that error', async () => {
+    stubRepositoryLink();
+    server.use(
+      http.get(CONFIG_URL, () => HttpResponse.json({ config: { github: { enabled: true, sourceIds: null } } })),
+      http.put(CONFIG_URL, () => HttpResponse.json({ error: 'invalid_config' }, { status: 400 })),
+    );
+
+    const { result } = renderHookWithProviders(() => useLinkRepositoryMutation());
+
+    result.current.mutate({ factoryProjectId: 'fp-1', repo });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('invalid_config');
+  });
+});

--- a/mastracode/factory-ui/src/hooks/__tests__/useFactories.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useFactories.msw.test.tsx
@@ -7,15 +7,14 @@
  * Drives the real services + React Query cache; only the network is mocked
  * (MSW) on the ApiConfig base URL the test providers inject.
  */
-import { waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../e2e/ui/msw-server';
-import { renderHookWithProviders, TEST_BASE_URL } from '../../../e2e/ui/render';
+import { renderHookWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../e2e/ui/render';
 import type { IntakeConfig } from '../../ui/domains/factory/services/intake';
 import type { GithubRepo } from '../../ui/domains/workspaces/services/github';
-import { useLinkRepositoryMutation } from '../useFactories';
+import { useFactoriesQuery, useLinkRepositoryMutation } from '../useFactories';
 import { useIntakeConfigQuery } from '../useIntakeConfig';
 
 const CONFIG_URL = `${TEST_BASE_URL}/web/intake/config`;
@@ -74,15 +73,16 @@ describe('useLinkRepositoryMutation', () => {
       linear: { enabled: false, sourceIds: null },
     });
 
-    const { result } = renderHookWithProviders(() => ({
+    const { client, result } = renderHookWithProviders(() => ({
       link: useLinkRepositoryMutation(),
       intake: useIntakeConfigQuery(),
     }));
-    await waitFor(() => expect(result.current.intake.data).toBeDefined());
+    await waitForMutationsIdle(client);
 
     result.current.link.mutate({ factoryProjectId: 'fp-1', repo });
 
-    await waitFor(() => expect(result.current.link.isSuccess).toBe(true));
+    await waitForMutationsIdle(client);
+    expect(result.current.link.isSuccess).toBe(true);
     expect(saved).toEqual([
       { github: { enabled: true, sourceIds: ['octo/hello'] }, linear: { enabled: false, sourceIds: null } },
     ]);
@@ -96,11 +96,12 @@ describe('useLinkRepositoryMutation', () => {
       linear: { enabled: false, sourceIds: null },
     });
 
-    const { result } = renderHookWithProviders(() => useLinkRepositoryMutation());
+    const { client, result } = renderHookWithProviders(() => useLinkRepositoryMutation());
 
     result.current.mutate({ factoryProjectId: 'fp-1', repo });
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitForMutationsIdle(client);
+    expect(result.current.isSuccess).toBe(true);
     expect(saved).toEqual([
       {
         github: { enabled: true, sourceIds: ['octo/other', 'octo/hello'] },
@@ -116,26 +117,38 @@ describe('useLinkRepositoryMutation', () => {
       linear: { enabled: false, sourceIds: null },
     });
 
-    const { result } = renderHookWithProviders(() => useLinkRepositoryMutation());
+    const { client, result } = renderHookWithProviders(() => useLinkRepositoryMutation());
 
     result.current.mutate({ factoryProjectId: 'fp-1', repo });
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitForMutationsIdle(client);
+    expect(result.current.isSuccess).toBe(true);
     expect(saved).toEqual([]);
   });
 
-  it('given the intake write fails, when a repository is linked, then the link surfaces that error', async () => {
+  it('given the intake write fails, when a repository is linked, then the error surfaces and the Factory list still refreshes', async () => {
     stubRepositoryLink();
+    let factoryListReads = 0;
     server.use(
-      http.get(CONFIG_URL, () => HttpResponse.json({ config: { github: { enabled: true, sourceIds: null } } })),
+      http.get(`${TEST_BASE_URL}/web/factory/projects`, () => {
+        factoryListReads += 1;
+        return HttpResponse.json({ projects: [] });
+      }),
+      http.get(CONFIG_URL, () => HttpResponse.json({ config: {} })),
       http.put(CONFIG_URL, () => HttpResponse.json({ error: 'invalid_config' }, { status: 400 })),
     );
 
-    const { result } = renderHookWithProviders(() => useLinkRepositoryMutation());
+    const { client, result } = renderHookWithProviders(() => ({
+      link: useLinkRepositoryMutation(),
+      factories: useFactoriesQuery(),
+    }));
+    await waitForMutationsIdle(client);
+    expect(factoryListReads).toBe(1);
 
-    result.current.mutate({ factoryProjectId: 'fp-1', repo });
+    result.current.link.mutate({ factoryProjectId: 'fp-1', repo });
 
-    await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(result.current.error?.message).toBe('invalid_config');
+    await waitForMutationsIdle(client);
+    expect(result.current.link.error?.message).toBe('invalid_config');
+    expect(factoryListReads).toBe(2);
   });
 });

--- a/mastracode/factory-ui/src/hooks/useFactories.ts
+++ b/mastracode/factory-ui/src/hooks/useFactories.ts
@@ -11,6 +11,8 @@ import {
   unlinkRepository,
 } from '../ui/domains/workspaces/services/github';
 import type { FactoryProject, GithubRepo } from '../ui/domains/workspaces/services/github';
+import { fetchIntakeConfig, selectIntakeSource } from '../ui/domains/factory/services/intake';
+import { useSaveIntakeConfigMutation } from './useIntakeConfig';
 
 function invalidateFactories(queryClient: ReturnType<typeof useQueryClient>) {
   void queryClient.invalidateQueries({ queryKey: queryKeys.factories() });
@@ -57,13 +59,19 @@ export function useCreateFactoryMutation() {
 /** @deprecated Use useCreateFactoryMutation. */
 export const useAddFactoryMutation = useCreateFactoryMutation;
 
+/** Also feeds the caller's issue intake; the server link is idempotent, so a failed intake write is safe to retry. */
 export function useLinkRepositoryMutation() {
   const { baseUrl } = useApiConfig();
   const queryClient = useQueryClient();
+  const saveIntakeConfig = useSaveIntakeConfigMutation();
   return useMutation({
     mutationFn: async ({ factoryProjectId, repo }: { factoryProjectId: string; repo: GithubRepo }) => {
       const connectionId = await connectInstallation(baseUrl, factoryProjectId, repo.installationStorageId);
-      return linkRepository(baseUrl, factoryProjectId, connectionId, repo);
+      const linked = await linkRepository(baseUrl, factoryProjectId, connectionId, repo);
+      const config = await fetchIntakeConfig(baseUrl);
+      const githubSelection = selectIntakeSource(config.github, repo.fullName);
+      if (githubSelection !== config.github) await saveIntakeConfig.mutateAsync({ ...config, github: githubSelection });
+      return linked;
     },
     onSuccess: () => invalidateFactories(queryClient),
   });

--- a/mastracode/factory-ui/src/hooks/useFactories.ts
+++ b/mastracode/factory-ui/src/hooks/useFactories.ts
@@ -59,7 +59,10 @@ export function useCreateFactoryMutation() {
 /** @deprecated Use useCreateFactoryMutation. */
 export const useAddFactoryMutation = useCreateFactoryMutation;
 
-/** Also feeds the caller's issue intake; the server link is idempotent, so a failed intake write is safe to retry. */
+/**
+ * Also feeds the caller's issue intake. The link lands first, so the Factory list
+ * refreshes even when the intake write fails; the server link is idempotent, so retrying is safe.
+ */
 export function useLinkRepositoryMutation() {
   const { baseUrl } = useApiConfig();
   const queryClient = useQueryClient();
@@ -68,12 +71,16 @@ export function useLinkRepositoryMutation() {
     mutationFn: async ({ factoryProjectId, repo }: { factoryProjectId: string; repo: GithubRepo }) => {
       const connectionId = await connectInstallation(baseUrl, factoryProjectId, repo.installationStorageId);
       const linked = await linkRepository(baseUrl, factoryProjectId, connectionId, repo);
-      const config = await fetchIntakeConfig(baseUrl);
-      const githubSelection = selectIntakeSource(config.github, repo.fullName);
-      if (githubSelection !== config.github) await saveIntakeConfig.mutateAsync({ ...config, github: githubSelection });
+      try {
+        const config = await fetchIntakeConfig(baseUrl);
+        const githubSelection = selectIntakeSource(config.github, repo.fullName);
+        if (githubSelection !== config.github)
+          await saveIntakeConfig.mutateAsync({ ...config, github: githubSelection });
+      } finally {
+        invalidateFactories(queryClient);
+      }
       return linked;
     },
-    onSuccess: () => invalidateFactories(queryClient),
   });
 }
 

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/CreateFactoryFlow.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/CreateFactoryFlow.msw.test.tsx
@@ -452,8 +452,9 @@ describe('Create Factory wizard', () => {
 
     await waitForMutationsIdle(client);
     expect(bindings).toEqual([{ integrationId: 'linear', sourceId: 'lin-1', factoryProjectId: 'fp-1' }]);
-    // Both picks land in one config write, each selected and switched on.
+    // The link feeds the repository first; the Linear pick lands on top of it.
     expect(intakeConfigs).toEqual([
+      { github: { enabled: true, sourceIds: ['octo/hello'] }, linear: { enabled: false, sourceIds: null } },
       { github: { enabled: true, sourceIds: ['octo/hello'] }, linear: { enabled: true, sourceIds: ['lin-1'] } },
     ]);
   });
@@ -569,14 +570,16 @@ const linkedRepository = {
 
 /**
  * Stub the intake config the last step reads and writes, collecting every
- * saved config body.
+ * saved config body. Stateful: each PUT becomes what the next GET returns.
  */
-function stubIntakeConfig(config: Record<string, unknown> = {}) {
+function stubIntakeConfig(initial: Record<string, unknown> = {}) {
+  let config = initial;
   const savedConfigs: unknown[] = [];
   server.use(
     http.get(`${TEST_BASE_URL}/web/intake/config`, () => HttpResponse.json({ config })),
-    http.put(`${TEST_BASE_URL}/web/intake/config`, async ({ request }) => {
-      savedConfigs.push(await request.json());
+    http.put<never, Record<string, unknown>>(`${TEST_BASE_URL}/web/intake/config`, async ({ request }) => {
+      config = await request.json();
+      savedConfigs.push(config);
       return HttpResponse.json({ config });
     }),
   );

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/FactoryCreateRefresh.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/FactoryCreateRefresh.msw.test.tsx
@@ -71,6 +71,8 @@ beforeEach(() => {
         },
       }),
     ),
+    http.get(`${TEST_BASE_URL}/web/intake/config`, () => HttpResponse.json({ config: {} })),
+    http.put(`${TEST_BASE_URL}/web/intake/config`, () => HttpResponse.json({ config: {} })),
     http.get(`${TEST_BASE_URL}/web/config/providers`, () =>
       HttpResponse.json({
         providers: [{ provider: 'anthropic', source: 'stored', oauth: { supported: true, modes: ['paste-code'] } }],

--- a/mastracode/factory-ui/src/ui/domains/workspaces/hooks/useCreateFactoryFromDraft.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/hooks/useCreateFactoryFromDraft.ts
@@ -19,10 +19,10 @@ export interface CreateFactoryFromDraftOptions {
 }
 
 /**
- * The wizard's single write: create the Factory, link the repository, feed its
- * issue intake (plus the Linear project when one was picked), and save the
- * model its runs start on. Nothing before this touches the server, so an
- * abandoned wizard leaves nothing behind.
+ * The wizard's single write: create the Factory, link the repository (which
+ * feeds its issue intake), route the Linear project when one was picked, and
+ * save the model its runs start on. Nothing before this touches the server, so
+ * an abandoned wizard leaves nothing behind.
  */
 export function useCreateFactoryFromDraft({
   draft,
@@ -38,21 +38,16 @@ export function useCreateFactoryFromDraft({
   const saveIntakeBinding = useSaveIntakeBindingMutation();
   const saveIntakeConfig = useSaveIntakeConfigMutation();
 
-  // One config write for both sources — two read-modify-writes would drop
-  // each other's selection.
-  const feedBoard = async (repositorySlug: string, linear?: { sourceId: string; factoryProjectId: string }) => {
-    if (linear) {
-      await saveIntakeBinding.mutateAsync({
-        integrationId: 'linear',
-        sourceId: linear.sourceId,
-        factoryProjectId: linear.factoryProjectId,
-      });
-    }
+  const feedLinearProject = async (linear: { sourceId: string; factoryProjectId: string }) => {
+    await saveIntakeBinding.mutateAsync({
+      integrationId: 'linear',
+      sourceId: linear.sourceId,
+      factoryProjectId: linear.factoryProjectId,
+    });
     const config = await fetchIntakeConfig(baseUrl);
-    const githubSelection = selectIntakeSource(config.github, repositorySlug);
-    const linearSelection = linear ? selectIntakeSource(config.linear, linear.sourceId) : config.linear;
-    if (githubSelection === config.github && linearSelection === config.linear) return;
-    await saveIntakeConfig.mutateAsync({ ...config, github: githubSelection, linear: linearSelection });
+    const linearSelection = selectIntakeSource(config.linear, linear.sourceId);
+    if (linearSelection === config.linear) return;
+    await saveIntakeConfig.mutateAsync({ ...config, linear: linearSelection });
   };
 
   return useMutation({
@@ -69,13 +64,12 @@ export function useCreateFactoryFromDraft({
         await onRepositoryLinked(linked.projectRepositoryId);
       }
 
-      const linearPick = draft.linearProjectId
-        ? { sourceId: draft.linearProjectId, factoryProjectId: factory.id }
-        : undefined;
       await Promise.all([
         updateFactoryDefaultModel(baseUrl, factory.id, modelId),
         applyOMDefaults.mutateAsync({ providerId, factoryModelId: modelId, factoryId: factory.id }),
-        feedBoard(draft.repository.fullName, linearPick),
+        draft.linearProjectId
+          ? feedLinearProject({ sourceId: draft.linearProjectId, factoryProjectId: factory.id })
+          : undefined,
       ]);
       await queryClient.invalidateQueries({ queryKey: queryKeys.factories() });
       await onCreated(factory);


### PR DESCRIPTION
**─────── TLDR ───────**
> Linking a repository to a Factory now also checks it under Work Intake › GitHub issues, so a fresh Factory's open issues reach the board without a trip to Settings.

Create a Factory, pick a repository, open Work Intake: the repository sits there unchecked and nothing syncs. Only the create-Factory wizard fed intake; onboarding and Settings › Repositories linked the repository and stopped. The shared link mutation now feeds intake for every path, and the wizard keeps only its Linear routing.

### Behavior changed

a repository linked during onboarding
&nbsp;&nbsp;├─ **was** — unchecked under Work Intake, no issues on the board
&nbsp;&nbsp;└─ **now** — checked and syncing

a repository linked from Settings › Repositories
&nbsp;&nbsp;├─ **was** — unchecked under Work Intake
&nbsp;&nbsp;└─ **now** — checked and syncing

GitHub issues switched off, then a repository linked
&nbsp;&nbsp;├─ **was** — stayed off
&nbsp;&nbsp;└─ **now** — switched back on with that repository selected, as the wizard already did

a repository linked by the create-Factory wizard
&nbsp;&nbsp;└─ **unchanged** — already fed intake; the Linear pick now lands in a second write after it

a repository that already feeds intake, linked again
&nbsp;&nbsp;└─ **unchanged** — no config write

### Decisions

- **an intake failure still fails the link, but the Factory list refreshes anyway** — the link has landed and the server link is idempotent, so Link again retries only intake; one `catch` away if you'd rather the link succeed alone
- **client-side, not in the server link route** — intake config is per user and the wizard already feeds it from the client; the server route would need the intake storage handle it does not have today

### Not verified

- [ ] against a running Factory — the flows ran through MSW only

---

> ██████████████████ **tests** `+164 −5`
> ████ **source** `+33 −24` — net +9
> █ **changeset** `+5`
