### PR TITLE
feat(factory): attention counts per kind, parked runs leave the badge

### DIFF
--- a/.changeset/attention-owner-axis.md
+++ b/.changeset/attention-owner-axis.md
@@ -2,4 +2,27 @@
 '@mastra/factory': patch
 ---
 
-The attention inbox now reports counts and the newest item per kind, and the UI decides what interrupts a person. Runs waiting for approval leave the sidebar badge, its preview, and the notification sound; the inbox page files them under "Waiting for approval", above "Activity". The sidebar asks the route for the kinds it shows with a repeatable `kind` query, which replaces the `tier` switch.
+The attention inbox now reports counts and the newest item per kind, and the UI decides what interrupts a person. Runs waiting for approval leave the sidebar badge, its preview, and the notification sound; the inbox page files them under "Waiting for approval", above "Activity".
+
+Breaking for callers of `GET /web/factory/projects/:id/attention`:
+
+- the `tier` query is gone; ask for the kinds you want with a repeatable `kind` query, or omit it for every kind
+- `openCount`, `badgeCount`, `unreadCount` and the three `latestOccurrence*` fields are gone; read `kinds[kind].open`, `kinds[kind].unread` and `kinds[kind].latest` instead. `kinds` always covers every kind, whatever `kind` filter the items use
+
+Before:
+
+```ts
+const inbox = await fetch(`${base}/attention?tier=badge`).then(r => r.json());
+inbox.badgeCount; // unread across the badge kinds
+inbox.latestOccurrenceAt; // newest badge item
+```
+
+After:
+
+```ts
+const query = new URLSearchParams([['kind', 'mention'], ['kind', 'automation-failed']]);
+const inbox = await fetch(`${base}/attention?${query}`).then(r => r.json());
+inbox.items; // mentions and failed automations only
+inbox.kinds.mention.unread + inbox.kinds['automation-failed'].unread; // the badge number
+inbox.kinds.mention.latest?.at; // newest mention, or null
+```

--- a/.changeset/attention-owner-axis.md
+++ b/.changeset/attention-owner-axis.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+The attention inbox now reports counts and the newest item per kind, and the UI decides what interrupts a person. Runs waiting for approval leave the sidebar badge, its preview, and the notification sound; the inbox page files them under "Waiting for approval", above "Activity". The sidebar asks the route for the kinds it shows with a repeatable `kind` query, which replaces the `tier` switch.

--- a/mastracode/factory-ui/e2e/ui/attention.ts
+++ b/mastracode/factory-ui/e2e/ui/attention.ts
@@ -1,0 +1,30 @@
+import type {
+  FactoryAttentionItem,
+  FactoryAttentionKind,
+  FactoryAttentionKindSummaries,
+  FactoryAttentionKindSummary,
+} from '../../src/ui/domains/factory/services/attention';
+
+function summarize(items: FactoryAttentionItem[], kind: FactoryAttentionKind): FactoryAttentionKindSummary {
+  const ofKind = items.filter(item => item.kind === kind);
+  const newest = ofKind.reduce<FactoryAttentionItem | undefined>(
+    (best, item) => (!best || Date.parse(item.occurredAt) > Date.parse(best.occurredAt) ? item : best),
+    undefined,
+  );
+  return {
+    open: ofKind.filter(item => !item.archived).length,
+    unread: ofKind.filter(item => !item.read && !item.archived).length,
+    latest: newest ? { key: newest.key, at: newest.occurredAt, unread: !newest.read && !newest.archived } : null,
+  };
+}
+
+/** What the attention route reports per kind for these items, whatever slice of them a page lists. */
+export function attentionKindSummaries(items: FactoryAttentionItem[]): FactoryAttentionKindSummaries {
+  return {
+    'automation-failed': summarize(items, 'automation-failed'),
+    'automation-proposed': summarize(items, 'automation-proposed'),
+    mention: summarize(items, 'mention'),
+    activity: summarize(items, 'activity'),
+    'supervisor-finding': summarize(items, 'supervisor-finding'),
+  };
+}

--- a/mastracode/factory-ui/e2e/ui/msw-server.ts
+++ b/mastracode/factory-ui/e2e/ui/msw-server.ts
@@ -1,6 +1,8 @@
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 
+import { attentionKindSummaries } from './attention';
+
 /**
  * Shared MSW server for the jsdom web-ui test suite. The global setup
  * (`vitest.setup.ts`) starts it with `onUnhandledRequest: 'error'` so any
@@ -28,17 +30,7 @@ export const server = setupServer(
   http.get('*/web/factory/projects/:id/source-control-connections', () => HttpResponse.json({ connections: [] })),
   http.get('*/web/factory/projects/:id/audit', () => HttpResponse.json({ events: [], actors: {} })),
   http.get('*/web/factory/projects/:id/attention', () =>
-    HttpResponse.json({
-      items: [],
-      openCount: 0,
-      badgeCount: 0,
-      unreadCount: 0,
-      activityUnreadCount: 0,
-      hasMore: false,
-      latestOccurrenceKey: null,
-      latestOccurrenceAt: null,
-      latestOccurrenceUnread: false,
-    }),
+    HttpResponse.json({ items: [], kinds: attentionKindSummaries([]), hasMore: false }),
   ),
   http.get('*/web/factory/projects/:id/decisions', () => HttpResponse.json({ decisions: [] })),
   http.get('*/web/factory/projects/:id/work-items', () => HttpResponse.json({ workItems: [] })),

