### PR TITLE
fix(server): correct the fields example in the workflow run route description

### DIFF
--- a/.changeset/steady-runs-describe.md
+++ b/.changeset/steady-runs-describe.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Corrected the description of `GET /api/workflows/:workflowId/runs/:runId`. It suggested `?fields=status,result,metadata`, but `status` and the metadata fields are always included and the query validator rejects those names with a 400. The example now reads `?fields=result,steps`.

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -422,7 +422,7 @@ export const GET_WORKFLOW_RUN_BY_ID_ROUTE = createRoute({
   responseSchema: workflowRunResultSchema,
   summary: 'Get workflow run by ID',
   description:
-    'Returns a workflow run with metadata and processed execution state. Use the fields query parameter to reduce payload size by requesting only specific fields (e.g., ?fields=status,result,metadata)',
+    'Returns a workflow run with metadata and processed execution state. Use the fields query parameter to reduce payload size by requesting only specific fields (e.g., ?fields=result,steps). Metadata fields and status are always included.',
   tags: ['Workflows'],
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, fields, withNestedWorkflows, requestContext }) => {


### PR DESCRIPTION
## Description

The route description for `GET /api/workflows/:workflowId/runs/:runId` suggests `?fields=status,result,metadata` as an example. `status` and the metadata fields (`runId`, `workflowName`, `resourceId`, `createdAt`, `updatedAt`) are always included, and `workflowRunResultQuerySchema` only accepts `result`, `error`, `payload`, `steps`, `activeStepsPath` and `serializedStepGraph`, so a request that follows the example fails:

```
GET /api/workflows/word-count/runs/<runId>?fields=status,result

{"error":"Invalid query parameters","issues":[{"field":"fields","message":"Invalid field name. Available fields: result, error, payload, steps, activeStepsPath, serializedStepGraph"}]}
```

Reproduced against `mastra dev` with `@mastra/server` 1.64.0. The `fields` parameter's own description on the schema already states the correct list. This changes the route description to `?fields=result,steps` and notes that metadata and `status` are always included, so the OpenAPI output matches what the validator accepts.

String-only change with a patch changeset for `@mastra/server`.

## Related issue(s)

Fixes #23262

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
