### PR TITLE
feat(factory): read parked runs live into Needs attention

### DIFF
--- a/.changeset/session-park-live.md
+++ b/.changeset/session-park-live.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+A Factory run parked on a plan or a question now shows up in Needs attention as an "agent waiting" item that opens the thread, and leaves the inbox by itself once someone answers. The card's wick and the sidebar row read "Waiting on you" meanwhile. Before, the dispatcher recorded the pause as a failed automation with a retry button that could do nothing, and the row stayed after the answer.

--- a/mastracode/factory-ui/src/hooks/__tests__/useWorkItems.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useWorkItems.msw.test.tsx
@@ -8,7 +8,7 @@ import { queryKeys } from '../../api/keys';
 import type { BoardSnapshot, WorkItem } from '../../ui/domains/factory/services/workItems';
 import { useDeleteWorkItemMutation, useRunningSessions, useTransitionWorkItemMutation } from '../useWorkItems';
 
-const board = (workItems: WorkItem[]): BoardSnapshot => ({ workItems, runningSessionIds: [] });
+const board = (workItems: WorkItem[]): BoardSnapshot => ({ workItems, runningSessionIds: [], parkedSessionIds: [] });
 
 const PROJECT_ID = 'project-1';
 const ITEM_ID = 'item-1';

--- a/mastracode/factory-ui/src/hooks/useWorkItems.ts
+++ b/mastracode/factory-ui/src/hooks/useWorkItems.ts
@@ -32,11 +32,11 @@ function requireFactoryProjectId(factoryProjectId: string | undefined): string {
   return factoryProjectId;
 }
 
-/** Rewrite the cached board's cards, keeping the run activity read alongside them. */
+/** Rewrite the cached board's cards, keeping the session activity read alongside them. */
 function patchCards(queryClient: QueryClient, listKey: QueryKey, patch: (cards: WorkItem[]) => WorkItem[]) {
   // Returning undefined skips the write: never seed a partial board before the list query loads.
   queryClient.setQueryData<BoardSnapshot>(listKey, board =>
-    board ? { runningSessionIds: board.runningSessionIds, workItems: patch(board.workItems) } : undefined,
+    board ? { ...board, workItems: patch(board.workItems) } : undefined,
   );
 }
 