--- a/mastracode/factory-ui/src/api/keys.ts
+++ b/mastracode/factory-ui/src/api/keys.ts
@@ -69,8 +69,8 @@ export const queryKeys = {
     ['factory', 'decisions', githubProjectId ?? null, statusKey] as const,
   factoryAttentionRoot: (factoryProjectId: string | undefined) =>
     ['factory', 'attention', factoryProjectId ?? null] as const,
-  factoryAttention: (factoryProjectId: string | undefined, view: string, limit: number, tier = 'all') =>
-    [...queryKeys.factoryAttentionRoot(factoryProjectId), view, limit, tier] as const,
+  factoryAttention: (factoryProjectId: string | undefined, view: string, limit: number, group = 'all') =>
+    [...queryKeys.factoryAttentionRoot(factoryProjectId), view, limit, group] as const,
   factorySupervisorHealth: (factoryProjectId: string | undefined) =>
     ['factory', 'supervisor', 'health', factoryProjectId ?? null] as const,
   factoryAudit: (githubProjectId: string | undefined, group: string, actorKey?: string) =>

--- a/mastracode/factory-ui/src/hooks/__tests__/useFactoryAttention.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useFactoryAttention.msw.test.tsx
@@ -2,6 +2,7 @@ import { waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
 
+import { attentionKindSummaries } from '../../../e2e/ui/attention';
 import { pushableFeedStream } from '../../../e2e/ui/feed-stream';
 import { server } from '../../../e2e/ui/msw-server';
 import { renderHookWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../e2e/ui/render';
@@ -15,14 +16,7 @@ const PAST_ONE_POLL_MS = ATTENTION_POLL_MS + 2_000;
 function attentionHandler(counter: { requests: number }) {
   return http.get(`${TEST_BASE_URL}/web/factory/projects/${PROJECT_ID}/attention`, () => {
     counter.requests += 1;
-    return HttpResponse.json({
-      items: [],
-      openCount: 0,
-      badgeCount: 0,
-      unreadCount: 0,
-      activityUnreadCount: 0,
-      hasMore: false,
-    });
+    return HttpResponse.json({ items: [], kinds: attentionKindSummaries([]), hasMore: false });
   });
 }
 

--- a/mastracode/factory-ui/src/hooks/useFactoryAttention.ts
+++ b/mastracode/factory-ui/src/hooks/useFactoryAttention.ts
@@ -4,14 +4,15 @@ import { useApiConfig } from '../api/config';
 import { queryKeys } from '../api/keys';
 import { useFeedEventsConnected } from '../ui/domains/factory/context/FeedEventsProvider';
 import {
+  attentionKindsIn,
   fetchFactoryAttention,
   markAllFactoryAttentionRead,
   updateFactoryAttentionReceipt,
 } from '../ui/domains/factory/services/attention';
 import type {
+  FactoryAttentionGroup,
   FactoryAttentionItem,
   FactoryAttentionReceiptAction,
-  FactoryAttentionTier,
   FactoryAttentionView,
 } from '../ui/domains/factory/services/attention';
 
@@ -25,14 +26,19 @@ export function useFactoryAttention(
   factoryProjectId: string | undefined,
   view: FactoryAttentionView,
   limit: number,
-  tier?: FactoryAttentionTier,
+  group?: FactoryAttentionGroup,
 ) {
   const { baseUrl } = useApiConfig();
   return useQuery({
-    queryKey: queryKeys.factoryAttention(factoryProjectId, view, limit, tier),
+    queryKey: queryKeys.factoryAttention(factoryProjectId, view, limit, group),
     queryFn: factoryProjectId
       ? ({ signal }) =>
-          fetchFactoryAttention(baseUrl, factoryProjectId, { view, limit, signal, ...(tier ? { tier } : {}) })
+          fetchFactoryAttention(baseUrl, factoryProjectId, {
+            view,
+            limit,
+            signal,
+            ...(group ? { kinds: attentionKindsIn(group) } : {}),
+          })
       : skipToken,
     refetchInterval: ATTENTION_POLL_MS,
     staleTime: 2_000,

--- a/mastracode/factory-ui/src/ui/domains/factory/components/OverviewLists.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/OverviewLists.tsx
@@ -244,7 +244,7 @@ function attentionWhere(item: FactoryAttentionItem): string {
 
 /** Read and archive stay on the attention page — a preview that acts is a second inbox. */
 export function AttentionPreview({ factoryProjectId }: { factoryProjectId: string | undefined }) {
-  const attention = useFactoryAttention(factoryProjectId, 'open', ATTENTION_PREVIEW_LIMIT, 'badge');
+  const attention = useFactoryAttention(factoryProjectId, 'open', ATTENTION_PREVIEW_LIMIT, 'attention');
   const items = attention.data?.items ?? [];
 
   if (attention.isPending) return <Skeleton className="h-24 w-full rounded-xl" />;

--- a/mastracode/factory-ui/src/ui/domains/factory/components/SidebarAttention.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/SidebarAttention.tsx
@@ -10,6 +10,7 @@ import { Link, useParams } from 'react-router';
 
 import { useFactoryAuth } from '../../../../hooks/useFactoryAuth';
 import { ATTENTION_PREVIEW_LIMIT, useFactoryAttention } from '../../../../hooks/useFactoryAttention';
+import { attentionCountsIn, latestUnreadOrNewestIn } from '../services/attention';
 import { playAttentionSoundOnce } from '../services/attentionSound';
 import { AttentionItemRow } from './AttentionItemRow';
 import { useAttentionItemActions } from './useAttentionItemActions';
@@ -25,13 +26,13 @@ function triggerLabel(openCount: number, unreadCount: number): string {
 export function SidebarAttention() {
   const { factoryId } = useParams<{ factoryId: string }>();
   const auth = useFactoryAuth();
-  const attention = useFactoryAttention(factoryId, 'open', ATTENTION_PREVIEW_LIMIT, 'badge');
+  const attention = useFactoryAttention(factoryId, 'open', ATTENTION_PREVIEW_LIMIT, 'attention');
   const rowProps = useAttentionItemActions(factoryId);
   const [open, setOpen] = useState(false);
   const items = attention.data?.items ?? [];
-  const openCount = attention.data?.openCount ?? 0;
-  const unreadCount = attention.data?.unreadCount ?? 0;
-  const badgeCount = attention.data?.badgeCount ?? 0;
+  const { open: openCount, unread: unreadCount } = attention.data
+    ? attentionCountsIn(attention.data.kinds, 'attention')
+    : { open: 0, unread: 0 };
   const soundScope = auth.data?.user?.userId ?? 'local';
   const soundBaseline = useRef<
     { scope: string; key: string | null; occurredAt: number; unreadCount: number } | undefined
@@ -40,11 +41,12 @@ export function SidebarAttention() {
   useEffect(() => {
     if (!attention.data) return;
     const scope = `${soundScope}:${factoryId ?? 'none'}`;
-    const key = attention.data.latestOccurrenceKey;
-    const occurredAt = Date.parse(attention.data.latestOccurrenceAt ?? '') || 0;
+    const latest = latestUnreadOrNewestIn(attention.data.kinds, 'attention');
+    const key = latest?.key ?? null;
+    const occurredAt = latest ? Date.parse(latest.at) : 0;
     const previous = soundBaseline.current;
     soundBaseline.current = { scope, key, occurredAt, unreadCount };
-    if (!previous || previous.scope !== scope || !key || !attention.data.latestOccurrenceUnread) return;
+    if (!previous || previous.scope !== scope || !latest?.unread) return;
     if (previous.key === key) return;
     if (
       occurredAt < previous.occurredAt ||
@@ -52,7 +54,7 @@ export function SidebarAttention() {
     ) {
       return;
     }
-    void playAttentionSoundOnce(scope, key);
+    void playAttentionSoundOnce(scope, latest.key);
   }, [attention.data, factoryId, soundScope, unreadCount]);
 
   if (!factoryId) return null;
@@ -69,9 +71,9 @@ export function SidebarAttention() {
           </span>
           <MainSidebar.NavLabel className="flex items-center gap-2">
             <span className="min-w-0 flex-1 truncate">Needs attention</span>
-            {badgeCount > 0 ? (
+            {unreadCount > 0 ? (
               <Badge variant="orange" size="sm">
-                {badgeCount}
+                {unreadCount}
               </Badge>
             ) : null}
           </MainSidebar.NavLabel>

--- a/mastracode/factory-ui/src/ui/domains/factory/components/__tests__/SidebarAttention.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/__tests__/SidebarAttention.msw.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { queryKeys } from '../../../../../api/keys';
+import { attentionKindSummaries } from '../../../../../../e2e/ui/attention';
 import { server } from '../../../../../../e2e/ui/msw-server';
 import { renderWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../../../../e2e/ui/render';
 import {
@@ -212,22 +213,12 @@ function stubAttention(initialItems: FactoryAttentionItem[]) {
         if (view === 'unread') return !item.read && !item.archived;
         return !item.archived;
       });
-      const unread = (rows: FactoryAttentionItem[]) => rows.filter(row => !row.read && !row.archived).length;
-      const badge = items.filter(item => item.kind !== 'activity');
-      const activity = items.filter(item => item.kind === 'activity');
-      const latest = badge[0];
-      const tierParam = url.searchParams.get('tier');
-      const tiered = tierParam === 'badge' ? visible.filter(item => item.kind !== 'activity') : visible;
+      const requestedKinds = url.searchParams.getAll('kind');
+      const matching = requestedKinds.length > 0 ? visible.filter(item => requestedKinds.includes(item.kind)) : visible;
       return HttpResponse.json({
-        items: tiered.slice(0, limit),
-        openCount: badge.filter(item => !item.archived).length,
-        badgeCount: unread(badge),
-        unreadCount: unread(badge),
-        activityUnreadCount: unread(activity),
-        latestOccurrenceKey: latest?.key ?? null,
-        latestOccurrenceAt: latest?.occurredAt ?? null,
-        latestOccurrenceUnread: latest !== undefined && !latest.read && !latest.archived,
-        hasMore: tiered.length > limit,
+        items: matching.slice(0, limit),
+        kinds: attentionKindSummaries(items),
+        hasMore: matching.length > limit,
       });
     }),
     http.post(
@@ -447,21 +438,21 @@ describe('Sidebar attention', () => {
     expect(screen.getByRole('link', { name: 'Open thread for Fix the loader' })).toBeVisible();
   });
 
-  it('a parked run shows as a row you can release', async () => {
-    const api = stubAttention([proposedItem()]);
+  it('a parked run stays out of the badge, the preview, and the sound', async () => {
+    const api = stubAttention([]);
     const user = userEvent.setup();
     const { client } = renderAttention();
+    await screen.findByRole('button', { name: 'Needs attention' });
 
-    await user.click(await screen.findByRole('button', { name: 'Needs attention, 1 unread, 1 open' }));
-
-    expect(await screen.findByText('Fix the loader')).toBeVisible();
-    expect(screen.getByText('Waiting for approval to run review')).toBeVisible();
-
-    await user.click(screen.getByRole('button', { name: 'Run Fix the loader' }));
+    api.setItems([proposedItem()]);
+    await client.invalidateQueries({ queryKey: queryKeys.factoryAttentionRoot(FACTORY_ID) });
     await waitForMutationsIdle(client);
 
-    expect(api.settled).toEqual([`${DECISION_ID}/approve`]);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Needs attention' })).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Needs attention' }));
+    expect(await screen.findByText('Nothing needs attention.')).toBeVisible();
+    expect(screen.queryByText('Waiting for approval to run review')).not.toBeInTheDocument();
+    expect(oscillatorStart).not.toHaveBeenCalled();
+    expect(api.listed.at(-1)).toBe('?view=open&kind=automation-failed&kind=supervisor-finding&kind=mention&limit=25');
   });
   it('the sidebar and the Overview preview share one attention query', async () => {
     const api = stubAttention([attentionItem()]);
@@ -492,7 +483,7 @@ describe('Sidebar attention', () => {
     await screen.findByRole('button', { name: 'Needs attention, 1 unread, 1 open' });
     expect(await screen.findByText('No active Factory binding for role work.')).toBeVisible();
     await waitForMutationsIdle(client);
-    expect(api.listed).toEqual(['?view=open&tier=badge&limit=25']);
+    expect(api.listed).toEqual(['?view=open&kind=automation-failed&kind=supervisor-finding&kind=mention&limit=25']);
   });
 
   it('deduplicates persisted sound claims by scope and occurrence', async () => {
@@ -505,7 +496,7 @@ describe('Sidebar attention', () => {
     expect(oscillatorStart).toHaveBeenCalledTimes(notesPerPlayback);
   });
 
-  it('keeps the popover on the badge tier when newer activity fills the page', async () => {
+  it('keeps the popover on what needs a person when newer activity fills the page', async () => {
     const chatter = ['item-2', 'item-3', 'item-4', 'item-5', 'item-6'].map(id => activityItem(id, `Chatter on ${id}`));
     stubAttention([...chatter, mentionItem()]);
     const user = userEvent.setup();

--- a/mastracode/factory-ui/src/ui/domains/factory/context/__tests__/FeedEventsProvider.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/context/__tests__/FeedEventsProvider.msw.test.tsx
@@ -4,6 +4,7 @@ import type { QueryClient } from '@tanstack/react-query';
 import { http, HttpResponse } from 'msw';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { attentionKindSummaries } from '../../../../../../e2e/ui/attention';
 import { pushableFeedStream } from '../../../../../../e2e/ui/feed-stream';
 import { server } from '../../../../../../e2e/ui/msw-server';
 import { renderHookWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../../../../e2e/ui/render';
@@ -47,14 +48,7 @@ function countComments(count: () => void) {
 function countAttention(count: () => void) {
   return http.get(ATTENTION_URL, () => {
     count();
-    return HttpResponse.json({
-      items: [],
-      openCount: 0,
-      badgeCount: 0,
-      unreadCount: 0,
-      activityUnreadCount: 0,
-      hasMore: false,
-    });
+    return HttpResponse.json({ items: [], kinds: attentionKindSummaries([]), hasMore: false });
   });
 }
 

--- a/mastracode/factory-ui/src/ui/domains/factory/services/attention.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/attention.ts
@@ -44,7 +44,7 @@ export interface FactoryMentionAttentionItem extends FactoryAttentionItemBase {
   authorName?: string;
 }
 
-/** The lower tier: the discussion on an item someone took part in moved on. */
+/** The discussion on an item someone took part in moved on. */
 export interface FactoryActivityAttentionItem extends FactoryAttentionItemBase {
   kind: 'activity';
   workItemId: string;
@@ -69,7 +69,7 @@ export type FactoryAttentionItem =
   | FactoryActivityAttentionItem
   | FactorySupervisorFindingAttentionItem;
 
-/** Automated attention items have no author; comment-driven tiers carry the person who wrote the comment. */
+/** Automated attention items have no author; comment-driven kinds carry the person who wrote the comment. */
 export function attentionAuthorName(item: FactoryAttentionItem): string | undefined {
   return item.kind === 'mention' || item.kind === 'activity' ? item.authorName : undefined;
 }
@@ -88,18 +88,77 @@ export function attentionItemSourceId(item: FactoryAttentionItem): string {
   }
 }
 
+export type FactoryAttentionKind = FactoryAttentionItem['kind'];
+
+/** Who an item is for: a person it interrupts, a queue a person releases, or a discussion they follow. */
+export type FactoryAttentionGroup = 'attention' | 'queue' | 'activity';
+
+const ATTENTION_GROUP_OF_KIND: Record<FactoryAttentionKind, FactoryAttentionGroup> = {
+  'automation-failed': 'attention',
+  'supervisor-finding': 'attention',
+  mention: 'attention',
+  'automation-proposed': 'queue',
+  activity: 'activity',
+};
+const ATTENTION_KINDS = Object.keys(ATTENTION_GROUP_OF_KIND) as FactoryAttentionKind[];
+
+export function attentionGroupOf(kind: FactoryAttentionKind): FactoryAttentionGroup {
+  return ATTENTION_GROUP_OF_KIND[kind];
+}
+
+export function attentionKindsIn(group: FactoryAttentionGroup): FactoryAttentionKind[] {
+  return ATTENTION_KINDS.filter(kind => ATTENTION_GROUP_OF_KIND[kind] === group);
+}
+
+export interface FactoryAttentionLatest {
+  key: string;
+  at: string;
+  unread: boolean;
+}
+
+export interface FactoryAttentionKindSummary {
+  open: number;
+  unread: number;
+  latest: FactoryAttentionLatest | null;
+}
+
+export type FactoryAttentionKindSummaries = Record<FactoryAttentionKind, FactoryAttentionKindSummary>;
+
 export interface FactoryAttentionResponse {
   items: FactoryAttentionItem[];
-  openCount: number;
-  badgeCount: number;
-  unreadCount: number;
-  /** Counted apart: the activity tier never reaches the sidebar badge. */
-  activityUnreadCount: number;
+  kinds: FactoryAttentionKindSummaries;
   hasMore: boolean;
-  latestOccurrenceKey: string | null;
-  latestOccurrenceAt: string | null;
-  latestOccurrenceUnread: boolean;
   nextCursor?: string;
+}
+
+export function attentionCountsIn(
+  kinds: FactoryAttentionKindSummaries,
+  group: FactoryAttentionGroup,
+): { open: number; unread: number } {
+  let open = 0;
+  let unread = 0;
+  for (const kind of attentionKindsIn(group)) {
+    open += kinds[kind].open;
+    unread += kinds[kind].unread;
+  }
+  return { open, unread };
+}
+
+export function latestUnreadOrNewestIn(
+  kinds: FactoryAttentionKindSummaries,
+  group: FactoryAttentionGroup,
+): FactoryAttentionLatest | null {
+  const latests = attentionKindsIn(group).flatMap(kind => kinds[kind].latest ?? []);
+  const unread = latests.filter(latest => latest.unread);
+  return newestOf(unread.length > 0 ? unread : latests);
+}
+
+function newestOf(latests: FactoryAttentionLatest[]): FactoryAttentionLatest | null {
+  let newest: FactoryAttentionLatest | null = null;
+  for (const latest of latests) {
+    if (!newest || Date.parse(latest.at) > Date.parse(newest.at)) newest = latest;
+  }
+  return newest;
 }
 
 export function factoryAttentionTargetPath(factoryId: string, target: FactoryAttentionTarget): string {
@@ -113,14 +172,12 @@ export function factoryAttentionTargetPath(factoryId: string, target: FactoryAtt
   return `/factories/${factoryId}/rules`;
 }
 
-export type FactoryAttentionTier = 'badge' | 'activity';
-
 export function fetchFactoryAttention(
   baseUrl: string,
   factoryProjectId: string,
   options: {
     view: FactoryAttentionView;
-    tier?: FactoryAttentionTier;
+    kinds?: FactoryAttentionKind[];
     before?: string;
     limit?: number;
     search?: string;
@@ -128,7 +185,7 @@ export function fetchFactoryAttention(
   },
 ): Promise<FactoryAttentionResponse> {
   const query = new URLSearchParams({ view: options.view });
-  if (options.tier) query.set('tier', options.tier);
+  for (const kind of options.kinds ?? []) query.append('kind', kind);
   if (options.before) query.set('before', options.before);
   if (options.limit) query.set('limit', String(options.limit));
   if (options.search) query.set('search', options.search);

--- a/mastracode/factory-ui/src/ui/pages/AttentionPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/AttentionPage.tsx
@@ -14,13 +14,24 @@ import { LoadMoreSentinel } from '../domains/factory/components/LoadMoreSentinel
 import { DayHeading, RailRow, RAIL_LIST } from '../domains/factory/components/Timeline';
 import { useAttentionItemActions } from '../domains/factory/components/useAttentionItemActions';
 import { DocumentFactoryPageShell } from '../domains/factory/components/FactoryPageShell';
-import type { FactoryAttentionItem, FactoryAttentionView } from '../domains/factory/services/attention';
+import { attentionCountsIn, attentionGroupOf } from '../domains/factory/services/attention';
+import type {
+  FactoryAttentionGroup,
+  FactoryAttentionItem,
+  FactoryAttentionView,
+} from '../domains/factory/services/attention';
 import { SkeletonRows } from '../ui/SkeletonRows';
 
 const VIEWS: Array<{ value: FactoryAttentionView; label: string; icon: typeof Inbox }> = [
   { value: 'open', label: 'Open', icon: Inbox },
   { value: 'unread', label: 'Unread', icon: Mail },
   { value: 'archived', label: 'Archived', icon: Archive },
+];
+
+/** What needs a person leads the page; what waits on their say-so and what they merely follow sit under it. */
+const SECTIONS_BELOW: Array<{ group: FactoryAttentionGroup; heading: string; headingId: string }> = [
+  { group: 'queue', heading: 'Waiting for approval', headingId: 'attention-queue-heading' },
+  { group: 'activity', heading: 'Activity', headingId: 'attention-activity-heading' },
 ];
 
 function attentionView(value: string | null): FactoryAttentionView {
@@ -81,10 +92,11 @@ export function AttentionContent({ factoryId }: { factoryId: string }) {
   const pages = attention.data?.pages ?? [];
   const summary = pages[0];
   const items = pages.flatMap(page => page.items);
-  const primary = items.filter(item => item.kind !== 'activity');
-  const activity = items.filter(item => item.kind === 'activity');
-  const activityUnread = view === 'archived' ? 0 : (summary?.activityUnreadCount ?? 0);
-  const unreadCount = (summary?.unreadCount ?? 0) + (summary?.activityUnreadCount ?? 0);
+  const itemsIn = (group: FactoryAttentionGroup) => items.filter(item => attentionGroupOf(item.kind) === group);
+  const unreadIn = (group: FactoryAttentionGroup) =>
+    summary && view !== 'archived' ? attentionCountsIn(summary.kinds, group).unread : 0;
+  const unreadCount = unreadIn('attention') + unreadIn('queue') + unreadIn('activity');
+  const interrupting = itemsIn('attention');
 
   return (
     <section className="mx-auto flex w-full max-w-4xl flex-col gap-6 pb-16" aria-labelledby="attention-heading">
@@ -155,23 +167,30 @@ export function AttentionContent({ factoryId }: { factoryId: string }) {
         </div>
       ) : (
         <>
-          {primary.length > 0 ? <AttentionRail factoryId={factoryId} items={primary} rowProps={rowProps} /> : null}
-
-          {activity.length > 0 ? (
-            <section aria-labelledby="attention-activity-heading" className="flex flex-col gap-4">
-              <span className="flex items-center gap-2">
-                <h2 id="attention-activity-heading" className="text-ui-sm text-icon3 m-0 font-medium">
-                  Activity
-                </h2>
-                {activityUnread > 0 ? (
-                  <span className="bg-surface4 text-ui-xs text-icon3 min-w-5 rounded-full px-1.5 py-0.5 text-center leading-none font-medium tabular-nums">
-                    {activityUnread}
-                  </span>
-                ) : null}
-              </span>
-              <AttentionRail factoryId={factoryId} items={activity} rowProps={rowProps} />
-            </section>
+          {interrupting.length > 0 ? (
+            <AttentionRail factoryId={factoryId} items={interrupting} rowProps={rowProps} />
           ) : null}
+
+          {SECTIONS_BELOW.map(section => {
+            const sectionItems = itemsIn(section.group);
+            if (sectionItems.length === 0) return null;
+            const unread = unreadIn(section.group);
+            return (
+              <section key={section.group} aria-labelledby={section.headingId} className="flex flex-col gap-4">
+                <span className="flex items-center gap-2">
+                  <h2 id={section.headingId} className="text-ui-sm text-icon3 m-0 font-medium">
+                    {section.heading}
+                  </h2>
+                  {unread > 0 ? (
+                    <span className="bg-surface4 text-ui-xs text-icon3 min-w-5 rounded-full px-1.5 py-0.5 text-center leading-none font-medium tabular-nums">
+                      {unread}
+                    </span>
+                  ) : null}
+                </span>
+                <AttentionRail factoryId={factoryId} items={sectionItems} rowProps={rowProps} />
+              </section>
+            );
+          })}
         </>
       )}
 

--- a/mastracode/factory-ui/src/ui/pages/__tests__/AttentionPage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/AttentionPage.msw.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from 'msw';
 import { MemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
+import { attentionKindSummaries } from '../../../../e2e/ui/attention';
 import { server } from '../../../../e2e/ui/msw-server';
 import { renderWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../../e2e/ui/render';
 import type {
@@ -107,13 +108,7 @@ describe('AttentionPage', () => {
           if (view === 'unread') return !attentionItem.read && !attentionItem.archived;
           return !attentionItem.archived;
         });
-        return HttpResponse.json({
-          items: visible,
-          openCount: items.filter(attentionItem => !attentionItem.archived).length,
-          badgeCount: items.filter(attentionItem => !attentionItem.read && !attentionItem.archived).length,
-          unreadCount: items.filter(attentionItem => !attentionItem.read && !attentionItem.archived).length,
-          hasMore: false,
-        });
+        return HttpResponse.json({ items: visible, kinds: attentionKindSummaries(items), hasMore: false });
       }),
       http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/attention/read-all`, ({ request }) => {
         markAllRequests += 1;
@@ -171,16 +166,7 @@ describe('AttentionPage', () => {
     const settled: string[] = [];
     server.use(
       http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/attention`, () =>
-        HttpResponse.json({
-          items,
-          openCount: items.length,
-          badgeCount: items.length,
-          unreadCount: items.length,
-          hasMore: false,
-          latestOccurrenceKey: null,
-          latestOccurrenceAt: null,
-          latestOccurrenceUnread: false,
-        }),
+        HttpResponse.json({ items, kinds: attentionKindSummaries(items), hasMore: false }),
       ),
       http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/decisions/:decisionId/:action`, ({ params }) => {
         settled.push(`${params.action}:${params.decisionId}`);
@@ -195,7 +181,9 @@ describe('AttentionPage', () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText('Fix the flaky auth test')).toBeVisible();
+    const queue = await screen.findByRole('region', { name: 'Waiting for approval' });
+    expect(within(queue).getByText('Fix the flaky auth test')).toBeVisible();
+    expect(within(queue).getByText('1')).toBeVisible();
     await user.click(screen.getByRole('button', { name: 'Run Fix the flaky auth test' }));
     await waitForMutationsIdle(client);
 
@@ -208,16 +196,7 @@ describe('AttentionPage', () => {
     const settled: string[] = [];
     server.use(
       http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/attention`, () =>
-        HttpResponse.json({
-          items,
-          openCount: items.length,
-          badgeCount: items.length,
-          unreadCount: items.length,
-          hasMore: false,
-          latestOccurrenceKey: null,
-          latestOccurrenceAt: null,
-          latestOccurrenceUnread: false,
-        }),
+        HttpResponse.json({ items, kinds: attentionKindSummaries(items), hasMore: false }),
       ),
       http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/decisions/:decisionId/:action`, ({ params }) => {
         settled.push(`${params.action}:${params.decisionId}`);
@@ -252,9 +231,7 @@ describe('AttentionPage', () => {
         const secondPage = [item('decision-2', 'Repair auth', false)];
         return HttpResponse.json({
           items: before === KIND_CURSOR ? secondPage : firstPage,
-          openCount: 3,
-          badgeCount: 3,
-          unreadCount: 3,
+          kinds: attentionKindSummaries([...firstPage, ...secondPage]),
           hasMore: before !== KIND_CURSOR,
           ...(before !== KIND_CURSOR ? { nextCursor: KIND_CURSOR } : {}),
         });
@@ -302,9 +279,7 @@ describe('AttentionPage', () => {
           : allItems;
         return HttpResponse.json({
           items: matching.slice(0, 25),
-          openCount: allItems.length,
-          badgeCount: allItems.length,
-          unreadCount: allItems.length,
+          kinds: attentionKindSummaries(allItems),
           hasMore: matching.length > 25,
           ...(matching.length > 25 ? { nextCursor: 'page-2' } : {}),
         });
@@ -325,20 +300,14 @@ describe('AttentionPage', () => {
 
   it('files activity under its own section, below what needs an answer', async () => {
     const receiptCalls: string[] = [];
+    const items = [
+      activityItem('item-4', 'Loader retry landed'),
+      mentionItem('comment-1', 'Fix login bug'),
+      item('decision-1', 'Fix the loader', false),
+    ];
     server.use(
       http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/attention`, () =>
-        HttpResponse.json({
-          items: [
-            activityItem('item-4', 'Loader retry landed'),
-            mentionItem('comment-1', 'Fix login bug'),
-            item('decision-1', 'Fix the loader', false),
-          ],
-          openCount: 2,
-          badgeCount: 2,
-          unreadCount: 2,
-          activityUnreadCount: 1,
-          hasMore: false,
-        }),
+        HttpResponse.json({ items, kinds: attentionKindSummaries(items), hasMore: false }),
       ),
       http.post(
         `${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/attention/:kind/:sourceId/:occurrence/:action`,
@@ -374,14 +343,7 @@ describe('AttentionPage', () => {
     ];
     server.use(
       http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/attention`, () =>
-        HttpResponse.json({
-          items,
-          openCount: items.length,
-          badgeCount: items.length,
-          unreadCount: items.length,
-          activityUnreadCount: 0,
-          hasMore: false,
-        }),
+        HttpResponse.json({ items, kinds: attentionKindSummaries(items), hasMore: false }),
       ),
     );
     renderWithProviders(

--- a/mastracode/factory/src/routes/attention-activity.ts
+++ b/mastracode/factory/src/routes/attention-activity.ts
@@ -1,4 +1,4 @@
-/** Projects `activity.ts` fan-out rows. Below the badge: the sidebar counts mentions and failures only. */
+/** Projects `activity.ts` fan-out rows. */
 
 import type {
   WorkItemActivityRow,
@@ -119,9 +119,15 @@ export class ActivityAttentionProvider implements AttentionProvider {
     return { open, unread };
   }
 
-  /** Always null: `latestOccurrence*` drives the notification sound, and this tier stays silent. */
-  async latest(): Promise<AttentionLatest | null> {
-    return null;
+  async latest(scope: AttentionScope): Promise<AttentionLatest | null> {
+    const rows = await this.#comments.listActivityForUser({ ...receiptScope(scope), limit: 10 });
+    const newest = (await this.#resolve(scope, rows))[0];
+    if (!newest) return null;
+    return {
+      key: factoryAttentionKey(scope.factoryProjectId, newest.identity),
+      at: newest.activity.occurredAt,
+      unread: newest.receipt === undefined,
+    };
   }
 
   async page(scope: AttentionScope, { view, search, before, limit }: AttentionPageArgs): Promise<AttentionPageResult> {

--- a/mastracode/factory/src/routes/attention.test.ts
+++ b/mastracode/factory/src/routes/attention.test.ts
@@ -1,7 +1,7 @@
 /**
  * Attention over HTTP with every provider live: mention items and counts, the
  * per-kind receipt currency, read-all across kinds, the merged cursor, and the
- * activity tier that sits below the badge.
+ * kind filter beside the per-kind summary.
  */
 
 import { Hono } from 'hono';
@@ -162,21 +162,18 @@ describe('supervisor finding attention items', () => {
           read: false,
         },
       ],
-      openCount: 1,
-      unreadCount: 1,
-      badgeCount: 1,
-      latestOccurrenceUnread: true,
+      kinds: { 'supervisor-finding': { open: 1, unread: 1, latest: { unread: true } } },
     });
 
     const receiptPath = `/web/factory/projects/${PROJECT_ID}/attention/supervisor-finding/${encodeURIComponent(`decision-stuck:${item.id}`)}/0`;
     expect((await request('POST', `${receiptPath}/read`)).status).toBe(200);
     await expect(
       (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?view=unread`)).json(),
-    ).resolves.toMatchObject({ items: [], unreadCount: 0, openCount: 1 });
+    ).resolves.toMatchObject({ items: [], kinds: { 'supervisor-finding': { open: 1, unread: 0 } } });
 
     expect((await request('POST', `${receiptPath}/archive`)).status).toBe(200);
     await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
-      { items: [], openCount: 0 },
+      { items: [], kinds: { 'supervisor-finding': { open: 0 } } },
     );
   });
 });
@@ -204,21 +201,18 @@ describe('mention attention items', () => {
           target: { kind: 'work-item', workItemId: item.id, commentId: comment.id },
         },
       ],
-      openCount: 1,
-      unreadCount: 1,
-      badgeCount: 1,
-      latestOccurrenceUnread: true,
+      kinds: { mention: { open: 1, unread: 1, latest: { unread: true } } },
     });
 
     const receiptPath = `/web/factory/projects/${PROJECT_ID}/attention/mention/${comment.id}/0`;
     expect((await request('POST', `${receiptPath}/read`)).status).toBe(200);
     await expect(
       (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?view=unread`)).json(),
-    ).resolves.toMatchObject({ items: [], unreadCount: 0, openCount: 1 });
+    ).resolves.toMatchObject({ items: [], kinds: { mention: { open: 1, unread: 0 } } });
 
     expect((await request('POST', `${receiptPath}/archive`)).status).toBe(200);
     await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
-      { items: [], openCount: 0 },
+      { items: [], kinds: { mention: { open: 0 } } },
     );
     await expect(
       (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?view=archived`)).json(),
@@ -226,7 +220,7 @@ describe('mention attention items', () => {
 
     expect((await request('POST', `${receiptPath}/restore`)).status).toBe(200);
     await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
-      { items: [{ kind: 'mention', read: true, archived: false }], openCount: 1 },
+      { items: [{ kind: 'mention', read: true, archived: false }], kinds: { mention: { open: 1 } } },
     );
   });
 
@@ -241,7 +235,7 @@ describe('mention attention items', () => {
     });
 
     await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
-      { items: [], openCount: 0, unreadCount: 0 },
+      { items: [], kinds: { mention: { open: 0, unread: 0 } } },
     );
   });
 
@@ -311,11 +305,11 @@ describe('mention attention items', () => {
     }
 
     await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
-      { items: [{ kind: 'mention', detail: 'real' }], openCount: 1, unreadCount: 1, badgeCount: 1 },
+      { items: [{ kind: 'mention', detail: 'real' }], kinds: { mention: { open: 1, unread: 1 } } },
     );
   });
 
-  it('keeps the latest pointer on an unread item even when a read one is newer', async () => {
+  it('reports the newest item of each kind with its own read state', async () => {
     const item = await seedWorkItem();
     await seedMention({ workItemId: item.id, body: 'older unread', occurredAt: new Date('2030-01-01T00:00:05.000Z') });
     const failure = await seedFailure(item, new Date('2030-01-01T00:00:10.000Z'));
@@ -327,15 +321,15 @@ describe('mention attention items', () => {
 
     await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
       {
-        latestOccurrenceAt: '2030-01-01T00:00:05.000Z',
-        latestOccurrenceUnread: true,
-        unreadCount: 1,
-        openCount: 2,
+        kinds: {
+          mention: { open: 1, unread: 1, latest: { at: '2030-01-01T00:00:05.000Z', unread: true } },
+          'automation-failed': { open: 1, unread: 0, latest: { at: '2030-01-01T00:00:10.000Z', unread: false } },
+        },
       },
     );
   });
 
-  it('sums counts across kinds for badge math', async () => {
+  it('counts every kind apart', async () => {
     const item = await seedWorkItem();
     await seedFailure(item, new Date('2030-01-01T00:00:10.000Z'));
     await seedMention({ workItemId: item.id, body: 'one', occurredAt: new Date('2030-01-01T00:00:05.000Z') });
@@ -343,10 +337,11 @@ describe('mention attention items', () => {
 
     await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
       {
-        openCount: 3,
-        unreadCount: 3,
-        badgeCount: 3,
-        latestOccurrenceAt: '2030-01-01T00:00:15.000Z',
+        kinds: {
+          'automation-failed': { open: 1, unread: 1 },
+          mention: { open: 2, unread: 2, latest: { at: '2030-01-01T00:00:15.000Z' } },
+          activity: { open: 0, unread: 0, latest: null },
+        },
       },
     );
   });
@@ -411,7 +406,7 @@ describe('mention attention items', () => {
     await expect(readAll.json()).resolves.toEqual({ ok: true, hasMore: false });
 
     await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
-      { unreadCount: 0, openCount: 2 },
+      { kinds: { 'automation-failed': { open: 1, unread: 0 }, mention: { open: 1, unread: 0 } } },
     );
     await expect(
       seed.workItems.listAttentionReceipts({
@@ -479,8 +474,7 @@ describe('proposed attention items', () => {
             archived: false,
           },
         ],
-        openCount: 1,
-        unreadCount: 1,
+        kinds: { 'automation-proposed': { open: 1, unread: 1 } },
       },
     );
 
@@ -491,7 +485,7 @@ describe('proposed attention items', () => {
     );
 
     await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
-      { items: [], openCount: 0, unreadCount: 0 },
+      { items: [], kinds: { 'automation-proposed': { open: 0, unread: 0 } } },
     );
     await expect(
       seed.workItems.listAttentionReceipts({
@@ -517,7 +511,7 @@ describe('proposed attention items', () => {
     ]);
   });
 
-  it('counts in the badge exactly the items it can list', async () => {
+  it('counts each kind exactly as it lists it', async () => {
     const item = await seedWorkItem();
     await seedProposal(item, new Date('2030-01-01T00:00:00.000Z'));
     await seedFailure(item, new Date('2030-01-01T00:01:00.000Z'));
@@ -525,19 +519,24 @@ describe('proposed attention items', () => {
 
     const page = await (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json();
     expect(page.items).toHaveLength(3);
-    expect(page.badgeCount).toBe(3);
-    expect(page.unreadCount).toBe(3);
-    expect(page).not.toHaveProperty('approvalCount');
+    expect(page.kinds).toMatchObject({
+      'automation-proposed': { open: 1, unread: 1 },
+      'automation-failed': { open: 1, unread: 1 },
+      mention: { open: 1, unread: 1 },
+    });
   });
 
-  it('read-all zeroes the badge and leaves the run parked', async () => {
+  it('read-all reads the proposal and leaves the run parked', async () => {
     const item = await seedWorkItem();
     await seedProposal(item, new Date('2030-01-01T00:00:00.000Z'));
 
     expect((await request('POST', `/web/factory/projects/${PROJECT_ID}/attention/read-all`)).status).toBe(200);
 
     await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
-      { items: [{ kind: 'automation-proposed', read: true }], badgeCount: 0, unreadCount: 0, openCount: 1 },
+      {
+        items: [{ kind: 'automation-proposed', read: true }],
+        kinds: { 'automation-proposed': { open: 1, unread: 0 } },
+      },
     );
   });
 });
@@ -555,7 +554,7 @@ describe('activity attention items', () => {
     });
   }
 
-  it('lists a comment on a followed item without ever reaching the badge', async () => {
+  it('lists a comment on a followed item with its own count and newest pointer', async () => {
     const item = await seedWorkItem();
     const comment = await seedActivity(item.id, 'moved this to review', new Date('2030-01-01T00:00:00.000Z'));
 
@@ -574,14 +573,12 @@ describe('activity attention items', () => {
           target: { kind: 'work-item', workItemId: item.id, commentId: comment.id },
         },
       ],
-      openCount: 0,
-      unreadCount: 0,
-      badgeCount: 0,
-      activityUnreadCount: 1,
+      kinds: {
+        activity: { open: 1, unread: 1, latest: { at: '2030-01-01T00:00:00.000Z', unread: true } },
+        mention: { open: 0, unread: 0, latest: null },
+      },
     });
-    // The sound is the badge tier's alone.
-    expect(page.latestOccurrenceKey).toBeNull();
-    expect(page.latestOccurrenceUnread).toBe(false);
+    expect(page.kinds.activity.latest.key).toBe(page.items[0].key);
   });
 
   it('re-unreads on the next comment and 409s the receipt the bump left behind', async () => {
@@ -591,12 +588,15 @@ describe('activity attention items', () => {
     const receiptPath = `/web/factory/projects/${PROJECT_ID}/attention/activity/${item.id}`;
     expect((await request('POST', `${receiptPath}/1/read`)).status).toBe(200);
     await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
-      { items: [{ kind: 'activity', read: true }], activityUnreadCount: 0 },
+      { items: [{ kind: 'activity', read: true }], kinds: { activity: { unread: 0 } } },
     );
 
     await seedActivity(item.id, 'second', new Date('2030-01-01T00:00:10.000Z'));
     await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
-      { items: [{ kind: 'activity', occurrence: 2, detail: 'second', read: false }], activityUnreadCount: 1 },
+      {
+        items: [{ kind: 'activity', occurrence: 2, detail: 'second', read: false }],
+        kinds: { activity: { unread: 1 } },
+      },
     );
 
     const stale = await request('POST', `${receiptPath}/1/read`);
@@ -639,17 +639,17 @@ describe('activity attention items', () => {
     expect(second.items).toMatchObject([{ kind: 'activity', workItemId: item.id, occurrence: 1 }]);
   });
 
-  it('read-all clears the activity tier too', async () => {
+  it('read-all clears activity too', async () => {
     const item = await seedWorkItem();
     await seedActivity(item.id, 'ping', new Date('2030-01-01T00:00:00.000Z'));
 
     expect((await request('POST', `/web/factory/projects/${PROJECT_ID}/attention/read-all`)).status).toBe(200);
 
     await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
-      { activityUnreadCount: 0, items: [{ kind: 'activity', read: true }] },
+      { kinds: { activity: { unread: 0 } }, items: [{ kind: 'activity', read: true }] },
     );
   });
-  it('keeps the badge tier in the page budget when activity is newer', async () => {
+  it('lists only the requested kinds so a preview keeps its page budget', async () => {
     const mentionItem = await seedWorkItem('Mentioned item');
     const mention = await seedMention({
       workItemId: mentionItem.id,
@@ -664,17 +664,16 @@ describe('activity attention items', () => {
     const merged = await (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?limit=2`)).json();
     expect(merged.items.map((entry: { kind: string }) => entry.kind)).toEqual(['activity', 'activity']);
 
-    const badge = await (
-      await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?limit=2&tier=badge`)
+    const requested = await (
+      await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?limit=2&kind=mention&kind=automation-failed`)
     ).json();
-    expect(badge.items).toMatchObject([{ kind: 'mention', commentId: mention.id }]);
-    expect(badge.badgeCount).toBe(1);
-    expect(badge.activityUnreadCount).toBe(2);
+    expect(requested.items).toMatchObject([{ kind: 'mention', commentId: mention.id }]);
+    expect(requested.kinds).toMatchObject({ mention: { unread: 1 }, activity: { unread: 2 } });
   });
 
-  it('rejects an unknown tier', async () => {
-    const response = await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?tier=bogus`);
+  it('rejects an unknown kind', async () => {
+    const response = await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?kind=bogus`);
     expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({ error: 'invalid_attention_tier' });
+    expect(await response.json()).toEqual({ error: 'invalid_attention_kind' });
   });
 });

--- a/mastracode/factory/src/routes/attention.ts
+++ b/mastracode/factory/src/routes/attention.ts
@@ -17,7 +17,6 @@ import { factoryAttentionKey } from '../storage/domains/work-items/base.js';
 import { ActivityAttentionProvider } from './attention-activity.js';
 import { proposedDecisionAttentionSpec } from './attention-proposed.js';
 import type {
-  AttentionLatest,
   AttentionPageResult,
   AttentionProvider,
   AttentionScope,
@@ -68,24 +67,12 @@ function isAttentionKind(value: string): value is FactoryAttentionKind {
   );
 }
 
-/** Kinds the sidebar badge and the notification sound answer to. */
-const BADGE_KINDS: ReadonlySet<FactoryAttentionKind> = new Set([
-  'automation-failed',
-  'automation-proposed',
-  'mention',
-  'supervisor-finding',
-]);
-
-type AttentionTier = 'all' | 'badge' | 'activity';
-
-function parseAttentionTier(raw: string | undefined): AttentionTier | undefined {
-  if (raw === undefined) return 'all';
-  return raw === 'badge' || raw === 'activity' ? raw : undefined;
-}
-
-function kindInTier(tier: AttentionTier, kind: FactoryAttentionKind): boolean {
-  if (tier === 'all') return true;
-  return tier === 'badge' ? BADGE_KINDS.has(kind) : !BADGE_KINDS.has(kind);
+function parseAttentionKinds(
+  raw: string[] | undefined,
+  every: FactoryAttentionKind[],
+): FactoryAttentionKind[] | undefined {
+  if (raw === undefined) return every;
+  return raw.every(isAttentionKind) ? raw : undefined;
 }
 
 function encodeAttentionCursor(cursors: AttentionCursorMap): string {
@@ -200,15 +187,6 @@ function mergeAttentionPages(
   };
 }
 
-function newestLatest(latests: Array<AttentionLatest | null>): AttentionLatest | null {
-  let newest: AttentionLatest | null = null;
-  for (const latest of latests) {
-    if (!latest) continue;
-    if (!newest || latest.at.getTime() > newest.at.getTime()) newest = latest;
-  }
-  return newest;
-}
-
 function receiptRoute(
   dependencies: AttentionRouteDependencies,
   verb: 'read' | 'archive' | 'restore',
@@ -269,11 +247,11 @@ export function buildAttentionRoutes(dependencies: AttentionRouteDependencies): 
         if ('response' in resolved) return resolved.response;
         const view = parseAttentionView(context.req.query('view'));
         if (view === undefined) return context.json({ error: 'invalid_attention_view' }, 400);
-        // `tier` scopes the item list only; the counts always describe every
-        // tier, so the badge popover can page badge kinds without losing the
-        // activity numbers.
-        const tier = parseAttentionTier(context.req.query('tier'));
-        if (tier === undefined) return context.json({ error: 'invalid_attention_tier' }, 400);
+        const kinds = parseAttentionKinds(
+          context.req.queries('kind'),
+          providers.map(provider => provider.kind),
+        );
+        if (kinds === undefined) return context.json({ error: 'invalid_attention_kind' }, 400);
         const cursorRaw = context.req.query('before');
         const before = parseAttentionCursor(cursorRaw);
         if (cursorRaw && !before) return context.json({ error: 'invalid_cursor' }, 400);
@@ -283,7 +261,7 @@ export function buildAttentionRoutes(dependencies: AttentionRouteDependencies): 
         const search = context.req.query('search')?.trim().toLowerCase().slice(0, 200);
         const limit = parseAttentionLimit(context.req.query('limit'));
         const active = providers.filter(
-          provider => kindInTier(tier, provider.kind) && (!before || before.has(provider.kind)),
+          provider => kinds.includes(provider.kind) && (!before || before.has(provider.kind)),
         );
 
         const [summaries, pages] = await Promise.all([
@@ -308,31 +286,19 @@ export function buildAttentionRoutes(dependencies: AttentionRouteDependencies): 
           ),
         ]);
 
-        // The badge tier and the activity tier are counted apart: activity
-        // leaking into `latests` would ring the notification sound on every
-        // teammate comment.
-        const badge = summaries.filter(summary => BADGE_KINDS.has(summary.kind));
-        const activity = summaries.filter(summary => !BADGE_KINDS.has(summary.kind));
-        const sum = (rows: typeof summaries, field: 'open' | 'unread') =>
-          rows.reduce((total, row) => total + row.counts[field], 0);
-        const openCount = sum(badge, 'open');
-        const unreadCount = sum(badge, 'unread');
-        // An unread item must never be masked by a newer already-read one of
-        // another kind — the streams are independent.
-        const latests = badge.map(summary => summary.latest);
-        const unreadLatests = latests.filter(latest => latest?.unread ?? false);
-        const latest = unreadLatests.length > 0 ? newestLatest(unreadLatests) : newestLatest(latests);
         const merged = mergeAttentionPages(pages, limit);
 
         return context.json({
           items: merged.items,
-          openCount,
-          badgeCount: unreadCount,
-          unreadCount,
-          activityUnreadCount: sum(activity, 'unread'),
-          latestOccurrenceKey: latest?.key ?? null,
-          latestOccurrenceAt: latest?.at.toISOString() ?? null,
-          latestOccurrenceUnread: latest?.unread ?? false,
+          kinds: Object.fromEntries(
+            summaries.map(summary => [
+              summary.kind,
+              {
+                ...summary.counts,
+                latest: summary.latest ? { ...summary.latest, at: summary.latest.at.toISOString() } : null,
+              },
+            ]),
+          ),
           hasMore: merged.hasMore,
           ...(merged.nextCursor ? { nextCursor: merged.nextCursor } : {}),
         });

--- a/mastracode/factory/src/routes/work-items.test.ts
+++ b/mastracode/factory/src/routes/work-items.test.ts
@@ -976,12 +976,9 @@ describe('GET /web/factory/projects/:id/attention', () => {
           target: { kind: 'work-item', workItemId: workItem.id, board: 'work' },
         },
       ],
-      openCount: 1,
-      badgeCount: 1,
-      unreadCount: 1,
-      latestOccurrenceKey: firstKey,
-      latestOccurrenceAt: now.toISOString(),
-      latestOccurrenceUnread: true,
+      kinds: {
+        'automation-failed': { open: 1, unread: 1, latest: { key: firstKey, at: now.toISOString(), unread: true } },
+      },
       hasMore: false,
     });
     const receiptRead = findMany.mock.calls.find(([collection]) => collection === 'factory_attention_receipts');
@@ -1023,13 +1020,12 @@ describe('GET /web/factory/projects/:id/attention', () => {
     expect((await json('POST', `${receiptPath}/read`)).status).toBe(200);
     await expect(
       (await json('GET', `/web/factory/projects/${PROJECT_ID}/attention?view=unread`)).json(),
-    ).resolves.toMatchObject({ items: [], openCount: 1, unreadCount: 0 });
+    ).resolves.toMatchObject({ items: [], kinds: { 'automation-failed': { open: 1, unread: 0 } } });
 
     expect((await json('POST', `${receiptPath}/archive`)).status).toBe(200);
     await expect((await json('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject({
       items: [],
-      openCount: 0,
-      unreadCount: 0,
+      kinds: { 'automation-failed': { open: 0, unread: 0 } },
     });
     expect((await json('POST', `${receiptPath}/read`)).status).toBe(200);
     await expect(
@@ -1041,8 +1037,7 @@ describe('GET /web/factory/projects/:id/attention', () => {
     expect((await json('POST', `${receiptPath}/restore`)).status).toBe(200);
     await expect((await json('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject({
       items: [{ key: firstKey, read: true, archived: false }],
-      openCount: 1,
-      unreadCount: 0,
+      kinds: { 'automation-failed': { open: 1, unread: 0 } },
     });
     await seed.workItems.setAttentionReceipt({
       orgId: 'org1',
@@ -1087,8 +1082,7 @@ describe('GET /web/factory/projects/:id/attention', () => {
           archived: false,
         },
       ],
-      openCount: 1,
-      unreadCount: 1,
+      kinds: { 'automation-failed': { open: 1, unread: 1 } },
     });
 
     const readAll = await json('POST', `/web/factory/projects/${PROJECT_ID}/attention/read-all`);
@@ -1096,8 +1090,7 @@ describe('GET /web/factory/projects/:id/attention', () => {
     await expect(readAll.json()).resolves.toEqual({ ok: true, hasMore: false });
     await expect((await json('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject({
       items: [{ occurrence: 2, read: true, archived: false }],
-      openCount: 1,
-      unreadCount: 0,
+      kinds: { 'automation-failed': { open: 1, unread: 0 } },
     });
 
     const [retried, staleReceipt] = await Promise.all([
@@ -1183,9 +1176,7 @@ describe('GET /web/factory/projects/:id/attention', () => {
           archived: false,
         },
       ],
-      badgeCount: 1,
-      openCount: 1,
-      unreadCount: 1,
+      kinds: { 'automation-proposed': { open: 1, unread: 1 } },
     });
 
     await seed.workItems.supersedeTerminalDecisionsForWorkItem({
@@ -1196,8 +1187,7 @@ describe('GET /web/factory/projects/:id/attention', () => {
     });
     await expect((await json('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject({
       items: [],
-      badgeCount: 0,
-      openCount: 0,
+      kinds: { 'automation-proposed': { open: 0 } },
     });
   });
 
@@ -1673,8 +1663,7 @@ describe('GET /web/factory/projects/:id/attention', () => {
       (await json('GET', `/web/factory/projects/${PROJECT_ID}/attention?limit=1`)).json(),
     ).resolves.toMatchObject({
       items: [{ decisionId: target.id }],
-      openCount: 1,
-      unreadCount: 1,
+      kinds: { 'automation-failed': { open: 1, unread: 1 } },
       hasMore: false,
     });
     await expect(


### PR DESCRIPTION
**─────── TLDR ───────**
> Runs waiting for approval no longer count in the sidebar badge or ring the notification sound.

Every approval a lane parked showed up as `suggested` in the sidebar, with a badge count and a chime, in the same list as the failures. Ten parked runs read as ten emergencies, and the two real ones drowned.

The route now reports one summary per kind: open, unread, and the newest item with its read state. Which kinds badge, sound, and preview is one map in the UI, beside the kind's glyph and label. The sidebar asks for the kinds it shows with a repeatable `kind` query; the inbox page files parked runs under their own heading.

### Behavior changed

the sidebar, with a run parked for approval
&nbsp;&nbsp;├─ **was** — badge +1, a chime, a `suggested` row in the preview
&nbsp;&nbsp;└─ **now** — nothing; the board and the inbox page carry it

the inbox page, with parked runs in it
&nbsp;&nbsp;├─ **was** — mixed into the main rail with failures and mentions
&nbsp;&nbsp;└─ **now** — a "Waiting for approval" section with its unread count, above Activity

a comment on a card you follow
&nbsp;&nbsp;└─ **unchanged** — counted under Activity, never in the badge or the sound

an unread mention older than a read failure
&nbsp;&nbsp;└─ **unchanged** — still the item the sound keys on; that rule moved from the route to the sidebar

### Shape changed

| | | |
|---|---|---|
| **−** | `BADGE_KINDS`, `tier` query | server-side policy over who badges; the UI owns it |
| **−** | `openCount` `badgeCount` `unreadCount` `activityUnreadCount` `latestOccurrence*` | five pre-summed fields, two of them always equal |
| **+** | `kinds` response field | `{ open, unread, latest }` per kind, the raw fact |
| **+** | `kind` query, repeatable | the caller names the kinds it lists |
| **+** | `attentionGroupOf`, `attentionKindsIn` | one map kind → attention / queue / activity |
| **~** | `ActivityAttentionProvider.latest` | the newest row instead of a hardcoded null |

- `mastracode/factory/src/routes/`
  - └─ `attention.ts` — `+18 −58`
  - └─ `attention-activity.ts` — a real `latest`
- `mastracode/factory-ui/src/ui/domains/factory/services/`
  - └─ `attention.ts` — the group map, `attentionCountsIn`, `latestUnreadOrNewestIn`
- `mastracode/factory-ui/e2e/ui/`
  - └─ `attention.ts` — one `attentionKindSummaries(items)` stub builder, replacing seven inline copies

what the reviewer now lives with
&nbsp;&nbsp;&nbsp;&nbsp;`GET …/attention?kind=mention&kind=…` · `kinds: Record<kind, { open, unread, latest }>` on the response · `useFactoryAttention(id, view, limit, group?)` · 400 `invalid_attention_kind`

removed: `tier=badge|activity`, `openCount`, `badgeCount`, `unreadCount`, `activityUnreadCount`, `latestOccurrenceKey/At/Unread`, 400 `invalid_attention_tier`

### Decisions

- **the group map lives in the attention service, not beside the glyph map in the row component** — hooks and pages import it, and a component is the wrong door for them; one move if you disagree
- **mentions stay in the badge and the sound** — someone asked for you by name; drop `mention` from the attention group to file them under Activity
- **the section says "Waiting for approval", not "Queue"** — it is what the row already says; one string away

### Watch

on deploy: nothing to migrate. A tab still running the old bundle sends `tier`, which the route now ignores, so its badge reads zero until the next reload.

### Not verified

- [ ] the changed-tests gate on `main` — `rejects an unknown kind` and the sidebar's parked-run test fail there by construction (the base ignores `kind` and lists `tier=badge`), not rerun against the base checkout here

---

> ██████████████████ **source** `+167 −111` — net +56, all of it the client helpers the route used to sum
> ███████████████ **tests** `+138 −187` — net −49
> █ **changeset** `+5`
