### PR TITLE
chore(factory): Update sync-template to install skill

### DIFF
--- a/mastracode/mastra-factory/scripts/sync-template.mjs
+++ b/mastracode/mastra-factory/scripts/sync-template.mjs
@@ -297,6 +297,27 @@ function writeReadme() {
   fs.copyFileSync(source, path.join(outDir, 'README.md'));
 }
 
+function installFactorySkill() {
+  console.log('sync-template: installing Mastra Factory skill...');
+  execFileSync(
+    'npx',
+    [
+      '--yes',
+      'skills',
+      'add',
+      'mastra-ai/skills',
+      '--skill',
+      'mastra-factory',
+      '--agent',
+      'universal',
+      'claude-code',
+      '--copy',
+      '-y',
+    ],
+    { cwd: outDir, stdio: 'inherit' },
+  );
+}
+
 function copySourceFile(relativePath) {
   const source = path.join(webRoot, relativePath);
   if (!fs.existsSync(source)) throw new Error(`sync-template: source file not found: ${source}`);
@@ -328,6 +349,7 @@ writeGitignore();
 writeNpmrc();
 writePnpmWorkspace();
 writeReadme();
+installFactorySkill();
 
 console.log(`sync-template: done. Template written to ${outDir}`);
 console.log('The sync-softwarefactory-template workflow pushes this to the template repo on main.');


### PR DESCRIPTION
## Description

Once https://github.com/mastra-ai/skills/pull/14 is merged we can also merge this PR to add the new skill to new factory templates

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

New factory templates now include the Mastra Factory skill automatically. This helps users start with the correct skills for Universal and Claude Code agents.

## Changes

- Added `installFactorySkill` to `sync-template.mjs`.
- Runs `npx skills add` in the generated output directory.
- Installs the skill for Universal and Claude Code agents.
- Runs after template files are written.

This change depends on `mastra-ai/skills#14`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->