### PR TITLE
refactor(factory-ui): load older audit events through the shared LoadMoreSentinel

### DIFF
--- a/.changeset/audit-load-more-sentinel.md
+++ b/.changeset/audit-load-more-sentinel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+The audit log's Load older events control now follows the board's Intake rule: coming into view loads one page of older events, and a page that adds nothing to scroll past waits for a click. With a time range selected, older events load on scroll as well, one page at a time, instead of only by click.

--- a/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditLogList.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditLogList.tsx
@@ -1,9 +1,7 @@
-import { Button } from '@mastra/playground-ui/components/Button';
 import { Code } from '@mastra/playground-ui/components/Code';
-import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { ChevronRight } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import type { ReactNode } from 'react';
 
 import { relativeTime } from '../../../../../lib/date/relativeTime';
@@ -15,6 +13,7 @@ import {
   auditVisibleMetadata,
 } from '../../auditPresentation';
 import type { AuditEvent } from '../../services/audit';
+import { LoadMoreSentinel } from '../LoadMoreSentinel';
 
 const AUDIT_GRID_CLASS =
   'grid-cols-[4.5rem_minmax(0,1fr)_1rem] lg:grid-cols-[7rem_minmax(8rem,0.8fr)_minmax(10rem,0.9fr)_minmax(11rem,1.1fr)_minmax(13rem,1.4fr)_1rem]';
@@ -122,62 +121,16 @@ function AuditEventRow({
   );
 }
 
-function InfiniteScrollTrigger({
-  hasNextPage,
-  autoLoad,
-  isFetchingNextPage,
-  onLoadMore,
-}: {
-  hasNextPage: boolean;
-  autoLoad: boolean;
-  isFetchingNextPage: boolean;
-  onLoadMore: () => void;
-}) {
-  const trigger = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const node = trigger.current;
-    if (!node || !hasNextPage || !autoLoad || isFetchingNextPage || typeof IntersectionObserver === 'undefined') return;
-
-    const observer = new IntersectionObserver(
-      entries => {
-        if (!entries[0]?.isIntersecting) return;
-        observer.disconnect();
-        onLoadMore();
-      },
-      { rootMargin: '0px 0px 320px' },
-    );
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [autoLoad, hasNextPage, isFetchingNextPage, onLoadMore]);
-
-  if (!hasNextPage) return null;
-
-  return (
-    <div ref={trigger} className="flex h-12 items-center justify-center" aria-live="polite">
-      {isFetchingNextPage ? (
-        <Spinner size="sm" aria-label="Loading older events" />
-      ) : (
-        <Button variant="ghost" size="xs" onClick={onLoadMore}>
-          Load older events
-        </Button>
-      )}
-    </div>
-  );
-}
-
 export function AuditLogList({
   events,
   actorNames,
   hasNextPage,
-  autoLoad,
   isFetchingNextPage,
   onLoadMore,
 }: {
   events: AuditEvent[];
   actorNames: ReadonlyMap<string, string>;
   hasNextPage: boolean;
-  autoLoad: boolean;
   isFetchingNextPage: boolean;
   onLoadMore: () => void;
 }) {
@@ -216,11 +169,11 @@ export function AuditLogList({
           />
         ))}
       </ul>
-      <InfiniteScrollTrigger
+      <LoadMoreSentinel
         hasNextPage={hasNextPage}
-        autoLoad={autoLoad}
         isFetchingNextPage={isFetchingNextPage}
         onLoadMore={onLoadMore}
+        label="Load older events"
       />
     </div>
   );

--- a/mastracode/factory-ui/src/ui/pages/AuditPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/AuditPage.tsx
@@ -170,7 +170,6 @@ function AuditContent({ factoryProjectId }: { factoryProjectId: string | undefin
             events={visibleEvents}
             actorNames={actorNames}
             hasNextPage={eventsQuery.hasNextPage}
-            autoLoad={!selectedRange}
             isFetchingNextPage={eventsQuery.isFetchingNextPage}
             onLoadMore={() => void eventsQuery.fetchNextPage()}
           />


### PR DESCRIPTION
**─────── TLDR ───────**
> The audit log's Load older events control is the board's `LoadMoreSentinel`, so both lists follow one rule and the private copy is gone.

`AuditLogList` carried its own IntersectionObserver trigger with an `autoLoad` switch that `AuditPage` turned off while a time range was selected. The range filters client-side, so a page that added nothing visible left the trigger in view and it chained: the walk #23220 removed from the Intake column. The shared sentinel loads one page per entry into view, so the switch has nothing left to guard. Builds on #23220, whose commits ride along here until it merges.

### Behavior changed

scrolling to the end of the audit log, no range selected
&nbsp;&nbsp;├─ **was** — the next page started 320px before the end
&nbsp;&nbsp;└─ **now** — as the control itself comes into view

a time range selected
&nbsp;&nbsp;├─ **was** — older events by click only
&nbsp;&nbsp;└─ **now** — one page per scroll into view, then the button

the Load older events button
&nbsp;&nbsp;├─ **was** — extra-small
&nbsp;&nbsp;└─ **now** — small, the Intake column's size

### Shape changed

| | | |
|---|---|---|
| **−** | `InfiniteScrollTrigger` | private second copy of the Intake sentinel |
| **−** | `autoLoad` on `AuditLogList` | guarded a walk the sentinel no longer does |

call sites updated, one prop dropped
&nbsp;&nbsp;&nbsp;&nbsp;`AuditPage.tsx`

### Decisions

- **based on main with #23220's commits included** — a PR based on a branch gets no Prebuild or Quality assurance run; the shared commits leave the diff when #23220 merges
- **no test** — the sentinel's rule is pinned in `BoardPageIntakePaging.msw.test.tsx`, and a button size is a screenshot, not a jsdom assertion

### Not verified

- [ ] the audit page in a browser — button size and spinner placement in the row

---

> ██████████████████ **source** `+4 −52` — net −48
> ██ **changeset** `+5`
