### PR TITLE
fix(core): keep the step outputs that crash recovery reads back

### DIFF
--- a/.changeset/plenty-pots-attend.md
+++ b/.changeset/plenty-pots-attend.md
@@ -1,0 +1,14 @@
+---
+'@mastra/core': patch
+---
+
+Fixed crash recovery for durable and evented agents failing with `TypeError: Cannot read properties of undefined (reading 'messages')` — or `(reading 'length')` when the process died between iterations.
+
+Running-history pruning removed `messageListState` / `accumulatedSteps` from every completed step of a `running` snapshot, but `restart()` reads completed step *outputs* back: the engine feeds a restarted step its predecessor's output, and the durable loop's `collect-tool-results` re-reads the LLM step's output after the tool-call foreach. So a crashed run could never be recovered — it failed in `durable-llm-execution` when the process died during the model call, in `durable-llm-mapping` when it died during a tool call, and in `durable-goal` when it died between iterations (where `onIterationComplete` hooks run), a gap in which the snapshot lists no active step at all.
+
+A running snapshot now keeps exactly what restart reads: the step it re-executes is resolved from the graph position, keeps its payload, and the newest completed output before it keeps the conversation state. Every older copy is still pruned, so duplication stays constant in run length.
+
+```ts
+// Recovers again instead of throwing on the first step.
+const recovered = await agent.recover(runId);
+```

