### PR TITLE
fix(factory-ui): space the Intake poll out by the number of loaded pages

### DIFF
--- a/.changeset/intake-poll-per-loaded-page.md
+++ b/.changeset/intake-poll-per-loaded-page.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+The board's candidate poll now spaces itself out by the number of loaded pages: every 30 seconds with one page, every minute with two, and so on. Each poll replays every loaded page through GitHub, so a tab costs the same however far the Intake column has been scrolled. Returning to the tab still refreshes at once.

--- a/mastracode/factory-ui/src/hooks/__tests__/useFactoryData.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useFactoryData.msw.test.tsx
@@ -10,7 +10,7 @@ import { http, HttpResponse } from 'msw';
 import { describe, expect, it, vi } from 'vitest';
 
 import { server } from '../../../e2e/ui/msw-server';
-import { renderHookWithProviders, TEST_BASE_URL } from '../../../e2e/ui/render';
+import { renderHookWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../e2e/ui/render';
 import type { GithubIssue, GithubPullRequest } from '../../ui/domains/factory/services/factory';
 import {
   INTAKE_ERROR_POLL_MS,
@@ -143,17 +143,19 @@ describe('useProjectIssuesQuery', () => {
         }),
       );
 
-      const { result } = renderHookWithProviders(() => useProjectIssuesQuery(PROJECT_ID));
+      const { result, client } = renderHookWithProviders(() => useProjectIssuesQuery(PROJECT_ID));
       await waitFor(() => expect(result.current.data).toHaveLength(1));
       await result.current.fetchNextPage();
-      await waitFor(() => expect(result.current.data).toHaveLength(2));
+      await waitForMutationsIdle(client);
+      expect(result.current.data).toHaveLength(2);
       expect(requestedPages).toEqual(['1', '2']);
 
       await vi.advanceTimersByTimeAsync(INTAKE_POLL_MS + 1_000);
       expect(requestedPages).toEqual(['1', '2']);
 
       await vi.advanceTimersByTimeAsync(INTAKE_POLL_MS);
-      await waitFor(() => expect(requestedPages).toEqual(['1', '2', '1', '2']));
+      await waitForMutationsIdle(client);
+      expect(requestedPages).toEqual(['1', '2', '1', '2']);
     } finally {
       vi.useRealTimers();
     }

--- a/mastracode/factory-ui/src/hooks/__tests__/useFactoryData.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useFactoryData.msw.test.tsx
@@ -129,6 +129,36 @@ describe('useProjectIssuesQuery', () => {
     }
   });
 
+  it('given two pages loaded, when one interval elapses, then the replay waits one interval per loaded page', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const requestedPages: string[] = [];
+      server.use(
+        http.get(ISSUES_URL, ({ request }) => {
+          const page = new URL(request.url).searchParams.get('page') ?? '1';
+          requestedPages.push(page);
+          return page === '1'
+            ? HttpResponse.json({ issues, nextPage: 2 })
+            : HttpResponse.json({ issues: [{ ...issues[0]!, number: 13, title: 'Older intake' }], nextPage: null });
+        }),
+      );
+
+      const { result } = renderHookWithProviders(() => useProjectIssuesQuery(PROJECT_ID));
+      await waitFor(() => expect(result.current.data).toHaveLength(1));
+      await result.current.fetchNextPage();
+      await waitFor(() => expect(result.current.data).toHaveLength(2));
+      expect(requestedPages).toEqual(['1', '2']);
+
+      await vi.advanceTimersByTimeAsync(INTAKE_POLL_MS + 1_000);
+      expect(requestedPages).toEqual(['1', '2']);
+
+      await vi.advanceTimersByTimeAsync(INTAKE_POLL_MS);
+      await waitFor(() => expect(requestedPages).toEqual(['1', '2', '1', '2']));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('given the server fails, when the hook resolves, then it surfaces the server message', async () => {
     server.use(
       http.get(ISSUES_URL, () => HttpResponse.json({ error: 'github_error', message: 'boom' }, { status: 502 })),

--- a/mastracode/factory-ui/src/hooks/useFactoryData.ts
+++ b/mastracode/factory-ui/src/hooks/useFactoryData.ts
@@ -17,8 +17,10 @@ export const INTAKE_POLL_MS = 30_000;
  * but the feed must still self-heal after the connection is repaired. */
 export const INTAKE_ERROR_POLL_MS = 5 * 60_000;
 
-function intakePollInterval(query: { state: { status: string } }): number {
-  return query.state.status === 'error' ? INTAKE_ERROR_POLL_MS : INTAKE_POLL_MS;
+function intakePollInterval(query: { state: { status: string; data: { pages: unknown[] } | undefined } }): number {
+  if (query.state.status === 'error') return INTAKE_ERROR_POLL_MS;
+  const loadedPages = query.state.data?.pages.length ?? 1;
+  return INTAKE_POLL_MS * loadedPages;
 }
 
 /**
@@ -35,9 +37,7 @@ export function useProjectIssuesQuery(projectRepositoryId: string | undefined, l
     initialPageParam: 1,
     getNextPageParam: lastPage => lastPage.nextPage,
     select: data => data.pages.flatMap(page => page.issues),
-    // New intake must show up on the board without a reload. The endpoint
-    // proxies the live GitHub API (and a refetch replays every loaded page),
-    // so poll gently and refresh when the user returns to the tab.
+    // A refetch replays every loaded page through GitHub, hence the spacing per page.
     refetchInterval: intakePollInterval,
     refetchOnWindowFocus: true,
   });


### PR DESCRIPTION
**─────── TLDR ───────**
> The Intake poll spaces itself out by the number of loaded pages, so a tab spends the same GitHub budget however deep the column has been scrolled.

A refetch of an infinite query replays every loaded page, that is how TanStack v5 keeps the pages consistent. At a flat 30 s, a user who had scrolled the Intake column ten pages deep cost ten GitHub calls plus the server-side ingest of three hundred polled events every half minute, for as long as the tab stayed focused. Follow-up to #23220, which stopped the column from loading those pages on its own.

### Behavior changed

one page loaded, the common case after #23220
&nbsp;&nbsp;└─ **unchanged** — new candidates show up within 30 s

two or more pages loaded
&nbsp;&nbsp;├─ **was** — every page replayed every 30 s
&nbsp;&nbsp;└─ **now** — replayed every 30 s per page: a minute at two, five minutes at ten

returning to the tab
&nbsp;&nbsp;└─ **unchanged** — a full refresh at once

the feed in error
&nbsp;&nbsp;└─ **unchanged** — one retry every five minutes

### Decisions

- **spacing, not a first-page-only poll** — refreshing page one alone drops the row that slid to page two behind a new arrival and duplicates the one that slid up; one condition away if the drift is acceptable
- **spacing, not an off switch past N pages** — a deep scroller keeps live updates, later rather than never

### Gain

GitHub calls per focused tab-hour, ten pages loaded:

> ██████████████████ **was** — 1 200, plus 36 000 ingested events
> ██ **now** — 120, plus 3 600 ingested events

One page loaded costs 120 an hour, before and after.

### Not verified

- [ ] the interval against the real GitHub rate budget — the spacing was checked with fake timers against MSW

---

> ██████████████████ **tests** `+30` — 75% of the additions
> ███ **source** `+5 −5`
> ███ **changeset** `+5`