@@ -56,7 +56,8 @@ export function stripCachedSessionRefs(queryClient: QueryClient, factoryProjectI
 // rebuilding it (and, for the set, breaking referential equality) per render.
 const selectCards = (board: BoardSnapshot) => board.workItems;
 const selectRunningSessions = (board: BoardSnapshot): ReadonlySet<string> => new Set(board.runningSessionIds);
-const NO_RUNNING_SESSIONS: ReadonlySet<string> = new Set();
+const selectParkedSessions = (board: BoardSnapshot): ReadonlySet<string> => new Set(board.parkedSessionIds);
+const NO_SESSIONS: ReadonlySet<string> = new Set();
 
 export function boardQueryOptions(baseUrl: string, factoryProjectId: string | undefined) {
   return queryOptions({
@@ -84,7 +85,14 @@ export function useWorkItemsQuery(factoryProjectId: string | undefined) {
 export function useRunningSessions(factoryProjectId: string | undefined): ReadonlySet<string> {
   const { baseUrl } = useApiConfig();
   const { data } = useQuery({ ...boardQueryOptions(baseUrl, factoryProjectId), select: selectRunningSessions });
-  return data ?? NO_RUNNING_SESSIONS;
+  return data ?? NO_SESSIONS;
+}
+
+/** Sessions parked on a plan or a question, read with the cards so a card and its marker agree. */
+export function useParkedSessions(factoryProjectId: string | undefined): ReadonlySet<string> {
+  const { baseUrl } = useApiConfig();
+  const { data } = useQuery({ ...boardQueryOptions(baseUrl, factoryProjectId), select: selectParkedSessions });
+  return data ?? NO_SESSIONS;
 }
 
 /**

--- a/mastracode/factory-ui/src/ui/domains/factory/components/AttentionItemRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/AttentionItemRow.tsx
@@ -8,6 +8,7 @@ import {
   ArchiveRestore,
   Brain,
   Check,
+  Hourglass,
   MailOpen,
   MessageSquare,
   MessagesSquare,
@@ -33,6 +34,7 @@ const KIND = {
   'automation-failed': { glyph: TriangleAlert, label: 'failed', tone: 'text-error', badge: 'red' },
   'automation-proposed': { glyph: Sparkles, label: 'suggested', tone: 'text-warning1', badge: 'orange' },
   'supervisor-finding': { glyph: Brain, label: 'finding', tone: 'text-accent1', badge: 'blue' },
+  'agent-waiting': { glyph: Hourglass, label: 'waiting', tone: 'text-warning1', badge: 'orange' },
 } satisfies Record<
   FactoryAttentionItem['kind'],
   { glyph: typeof MessageSquare; label: string; tone: string; badge: BadgeVariant }

--- a/mastracode/factory-ui/src/ui/domains/factory/components/OverviewLists.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/OverviewLists.tsx
@@ -1,7 +1,7 @@
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { GithubIcon } from '@mastra/playground-ui/icons/GithubIcon';
-import { Bot, Brain, CircleAlert, MessageSquare, Sparkles, User, Zap } from 'lucide-react';
+import { Bot, Brain, CircleAlert, Hourglass, MessageSquare, Sparkles, User, Zap } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useState, type ReactNode } from 'react';
 import { Link } from 'react-router';
@@ -227,6 +227,7 @@ const ATTENTION_GLYPHS: Record<FactoryAttentionItem['kind'], { Glyph: LucideIcon
   'automation-proposed': { Glyph: Sparkles, tone: 'text-warning1', label: 'Suggested run' },
   'supervisor-finding': { Glyph: Brain, tone: 'text-accent1', label: 'Supervisor finding' },
   activity: { Glyph: MessageSquare, tone: 'text-icon3', label: 'Comment' },
+  'agent-waiting': { Glyph: Hourglass, tone: 'text-warning1', label: 'Agent waiting' },
 };
 
 /** What landed. Unread lives at the row's edge instead, so the titles stay aligned. */

--- a/mastracode/factory-ui/src/ui/domains/factory/hooks/useItemSessionStatuses.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/hooks/useItemSessionStatuses.ts
@@ -1,4 +1,5 @@
 import { useActiveRunResources } from '../../../../hooks/useActiveRunResources';
+import { useParkedSessions } from '../../../../hooks/useWorkItems';
 import { allSessionRows, useWorkspacesQuery } from '../../../../hooks/useWorkspaces';
 import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
 import { sessionRowStatus } from '../../workspaces/services/sessionStatus';
@@ -7,13 +8,15 @@ import type { WorkItem } from '../services/workItems';
 
 /**
  * Live status per board card, from the same inputs the sidebar rows read: the
- * shared controller poll and the workspace records. A card waiting on a person
- * speaks through its own status row, not through the wick.
+ * shared controller poll, the workspace records and the board's parked sessions.
+ * A parked rule speaks through the card's own status row, not through the wick.
  */
 export function useItemSessionStatuses({
+  factoryProjectId,
   projectRepositoryId,
   items,
 }: {
+  factoryProjectId: string;
   projectRepositoryId: string;
   items: readonly WorkItem[];
 }): ReadonlyMap<string, SessionRowStatus> {
@@ -22,6 +25,7 @@ export function useItemSessionStatuses({
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceIds: boundSessionIds,
   });
+  const parkedSessionIds = useParkedSessions(factoryProjectId);
   const workspaces = useWorkspacesQuery(projectRepositoryId);
   const materializingSessionIds = new Set(
     allSessionRows(workspaces.data)
@@ -36,6 +40,7 @@ export function useItemSessionStatuses({
     const status = sessionRowStatus({
       running: refs.some(ref => runningBySessionId[ref.sessionId] === true),
       initializing: refs.some(ref => materializingSessionIds.has(ref.sessionId)),
+      attention: refs.some(ref => parkedSessionIds.has(ref.sessionId)),
     });
     if (status !== undefined) statuses.set(item.id, status);
   }

--- a/mastracode/factory-ui/src/ui/domains/factory/services/attention.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/attention.ts
@@ -62,7 +62,18 @@ export interface FactorySupervisorFindingAttentionItem extends FactoryAttentionI
   suggestedRepair: FactoryHealthRepair | null;
 }
 
+/** A run parked on a plan or a question: the item lives exactly as long as the answer is owed. */
+export interface FactoryAgentWaitingAttentionItem extends FactoryAttentionItemBase {
+  kind: 'agent-waiting';
+  workItemId: string;
+  sessionId: string;
+  threadId: string;
+  role: string;
+  toolName: string;
+}
+
 export type FactoryAttentionItem =
+  | FactoryAgentWaitingAttentionItem
   | FactoryAutomationFailedAttentionItem
   | FactoryAutomationProposedAttentionItem
   | FactoryMentionAttentionItem
@@ -85,6 +96,8 @@ export function attentionItemSourceId(item: FactoryAttentionItem): string {
       return item.decisionId;
     case 'supervisor-finding':
       return item.findingKey;
+    case 'agent-waiting':
+      return item.sessionId;
   }
 }
 

--- a/mastracode/factory-ui/src/ui/domains/factory/services/workItems.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/workItems.ts
@@ -191,6 +191,8 @@ export interface UpdateWorkItemInput {
 export interface BoardSnapshot {
   workItems: WorkItem[];
   runningSessionIds: string[];
+  /** Sessions parked on a tool until someone answers, read live with the cards. */
+  parkedSessionIds: string[];
 }
 
 /** List the org's work items for a Factory project. */
@@ -199,11 +201,16 @@ export async function listWorkItems(
   factoryProjectId: string,
   signal?: AbortSignal,
 ): Promise<BoardSnapshot> {
-  const data = await requestJson<{ workItems: WireWorkItem[]; runningSessionIds?: string[] }>(
-    `${baseUrl}/web/factory/projects/${encodeURIComponent(factoryProjectId)}/work-items`,
-    { signal },
-  );
-  return { workItems: data.workItems.map(fromWireWorkItem), runningSessionIds: data.runningSessionIds ?? [] };
+  const data = await requestJson<{
+    workItems: WireWorkItem[];
+    runningSessionIds?: string[];
+    parkedSessionIds?: string[];
+  }>(`${baseUrl}/web/factory/projects/${encodeURIComponent(factoryProjectId)}/work-items`, { signal });
+  return {
+    workItems: data.workItems.map(fromWireWorkItem),
+    runningSessionIds: data.runningSessionIds ?? [],
+    parkedSessionIds: data.parkedSessionIds ?? [],
+  };
 }
 
 /** Create a work item; the server upserts on its external source identity so repeats reuse the card. */

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -9,7 +9,7 @@ import { useLocation, useNavigate, useParams } from 'react-router';
 
 import { useFactoryAuth } from '../../../../hooks/useFactoryAuth';
 import { useActiveRunResources } from '../../../../hooks/useActiveRunResources';
-import { useWorkItemsQuery } from '../../../../hooks/useWorkItems';
+import { useParkedSessions, useWorkItemsQuery } from '../../../../hooks/useWorkItems';
 import { useWorkspacePullRequestMerges } from '../../../../hooks/useWorkspacePullRequestMerges';
 import { useDeleteWorkspaceMutation, useWorkspacesQuery } from '../../../../hooks/useWorkspaces';
 import { useChatSessionContext } from '../../chat/context/useChatSessionContext';
@@ -73,6 +73,7 @@ export function WorkspacesSection() {
   const viewerUserId = auth.data?.user?.userId;
   const { pinnedSessions, setPinned } = usePinnedSessions();
   const workItems = useWorkItemsQuery(factoryId);
+  const parkedSessions = useParkedSessions(factoryId);
   const workspaceRows = workspaces.data?.workspaces ?? [];
   const workspaceIds = workspaceRows.map(workspace => workspace.sessionId);
   const runningByPath = useActiveRunResources({
@@ -115,7 +116,9 @@ export function WorkspacesSection() {
         active,
         initializing,
         running,
-        attention: item !== undefined && itemAwaitsPerson(proposalByItem.get(item.id), effectByItem.get(item.id)),
+        attention:
+          parkedSessions.has(workspace.sessionId) ||
+          (item !== undefined && itemAwaitsPerson(proposalByItem.get(item.id), effectByItem.get(item.id))),
         review: getFactorySessionKind(workspace, item) === 'review',
         itemLabel: item && item.source !== 'manual' ? relationshipLabel(item) : undefined,
         itemTitle: item?.title,

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspacesSectionOrder.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspacesSectionOrder.msw.test.tsx
@@ -74,13 +74,14 @@ function stubSidebar(
   sessions: FactoryUserSession[],
   workItems: ReturnType<typeof reviewCard>[],
   runningSessionIds: string[] = [],
+  parkedSessionIds: string[] = [],
 ) {
   server.use(
     http.get(`${TEST_BASE_URL}/web/github/projects/${projectRepositoryId}/sessions`, () =>
       HttpResponse.json({ sessions }),
     ),
     http.get(`${TEST_BASE_URL}/web/factory/projects/${factoryProjectId}/work-items`, () =>
-      HttpResponse.json({ workItems }),
+      HttpResponse.json({ workItems, parkedSessionIds }),
     ),
     http.get(`${TEST_BASE_URL}/api/agent-controller/code/active-runs`, () =>
       HttpResponse.json({
@@ -164,6 +165,23 @@ describe('Workspaces sidebar order', () => {
     const { client } = renderSection();
 
     expect(await reviewRowLabels(client)).toEqual(['factory/pr-302', 'factory/pr-301']);
+  });
+
+  it('keeps a merged session up top while its agent waits on an answer', async () => {
+    const openSession = reviewSession(401, '2026-07-23T11:00:00.000Z');
+    const mergedButParked = reviewSession(402, '2026-07-23T09:00:00.000Z');
+
+    stubSidebar(
+      [openSession, mergedButParked],
+      [reviewCard(openSession, 401), reviewCard(mergedButParked, 402, '2026-07-23T23:00:00.000Z')],
+      [],
+      [mergedButParked.sessionId],
+    );
+
+    const { client } = renderSection();
+
+    expect(await reviewRowLabels(client)).toEqual(['factory/pr-402', 'factory/pr-401']);
+    expect(screen.getByRole('status', { name: /^factory\/pr-402 waiting on you$/i })).toBeInTheDocument();
   });
 
   it('leaves the open session where creation order put it', async () => {

--- a/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
@@ -134,6 +134,7 @@ function BoardContent({
   const runs = useBoardRuns({ factoryProjectId, refetchItems: items.refetch });
   const relatedItemsFor = relatedWorkItemIndex(items.all);
   const sessionStatuses = useItemSessionStatuses({
+    factoryProjectId,
     projectRepositoryId: repository.projectRepositoryId,
     items: items.all,
   });

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -79,6 +79,7 @@ import { handleServerError } from './server-error.js';
 import { observeSessionFilesystem } from './session/filesystem-capture.js';
 import { observeSessionFirstExec } from './session/first-exec-capture.js';
 import { observeSessionFirstMessage } from './session/first-message-capture.js';
+import { LiveSessions } from './session/live-sessions.js';
 import { hydrateSessionMemorySettings } from './session/memory-settings-hydration.js';
 import { hydrateSessionModelPack } from './session/model-pack-hydration.js';
 import { observeSessionThreadTitle } from './session/thread-title-mirror.js';
@@ -304,6 +305,16 @@ function parentDomainFromPublicUrl(publicUrl: string): string | undefined {
     if (hostname.endsWith(`.${parent}`)) return `.${parent}`;
   }
   return undefined;
+}
+
+/** A session parking or being answered is inbox news, so the registry bumps the project's feed. */
+function liveSessionsTouchingTheFeed(controller: BuildApiRoutesDeps['controller'], eventBus: PubSub): LiveSessions {
+  const liveSessions = new LiveSessions(controller);
+  liveSessions.onParkedChanged(session => {
+    const { factoryOrgId, factoryProjectId } = session.state.get();
+    if (factoryOrgId && factoryProjectId) touchFeed(eventBus, { orgId: factoryOrgId, factoryProjectId });
+  });
+  return liveSessions;
 }
 
 export class MastraFactory {
@@ -894,6 +905,7 @@ export class MastraFactory {
           ...assembleFactoryApiRoutes({
             controllerId: CONTROLLER_ID,
             controller,
+            liveSessions: liveSessionsTouchingTheFeed(controller, eventBus),
             auth: routeAuth,
             ...(auth && isUserProvider(auth) ? { users: auth } : {}),
             authStorage,

--- a/mastracode/factory/src/routes/attention-parked.ts
+++ b/mastracode/factory/src/routes/attention-parked.ts
@@ -42,7 +42,7 @@ function parkedRunLabel(toolName: string): string {
 function olderThan(entry: ParkedSession, before: AttentionStreamPosition | undefined): boolean {
   if (!before) return true;
   const gap = entry.occurredAt.getTime() - before.occurredAt.getTime();
-  return gap < 0 || (gap === 0 && entry.sessionId < before.id);
+  return gap < 0 || (gap === 0 && entry.sessionId.localeCompare(before.id) > 0);
 }
 
 function toItem(scope: AttentionScope, { entry, receipt }: ReceiptedParkedSession): Record<string, unknown> {
@@ -67,14 +67,14 @@ function toItem(scope: AttentionScope, { entry, receipt }: ReceiptedParkedSessio
 export class ParkedRunAttentionProvider implements AttentionProvider {
   readonly kind = 'agent-waiting' as const;
   readonly #workItems: WorkItemsStorage;
-  readonly #liveSessions: Pick<LiveSessions, 'parked'>;
+  readonly #liveSessions: Pick<LiveSessions, 'parkedIn'>;
 
   constructor({
     workItems,
     liveSessions,
   }: {
     workItems: WorkItemsStorage;
-    liveSessions: Pick<LiveSessions, 'parked'>;
+    liveSessions: Pick<LiveSessions, 'parkedIn'>;
   }) {
     this.#workItems = workItems;
     this.#liveSessions = liveSessions;
@@ -82,11 +82,15 @@ export class ParkedRunAttentionProvider implements AttentionProvider {
 
   /** Newest park first. A session bound to several cards is listed once, under the first card. */
   async #parked(scope: AttentionScope): Promise<ParkedSession[]> {
+    const runBySession = new Map(
+      this.#liveSessions.parkedIn(scope.factoryProjectId).map(({ sessionId, run }) => [sessionId, run]),
+    );
+    if (runBySession.size === 0) return [];
     const items = await this.#workItems.list({ orgId: scope.orgId, factoryProjectId: scope.factoryProjectId });
     const bySession = new Map<string, ParkedSession>();
     for (const item of items) {
       for (const [role, ref] of Object.entries(item.sessions)) {
-        const run = this.#liveSessions.parked(ref.sessionId);
+        const run = runBySession.get(ref.sessionId);
         if (!run || bySession.has(ref.sessionId)) continue;
         bySession.set(ref.sessionId, {
           item,
@@ -153,8 +157,11 @@ export class ParkedRunAttentionProvider implements AttentionProvider {
     return { entries, hasMore: false };
   }
 
-  async markAllRead(scope: AttentionScope, { now }: { now: Date }): Promise<{ hasMore: boolean }> {
-    const parked = await this.#parked(scope);
+  async markAllRead(
+    scope: AttentionScope,
+    { before, now }: { before?: AttentionStreamPosition; now: Date },
+  ): Promise<{ hasMore: boolean }> {
+    const parked = (await this.#parked(scope)).filter(entry => olderThan(entry, before));
     if (parked.length > 0) {
       await this.#workItems.markAttentionReceiptsRead({
         ...receiptScope(scope),

--- a/mastracode/factory/src/routes/attention-parked.ts
+++ b/mastracode/factory/src/routes/attention-parked.ts
@@ -1,0 +1,167 @@
+/** Sessions parked on a tool, read live from the registry: the item exists exactly as long as an answer is owed. */
+
+import type { LiveSessions } from '../session/live-sessions.js';
+import type {
+  FactoryAttentionIdentity,
+  FactoryAttentionReceiptRecord,
+  WorkItemRow,
+  WorkItemsStorage,
+} from '../storage/domains/work-items/base.js';
+import { factoryAgentWaitingAttentionIdentity, factoryAttentionKey } from '../storage/domains/work-items/base.js';
+import type {
+  AttentionCounts,
+  AttentionEntry,
+  AttentionLatest,
+  AttentionPageArgs,
+  AttentionPageResult,
+  AttentionProvider,
+  AttentionScope,
+  AttentionStreamPosition,
+} from './attention-providers.js';
+import { matchesView, receiptScope } from './attention-providers.js';
+
+interface ParkedSession {
+  item: WorkItemRow;
+  role: string;
+  sessionId: string;
+  threadId: string;
+  toolName: string;
+  occurredAt: Date;
+  identity: FactoryAttentionIdentity;
+}
+
+interface ReceiptedParkedSession {
+  entry: ParkedSession;
+  receipt: FactoryAttentionReceiptRecord | undefined;
+}
+
+function parkedRunLabel(toolName: string): string {
+  return toolName === 'submit_plan' ? 'Plan waiting for review' : 'Agent is waiting for an answer';
+}
+
+function olderThan(entry: ParkedSession, before: AttentionStreamPosition | undefined): boolean {
+  if (!before) return true;
+  const gap = entry.occurredAt.getTime() - before.occurredAt.getTime();
+  return gap < 0 || (gap === 0 && entry.sessionId < before.id);
+}
+
+function toItem(scope: AttentionScope, { entry, receipt }: ReceiptedParkedSession): Record<string, unknown> {
+  return {
+    key: factoryAttentionKey(scope.factoryProjectId, entry.identity),
+    kind: 'agent-waiting' as const,
+    sessionId: entry.sessionId,
+    threadId: entry.threadId,
+    role: entry.role,
+    toolName: entry.toolName,
+    occurrence: entry.identity.occurrence,
+    workItemId: entry.item.id,
+    title: entry.item.title,
+    detail: parkedRunLabel(entry.toolName),
+    occurredAt: entry.occurredAt.toISOString(),
+    read: receipt !== undefined,
+    archived: receipt?.state === 'archived',
+    target: { kind: 'thread' as const, sessionId: entry.sessionId, threadId: entry.threadId },
+  };
+}
+
+export class ParkedRunAttentionProvider implements AttentionProvider {
+  readonly kind = 'agent-waiting' as const;
+  readonly #workItems: WorkItemsStorage;
+  readonly #liveSessions: Pick<LiveSessions, 'parked'>;
+
+  constructor({
+    workItems,
+    liveSessions,
+  }: {
+    workItems: WorkItemsStorage;
+    liveSessions: Pick<LiveSessions, 'parked'>;
+  }) {
+    this.#workItems = workItems;
+    this.#liveSessions = liveSessions;
+  }
+
+  /** Newest park first. A session bound to several cards is listed once, under the first card. */
+  async #parked(scope: AttentionScope): Promise<ParkedSession[]> {
+    const items = await this.#workItems.list({ orgId: scope.orgId, factoryProjectId: scope.factoryProjectId });
+    const bySession = new Map<string, ParkedSession>();
+    for (const item of items) {
+      for (const [role, ref] of Object.entries(item.sessions)) {
+        const run = this.#liveSessions.parked(ref.sessionId);
+        if (!run || bySession.has(ref.sessionId)) continue;
+        bySession.set(ref.sessionId, {
+          item,
+          role,
+          sessionId: ref.sessionId,
+          threadId: ref.threadId,
+          toolName: run.toolName,
+          occurredAt: new Date(run.suspendedAt),
+          identity: factoryAgentWaitingAttentionIdentity(ref.sessionId, run.suspendedAt),
+        });
+      }
+    }
+    return [...bySession.values()].sort(
+      (a, b) => b.occurredAt.getTime() - a.occurredAt.getTime() || a.sessionId.localeCompare(b.sessionId),
+    );
+  }
+
+  async #withReceipts(scope: AttentionScope, parked: ParkedSession[]): Promise<ReceiptedParkedSession[]> {
+    const receipts = await this.#workItems.listAttentionReceipts({
+      ...receiptScope(scope),
+      identities: parked.map(entry => entry.identity),
+    });
+    const byKey = new Map(receipts.map(receipt => [factoryAttentionKey(scope.factoryProjectId, receipt), receipt]));
+    return parked.map(entry => ({
+      entry,
+      receipt: byKey.get(factoryAttentionKey(scope.factoryProjectId, entry.identity)),
+    }));
+  }
+
+  async counts(scope: AttentionScope): Promise<AttentionCounts> {
+    let open = 0;
+    let unread = 0;
+    for (const { receipt } of await this.#withReceipts(scope, await this.#parked(scope))) {
+      if (receipt?.state !== 'archived') open += 1;
+      if (receipt === undefined) unread += 1;
+    }
+    return { open, unread };
+  }
+
+  async latest(scope: AttentionScope): Promise<AttentionLatest | null> {
+    const [newest] = await this.#withReceipts(scope, (await this.#parked(scope)).slice(0, 1));
+    if (!newest) return null;
+    return {
+      key: factoryAttentionKey(scope.factoryProjectId, newest.entry.identity),
+      at: newest.entry.occurredAt,
+      unread: newest.receipt === undefined,
+    };
+  }
+
+  async page(scope: AttentionScope, { view, search, before, limit }: AttentionPageArgs): Promise<AttentionPageResult> {
+    const parked = (await this.#parked(scope)).filter(entry => olderThan(entry, before));
+    const entries: AttentionEntry[] = [];
+    for (const receipted of await this.#withReceipts(scope, parked)) {
+      const { entry, receipt } = receipted;
+      if (!matchesView(view, receipt)) continue;
+      if (search && !`${entry.item.title} ${parkedRunLabel(entry.toolName)}`.toLowerCase().includes(search)) continue;
+      if (entries.length === limit) return { entries, hasMore: true };
+      entries.push({
+        occurredAt: entry.occurredAt,
+        resumeCursor: { occurredAt: entry.occurredAt, id: entry.sessionId },
+        item: toItem(scope, receipted),
+      });
+    }
+    return { entries, hasMore: false };
+  }
+
+  async markAllRead(scope: AttentionScope, { now }: { now: Date }): Promise<{ hasMore: boolean }> {
+    const parked = await this.#parked(scope);
+    if (parked.length > 0) {
+      await this.#workItems.markAttentionReceiptsRead({
+        ...receiptScope(scope),
+        identities: parked.map(entry => entry.identity),
+        now,
+      });
+    }
+    return { hasMore: false };
+  }
+}

--- a/mastracode/factory/src/routes/attention.test.ts
+++ b/mastracode/factory/src/routes/attention.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { builtInFactoryRules } from '../rules/defaults.js';
 import { FactoryTransitionService } from '../rules/transition-service.js';
+import type { ParkedRun } from '../session/live-sessions.js';
 import type { FactoryDeferredDecisionRecord, WorkItemRow } from '../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
 import type { FactoryStorageTestSeed } from '../storage/test-utils.js';
@@ -19,6 +20,8 @@ const orgUser = { workosId: 'u1', organizationId: 'org1' };
 
 let seed: FactoryStorageTestSeed;
 let PROJECT_ID = '';
+
+const parkedBySession = new Map<string, ParkedRun>();
 
 function buildApp(user: typeof orgUser | null = orgUser) {
   const app = new Hono();
@@ -36,7 +39,7 @@ function buildApp(user: typeof orgUser | null = orgUser) {
       comments: seed.comments,
       queueHealth: seed.queueHealth,
       transitionService: new FactoryTransitionService({ rules: builtInFactoryRules(), storage: seed.workItems }),
-      liveSessions: { isRunning: () => false },
+      liveSessions: { isRunning: () => false, parked: sessionId => parkedBySession.get(sessionId) },
     }).routes(),
   );
   return app;
@@ -178,6 +181,75 @@ describe('supervisor finding attention items', () => {
     await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
       { items: [], openCount: 0 },
     );
+  });
+});
+
+describe('agent waiting attention items', () => {
+  const sessionId = '6f1a2b3c-4d5e-4f60-8a71-92b3c4d5e6f7';
+  const suspendedAt = new Date('2030-01-01T00:00:00.000Z').getTime();
+
+  beforeEach(() => parkedBySession.clear());
+
+  it('lists a parked session in the badge, opens its thread, and leaves once it is answered', async () => {
+    const item = await seedWorkItem('Ship the login fix');
+    await seed.workItems.update({
+      orgId: 'org1',
+      userId: 'u1',
+      id: item.id,
+      patch: { sessions: { work: { sessionId, branch: 'factory/login', threadId: 'thread-1' } } },
+    });
+    parkedBySession.set(sessionId, { toolName: 'submit_plan', suspendedAt });
+
+    const open = await (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json();
+    expect(open).toMatchObject({
+      items: [
+        {
+          kind: 'agent-waiting',
+          sessionId,
+          threadId: 'thread-1',
+          role: 'work',
+          toolName: 'submit_plan',
+          occurrence: suspendedAt,
+          workItemId: item.id,
+          title: 'Ship the login fix',
+          detail: 'Plan waiting for review',
+          occurredAt: '2030-01-01T00:00:00.000Z',
+          read: false,
+          target: { kind: 'thread', sessionId, threadId: 'thread-1' },
+        },
+      ],
+      openCount: 1,
+      badgeCount: 1,
+      unreadCount: 1,
+    });
+
+    const receiptPath = `/web/factory/projects/${PROJECT_ID}/attention/agent-waiting/${sessionId}/${suspendedAt}`;
+    expect((await request('POST', `${receiptPath}/read`)).status).toBe(200);
+    await expect(
+      (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?view=unread`)).json(),
+    ).resolves.toMatchObject({ items: [], unreadCount: 0, openCount: 1 });
+
+    parkedBySession.delete(sessionId);
+    await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
+      { items: [], openCount: 0, badgeCount: 0 },
+    );
+    expect((await request('POST', `${receiptPath}/archive`)).status).toBe(409);
+  });
+
+  it('409s a receipt for a park that has since been answered and re-parked', async () => {
+    const item = await seedWorkItem('Answer me');
+    await seed.workItems.update({
+      orgId: 'org1',
+      userId: 'u1',
+      id: item.id,
+      patch: { sessions: { work: { sessionId, branch: 'factory/answer', threadId: 'thread-1' } } },
+    });
+    parkedBySession.set(sessionId, { toolName: 'ask_user', suspendedAt: suspendedAt + 1_000 });
+
+    const stale = `/web/factory/projects/${PROJECT_ID}/attention/agent-waiting/${sessionId}/${suspendedAt}/read`;
+    expect((await request('POST', stale)).status).toBe(409);
+    const open = await (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?view=unread`)).json();
+    expect(open).toMatchObject({ items: [{ detail: 'Agent is waiting for an answer' }], unreadCount: 1 });
   });
 });
 

--- a/mastracode/factory/src/routes/attention.test.ts
+++ b/mastracode/factory/src/routes/attention.test.ts
@@ -39,7 +39,11 @@ function buildApp(user: typeof orgUser | null = orgUser) {
       comments: seed.comments,
       queueHealth: seed.queueHealth,
       transitionService: new FactoryTransitionService({ rules: builtInFactoryRules(), storage: seed.workItems }),
-      liveSessions: { isRunning: () => false, parked: sessionId => parkedBySession.get(sessionId) },
+      liveSessions: {
+        isRunning: () => false,
+        parked: sessionId => parkedBySession.get(sessionId),
+        parkedIn: () => [...parkedBySession].map(([sessionId, run]) => ({ sessionId, run })),
+      },
     }).routes(),
   );
   return app;
@@ -234,6 +238,59 @@ describe('agent waiting attention items', () => {
       { items: [], openCount: 0, badgeCount: 0 },
     );
     expect((await request('POST', `${receiptPath}/archive`)).status).toBe(409);
+  });
+
+  it('pages two sessions parked in the same millisecond without repeating or losing one', async () => {
+    const otherSessionId = '7a1a2b3c-4d5e-4f60-8a71-92b3c4d5e6f7';
+    for (const [title, id] of [
+      ['First card', sessionId],
+      ['Second card', otherSessionId],
+    ] as const) {
+      const item = await seedWorkItem(title);
+      await seed.workItems.update({
+        orgId: 'org1',
+        userId: 'u1',
+        id: item.id,
+        patch: { sessions: { work: { sessionId: id, branch: `factory/${id}`, threadId: 'thread-1' } } },
+      });
+      parkedBySession.set(id, { toolName: 'ask_user', suspendedAt });
+    }
+
+    const first = await (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?limit=1`)).json();
+    expect(first.items.map((entry: any) => entry.sessionId)).toEqual([sessionId]);
+    expect(first.hasMore).toBe(true);
+    const second = await (
+      await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?limit=1&before=${first.nextCursor}`)
+    ).json();
+    expect(second.items.map((entry: any) => entry.sessionId)).toEqual([otherSessionId]);
+    expect(second.hasMore).toBe(false);
+  });
+
+  it('read-all with a cursor leaves the parks newer than the cursor unread', async () => {
+    const newerSessionId = '7a1a2b3c-4d5e-4f60-8a71-92b3c4d5e6f7';
+    for (const [title, id, at] of [
+      ['Older park', sessionId, suspendedAt],
+      ['Newer park', newerSessionId, suspendedAt + 1_000],
+    ] as const) {
+      const item = await seedWorkItem(title);
+      await seed.workItems.update({
+        orgId: 'org1',
+        userId: 'u1',
+        id: item.id,
+        patch: { sessions: { work: { sessionId: id, branch: `factory/${id}`, threadId: 'thread-1' } } },
+      });
+      parkedBySession.set(id, { toolName: 'ask_user', suspendedAt: at });
+    }
+
+    const first = await (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?limit=1`)).json();
+    expect(first.items.map((entry: any) => entry.sessionId)).toEqual([newerSessionId]);
+    const readAll = await request(
+      'POST',
+      `/web/factory/projects/${PROJECT_ID}/attention/read-all?before=${first.nextCursor}`,
+    );
+    expect(readAll.status).toBe(200);
+    const unread = await (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?view=unread`)).json();
+    expect(unread.items.map((entry: any) => entry.sessionId)).toEqual([newerSessionId]);
   });
 
   it('409s a receipt for a park that has since been answered and re-parked', async () => {

--- a/mastracode/factory/src/routes/attention.ts
+++ b/mastracode/factory/src/routes/attention.ts
@@ -43,7 +43,7 @@ const MAX_PAGE_SIZE = 50;
 interface AttentionRouteDependencies {
   workItems: WorkItemsStorage;
   comments: WorkItemCommentsStorage;
-  liveSessions: Pick<LiveSessions, 'parked'>;
+  liveSessions: Pick<LiveSessions, 'parked' | 'parkedIn'>;
   resolveProject(context: unknown): Promise<AttentionScope | { response: Response }>;
 }
 

--- a/mastracode/factory/src/routes/attention.ts
+++ b/mastracode/factory/src/routes/attention.ts
@@ -7,6 +7,7 @@
 import type { ApiRoute } from '@mastra/core/server';
 import { registerApiRoute } from '@mastra/core/server';
 
+import type { LiveSessions } from '../session/live-sessions.js';
 import type { WorkItemCommentsStorage } from '../storage/domains/comments/base.js';
 import type {
   FactoryAttentionKind,
@@ -15,6 +16,7 @@ import type {
 } from '../storage/domains/work-items/base.js';
 import { factoryAttentionKey } from '../storage/domains/work-items/base.js';
 import { ActivityAttentionProvider } from './attention-activity.js';
+import { ParkedRunAttentionProvider } from './attention-parked.js';
 import { proposedDecisionAttentionSpec } from './attention-proposed.js';
 import type {
   AttentionLatest,
@@ -41,6 +43,7 @@ const MAX_PAGE_SIZE = 50;
 interface AttentionRouteDependencies {
   workItems: WorkItemsStorage;
   comments: WorkItemCommentsStorage;
+  liveSessions: Pick<LiveSessions, 'parked'>;
   resolveProject(context: unknown): Promise<AttentionScope | { response: Response }>;
 }
 
@@ -64,7 +67,8 @@ function isAttentionKind(value: string): value is FactoryAttentionKind {
     value === 'automation-proposed' ||
     value === 'mention' ||
     value === 'activity' ||
-    value === 'supervisor-finding'
+    value === 'supervisor-finding' ||
+    value === 'agent-waiting'
   );
 }
 
@@ -74,6 +78,7 @@ const BADGE_KINDS: ReadonlySet<FactoryAttentionKind> = new Set([
   'automation-proposed',
   'mention',
   'supervisor-finding',
+  'agent-waiting',
 ]);
 
 type AttentionTier = 'all' | 'badge' | 'activity';
@@ -228,6 +233,9 @@ function receiptRoute(
       if (!kind || !isAttentionKind(kind) || !sourceId || !validSourceId || occurrence === undefined) {
         return context.json({ error: 'invalid_attention_item' }, 422);
       }
+      const stillParked =
+        kind !== 'agent-waiting' || dependencies.liveSessions.parked(sourceId)?.suspendedAt === occurrence;
+      if (!stillParked) return context.json({ error: 'attention_item_not_current' }, 409);
       await dependencies.workItems.ensureReady();
       const receipt = await dependencies.workItems.setAttentionReceipt({
         orgId: resolved.orgId,
@@ -251,13 +259,14 @@ function receiptRoute(
 }
 
 export function buildAttentionRoutes(dependencies: AttentionRouteDependencies): ApiRoute[] {
-  const { workItems, comments } = dependencies;
+  const { workItems, comments, liveSessions } = dependencies;
   const providers: AttentionProvider[] = [
     new DecisionAttentionProvider({ workItems }, failedDecisionAttentionSpec),
     new DecisionAttentionProvider({ workItems }, proposedDecisionAttentionSpec),
     new SupervisorFindingAttentionProvider({ workItems }),
     new MentionAttentionProvider({ workItems, comments }),
     new ActivityAttentionProvider({ workItems, comments }),
+    new ParkedRunAttentionProvider({ workItems, liveSessions }),
   ];
 
   return [

--- a/mastracode/factory/src/routes/supervisor.test.ts
+++ b/mastracode/factory/src/routes/supervisor.test.ts
@@ -35,7 +35,7 @@ function buildApp(user: typeof orgUser | null = orgUser) {
       comments: seed.comments,
       queueHealth: seed.queueHealth,
       transitionService: new FactoryTransitionService({ rules: builtInFactoryRules(), storage: seed.workItems }),
-      liveSessions: { isRunning: () => false },
+      liveSessions: { isRunning: () => false, parked: () => undefined },
     }).routes(),
   );
   return app;

--- a/mastracode/factory/src/routes/supervisor.test.ts
+++ b/mastracode/factory/src/routes/supervisor.test.ts
@@ -35,7 +35,7 @@ function buildApp(user: typeof orgUser | null = orgUser) {
       comments: seed.comments,
       queueHealth: seed.queueHealth,
       transitionService: new FactoryTransitionService({ rules: builtInFactoryRules(), storage: seed.workItems }),
-      liveSessions: { isRunning: () => false, parked: () => undefined },
+      liveSessions: { isRunning: () => false, parked: () => undefined, parkedIn: () => [] },
     }).routes(),
   );
   return app;

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -24,7 +24,7 @@ import {
   resolveFactoryProjectForSession,
 } from '../session/factory-session.js';
 import type { EnsuredFactorySourceSession } from '../session/factory-session.js';
-import { LiveSessions } from '../session/live-sessions.js';
+import type { LiveSessions } from '../session/live-sessions.js';
 import type { StateSigner } from '../state-signing.js';
 import type { AuditEmitter } from '../storage/domains/audit/domain.js';
 import type { ChannelIdentityStorage } from '../storage/domains/channel-identity/base.js';
@@ -79,6 +79,8 @@ export interface IntegrationRegistration {
 export interface FactoryApiRoutesDeps {
   controllerId: string;
   controller: AgentController<MastraCodeState>;
+  /** Registry of the sessions this process holds, owned by the host so it can watch them too. */
+  liveSessions: LiveSessions;
   /** Request-auth seam threaded from the host (no service locator). */
   auth: RouteAuth;
   /** Optional user directory for resolving persisted owners to display profiles. */
@@ -558,7 +560,7 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
           queueHealth: deps.domains.queueHealth,
           transitionService,
           startCoordinator,
-          liveSessions: new LiveSessions(deps.controller),
+          liveSessions: deps.liveSessions,
         }).routes()
       : []),
   ];

--- a/mastracode/factory/src/routes/work-items.test.ts
+++ b/mastracode/factory/src/routes/work-items.test.ts
@@ -55,6 +55,7 @@ function buildApp(
   requestContext?: RequestContext,
   running: ReadonlySet<string> = new Set(),
   boardRegistry: BoardRegistry = createBoardRegistry(),
+  parked: ReadonlySet<string> = new Set(),
 ) {
   const app = new Hono();
   app.use('*', async (c, next) => {
@@ -78,7 +79,10 @@ function buildApp(
         boards: boardRegistry,
       }),
       startCoordinator,
-      liveSessions: { isRunning: sessionId => running.has(sessionId) },
+      liveSessions: {
+        isRunning: sessionId => running.has(sessionId),
+        parked: sessionId => (parked.has(sessionId) ? { toolName: 'ask_user', suspendedAt: 0 } : undefined),
+      },
     }).routes(),
   );
   return app;
@@ -1916,6 +1920,23 @@ describe('run activity on the work-item listing', () => {
     const body = await res.json();
     expect(body.workItems).toHaveLength(2);
     expect(body.runningSessionIds).toEqual(['session-running']);
+    expect(body.parkedSessionIds).toEqual([]);
+  });
+
+  it('reports the listed cards whose session waits on an answer', async () => {
+    await startRun('session-parked');
+    await startRun('session-idle');
+
+    const res = await buildApp(
+      orgUser,
+      undefined,
+      undefined,
+      new Set(),
+      undefined,
+      new Set(['session-parked']),
+    ).request(`/web/factory/projects/${PROJECT_ID}/work-items`);
+
+    expect((await res.json()).parkedSessionIds).toEqual(['session-parked']);
   });
 
   it('reports no activity for a session that belongs to no card in the project', async () => {

--- a/mastracode/factory/src/routes/work-items.test.ts
+++ b/mastracode/factory/src/routes/work-items.test.ts
@@ -49,6 +49,8 @@ import { fakeRouteAuth, mountApiRoutes } from './test-utils.js';
 import { parseCreateWorkItem, parseUpdateWorkItem, WorkItemRoutes } from './work-items.js';
 
 // ── Test harness ─────────────────────────────────────────────────────────
+const PARKED_RUN = { toolName: 'ask_user', suspendedAt: 0 };
+
 function buildApp(
   user: { workosId: string; organizationId?: string } | null,
   startCoordinator?: { prepare: (input: any) => Promise<any> },
@@ -81,7 +83,8 @@ function buildApp(
       startCoordinator,
       liveSessions: {
         isRunning: sessionId => running.has(sessionId),
-        parked: sessionId => (parked.has(sessionId) ? { toolName: 'ask_user', suspendedAt: 0 } : undefined),
+        parked: sessionId => (parked.has(sessionId) ? PARKED_RUN : undefined),
+        parkedIn: () => [...parked].map(sessionId => ({ sessionId, run: PARKED_RUN })),
       },
     }).routes(),
   );

--- a/mastracode/factory/src/routes/work-items.ts
+++ b/mastracode/factory/src/routes/work-items.ts
@@ -70,8 +70,8 @@ export interface WorkItemRoutesDeps extends RouteDependencies {
   transitionService?: Pick<FactoryTransitionService, 'transition' | 'ruleSetVersion'>;
   /** Coordinator that binds a Factory run before dispatching its kickoff. */
   startCoordinator?: Pick<FactoryStartCoordinator, 'prepare'>;
-  /** Materialized sessions, read to report which of the listed cards are being worked. */
-  liveSessions: Pick<LiveSessions, 'isRunning'>;
+  /** Materialized sessions, read to report which of the listed cards are being worked or wait on someone. */
+  liveSessions: Pick<LiveSessions, 'isRunning' | 'parked'>;
 }
 
 /** The card as clients see it, without the dispatcher's internal bookkeeping. */
@@ -86,15 +86,15 @@ function toWireWorkItem(item: WorkItemRow): WorkItemRow {
   return { ...item, metadata: publicWorkItemMetadata(item.metadata) ?? {} };
 }
 
-/** Session ids of the listed cards whose agent run is in flight. */
-function runningSessionIds(items: WorkItemRow[], liveSessions: Pick<LiveSessions, 'isRunning'>): string[] {
-  const running = new Set<string>();
+/** Session ids of the listed cards that the predicate picks, each once. */
+function sessionIdsWhere(items: WorkItemRow[], predicate: (sessionId: string) => boolean): string[] {
+  const picked = new Set<string>();
   for (const item of items) {
     for (const { sessionId } of Object.values(item.sessions)) {
-      if (liveSessions.isRunning(sessionId)) running.add(sessionId);
+      if (predicate(sessionId)) picked.add(sessionId);
     }
   }
-  return [...running];
+  return [...picked];
 }
 
 function loose(c: unknown): Context {
@@ -584,7 +584,8 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
           });
           return c.json({
             workItems: items.map(toWireWorkItem),
-            runningSessionIds: runningSessionIds(items, liveSessions),
+            runningSessionIds: sessionIdsWhere(items, sessionId => liveSessions.isRunning(sessionId)),
+            parkedSessionIds: sessionIdsWhere(items, sessionId => liveSessions.parked(sessionId) !== undefined),
           });
         },
       }),
@@ -658,6 +659,7 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
       ...buildAttentionRoutes({
         workItems,
         comments: this.deps.comments,
+        liveSessions,
         resolveProject: context => this.#resolveProject(loose(context)),
       }),
 

--- a/mastracode/factory/src/routes/work-items.ts
+++ b/mastracode/factory/src/routes/work-items.ts
@@ -71,7 +71,7 @@ export interface WorkItemRoutesDeps extends RouteDependencies {
   /** Coordinator that binds a Factory run before dispatching its kickoff. */
   startCoordinator?: Pick<FactoryStartCoordinator, 'prepare'>;
   /** Materialized sessions, read to report which of the listed cards are being worked or wait on someone. */
-  liveSessions: Pick<LiveSessions, 'isRunning' | 'parked'>;
+  liveSessions: Pick<LiveSessions, 'isRunning' | 'parked' | 'parkedIn'>;
 }
 
 /** The card as clients see it, without the dispatcher's internal bookkeeping. */

--- a/mastracode/factory/src/rules/dispatch-errors.ts
+++ b/mastracode/factory/src/rules/dispatch-errors.ts
@@ -11,8 +11,6 @@ const FAILURE_METADATA = {
   source_repository_missing: { canRetry: true, label: 'Source repository unavailable' },
   unsupported_provider_item: { canRetry: false, label: 'Unsupported provider work item' },
   notification_delivery_failed: { canRetry: true, label: 'Factory message delivery failed' },
-  plan_awaiting_approval: { canRetry: false, label: 'Plan waiting for review' },
-  run_awaiting_input: { canRetry: false, label: 'Agent is waiting for an answer' },
   repository_git_missing: { canRetry: false, label: 'Git is unavailable in the workspace' },
   repository_egress_blocked: { canRetry: false, label: 'Repository network access is blocked' },
   repository_clone_failed: { canRetry: true, label: 'Repository clone failed' },

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -2620,7 +2620,7 @@ describe('FactoryDecisionDispatcher', () => {
     expect((await storage.listDeferredDecisions('org-1', PROJECT_ID))[0]?.status).toBe('succeeded');
   });
 
-  it('fails the run loudly when plan review is on and nobody answers the plan', async () => {
+  it('leaves a plan parked for review and calls the kickoff done', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const { item, transitionService } = await queueDecision(storage, {
       type: 'invokeSkill',
@@ -2641,25 +2641,14 @@ describe('FactoryDecisionDispatcher', () => {
 
     await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
 
-    // The pause is a designed checkpoint, not a crash — but it must be visible:
-    // the decision lands in Needs attention with its reason attached.
     expect(session.respondToToolSuspension).not.toHaveBeenCalled();
     const [record] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
-    expect(record).toMatchObject({ status: 'failed', failureCode: 'plan_awaiting_approval' });
-
-    // Not just the row: the surface a person actually reads.
+    expect(record).toMatchObject({ status: 'succeeded', failureCode: null });
     const provider = new DecisionAttentionProvider({ workItems: storage }, failedDecisionAttentionSpec);
-    const scope = { orgId: 'org-1', factoryProjectId: PROJECT_ID };
-    expect(await provider.counts(scope)).toMatchObject({ open: 1, unread: 1 });
-    const page = await provider.page(scope, { view: 'open', search: undefined, before: undefined, limit: 10 });
-    expect(page.entries[0]?.item).toMatchObject({
-      kind: 'automation-failed',
-      failureCode: 'plan_awaiting_approval',
-      workItemId: record?.workItemId,
-    });
+    expect(await provider.counts({ orgId: 'org-1', factoryProjectId: PROJECT_ID })).toMatchObject({ open: 0 });
   });
 
-  it('escalates a run parked on a question nobody is there to answer', async () => {
+  it('leaves a run parked on a question to whoever reads the inbox', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const { item, transitionService } = await queueDecision(storage, {
       type: 'invokeSkill',
@@ -2682,7 +2671,7 @@ describe('FactoryDecisionDispatcher', () => {
 
     expect(session.respondToToolSuspension).not.toHaveBeenCalled();
     const [record] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
-    expect(record).toMatchObject({ status: 'failed', failureCode: 'run_awaiting_input' });
+    expect(record).toMatchObject({ status: 'succeeded' });
   });
 
   it('auto-approve answers plans, never questions', async () => {
@@ -2710,7 +2699,7 @@ describe('FactoryDecisionDispatcher', () => {
     // the project's behalf would be inventing the answer.
     expect(session.respondToToolSuspension).not.toHaveBeenCalled();
     const [record] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
-    expect(record).toMatchObject({ status: 'failed', failureCode: 'run_awaiting_input' });
+    expect(record).toMatchObject({ status: 'succeeded' });
 
     // And never into failing a person's pause: a person-started run parked on
     // ask_user is that person's question to answer, not a stall.
@@ -2845,7 +2834,7 @@ describe('FactoryDecisionDispatcher', () => {
 
     expect(session.respondToToolSuspension).toHaveBeenCalledTimes(3);
     const [record] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
-    expect(record).toMatchObject({ status: 'failed', failureCode: 'plan_awaiting_approval' });
+    expect(record).toMatchObject({ status: 'succeeded' });
   });
 
   it('never runs a dismissed proposal', async () => {

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -54,26 +54,16 @@ function isTerminalFailure(attempts: number, failureCode: FactoryDispatchFailure
   return attempts >= MAX_ATTEMPTS || !factoryDispatchFailureMetadata(failureCode).canRetry;
 }
 
-/**
- * `await` leaves a pause alone: a person asked for this run and is reading it.
- * `escalate` fails it loudly: nobody is watching an unattended run.
- * Plans are answered separately (`approvePlans`) — a plan has an approvable
- * default, a question does not, so the two never share a policy.
- */
-type ParkedRunPolicy = 'escalate' | 'await';
-
 function watchRun(
   session: Pick<DispatcherSession, 'subscribe' | 'respondToToolSuspension'>,
   {
     timeoutMs,
     approvePlans,
-    onParkedRun,
     onAgentEnd,
     label,
   }: {
     timeoutMs: number;
     approvePlans: boolean;
-    onParkedRun: ParkedRunPolicy;
     onAgentEnd?: () => Promise<boolean>;
     label: string;
   },
@@ -118,7 +108,7 @@ function watchRun(
     /** The run's own verdict, thrown as what the dispatcher should record. */
     async settle(): Promise<void> {
       let observed = await wait();
-      // Exhausting the cap falls through to the escalate branch below.
+      // Past the cap the plan stays parked: the person it waits for sees it in the inbox.
       if (approvePlans) {
         for (let approvals = 0; parked?.toolName === 'submit_plan' && approvals < MAX_PLAN_APPROVALS; approvals += 1) {
           const { toolCallId } = parked;
@@ -127,19 +117,6 @@ function watchRun(
           await session.respondToToolSuspension({ resumeData: { action: 'approved' }, toolCallId });
           observed = await wait();
         }
-      }
-      if (parked !== undefined && (!observed || endReason === 'suspended')) {
-        if (onParkedRun === 'await') return;
-        if (parked.toolName === 'submit_plan') {
-          throw new FactoryDispatchError(
-            'plan_awaiting_approval',
-            'Factory run wrote a plan and is waiting for it to be reviewed.',
-          );
-        }
-        throw new FactoryDispatchError(
-          'run_awaiting_input',
-          `Factory run is waiting on ${parked.toolName} for an answer.`,
-        );
       }
       if (!observed) {
         // A completed decision with no observed run end is exactly the
@@ -760,7 +737,6 @@ export class FactoryDecisionDispatcher {
         const run = watchRun(session, {
           timeoutMs: this.#skillCompletionObservationTimeoutMs,
           approvePlans: await this.#plansAreAutoApproved(record, item),
-          onParkedRun: 'escalate',
           onAgentEnd: () => this.#roleSuperseded(record, decision.role),
           label: 'Factory skill run',
         });
@@ -1180,7 +1156,6 @@ export class FactoryDecisionDispatcher {
           const run = watchRun(session, {
             timeoutMs: this.#skillCompletionObservationTimeoutMs,
             approvePlans: await this.#plansAreAutoApproved(record, item),
-            onParkedRun: 'await',
             label: 'Factory kickoff run',
           });
           const sendKickoff = (dedupeKey: string) =>

--- a/mastracode/factory/src/session/live-sessions.test.ts
+++ b/mastracode/factory/src/session/live-sessions.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import type { AgentControllerEvent } from '@mastra/core/agent-controller';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { LiveSession } from './live-sessions.js';
 import { LiveSessions } from './live-sessions.js';
@@ -20,16 +21,49 @@ function fakeController() {
   };
 }
 
-function fakeSession(id: string, running: { value: boolean }): LiveSession {
-  return { identity: { getId: () => id }, run: { isRunning: () => running.value } };
+function fakeSession(id: string, running: { value: boolean } = { value: false }) {
+  const listeners = new Set<(event: AgentControllerEvent) => void>();
+  const pendingSuspensions = new Map<string, { toolName: string }>();
+  const session: LiveSession = {
+    identity: { getId: () => id },
+    run: { isRunning: () => running.value },
+    state: { get: () => ({ factoryOrgId: 'org-1', factoryProjectId: 'project-1' }) },
+    displayState: { get: () => ({ pendingSuspensions }) },
+    subscribe: listener => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+  const emit = (event: AgentControllerEvent) => listeners.forEach(listener => listener(event));
+  return {
+    session,
+    park: (toolCallId: string, toolName: string) => {
+      pendingSuspensions.set(toolCallId, { toolName });
+      emit({ type: 'tool_suspended', toolCallId, toolName, args: {}, suspendPayload: {} });
+    },
+    answer: (toolCallId: string) => {
+      pendingSuspensions.delete(toolCallId);
+      emit({ type: 'tool_suspension_cancelled', toolCallId, toolName: 'ask_user', reason: 'answered' });
+    },
+    end: (reason: 'complete' | 'suspended') => {
+      if (reason !== 'suspended') pendingSuspensions.clear();
+      emit({ type: 'agent_end', reason });
+    },
+  };
 }
 
 describe('LiveSessions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2030-01-01T00:00:00Z'));
+  });
+  afterEach(() => vi.useRealTimers());
+
   it('reads the session state on every call, so a run that starts later is reported', () => {
     const controller = fakeController();
     const registry = new LiveSessions(controller);
     const running = { value: false };
-    controller.create(fakeSession('session-1', running));
+    controller.create(fakeSession('session-1', running).session);
 
     expect(registry.isRunning('session-1')).toBe(false);
     running.value = true;
@@ -39,11 +73,56 @@ describe('LiveSessions', () => {
   it('reports sessions it never saw, and torn-down ones, as not running', () => {
     const controller = fakeController();
     const registry = new LiveSessions(controller);
-    const session = fakeSession('session-1', { value: true });
+    const { session } = fakeSession('session-1', { value: true });
     controller.create(session);
 
     expect(registry.isRunning('unknown')).toBe(false);
     controller.delete(session);
     expect(registry.isRunning('session-1')).toBe(false);
+  });
+
+  it('reports the tool a session has waited on longest, dated when it parked', () => {
+    const controller = fakeController();
+    const registry = new LiveSessions(controller);
+    const fake = fakeSession('session-1');
+    controller.create(fake.session);
+
+    expect(registry.parked('session-1')).toBeUndefined();
+    fake.park('call-1', 'ask_user');
+    vi.advanceTimersByTime(1_000);
+    fake.park('call-2', 'submit_plan');
+    fake.end('suspended');
+    expect(registry.parked('session-1')).toEqual({
+      toolName: 'ask_user',
+      suspendedAt: new Date('2030-01-01T00:00:00Z').getTime(),
+    });
+
+    fake.answer('call-1');
+    expect(registry.parked('session-1')).toEqual({
+      toolName: 'submit_plan',
+      suspendedAt: new Date('2030-01-01T00:00:01Z').getTime(),
+    });
+    fake.end('complete');
+    expect(registry.parked('session-1')).toBeUndefined();
+  });
+
+  it('announces every park, answer and finished turn, and stops once the session is gone', () => {
+    const controller = fakeController();
+    const registry = new LiveSessions(controller);
+    const fake = fakeSession('session-1');
+    controller.create(fake.session);
+    const changed = vi.fn();
+    registry.onParkedChanged(changed);
+
+    fake.park('call-1', 'ask_user');
+    fake.end('suspended');
+    fake.answer('call-1');
+    fake.end('complete');
+    expect(changed).toHaveBeenCalledTimes(3);
+    expect(changed).toHaveBeenLastCalledWith(fake.session);
+
+    controller.delete(fake.session);
+    fake.park('call-2', 'ask_user');
+    expect(changed).toHaveBeenCalledTimes(3);
   });
 });

--- a/mastracode/factory/src/session/live-sessions.test.ts
+++ b/mastracode/factory/src/session/live-sessions.test.ts
@@ -21,13 +21,13 @@ function fakeController() {
   };
 }
 
-function fakeSession(id: string, running: { value: boolean } = { value: false }) {
+function fakeSession(id: string, running: { value: boolean } = { value: false }, factoryProjectId = 'project-1') {
   const listeners = new Set<(event: AgentControllerEvent) => void>();
   const pendingSuspensions = new Map<string, { toolName: string }>();
   const session: LiveSession = {
     identity: { getId: () => id },
     run: { isRunning: () => running.value },
-    state: { get: () => ({ factoryOrgId: 'org-1', factoryProjectId: 'project-1' }) },
+    state: { get: () => ({ factoryOrgId: 'org-1', factoryProjectId }) },
     displayState: { get: () => ({ pendingSuspensions }) },
     subscribe: listener => {
       listeners.add(listener);
@@ -104,6 +104,24 @@ describe('LiveSessions', () => {
     });
     fake.end('complete');
     expect(registry.parked('session-1')).toBeUndefined();
+  });
+
+  it('lists the parked sessions of one project only', () => {
+    const controller = fakeController();
+    const registry = new LiveSessions(controller);
+    const parked = fakeSession('session-1');
+    const idle = fakeSession('session-2');
+    const elsewhere = fakeSession('session-3', { value: false }, 'project-2');
+    for (const fake of [parked, idle, elsewhere]) controller.create(fake.session);
+    parked.park('call-1', 'ask_user');
+    elsewhere.park('call-2', 'submit_plan');
+
+    expect(registry.parkedIn('project-1')).toEqual([
+      {
+        sessionId: 'session-1',
+        run: { toolName: 'ask_user', suspendedAt: new Date('2030-01-01T00:00:00Z').getTime() },
+      },
+    ]);
   });
 
   it('announces every park, answer and finished turn, and stops once the session is gone', () => {

--- a/mastracode/factory/src/session/live-sessions.ts
+++ b/mastracode/factory/src/session/live-sessions.ts
@@ -1,12 +1,30 @@
-/** The slice of a live session this registry needs: its id, and whether it is running. */
+import type { AgentControllerEvent } from '@mastra/core/agent-controller';
+
+/** The slice of a live session this registry needs: its id, its run, its parked tools, and who it works for. */
 export interface LiveSession {
   readonly identity: { getId(): string };
   readonly run: { isRunning(): boolean };
+  readonly state: { get(): Readonly<{ factoryOrgId?: string; factoryProjectId?: string }> };
+  readonly displayState: { get(): { pendingSuspensions: ReadonlyMap<string, { toolName: string }> } };
+  subscribe(listener: (event: AgentControllerEvent) => void): () => void;
 }
 
 interface SessionNotifier {
   onSessionCreated(listener: (session: LiveSession) => void): () => void;
   onSessionDeleted(listener: (session: LiveSession) => void): () => void;
+}
+
+/** The tool a session has waited on longest, and since when (epoch ms). */
+export interface ParkedRun {
+  toolName: string;
+  suspendedAt: number;
+}
+
+interface TrackedSession {
+  session: LiveSession;
+  seenAt: number;
+  suspendedAt: Map<string, number>;
+  unsubscribe: () => void;
 }
 
 /**
@@ -18,19 +36,55 @@ interface SessionNotifier {
  * sandbox, minutes on a cold clone. Notifications only fire once a session
  * exists, so a read never waits.
  *
- * Whether a session is *running* is read from the session itself, never
- * tracked here: no missed run event can leave the answer stuck.
+ * Whether a session is *running* or *parked* is read from the session itself,
+ * never tracked here: no missed run event can leave the answer stuck. Only the
+ * moment each suspension arrived is kept, since the session does not date them.
  */
 export class LiveSessions {
-  readonly #byId = new Map<string, LiveSession>();
+  readonly #byId = new Map<string, TrackedSession>();
+  readonly #parkedListeners = new Set<(session: LiveSession) => void>();
 
   constructor(controller: SessionNotifier) {
-    controller.onSessionCreated(session => this.#byId.set(session.identity.getId(), session));
-    controller.onSessionDeleted(session => this.#byId.delete(session.identity.getId()));
+    controller.onSessionCreated(session => this.#track(session));
+    controller.onSessionDeleted(session => {
+      const id = session.identity.getId();
+      this.#byId.get(id)?.unsubscribe();
+      this.#byId.delete(id);
+    });
+  }
+
+  #track(session: LiveSession): void {
+    const suspendedAt = new Map<string, number>();
+    const unsubscribe = session.subscribe(event => {
+      if (event.type === 'tool_suspended') suspendedAt.set(event.toolCallId, Date.now());
+      else if (event.type === 'tool_suspension_cancelled') suspendedAt.delete(event.toolCallId);
+      else if (event.type === 'agent_end' && event.reason !== 'suspended') suspendedAt.clear();
+      else return;
+      for (const listener of this.#parkedListeners) listener(session);
+    });
+    this.#byId.set(session.identity.getId(), { session, seenAt: Date.now(), suspendedAt, unsubscribe });
   }
 
   /** Whether the session has an agent run in flight right now. */
   isRunning(sessionId: string): boolean {
-    return this.#byId.get(sessionId)?.run.isRunning() ?? false;
+    return this.#byId.get(sessionId)?.session.run.isRunning() ?? false;
+  }
+
+  /** The tool the session is parked on, oldest first, or nothing when no answer is owed. */
+  parked(sessionId: string): ParkedRun | undefined {
+    const tracked = this.#byId.get(sessionId);
+    if (!tracked) return undefined;
+    let oldest: ParkedRun | undefined;
+    for (const [toolCallId, { toolName }] of tracked.session.displayState.get().pendingSuspensions) {
+      const suspendedAt = tracked.suspendedAt.get(toolCallId) ?? tracked.seenAt;
+      if (!oldest || suspendedAt < oldest.suspendedAt) oldest = { toolName, suspendedAt };
+    }
+    return oldest;
+  }
+
+  /** Fires when a session parks, is answered, or finishes a turn: whoever shows parked runs re-reads. */
+  onParkedChanged(listener: (session: LiveSession) => void): () => void {
+    this.#parkedListeners.add(listener);
+    return () => this.#parkedListeners.delete(listener);
   }
 }

--- a/mastracode/factory/src/session/live-sessions.ts
+++ b/mastracode/factory/src/session/live-sessions.ts
@@ -82,6 +82,17 @@ export class LiveSessions {
     return oldest;
   }
 
+  /** Every parked session of a project, so the inbox reads no card when nothing waits. */
+  parkedIn(factoryProjectId: string): Array<{ sessionId: string; run: ParkedRun }> {
+    const parked: Array<{ sessionId: string; run: ParkedRun }> = [];
+    for (const [sessionId, tracked] of this.#byId) {
+      if (tracked.session.state.get().factoryProjectId !== factoryProjectId) continue;
+      const run = this.parked(sessionId);
+      if (run) parked.push({ sessionId, run });
+    }
+    return parked;
+  }
+
   /** Fires when a session parks, is answered, or finishes a turn: whoever shows parked runs re-reads. */
   onParkedChanged(listener: (session: LiveSession) => void): () => void {
     this.#parkedListeners.add(listener);

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -158,8 +158,6 @@ const FACTORY_DISPATCH_FAILURE_CODES = [
   'source_repository_missing',
   'unsupported_provider_item',
   'notification_delivery_failed',
-  'plan_awaiting_approval',
-  'run_awaiting_input',
   'repository_git_missing',
   'repository_egress_blocked',
   'repository_clone_failed',
@@ -233,7 +231,8 @@ export type FactoryAttentionKind =
   | 'automation-proposed'
   | 'mention'
   | 'activity'
-  | 'supervisor-finding';
+  | 'supervisor-finding'
+  | 'agent-waiting';
 export type FactoryAttentionReceiptState = 'read' | 'archived';
 
 export interface FactorySupervisorFindingRecord {
@@ -313,6 +312,11 @@ export function factorySupervisorFindingAttentionIdentity(
   occurrence: number,
 ): FactoryAttentionIdentity {
   return { kind: 'supervisor-finding', sourceId: findingKey, occurrence };
+}
+
+/** Dated by the park itself, so an answer and a new park never share a receipt. */
+export function factoryAgentWaitingAttentionIdentity(sessionId: string, suspendedAt: number): FactoryAttentionIdentity {
+  return { kind: 'agent-waiting', sourceId: sessionId, occurrence: suspendedAt };
 }
 
 export function factoryAttentionKey(factoryProjectId: string, identity: FactoryAttentionIdentity): string {
@@ -1086,7 +1090,8 @@ function attentionReceiptKind(value: unknown): FactoryAttentionKind {
     value === 'automation-proposed' ||
     value === 'mention' ||
     value === 'activity' ||
-    value === 'supervisor-finding'
+    value === 'supervisor-finding' ||
+    value === 'agent-waiting'
   ) {
     return value;
   }
@@ -2092,6 +2097,8 @@ export class WorkItemsStorage extends FactoryStorageDomain {
       );
       return Boolean(decision) && parked;
     }
+    // A parked session has no row here; the route checks it against the live registry.
+    if (identity.kind === 'agent-waiting') return true;
     if (identity.kind === 'activity') {
       // Occurrence-exact: a bump since the read makes that receipt stale, and
       // the route answers 409. Scoped to this user or every badge would skew.


### PR DESCRIPTION
**─────── TLDR ───────**
> A run that stops on a plan or a question now shows in Needs attention as a live "agent waiting" item that leaves by itself once someone answers.

The dispatcher used to record the pause as a failure: `plan_awaiting_approval` or `run_awaiting_input` on the decision, "Automated run could not start" on the card, a retry button that could do nothing, and a row that stayed in the inbox after the plan was approved. A person-started run that parked left nothing anywhere.

The session registry the routes already hold now reads parked tools off the session itself and dates each park from the `tool_suspended` event. A new attention provider lists those sessions under their card; the board list returns them beside the running ones, so the wick, the sidebar row and the inbox come from one read. The two failure codes and the escalate policy are deleted.

### Behavior changed

a rule-started run parks on `submit_plan` or `ask_user`
&nbsp;&nbsp;├─ **was** — the decision fails, the card says "Automated run could not start" with a dead retry button
&nbsp;&nbsp;└─ **now** — the decision succeeds; the inbox lists "Plan waiting for review" or "Agent is waiting for an answer" under the card, opening the thread

the plan is approved or the question answered
&nbsp;&nbsp;├─ **was** — the failed row stayed until archived
&nbsp;&nbsp;└─ **now** — the item is gone on the next read, and a late receipt on it answers 409

a card whose session is parked
&nbsp;&nbsp;├─ **was** — no marker on the board or in the sidebar
&nbsp;&nbsp;└─ **now** — wick and sidebar row read "Waiting on you"

a person-started run that parks
&nbsp;&nbsp;├─ **was** — nothing in the inbox, the thread had to be open
&nbsp;&nbsp;└─ **now** — listed like any parked run

auto-approve past the plan cap
&nbsp;&nbsp;├─ **was** — failed the decision
&nbsp;&nbsp;└─ **now** — leaves the last plan parked, in the inbox

### Shape changed

| | | |
|---|---|---|
| **+** | `LiveSessions.parked` / `parkedIn` / `onParkedChanged` | the registry already watching sessions dates each park |
| **+** | `ParkedRunAttentionProvider` | kind `agent-waiting`, mirrors the activity provider |
| **+** | `parkedSessionIds` on the board list | beside `runningSessionIds`, same read |
| **−** | `plan_awaiting_approval` / `run_awaiting_input` | failure codes with nothing to retry |
| **−** | `ParkedRunPolicy` / `onParkedRun` | a pause is not a failure on any path |
| **~** | `FactoryApiRoutesDeps.liveSessions` | the host builds the registry so it can bump the feed |

- `mastracode/factory/src/`
  - └─ `session/live-sessions.ts` — `+72 −7`, parked read and park stamps
  - └─ `routes/attention-parked.ts` — new, 174 lines; reads no card when nothing is parked
  - └─ `rules/dispatcher.ts` — `+1 −26`, the throw block and policy gone
  - └─ `factory.ts` — `+12`, parked change bumps the project feed
- `mastracode/factory-ui/src/`
  - └─ `hooks/useWorkItems.ts` — `useParkedSessions`, board patch keeps every session list
  - └─ `ui/domains/factory/hooks/useItemSessionStatuses.ts` — parked feeds `attention`

what the client now lives with
&nbsp;&nbsp;&nbsp;&nbsp;`GET …/work-items → { workItems, runningSessionIds, parkedSessionIds }` · `POST …/attention/agent-waiting/:sessionId/:suspendedAt/read|archive|restore` · `FactoryAttentionKind` gains `agent-waiting` · item `{ sessionId, threadId, role, toolName, workItemId, target: thread }`

removed: the two dispatch failure codes; a stored decision still carrying one reads as a generic retryable failure.

### Decisions

- **parked state lives in the registry, not a table** — the process holding the session is the only thing that knows it is parked, and a restart drops the session anyway; the item is back once the session is reopened
- **one item per session, under the first card it is bound to, oldest tool first** — a session answering several questions is one wait, not several; one line to split if you disagree
- **the feed is bumped on every finished turn of a tracked session** — a turn end is one of the two ways a park ends, and the event does not say whether one was open; one condition away if the feed gets loud

### Watch

on deploy: decisions stored with a removed code read as `failureCode: null`, so their card offers a retry that re-kicks the run; my local DB holds none.

### Not verified

- [ ] the inbox against a live parked session — the registry ran only against the fake session, the route against a stubbed registry

---

> ██████████████████ **source** `+349 −65` — net +284, 174 of them the new provider
> ███████████████ **tests** `+285 −28`
> █ **changeset** `+5`