--- a/packages/core/src/agent/durable/__tests__/recover-after-crash.test.ts
+++ b/packages/core/src/agent/durable/__tests__/recover-after-crash.test.ts
@@ -1,0 +1,354 @@
+/**
+ * End-to-end crash recovery for a durable run whose snapshot was pruned
+ * (issue #22636).
+ *
+ * `recoverActiveRuns()` / `recover()` re-drive a `running` snapshot through
+ * `restart()`, and the engine reads *outputs* on the way back in: a restarted
+ * step is fed its predecessor's `output` (`engine.getStepOutput`), and the
+ * durable loop's `collect-tool-results` map re-reads
+ * `getStepResult('durable-llm-execution')` after the tool-call foreach. The
+ * running-history pruner removed `messageListState` from every completed step,
+ * so both reads handed `MessageList.deserialize` an `undefined` and recovery
+ * died with `Cannot read properties of undefined (reading 'messages')`:
+ *
+ *  - killed while `durable-llm-execution` is active -> the restarted step
+ *    itself throws, in `resolveRuntimeDependencies`;
+ *  - killed while the `durable-tool-call` foreach is active -> the tool call
+ *    re-runs fine and the run dies one step later, in `durable-llm-mapping`;
+ *  - killed between iterations -> the nested run's last step has written its
+ *    `entry-end` snapshot and the outer loop is awaiting its predicate (where
+ *    user `onIterationComplete` hooks run). Nothing is listed as active any
+ *    more, so which output restart needs can only be read off the graph
+ *    position; getting it wrong dies reading `accumulatedSteps.length`.
+ *
+ * All three shapes are covered here. Each test captures a real `running`
+ * snapshot from a live run, JSON round-trips it (a fresh process only ever
+ * sees serialized state), and recovers it against a second store with the
+ * run's in-process registry entry dropped — the state a restarted worker
+ * actually starts from.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { Mastra } from '../../../mastra';
+import { InMemoryStore } from '../../../storage';
+import { createTool } from '../../../tools';
+import type { WorkflowRunState } from '../../../workflows/types';
+import { Agent } from '../../agent';
+import { DurableStepIds } from '../constants';
+import { createDurableAgent } from '../create-durable-agent';
+import { globalRunRegistry } from '../run-registry';
+
+const AGENT_ID = 'crash-recovery-agent';
+const TOOL_NAME = 'slowTool';
+/** The last step of the nested execution workflow (see `workflows/steps/goal.ts`). */
+const GOAL_STEP_ID = 'durable-goal';
+const CAPTURE_TIMEOUT_MS = 20_000;
+
+type ModelTurn = 'tool-call' | 'text';
+
+/** Minimal v3 model that emits one tool call, then finishing text. */
+function createScriptedModel(turns: ModelTurn[], finalText: string, onCall: () => void = () => {}) {
+  let call = 0;
+  return {
+    specificationVersion: 'v3' as const,
+    provider: 'crash-recovery',
+    modelId: 'crash-recovery-model',
+    supportedUrls: {},
+    async doGenerate() {
+      throw new Error('Streaming only');
+    },
+    async doStream() {
+      const turn = turns[Math.min(call, turns.length - 1)];
+      call += 1;
+      onCall();
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings: [] });
+            if (turn === 'tool-call') {
+              controller.enqueue({
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: TOOL_NAME,
+                input: JSON.stringify({ value: 'x' }),
+                providerExecuted: false,
+              });
+              controller.enqueue({ type: 'finish', finishReason: 'tool-calls', usage: usage() });
+            } else {
+              controller.enqueue({ type: 'text-start', id: 'text' });
+              controller.enqueue({ type: 'text-delta', id: 'text', delta: finalText });
+              controller.enqueue({ type: 'text-end', id: 'text' });
+              controller.enqueue({ type: 'finish', finishReason: 'stop', usage: usage() });
+            }
+            controller.close();
+          },
+        }),
+      };
+    },
+  };
+}
+
+function usage() {
+  return {
+    inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+    outputTokens: { total: 1, text: 1, reasoning: 0 },
+  };
+}
+
+async function createStack(model: unknown, execute: (args: any) => Promise<any>) {
+  const store = new InMemoryStore();
+  // A database holds a serialized copy of each write. `InMemoryStore` keeps the
+  // object it is handed, and the engine hands it its live `activeStepsPath`, so
+  // without this the stored snapshot would silently track in-process mutations
+  // that a real store never sees.
+  const workflows = (await store.getStore('workflows'))!;
+  const persist = workflows.persistWorkflowSnapshot.bind(workflows);
+  workflows.persistWorkflowSnapshot = (args: Parameters<typeof persist>[0]) =>
+    persist({ ...args, snapshot: JSON.parse(JSON.stringify(args.snapshot)) });
+
+  const durableAgent = createDurableAgent({
+    agent: new Agent({
+      id: AGENT_ID,
+      name: 'Crash Recovery Agent',
+      instructions: 'Call the tool, then answer.',
+      model: model as any,
+      tools: {
+        [TOOL_NAME]: createTool({
+          id: TOOL_NAME,
+          description: 'A tool the capture process never returns from.',
+          inputSchema: z.object({ value: z.string() }),
+          execute,
+        }),
+      },
+    }),
+  });
+  const mastra = new Mastra({ agents: { [AGENT_ID]: durableAgent as any }, logger: false, storage: store });
+  return { mastra, store, agent: mastra.getAgentById(AGENT_ID) as any };
+}
+
+type Snapshots = { loop: WorkflowRunState; execution: WorkflowRunState };
+
+/** Polls until both workflow snapshots satisfy `ready`, then returns serialized copies. */
+async function captureSnapshots(
+  store: InMemoryStore,
+  runId: string,
+  ready: (loop: any, execution: any) => boolean,
+  description: string,
+): Promise<Snapshots> {
+  const workflows = (await store.getStore('workflows'))!;
+  const deadline = Date.now() + CAPTURE_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const loop = await workflows.getWorkflowRunById({ runId, workflowName: DurableStepIds.AGENTIC_LOOP });
+    const execution = await workflows.getWorkflowRunById({
+      runId,
+      workflowName: DurableStepIds.AGENTIC_EXECUTION,
+    });
+    if (ready(loop?.snapshot, execution?.snapshot)) {
+      // A fresh process only ever sees serialized state.
+      return JSON.parse(JSON.stringify({ loop: loop!.snapshot, execution: execution!.snapshot })) as Snapshots;
+    }
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+function isActive(snapshot: any, activeStep: string): boolean {
+  if (snapshot?.status !== 'running') return false;
+  return JSON.stringify(snapshot.activeStepsPath?.[activeStep]) === JSON.stringify(snapshot.activePaths);
+}
+
+/** Both snapshots `running` with `activeStep` the live step of the nested run. */
+function isRunningStep(activeStep: string) {
+  return (loop: any, execution: any) =>
+    isActive(loop, DurableStepIds.AGENTIC_EXECUTION) && isActive(execution, activeStep);
+}
+
+/**
+ * The nested run's last step has completed and written its `entry-end`
+ * snapshot, nothing has started since: the outer loop is inside its predicate.
+ */
+function isBetweenIterations(loop: any, execution: any): boolean {
+  return (
+    isActive(loop, DurableStepIds.AGENTIC_EXECUTION) &&
+    execution?.status === 'running' &&
+    Object.keys(execution.activeStepsPath ?? {}).length === 0 &&
+    execution.context?.[GOAL_STEP_ID]?.status === 'success'
+  );
+}
+
+async function seedSnapshots(store: InMemoryStore, runId: string, snapshots: Snapshots) {
+  const workflows = (await store.getStore('workflows'))!;
+  await workflows.persistWorkflowSnapshot({
+    workflowName: DurableStepIds.AGENTIC_LOOP,
+    runId,
+    snapshot: snapshots.loop,
+  });
+  await workflows.persistWorkflowSnapshot({
+    workflowName: DurableStepIds.AGENTIC_EXECUTION,
+    runId,
+    snapshot: snapshots.execution,
+  });
+}
+
+/** A durable run deletes both of its snapshot rows once it reaches a terminal state. */
+async function waitForRunToFinish(store: InMemoryStore, runId: string) {
+  const workflows = (await store.getStore('workflows'))!;
+  const deadline = Date.now() + CAPTURE_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const loop = await workflows.getWorkflowRunById({ runId, workflowName: DurableStepIds.AGENTIC_LOOP });
+    if (!loop || (loop.snapshot as any)?.status !== 'running') return;
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  throw new Error('Timed out waiting for the recovered run to finish');
+}
+
+const shutdowns: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (shutdowns.length) await shutdowns.pop()!().catch(() => undefined);
+});
+
+/**
+ * Runs an agent until `activeStep` is the live step, then abandons it the way a
+ * `SIGKILL` would: no cleanup, no shutdown, just the persisted snapshots.
+ */
+async function crashDuring(activeStep: string, runId: string) {
+  // Deliberately never shut down: a killed process does not get to clean up.
+  const captureStack = await createStack(createScriptedModel(['tool-call'], 'unused'), () => new Promise(() => {}));
+  void captureStack.agent.stream('start', { runId }).catch(() => undefined);
+  const snapshots = await captureSnapshots(
+    captureStack.store,
+    runId,
+    isRunningStep(activeStep),
+    `a running snapshot with ${activeStep} active`,
+  );
+  // A restarted worker has no in-process state for the run.
+  globalRunRegistry.delete(runId);
+  return snapshots;
+}
+
+describe('durable crash recovery after running-history pruning (issue #22636)', () => {
+  it('recovers a run killed while the tool call was in flight', async () => {
+    const runId = 'crash-in-tool-call';
+    const snapshots = await crashDuring(DurableStepIds.TOOL_CALL, runId);
+
+    let toolCalls = 0;
+    const recoveryStack = await createStack(createScriptedModel(['text'], 'Recovered'), async () => {
+      toolCalls += 1;
+      return { ok: true };
+    });
+    shutdowns.push(() => recoveryStack.mastra.shutdown());
+    await seedSnapshots(recoveryStack.store, runId, snapshots);
+
+    const recovered = await recoveryStack.agent.recover(runId);
+    const output = await recovered.output.getFullOutput();
+
+    expect(output.text).toBe('Recovered');
+    expect(toolCalls).toBe(1);
+    recovered.cleanup?.();
+
+    // What made that possible: exactly one completed conversation copy is
+    // retained — the newest, which is what `collect-tool-results` reads back
+    // after the foreach. The older one is still pruned.
+    const execution = snapshots.execution.context as Record<string, any>;
+    expect(execution[DurableStepIds.LLM_EXECUTION].output.messageListState).toBeDefined();
+    expect(execution['map-to-llm-input'].output).not.toHaveProperty('messageListState');
+  }, 60_000);
+
+  it('recovers a run killed while the LLM step was in flight', async () => {
+    const runId = 'crash-in-llm-execution';
+    const captureStack = await createStack(
+      {
+        specificationVersion: 'v3' as const,
+        provider: 'crash-recovery',
+        modelId: 'crash-recovery-model',
+        supportedUrls: {},
+        async doGenerate() {
+          throw new Error('Streaming only');
+        },
+        // Opens the stream and never closes it: the LLM step stays active.
+        async doStream() {
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+              },
+            }),
+          };
+        },
+      },
+      async () => ({ ok: true }),
+    );
+    void captureStack.agent.stream('start', { runId }).catch(() => undefined);
+    const snapshots = await captureSnapshots(
+      captureStack.store,
+      runId,
+      isRunningStep(DurableStepIds.LLM_EXECUTION),
+      `a running snapshot with ${DurableStepIds.LLM_EXECUTION} active`,
+    );
+    globalRunRegistry.delete(runId);
+
+    const recoveryStack = await createStack(createScriptedModel(['text'], 'Recovered'), async () => ({ ok: true }));
+    shutdowns.push(() => recoveryStack.mastra.shutdown());
+    await seedSnapshots(recoveryStack.store, runId, snapshots);
+
+    const recovered = await recoveryStack.agent.recover(runId);
+    const output = await recovered.output.getFullOutput();
+
+    expect(output.text).toBe('Recovered');
+    recovered.cleanup?.();
+
+    // Restart feeds the LLM step its predecessor's output, and that
+    // predecessor is terminal by the time the snapshot is written.
+    const execution = snapshots.execution.context as Record<string, any>;
+    expect(execution['map-to-llm-input'].output.messageListState).toBeDefined();
+  }, 60_000);
+
+  it('recovers a run killed between iterations, inside the loop predicate', async () => {
+    const runId = 'crash-between-iterations';
+    const captureStack = await createStack(createScriptedModel(['text'], 'Captured'), async () => ({ ok: true }));
+    // Park the run in the predicate: the iteration is complete, its last step
+    // has persisted, and a user hook that never settles keeps the next one
+    // from starting — the window a slow `onIterationComplete` opens.
+    void captureStack.agent
+      .stream('start', { runId, onIterationComplete: () => new Promise<void>(() => {}) })
+      .catch(() => undefined);
+    const snapshots = await captureSnapshots(
+      captureStack.store,
+      runId,
+      isBetweenIterations,
+      'a running snapshot parked between iterations',
+    );
+    globalRunRegistry.delete(runId);
+
+    let modelCalls = 0;
+    const recoveryStack = await createStack(
+      createScriptedModel(['text'], 'unused', () => {
+        modelCalls += 1;
+      }),
+      async () => ({ ok: true }),
+    );
+    shutdowns.push(() => recoveryStack.mastra.shutdown());
+    await seedSnapshots(recoveryStack.store, runId, snapshots);
+
+    const recovered = await recoveryStack.agent.recover(runId);
+    const output = await recovered.output.getFullOutput();
+    await waitForRunToFinish(recoveryStack.store, runId);
+
+    // The LLM turn had already finished before the crash: recovery completes
+    // the run's bookkeeping without re-running it.
+    expect(output.finishReason).toBe('stop');
+    expect(modelCalls).toBe(0);
+    recovered.cleanup?.();
+
+    // Restart re-executes the step at the graph position the snapshot records
+    // (`durable-goal`, no longer listed as active) from its own payload, fed
+    // its predecessor's output; the output it will rebuild is the one dropped.
+    const execution = snapshots.execution.context as Record<string, any>;
+    expect(Object.keys(snapshots.execution.activeStepsPath ?? {})).toEqual([]);
+    expect(execution[DurableStepIds.IS_TASK_COMPLETE].output.messageListState).toBeDefined();
+    expect(execution[GOAL_STEP_ID].payload.messageListState).toBeDefined();
+    expect(execution[GOAL_STEP_ID].output).not.toHaveProperty('messageListState');
+  }, 60_000);
+});

