### PR TITLE
fix(factory): health check leaves failed decisions and proposals to the inbox

### DIFF
--- a/.changeset/findings-leave-decisions-to-the-inbox.md
+++ b/.changeset/findings-leave-decisions-to-the-inbox.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+The supervisor health check no longer reports failed decisions and proposals waiting on a person as findings. The board and the attention inbox already carry both, so every one of them showed up twice in the inbox. The supervisor agent reads them with `factory_list_attention`; rows already stored for these kinds resolve on the next health tick.

--- a/mastracode/factory-ui/src/ui/domains/factory/components/__tests__/SidebarAttention.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/__tests__/SidebarAttention.msw.test.tsx
@@ -122,7 +122,7 @@ function supervisorFindingItem(): FactorySupervisorFindingAttentionItem {
     findingTitle: 'A decision is stuck',
     evidence: 'The decision has been retrying past its backoff.',
     ageMs: 15 * 60_000,
-    suggestedRepair: { action: 'retry-decision', decisionId: DECISION_ID },
+    suggestedRepair: null,
     occurrence: 0,
     workItemId: 'item-1',
     title: 'A decision is stuck',

--- a/mastracode/factory-ui/src/ui/domains/supervisor/components/SupervisorFindingsPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/supervisor/components/SupervisorFindingsPanel.tsx
@@ -22,12 +22,10 @@ interface SupervisorFindingsPanelProps {
 const MAX_VISIBLE_FINDINGS_PER_GROUP = 5;
 
 const FINDING_LABELS: Record<FactoryHealthFinding['kind'], string> = {
-  'decision-failed': 'Failed decisions',
   'decision-stuck': 'Stuck decisions',
   'start-stalled': 'Stalled starts',
   'seat-orphaned': 'Orphaned seats',
   'seat-missing': 'Missing seats',
-  'proposal-waiting': 'Proposals waiting',
   'held-waiting': 'Held cards waiting',
   'label-drift': 'Label drift',
 };

--- a/mastracode/factory-ui/src/ui/domains/supervisor/services/supervisor.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/supervisor/services/supervisor.test.ts
@@ -16,7 +16,7 @@ describe('supervisor prompts', () => {
   it('labels hostile-looking finding content as untrusted evidence', () => {
     const prompt = findingPrompt({
       id: 'finding-1',
-      kind: 'decision-failed',
+      kind: 'decision-stuck',
       title: hostileTitle,
       workItemId: 'item-1',
       workItemNumber: 123,

--- a/mastracode/factory-ui/src/ui/pages/__tests__/OverviewPage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/OverviewPage.msw.test.tsx
@@ -39,12 +39,10 @@ function card(stageHistory: WorkItemStageEntry[], overrides: Record<string, unkn
 
 function stubBoard(workItems: unknown[], runningSessionIds: string[] = [], findings: unknown[] = []) {
   const counts = {
-    'decision-failed': 0,
     'decision-stuck': 0,
     'start-stalled': 0,
     'seat-orphaned': 0,
     'seat-missing': 0,
-    'proposal-waiting': 0,
     'held-waiting': 0,
     'label-drift': 0,
   };

--- a/mastracode/factory-ui/src/ui/pages/__tests__/SupervisorPage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/SupervisorPage.msw.test.tsx
@@ -20,12 +20,10 @@ const AC = `${TEST_BASE_URL}/api/agent-controller/code`;
 
 function report(findings: FactoryHealthReport['findings']): FactoryHealthReport {
   const counts = {
-    'decision-failed': 0,
     'decision-stuck': 0,
     'start-stalled': 0,
     'seat-orphaned': 0,
     'seat-missing': 0,
-    'proposal-waiting': 0,
     'held-waiting': 0,
     'label-drift': 0,
   };
@@ -112,19 +110,19 @@ describe('SupervisorPage', () => {
     });
   });
 
-  describe('when failed decision findings are available', () => {
+  describe('when stuck decision findings are available', () => {
     it('keeps the panel bounded and links to the complete Attention inbox', async () => {
       stubSupervisorRoute(
         report(
           Array.from({ length: 6 }, (_, index) => ({
-            kind: 'decision-failed' as const,
+            kind: 'decision-stuck' as const,
             id: `dec-${index + 1}`,
             workItemId: `wi-${index + 1}`,
             workItemNumber: 22874 + index,
-            title: `Failed decision ${index + 1}`,
+            title: `Stuck decision ${index + 1}`,
             evidence: 'The decision exhausted its retry attempts.',
             ageMs: 3_600_000,
-            suggestedRepair: { action: 'retry-decision' as const, decisionId: `dec-${index + 1}` },
+            suggestedRepair: null,
           })),
         ),
       );
@@ -132,10 +130,10 @@ describe('SupervisorPage', () => {
 
       await userEvent.click(await screen.findByRole('button', { name: 'Supervisor findings' }));
       const findings = screen.getByRole('region', { name: 'Supervisor findings' });
-      await userEvent.click(within(findings).getByRole('button', { name: /Failed decisions/ }));
+      await userEvent.click(within(findings).getByRole('button', { name: /Stuck decisions/ }));
 
-      expect(within(findings).getByText('Failed decision 5')).toBeInTheDocument();
-      expect(within(findings).queryByText('Failed decision 6')).not.toBeInTheDocument();
+      expect(within(findings).getByText('Stuck decision 5')).toBeInTheDocument();
+      expect(within(findings).queryByText('Stuck decision 6')).not.toBeInTheDocument();
       expect(within(findings).getByRole('link', { name: 'View all in Attention' })).toHaveAttribute(
         'href',
         `/factories/${FACTORY_ID}/attention`,
@@ -146,14 +144,14 @@ describe('SupervisorPage', () => {
       stubSupervisorRoute(
         report([
           {
-            kind: 'decision-failed',
+            kind: 'decision-stuck',
             id: 'dec-1',
             workItemId: 'wi-1',
             workItemNumber: 22874,
             title: 'Plan step could not start',
             evidence: 'invokeSkill plan failed after 5 attempts: No active Factory binding for role plan.',
             ageMs: 3_600_000,
-            suggestedRepair: { action: 'retry-decision', decisionId: 'dec-1' },
+            suggestedRepair: null,
           },
         ]),
       );
@@ -161,7 +159,7 @@ describe('SupervisorPage', () => {
 
       await userEvent.click(await screen.findByRole('button', { name: 'Supervisor findings' }));
       const findings = screen.getByRole('region', { name: 'Supervisor findings' });
-      await userEvent.click(within(findings).getByRole('button', { name: /Failed decisions/ }));
+      await userEvent.click(within(findings).getByRole('button', { name: /Stuck decisions/ }));
       await userEvent.click(within(findings).getByRole('button', { name: 'Ask supervisor' }));
 
       const composer = screen.getByRole('region', { name: 'Supervisor composer' });

--- a/mastracode/factory/src/routes/attention.test.ts
+++ b/mastracode/factory/src/routes/attention.test.ts
@@ -144,7 +144,7 @@ describe('supervisor finding attention items', () => {
           title: 'A decision is stuck',
           evidence: 'decision-1 has been retrying past its backoff.',
           ageMs: 600_000,
-          suggestedRepair: { action: 'retry-decision', decisionId: 'decision-1' },
+          suggestedRepair: null,
         },
       ],
       now: new Date('2030-01-01T00:00:00.000Z'),

--- a/mastracode/factory/src/routes/supervisor.test.ts
+++ b/mastracode/factory/src/routes/supervisor.test.ts
@@ -131,22 +131,16 @@ describe('GET /supervisor/health', () => {
     expect(typeof body.checkedAt).toBe('string');
   });
 
-  it('surfaces a failed decision as a finding that points at its card', async () => {
+  it('leaves a failed decision to the board and the inbox instead of reporting it', async () => {
     const item = await seedWorkItem(['execute']);
-    const failed = await seedFailure(item, new Date());
+    await seedFailure(item, new Date());
 
     const res = await request('GET', `/web/factory/projects/${PROJECT_ID}/supervisor/health`);
     expect(res.status).toBe(200);
     const body = await res.json();
-    const finding = body.findings.find((f: { kind: string }) => f.kind === 'decision-failed');
-    expect(finding).toMatchObject({
-      workItemId: item.id,
-      suggestedRepair: { action: 'retry-decision', decisionId: failed.id },
-    });
-    expect(finding.evidence).toContain('No active Factory binding');
-    expect(body.counts['decision-failed']).toBe(1);
+    expect(body.findings.map((f: { kind: string }) => f.kind)).not.toContain('decision-failed');
+    expect(body.counts).not.toHaveProperty('decision-failed');
   });
-
   it('is scoped to the caller org', async () => {
     const other = { workosId: 'u2', organizationId: 'org2' };
     const res = await request('GET', `/web/factory/projects/${PROJECT_ID}/supervisor/health`, other);

--- a/mastracode/factory/src/supervisor/health.test.ts
+++ b/mastracode/factory/src/supervisor/health.test.ts
@@ -128,7 +128,20 @@ describe('computeFactoryHealth', () => {
     expect(report.checkedAt).toBe(NOW.toISOString());
   });
 
-  it('flags a terminally failed decision with its error and a retry repair', () => {
+  it('leaves a failed decision to the board and the inbox: it is not a finding', () => {
+    const report = computeFactoryHealth(
+      {
+        ...empty,
+        items: [item({ id: 'item-1' })],
+        bindings: [binding({ id: 'b-1' })],
+        decisions: [decision({ id: 'd-fail', status: 'failed', attempts: 5, failureCode: 'session_unavailable' })],
+      },
+      NOW,
+    );
+    expect(report.findings).toEqual([]);
+  });
+
+  it('leaves a proposal to the board and the inbox: it is not a finding', () => {
     const report = computeFactoryHealth(
       {
         ...empty,
@@ -136,28 +149,15 @@ describe('computeFactoryHealth', () => {
         bindings: [binding({ id: 'b-1' })],
         decisions: [
           decision({
-            id: 'd-fail',
-            status: 'failed',
-            attempts: 5,
-            failureCode: 'session_unavailable',
-            lastError: 'No active Factory binding for role plan.',
+            id: 'd-old',
+            status: 'proposed',
+            createdAt: ago(DEFAULT_HEALTH_THRESHOLDS.waitingOnPersonMs + 1),
           }),
         ],
       },
       NOW,
     );
-    expect(report.findings).toEqual([
-      expect.objectContaining({
-        kind: 'decision-failed',
-        id: 'decision-failed:d-fail',
-        workItemId: 'item-1',
-        workItemNumber: 42,
-        suggestedRepair: { action: 'retry-decision', decisionId: 'd-fail' },
-      }),
-    ]);
-    expect(report.findings[0]!.evidence).toContain('invokeSkill (plan)');
-    expect(report.findings[0]!.evidence).toContain('[session_unavailable]');
-    expect(report.findings[0]!.evidence).toContain('No active Factory binding');
+    expect(report.findings).toEqual([]);
   });
 
   it('flags retry decisions the dispatcher never picked up, but not ones inside their backoff', () => {
@@ -285,27 +285,6 @@ describe('computeFactoryHealth', () => {
     expect(report.findings[0]!.evidence).toContain('feature request');
   });
 
-  it('flags a proposal a person has left waiting', () => {
-    const report = computeFactoryHealth(
-      {
-        ...empty,
-        items: [item({ id: 'item-1' })],
-        bindings: [binding({ id: 'b-1' })],
-        decisions: [
-          decision({
-            id: 'd-old',
-            status: 'proposed',
-            createdAt: ago(DEFAULT_HEALTH_THRESHOLDS.waitingOnPersonMs + 1),
-          }),
-          decision({ id: 'd-new', status: 'proposed', createdAt: ago(1_000) }),
-        ],
-      },
-      NOW,
-    );
-    expect(report.findings.map(f => f.id)).toEqual(['proposal-waiting:d-old']);
-    expect(report.findings[0]!.suggestedRepair).toEqual({ action: 'resolve-proposal', decisionId: 'd-old' });
-  });
-
   it('flags an accepted card that still wears the needs-approval label', () => {
     const report = computeFactoryHealth(
       {
@@ -339,14 +318,14 @@ describe('computeFactoryHealth', () => {
         items: [item({ id: 'item-1' })],
         bindings: [binding({ id: 'b-1' })],
         decisions: [
-          decision({ id: 'd-recent', status: 'failed', updatedAt: ago(1_000) }),
-          decision({ id: 'd-older', status: 'failed', updatedAt: ago(HOUR) }),
+          decision({ id: 'd-recent', status: 'retry', availableAt: ago(HOUR) }),
+          decision({ id: 'd-older', status: 'retry', availableAt: ago(2 * HOUR) }),
         ],
       },
       NOW,
     );
-    expect(report.findings.map(f => f.id)).toEqual(['decision-failed:d-older', 'decision-failed:d-recent']);
-    expect(report.counts['decision-failed']).toBe(2);
+    expect(report.findings.map(f => f.id)).toEqual(['decision-stuck:d-older', 'decision-stuck:d-recent']);
+    expect(report.counts['decision-stuck']).toBe(2);
     expect(report.counts['seat-missing']).toBe(0);
   });
 });

--- a/mastracode/factory/src/supervisor/health.ts
+++ b/mastracode/factory/src/supervisor/health.ts
@@ -23,19 +23,14 @@ import type {
 } from '../storage/domains/work-items/base.js';
 
 export type FactoryHealthFindingKind =
-  | 'decision-failed'
   | 'decision-stuck'
   | 'start-stalled'
   | 'seat-orphaned'
   | 'seat-missing'
-  | 'proposal-waiting'
   | 'held-waiting'
   | 'label-drift';
 
 export type FactoryHealthRepair =
-  | { action: 'retry-decision'; decisionId: string }
-  | { action: 'dismiss-decision'; decisionId: string }
-  | { action: 'resolve-proposal'; decisionId: string }
   | { action: 'revoke-binding'; bindingId: string }
   | { action: 'accept-work-item'; workItemId: string }
   | { action: 'start-run'; workItemId: string; role: string }
@@ -69,7 +64,7 @@ export interface FactoryHealthThresholds {
   expiredLeaseMs: number;
   /** A pending start this old is not "booting", it is stalled. */
   stalledStartMs: number;
-  /** Proposals and held cards older than this are worth nudging a person about. */
+  /** Held cards older than this are worth nudging a maintainer about. */
   waitingOnPersonMs: number;
 }
 
@@ -81,12 +76,10 @@ export const DEFAULT_HEALTH_THRESHOLDS: FactoryHealthThresholds = {
 };
 
 const FINDING_KINDS: FactoryHealthFindingKind[] = [
-  'decision-failed',
   'decision-stuck',
   'start-stalled',
   'seat-orphaned',
   'seat-missing',
-  'proposal-waiting',
   'held-waiting',
   'label-drift',
 ];
@@ -153,17 +146,6 @@ export function computeFactoryHealth(
 
   for (const decision of inputs.decisions) {
     const base = subject(decision.workItemId);
-    if (decision.status === 'failed') {
-      findings.push({
-        kind: 'decision-failed',
-        id: `decision-failed:${decision.id}`,
-        ...base,
-        evidence: `Decision ${decision.id} (${describeDecision(decision)}) failed after ${decision.attempts} attempt(s) at ${decision.updatedAt.toISOString()}${decision.failureCode ? ` [${decision.failureCode}]` : ''}: ${truncate(decision.lastError ?? 'no error recorded')}`,
-        ageMs: now.getTime() - decision.updatedAt.getTime(),
-        suggestedRepair: { action: 'retry-decision', decisionId: decision.id },
-      });
-      continue;
-    }
     if (decision.status === 'retry' || decision.status === 'pending') {
       const overdue = now.getTime() - decision.availableAt.getTime();
       if (overdue > thresholds.stuckDecisionMs) {
@@ -188,20 +170,6 @@ export function computeFactoryHealth(
           evidence: `Decision ${decision.id} (${describeDecision(decision)}) is still leased by ${decision.leaseOwner ?? 'unknown'} though the lease expired at ${decision.leaseExpiresAt.toISOString()}; the worker likely died mid-dispatch.`,
           ageMs: expired,
           suggestedRepair: null,
-        });
-      }
-      continue;
-    }
-    if (decision.status === 'proposed') {
-      const waiting = now.getTime() - decision.createdAt.getTime();
-      if (waiting > thresholds.waitingOnPersonMs) {
-        findings.push({
-          kind: 'proposal-waiting',
-          id: `proposal-waiting:${decision.id}`,
-          ...base,
-          evidence: `Proposed run ${decision.id} (${describeDecision(decision)}) has waited for a person since ${decision.createdAt.toISOString()}.`,
-          ageMs: waiting,
-          suggestedRepair: { action: 'resolve-proposal', decisionId: decision.id },
         });
       }
     }

--- a/mastracode/factory/src/supervisor/instructions.ts
+++ b/mastracode/factory/src/supervisor/instructions.ts
@@ -22,8 +22,9 @@ You have no repository and no sandbox. Everything you know comes from the
 - Ground every claim in a tool result. Quote ids (card number, decision id,
   seat id, thread id) and timestamps so the person can click through. Never
   guess at a cause the records do not show.
-- Start with \`factory_health_check\` for "what's wrong / what needs me", and
-  \`factory_inspect_work_item\` for questions about one card. Use
+- Start with \`factory_health_check\` for "what's wrong", \`factory_list_attention\`
+  for "what needs me", and \`factory_inspect_work_item\` for questions about one
+  card. Use
   \`factory_read_session\` only when the records don't explain a card and the
   worker's own transcript might.
 - Lead with the answer, then the evidence, then the standard repair. Keep it
@@ -33,10 +34,11 @@ You have no repository and no sandbox. Everything you know comes from the
 
 ## Reading the records
 
-- \`decision-failed\` — the dispatcher gave up. If the cause was transient
-  (a restart, a fixed bug, a rate limit), a retry will succeed. If the card
-  has already moved on past the role the decision was for, the decision is
-  moot and should be dismissed, not retried.
+- Failed decisions and proposals waiting on a person are not health findings;
+  the board and the attention inbox already carry them. Read them with
+  \`factory_list_attention\`. A failed decision whose cause was transient (a
+  restart, a fixed bug, a rate limit) will succeed on retry; one whose card
+  already moved past its role is moot and should be dismissed, not retried.
 - \`decision-stuck\` — retry/pending past its backoff, or a lease that
   expired: the dispatcher is not picking it up. Usually a stalled process.
 - \`seat-missing\` — a card sits in a working lane with nobody bound to it
@@ -44,8 +46,8 @@ You have no repository and no sandbox. Everything you know comes from the
 - \`seat-orphaned\` — a seat is active on a card that already finished or
   left that role's lane; a lifecycle bug left it behind.
 - \`start-stalled\` — a run was asked for but the kickoff never landed.
-- \`proposal-waiting\` / \`held-waiting\` — a person is the blocker. Say so
-  plainly and name what they need to decide.
+- \`held-waiting\` — a maintainer is the blocker. Say so plainly and name
+  what they need to decide.
 - \`label-drift\` — the GitHub labels disagree with the card's accepted
   state; reconcile its acceptance labels after confirming the repair.
 

--- a/mastracode/factory/src/supervisor/read-tools.test.ts
+++ b/mastracode/factory/src/supervisor/read-tools.test.ts
@@ -117,7 +117,7 @@ describe('createFactorySupervisorReadTools', () => {
 
     const report = await execute<any>(tools.factory_health_check, {});
 
-    expect(report.findings.map((f: any) => f.kind).sort()).toEqual(['decision-failed', 'seat-missing']);
+    expect(report.findings.map((f: any) => f.kind)).toEqual(['seat-missing']);
   });
 
   it('factory_inspect_work_item resolves a card by number with its seats, decisions, audit and feed', async () => {

--- a/mastracode/factory/src/supervisor/read-tools.ts
+++ b/mastracode/factory/src/supervisor/read-tools.ts
@@ -231,7 +231,7 @@ export function createFactorySupervisorReadTools(deps: SupervisorReadDependencie
     factory_health_check: createTool({
       id: 'factory_health_check',
       description:
-        'Deterministic list of things wrong with this Factory right now (failed or stuck decisions, stalled starts, orphaned or missing seats, proposals and held cards waiting on a person, label drift). Each finding carries evidence and the standard repair. Explain these; do not invent findings that are not listed.',
+        'Deterministic list of things wrong with this Factory right now (stuck decisions, stalled starts, orphaned or missing seats, held cards waiting on a person, label drift). Each finding carries evidence and the standard repair. Explain these; do not invent findings that are not listed.',
       inputSchema: z.object({}).strict(),
       execute: async (): Promise<FactoryHealthReport> =>
         runFactoryHealthCheck(deps.workItems, scope, { now: now(), thresholds: deps.healthThresholds }),


### PR DESCRIPTION
**─────── TLDR ───────**
> The supervisor health check stops reporting failed decisions and waiting proposals, which the board and the attention inbox already show, so neither appears twice in the inbox anymore.

The health worker syncs every finding into the inbox as a `supervisor-finding` row. Two of its eight kinds restated rows the inbox already lists under their own kind: a failed decision is an `automation-failed` row and a red card, a proposal is an `automation-proposed` row and a "suggested" card. On my local database that was 223 of the 266 open findings, every one a duplicate of a row one screen up.

### Behavior changed

a run that could not start
&nbsp;&nbsp;├─ **was** — red card, a `failed` inbox row, and a `finding` row saying the same thing
&nbsp;&nbsp;└─ **now** — red card and the `failed` row

a proposal older than a day
&nbsp;&nbsp;├─ **was** — a `suggested` inbox row, then a second `finding` row after 24 hours
&nbsp;&nbsp;└─ **now** — the `suggested` row only

the supervisor agent asked "what needs me"
&nbsp;&nbsp;├─ **was** — `factory_health_check` listed failed decisions and waiting proposals
&nbsp;&nbsp;└─ **now** — the prompt sends it to `factory_list_attention`, which already lists both

### Shape changed

| | | |
|---|---|---|
| **−** | `decision-failed`, `proposal-waiting` | finding kinds restating inbox rows |
| **−** | `retry-decision`, `resolve-proposal` | suggested repairs only those kinds produced |
| **−** | `dismiss-decision` | a repair nothing ever produced |

wire types the supervisor page and the inbox item read, both narrower
&nbsp;&nbsp;&nbsp;&nbsp;`FactoryHealthFindingKind` · `FactoryHealthRepair` · `FactoryHealthReport.counts`
removed: the two `counts` keys on the health report

### Decisions

- **deleted from the detector rather than filtered before the sync** — the supervisor page and the health tool would otherwise keep showing rows the inbox owns — one `filter` in the worker if you want them back on the page

on deploy: rows already stored for these kinds resolve on the next health tick, since the sync closes any finding the detector no longer returns; the duplicate inbox rows leave on their own within five minutes.

---

> ██████████████████ **tests** `+40 −69`
> █████ **source** `+11 −43` — net −32
> ██ **changeset** `+5`
