### PR TITLE
fix(core): defer durable agent model selection until requested

### DIFF
--- a/.changeset/tame-grapes-sin.md
+++ b/.changeset/tame-grapes-sin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed durable agent construction resolving dynamic models before a request supplies its context.

--- a/packages/core/src/agent/durable/__tests__/durable-agent-constructor.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-constructor.test.ts
@@ -1,0 +1,108 @@
+import net from 'node:net';
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RequestContext } from '../../../request-context';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../create-durable-agent';
+
+function textModel(text: string) {
+  return new MockLanguageModelV2({
+    doStream: async () => ({
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'text-start', id: 'text' },
+        { type: 'text-delta', id: 'text', delta: text },
+        { type: 'text-end', id: 'text' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+      ]),
+    }),
+  });
+}
+
+describe('DurableAgent constructor model resolution', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      throw new Error('No network in constructor tests');
+    });
+    vi.spyOn(net.Socket.prototype, 'connect').mockImplementation(() => {
+      throw new Error('No sockets in constructor tests');
+    });
+  });
+
+  afterEach(() => {
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(net.Socket.prototype.connect).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it.each(['synchronous', 'asynchronous'] as const)(
+    'defers an unavailable %s model and preserves its awaited rejection',
+    async kind => {
+      const unavailable = new Error('No model is currently available');
+      const resolver = vi.fn(() => {
+        if (kind === 'asynchronous') return Promise.reject(unavailable);
+        throw unavailable;
+      });
+      const agent = new Agent({
+        id: 'unavailable-model',
+        name: 'Unavailable model',
+        instructions: 'Test',
+        model: resolver,
+      });
+      const durable = createDurableAgent({ agent });
+
+      // Let an eagerly created rejection surface rather than hiding it in a constructor assertion.
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(resolver).not.toHaveBeenCalled();
+      await expect(durable.getModel()).rejects.toBe(unavailable);
+      expect(resolver).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('preserves a static model without resolving it during construction', async () => {
+    const model = textModel('Static response');
+    const agent = new Agent({ id: 'static-model', name: 'Static model', instructions: 'Test', model });
+    const getModel = vi.spyOn(agent, 'getModel');
+    const durable = createDurableAgent({ agent });
+
+    expect(getModel).not.toHaveBeenCalled();
+    expect(await durable.getModel()).toMatchObject({ modelId: model.modelId, provider: model.provider });
+    const { output, cleanup } = await durable.stream('Hello', { maxSteps: 1 });
+    try {
+      expect(await output.text).toBe('Static response');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('resolves the current request context during each durable execution', async () => {
+    const firstModel = textModel('First response');
+    const secondModel = textModel('Second response');
+    const selected: string[] = [];
+    const resolver = vi.fn(({ requestContext }: { requestContext: RequestContext }) => {
+      const selection = requestContext.get('selection');
+      if (selection !== 'first' && selection !== 'second') throw new Error('A request selection is required');
+      selected.push(selection);
+      return selection === 'first' ? firstModel : secondModel;
+    });
+    const agent = new Agent({ id: 'request-model', name: 'Request model', instructions: 'Test', model: resolver });
+    const durable = createDurableAgent({ agent });
+    expect(resolver).not.toHaveBeenCalled();
+
+    for (const [selection, expected] of [
+      ['first', 'First response'],
+      ['second', 'Second response'],
+    ]) {
+      const requestContext = new RequestContext();
+      requestContext.set('selection', selection);
+      const { output, cleanup } = await durable.stream('Hello', { requestContext, maxSteps: 1 });
+      try {
+        expect(await output.text).toBe(expected);
+      } finally {
+        cleanup();
+      }
+    }
+    expect(selected).toContain('first');
+    expect(selected).toContain('second');
+  });
+});

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -591,8 +591,8 @@ export class DurableAgent<
       name: agentName,
       // Delegate to wrapped agent's instructions
       instructions: ({ requestContext }) => agent.getInstructions({ requestContext }),
-      // We need to provide model to satisfy the base class, but we'll delegate to wrapped agent
-      model: (agent as any).__model ?? agent.getModel(),
+      // Resolve only when requested, with the caller's context and awaited error handling.
+      model: ({ requestContext }) => agent.getModel({ requestContext }),
     });
 
     this.#wrappedAgent = agent;


### PR DESCRIPTION
Wrapping an Agent with createDurableAgent currently calls getModel() before a request supplies its context. An async resolver that rejects can leave an unhandled rejection even though the wrapper constructor returned.

This defers that lookup through the existing model callback and passes the current RequestContext. Explicit model resolution still rejects with the original error; static models and request-specific streams keep working.

Before, `createDurableAgent({ agent })` could run the resolver immediately. After, construction makes no lookup, and `await durable.getModel({ requestContext })` owns resolution and its error.

Four regression cases fail on the unchanged constructor and pass with this fix. All 42 focused native tests, Core type checking, scoped lint and formatting pass. The new cases use fake model streams and assert zero fetch or socket calls.