--- a/packages/core/src/loop/workflows/prune-snapshot.test.ts
+++ b/packages/core/src/loop/workflows/prune-snapshot.test.ts
@@ -76,6 +76,213 @@ describe('pruneAgentLoopSnapshot running history', () => {
   });
 });
 
+/**
+ * Issue #22636: a `running` snapshot is re-driven by `restart()`, which reads
+ * *outputs* back — the restarted step is fed its predecessor's output, and the
+ * durable loop re-reads the LLM step's output after the tool-call foreach.
+ * Pruning every completed output made both reads hand `MessageList.deserialize`
+ * an `undefined`.
+ */
+describe('pruneAgentLoopSnapshot restart-readable output', () => {
+  const conversation = { messages: [{ role: 'user', content: 'earlier turn' }] };
+
+  /** The durable execution workflow, killed with `active` as the live step. */
+  function durableSnapshot(active: 'durable-llm-execution' | 'durable-tool-call'): WorkflowRunState {
+    const activePaths = active === 'durable-llm-execution' ? [1] : [3];
+    return {
+      status: 'running',
+      activePaths,
+      activeStepsPath: { [active]: activePaths },
+      context: {
+        input: { messageListState: conversation },
+        'map-to-llm-input': {
+          status: 'success',
+          startedAt: 1,
+          endedAt: 2,
+          payload: { messageListState: conversation },
+          output: { messageListState: conversation, accumulatedSteps: ['a'] },
+        },
+        'durable-llm-execution': {
+          status: active === 'durable-llm-execution' ? 'running' : 'success',
+          startedAt: 3,
+          ...(active === 'durable-llm-execution' ? {} : { endedAt: 4 }),
+          payload: { messageListState: conversation },
+          output: { messageListState: conversation, accumulatedSteps: ['a', 'b'] },
+        },
+        ...(active === 'durable-tool-call'
+          ? {
+              'extract-tool-calls': {
+                status: 'success',
+                startedAt: 5,
+                endedAt: 6,
+                payload: {},
+                output: [{ toolCallId: 'call-1' }],
+              },
+              'durable-tool-call': { status: 'running', startedAt: 7, payload: { toolCallId: 'call-1' } },
+            }
+          : {}),
+      },
+    } as unknown as WorkflowRunState;
+  }
+
+  it('keeps the predecessor output a step restarted mid-LLM-call is fed', () => {
+    const context = pruneAgentLoopSnapshot({ snapshot: durableSnapshot('durable-llm-execution') }).context as Record<
+      string,
+      any
+    >;
+
+    expect(context['map-to-llm-input'].output.messageListState).toEqual(conversation);
+    expect(context['map-to-llm-input'].output.accumulatedSteps).toEqual(['a']);
+  });
+
+  it('keeps the completed LLM output that collect-tool-results reads back after the foreach', () => {
+    const context = pruneAgentLoopSnapshot({ snapshot: durableSnapshot('durable-tool-call') }).context as Record<
+      string,
+      any
+    >;
+
+    expect(context['durable-llm-execution'].output.messageListState).toEqual(conversation);
+    // Only the newest one: the older copy is still dropped, so duplication
+    // stays O(1) in run length.
+    expect(context['map-to-llm-input'].output).not.toHaveProperty('messageListState');
+    // Nothing reads a terminal payload back, so it is pruned either way.
+    expect(context['durable-llm-execution'].payload).not.toHaveProperty('messageListState');
+  });
+
+  it('follows the conversation forward as later steps complete', () => {
+    const snapshot = {
+      status: 'running',
+      activePaths: [2],
+      activeStepsPath: { third: [2] },
+      context: {
+        input: {},
+        first: { status: 'success', startedAt: 1, endedAt: 2, output: { messageListState: conversation } },
+        second: {
+          status: 'success',
+          startedAt: 3,
+          endedAt: 4,
+          output: { llmOutput: { messageListState: conversation } },
+        },
+        third: { status: 'running', startedAt: 5, payload: { messageListState: conversation } },
+      },
+    } as unknown as WorkflowRunState;
+
+    const context = pruneAgentLoopSnapshot({ snapshot }).context as Record<string, any>;
+
+    // The nested `llmOutput` copy the mapping steps carry counts as the newest.
+    expect(context.second.output.llmOutput.messageListState).toEqual(conversation);
+    expect(context.first.output).not.toHaveProperty('messageListState');
+  });
+
+  /**
+   * The default engine drops a step from `activeStepsPath` before its
+   * `entry-end` write, and storage holds that write until the next step's start
+   * write lands. Restart re-executes the step at `activePaths[0]`, so the graph
+   * — not `activeStepsPath` — says whose predecessor output must survive.
+   */
+  it('keeps the predecessor output across the gap between a step completing and the next one starting', () => {
+    const snapshot = {
+      status: 'running',
+      activePaths: [1],
+      activeStepsPath: {},
+      serializedStepGraph: [
+        { type: 'mapping', id: 'map-to-llm-input', mapConfig: '' },
+        { type: 'step', step: { id: 'durable-llm-execution' } },
+        { type: 'mapping', id: 'extract-tool-calls', mapConfig: '' },
+      ],
+      context: {
+        input: { messageListState: conversation },
+        'map-to-llm-input': {
+          status: 'success',
+          startedAt: 1,
+          endedAt: 2,
+          payload: { messageListState: conversation },
+          output: { messageListState: conversation, accumulatedSteps: ['a'] },
+        },
+        'durable-llm-execution': {
+          status: 'success',
+          startedAt: 3,
+          endedAt: 4,
+          payload: { messageListState: conversation, accumulatedSteps: ['a'] },
+          output: { messageListState: conversation, accumulatedSteps: ['a', 'b'] },
+        },
+      },
+    } as unknown as WorkflowRunState;
+
+    const context = pruneAgentLoopSnapshot({ snapshot }).context as Record<string, any>;
+
+    // Restart re-runs `durable-llm-execution` fed `map-to-llm-input.output`...
+    expect(context['map-to-llm-input'].output.messageListState).toEqual(conversation);
+    expect(context['map-to-llm-input'].output.accumulatedSteps).toEqual(['a']);
+    // ...from its own payload, while the output it will rebuild is dropped.
+    expect(context['durable-llm-execution'].payload.messageListState).toEqual(conversation);
+    expect(context['durable-llm-execution'].output).not.toHaveProperty('messageListState');
+    expect(context['durable-llm-execution'].output).not.toHaveProperty('accumulatedSteps');
+  });
+
+  it('resolves the restart target through a loop entry', () => {
+    // The outer durable loop: the whole between-iterations stretch (where user
+    // `onIterationComplete` hooks run) sits after the nested run's last
+    // entry-end write, and the outer loop restarts from the nested step's
+    // payload.
+    const snapshot = {
+      status: 'running',
+      activePaths: [1],
+      activeStepsPath: {},
+      serializedStepGraph: [
+        { type: 'mapping', id: 'init-iteration-state', mapConfig: '' },
+        {
+          type: 'loop',
+          loopType: 'dowhile',
+          serializedCondition: { id: 'c', fn: '' },
+          step: { type: 'step', step: { id: 'durable-agentic-execution' } },
+        },
+      ],
+      context: {
+        input: { messageListState: conversation },
+        'init-iteration-state': {
+          status: 'success',
+          startedAt: 1,
+          endedAt: 2,
+          payload: {},
+          output: { messageListState: conversation, accumulatedSteps: [] },
+        },
+        'durable-agentic-execution': {
+          status: 'success',
+          startedAt: 3,
+          endedAt: 4,
+          payload: { messageListState: conversation, accumulatedSteps: [] },
+          output: { messageListState: conversation, accumulatedSteps: ['a'] },
+        },
+      },
+    } as unknown as WorkflowRunState;
+
+    const context = pruneAgentLoopSnapshot({ snapshot }).context as Record<string, any>;
+
+    expect(context['init-iteration-state'].output.messageListState).toEqual(conversation);
+    expect(context['durable-agentic-execution'].payload.messageListState).toEqual(conversation);
+    expect(context['durable-agentic-execution'].output).not.toHaveProperty('messageListState');
+  });
+
+  it('leaves a suspended snapshot alone', () => {
+    const snapshot = {
+      status: 'suspended',
+      activePaths: [],
+      activeStepsPath: {},
+      context: {
+        input: {},
+        first: { status: 'success', startedAt: 1, endedAt: 2, output: { messageListState: conversation } },
+        second: { status: 'success', startedAt: 3, endedAt: 4, output: { messageListState: conversation } },
+      },
+    } as unknown as WorkflowRunState;
+
+    const context = pruneAgentLoopSnapshot({ snapshot }).context as Record<string, any>;
+
+    expect(context.first.output.messageListState).toEqual(conversation);
+    expect(context.second.output.messageListState).toEqual(conversation);
+  });
+});
+
 describe('pruneAgentLoopSnapshot stepResult.request strip', () => {
   it('strips the request echo from a terminal step on both payload and output', () => {
     const pruned = pruneAgentLoopSnapshot({

--- a/packages/core/src/loop/workflows/prune-snapshot.ts
+++ b/packages/core/src/loop/workflows/prune-snapshot.ts
@@ -1,4 +1,4 @@
-import type { WorkflowRunState } from '../../workflows/types';
+import type { SerializedSingleStepEntry, WorkflowRunState } from '../../workflows/types';
 
 /**
  * Snapshot pruning for the internal agent-loop workflows (issue #18647).
@@ -33,7 +33,10 @@ import type { WorkflowRunState } from '../../workflows/types';
  *    conversation copy): heavy fields are stripped.
  *  - on a **`running`** snapshot only, completed steps additionally give up
  *    `messageListState` / `accumulatedSteps` (issue #20747 — see
- *    `pruneRunningHistory`).
+ *    `pruneRunningHistory`), except what `restart()` reads back (issue
+ *    #22636): the newest completed `output` that still feeds a later step
+ *    (`getRestartReadableStepId`) and the `payload` of the step restart
+ *    re-executes (`getRestartTargetStepIds`).
  *  - engine routing state (`suspendedPaths`, `waitingPaths`, `activePaths`,
  *    `resumeLabels`, `serializedStepGraph`, `status`, `runId`, timestamps,
  *    request context) is never touched.
@@ -317,10 +320,14 @@ function stripRunningHistoryFields<T>(value: T): T {
  * curve behind 135 MB on disk for a 57-step run.
  *
  * Live execution never reads historical copies back. Recovery does need the
- * active step's payload, including after that step has reached a terminal state
- * but before the next step starts, because `restart()` uses it as `prevResult`.
- * Keep that one active-path copy and remove conversation state from every older
- * terminal step, bounding duplication independently of run length.
+ * payload of the step `restart()` re-executes — the active step, or, once that
+ * step has completed but before the next one starts, the step at
+ * `activePaths[0]` (`getRestartTargetStepIds`) — because the loop handler
+ * re-reads it as the loop input; it also needs the newest completed `output`
+ * before that step, which is what the engine and the durable loop feed it
+ * (`getRestartReadableStepId`). Keep those two copies and remove conversation
+ * state from every older terminal step, bounding duplication independently of
+ * run length.
  *
  * Suspended/paused snapshots are untouched — they are the resume path and keep
  * exactly the bytes they keep today.
@@ -337,14 +344,114 @@ function getActiveStepIds(snapshot: WorkflowRunState): Set<string> {
   );
 }
 
-function pruneRunningHistory(context: WorkflowRunState['context'], activeStepIds: ReadonlySet<string>): void {
+function getSerializedEntryId(entry: SerializedSingleStepEntry): string {
+  return entry.type === 'step' ? entry.step.id : entry.id;
+}
+
+/**
+ * The step(s) `restart()` re-executes first. The engine picks up at
+ * `activePaths[0]` — the top-level graph index it was at when the snapshot was
+ * written — and re-runs that entry from scratch, so whichever step lives there
+ * is the restart target whether or not the snapshot still lists it as active.
+ * A `start` write does; but the default engine drops a step from
+ * `activeStepsPath` before its `entry-end` write, and that write is what
+ * storage holds until the next step's start write lands — the whole
+ * between-iterations stretch of the durable loop, where `onIterationComplete`
+ * hooks run, included.
+ */
+function getRestartTargetStepIds(snapshot: WorkflowRunState): Set<string> {
+  const index = snapshot.activePaths?.[0];
+  const entry = typeof index === 'number' ? snapshot.serializedStepGraph?.[index] : undefined;
+  if (!entry) return new Set();
+  switch (entry.type) {
+    case 'loop':
+    case 'foreach':
+      return new Set([getSerializedEntryId(entry.step)]);
+    case 'parallel':
+    case 'conditional':
+      return new Set(entry.steps.map(getSerializedEntryId));
+    case 'sleep':
+    case 'sleepUntil':
+      return new Set([entry.id]);
+    default:
+      return new Set([getSerializedEntryId(entry)]);
+  }
+}
+
+function hasRunningHistoryFields(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  if (RUNNING_HISTORY_FIELDS.some(key => key in value)) return true;
+  return isPlainObject(value.llmOutput) && RUNNING_HISTORY_FIELDS.some(key => key in value.llmOutput);
+}
+
+/** When a step finished, falling back to its start when no end time was written. */
+function stepCompletedAt(value: Record<string, any>): number {
+  if (typeof value.endedAt === 'number') return value.endedAt;
+  return typeof value.startedAt === 'number' ? value.startedAt : 0;
+}
+
+/**
+ * The completed step whose `output` is still a live input after a restart
+ * (issue #22636).
+ *
+ * A `running` snapshot is re-driven by `restart()`, and the engine reads
+ * *outputs*, not payloads, on the way back in:
+ *  - `executeEntry` derives the restarted step's input from its predecessor's
+ *    `output` (`engine.getStepOutput`), and that predecessor is terminal by
+ *    then — the crash the issue reports, at `durable-llm-execution`;
+ *  - the durable loop's `collect-tool-results` map re-reads
+ *    `getStepResult('durable-llm-execution')` after the tool-call foreach, so a
+ *    restart that lands inside the foreach reaches a *completed* step's output
+ *    one step later and dies in `durable-llm-mapping` instead.
+ *
+ * Both reads want the newest conversation-carrying output *before* the step
+ * restart re-executes (`excludedStepIds`: the active steps and the restart
+ * target — a completed target's output is rebuilt, never read), so keeping
+ * exactly that one output is what restart needs. That is one extra copy in a
+ * snapshot that already holds two (`context.input` and the restart target's
+ * payload), so duplication stays O(1) in run length and the O(N^2) curve
+ * #22127 removed does not come back.
+ */
+function getRestartReadableStepId(
+  context: WorkflowRunState['context'],
+  excludedStepIds: ReadonlySet<string>,
+): string | undefined {
+  let latestId: string | undefined;
+  let latestAt = -Infinity;
+  for (const [key, value] of Object.entries(context ?? {})) {
+    if (key === 'input' || excludedStepIds.has(key) || !isPlainObject(value)) continue;
+    if (!TERMINAL_STEP_STATUSES.has((value as any).status)) continue;
+    if (!hasRunningHistoryFields((value as any).output)) continue;
+
+    // `>=` so a missing or tied timestamp resolves to the later-written step —
+    // `context` keys arrive in step-completion order.
+    const completedAt = stepCompletedAt(value as Record<string, any>);
+    if (completedAt >= latestAt) {
+      latestAt = completedAt;
+      latestId = key;
+    }
+  }
+  return latestId;
+}
+
+function pruneRunningHistory(
+  context: WorkflowRunState['context'],
+  activeStepIds: ReadonlySet<string>,
+  restartTargetIds: ReadonlySet<string>,
+): void {
+  const restartReadableStepId = getRestartReadableStepId(context, new Set([...activeStepIds, ...restartTargetIds]));
+
   for (const [key, value] of Object.entries(context ?? {})) {
     if (key === 'input' || activeStepIds.has(key) || !isPlainObject(value)) continue;
     if (!TERMINAL_STEP_STATUSES.has((value as any).status)) continue;
 
     const pruned: Record<string, any> = { ...value };
-    pruned.payload = stripRunningHistoryFields(pruned.payload);
-    if ('output' in pruned) pruned.output = stripRunningHistoryFields(pruned.output);
+    // A completed restart target is re-executed from its payload (the loop
+    // handler reads it back as the loop input), while its output is rebuilt.
+    if (!restartTargetIds.has(key)) pruned.payload = stripRunningHistoryFields(pruned.payload);
+    if ('output' in pruned && key !== restartReadableStepId) {
+      pruned.output = stripRunningHistoryFields(pruned.output);
+    }
     if ('prevOutput' in pruned) pruned.prevOutput = stripRunningHistoryFields(pruned.prevOutput);
     context[key] = pruned as any;
   }
@@ -365,6 +472,7 @@ export function pruneAgentLoopSnapshot({
 }): WorkflowRunState {
   const isRunning = (workflowStatus ?? snapshot.status) === 'running';
   const activeStepIds = isRunning ? getActiveStepIds(snapshot) : new Set<string>();
+  const restartTargetIds = isRunning ? getRestartTargetStepIds(snapshot) : new Set<string>();
   const context: WorkflowRunState['context'] = {} as WorkflowRunState['context'];
   for (const [key, value] of Object.entries(snapshot.context ?? {})) {
     if (key === 'input') {
@@ -382,14 +490,14 @@ export function pruneAgentLoopSnapshot({
       context.input = strippedInput;
     } else {
       context[key] = pruneStepResult(value as Record<string, any>, {
-        preserveTerminalPayloadState: activeStepIds.has(key),
+        preserveTerminalPayloadState: activeStepIds.has(key) || restartTargetIds.has(key),
       }) as any;
     }
   }
 
   // `context` is freshly built above, so this is still copy-on-write with
   // respect to the caller's snapshot.
-  if (isRunning) pruneRunningHistory(context, activeStepIds);
+  if (isRunning) pruneRunningHistory(context, activeStepIds, restartTargetIds);
 
   const result =
     isPlainObject(snapshot.result) && typeof snapshot.result.status === 'string'

--- a/packages/core/src/workflows/__tests__/snapshot-write-amplification.test.ts
+++ b/packages/core/src/workflows/__tests__/snapshot-write-amplification.test.ts
@@ -191,9 +191,19 @@ describe('durable snapshot write amplification (issue #20747)', () => {
     // copy on the payload side, the output side, and again nested under
     // `llmOutput`. Measured 30 before this fix, 12 after.
     //
+    // 14 since issue #22636: restart reads two copies back, and both stay —
+    // the newest completed `output` before the step restart re-executes (the
+    // engine feeds a restarted step its predecessor's output, and
+    // `collect-tool-results` re-reads the LLM step's output after the
+    // tool-call foreach) and that step's own `payload` (the loop handler
+    // re-reads it as the loop input). Each carries `messageListState` +
+    // `accumulatedSteps`, hence two marker copies, not one. Pruning them made
+    // every crash recovery throw on `MessageList.deserialize(undefined)`.
+    // Measured 14 at both 4 and 8 steps.
+    //
     // It must not grow with run length, and it must not creep back up.
     expect(large.maxDuplicatesPerWrite).toBeLessThanOrEqual(small.maxDuplicatesPerWrite);
-    expect(large.maxDuplicatesPerWrite).toBeLessThanOrEqual(12);
+    expect(large.maxDuplicatesPerWrite).toBeLessThanOrEqual(14);
 
     // Size of a single running write. Before: 301 kB at 4 steps, 561 kB at 8
     // (1.86x). After: 78 kB and 118 kB (1.51x). This still grows, because a


### PR DESCRIPTION
## Description

Since 1.62, `DurableAgent.recover()`, `EventedAgent.recover()` and `recoverActiveRuns()` cannot recover a crashed run. Recovery throws within milliseconds and Mastra then deletes the run's snapshot rows, so the evidence goes with it:

```
TypeError: Cannot read properties of undefined (reading 'messages')
    at MessageList.deserialize
```

Running-history pruning (#22127) strips `messageListState` / `accumulatedSteps` from every completed step of a `running` snapshot and keeps them only on the step listed as active. Live execution never reads those copies back, but `restart()` does, and it reads outputs rather than payloads. Tracing the engine's write points turned up three crash shapes, two of them not in the issue. Killed during the model call, the restarted `durable-llm-execution` step is fed its predecessor's pruned output (the issue's trace). Killed during a tool call, the tool re-runs fine and `durable-llm-mapping` then dies re-reading the LLM step's output. Killed between iterations (where `onIterationComplete` hooks run), the snapshot lists no active step at all, because the engine drops a step from `activeStepsPath` before its `entry-end` write, and `durable-goal` dies on `accumulatedSteps.length`. So the one-line `executeEntry` widening suggested in the issue comments is not enough on its own.

`pruneRunningHistory` now keeps exactly what restart reads. The step restart re-executes is resolved from the graph position (`activePaths[0]` through `serializedStepGraph`) instead of `activeStepsPath`, and keeps its payload; the newest completed output before it keeps the conversation state. Every older copy is pruned as before, so duplication stays constant in run length and the growth curve #22127 removed does not come back. The write-amplification guard moves from 12 to 14 copies per running write (measured at both 4 and 8 steps); its size assertions are unchanged.

```ts
// main:    TypeError: Cannot read properties of undefined (reading 'messages')
// this PR: the run continues from its last completed step
const recovered = await agent.recover(runId);
```

Tests: `recover-after-crash.test.ts` runs a real durable agent into each of the three states, abandons it the way a SIGKILL would, JSON round-trips the persisted snapshots and recovers against a second store. All three fail on `main`; with the fix all three finish, and the between-iterations one does so without calling the model again. `prune-snapshot.test.ts` covers the retention rule, and the issue's own two-process `repro.mjs` passes against this build. A sweep that recovers from the storage state after every one of the 53 snapshot writes of a two-iteration run goes from 7 recoverable states on `main` to 50. The remaining three fail identically on `main` for reasons outside pruning and are left for follow-ups: one where the outer step-start write has landed but the nested run has no snapshot row yet (`This workflow run was not active`), and two where the process died during `execute-scorers` after the finish chunk was already emitted, so the recovered stream's `getFullOutput()` never resolves.

## Related issue(s)

Fixes #22636

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an agent crashes, it can now restart with the information it needs instead of failing. The fix covers crashes during model calls, tool calls, and loop steps.

## Changes

- Preserve the step payload, `messageListState`, and latest completed output required by `restart()`.
- Restore restart targets from the serialized workflow position.
- Prevent recovery from restoring undefined predecessor data.
- Support `EventedAgent.recover()` and `recoverActiveRuns()` for orphaned nested durable LLM steps.
- Keep older snapshot copies pruned while increasing the write-amplification limit from 12 to 14.
- Add end-to-end recovery tests using JSON-round-tripped snapshots, a second store, and a deterministic mock model.
- Add pruning tests for model-call, tool-call, step-boundary, and loop-entry recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->