### PR TITLE
fix(factory): settle a failed automation on a done card as superseded

### DIFF
--- a/.changeset/factory-settled-card-failure.md
+++ b/.changeset/factory-settled-card-failure.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed a Factory automation that failed on a card already at Done or Canceled staying in Needs attention until the server restarted. The session row and the board card kept the "waiting on you" marker, and Retry could only fail the same way again. Such a failure now settles as superseded the moment it happens, the way a restart already repaired it, so the marker clears on the next poll.

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -2267,6 +2267,64 @@ describe('FactoryDecisionDispatcher', () => {
     expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['canceled']);
   });
 
+  it('settles an automation that fails on a done card as superseded instead of paging a person', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = (
+      await storage.upsert({
+        orgId: 'org-1',
+        userId: 'user-1',
+        factoryProjectId: PROJECT_ID,
+        input: {
+          externalSource: { integrationId: 'github', type: 'pull-request', externalId: 'github-pr:7' },
+          title: 'Reviewed pull request',
+          stages: ['done'],
+          sessions: {},
+          metadata: { authorTrusted: true },
+        },
+      })
+    ).item;
+    const transitionService = new FactoryTransitionService({
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+      storage,
+    });
+    // The PR closes after its review card already settled: the mirrored move has nowhere to go.
+    await storage.commitRuleEvaluation({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: item.id,
+      ingress: { identity: 'closed-after-done', triggerType: 'github' },
+      ruleSetVersion: 'rules-v1',
+      expectedRevision: item.revision,
+      actor: { type: 'github', login: 'author', trusted: true, factoryAuthored: false },
+      outcome: { status: 'accepted' },
+      decisions: [{ type: 'transition', board: 'review', stage: 'canceled', idempotencyKey: 'closed-after-done' }],
+      causalChain: [],
+      now: new Date('2030-01-01T00:00:00Z'),
+    });
+    const { controller } = createSession();
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+      isAutoRunEnabled: async () => false,
+    });
+    const start = new Date('2030-01-01T00:01:00Z');
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await dispatcher.runOnce(new Date(start.getTime() + attempt * 120_000));
+    }
+
+    const [decision] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(decision).toMatchObject({
+      status: 'superseded',
+      lastError: expect.stringContaining('invalid_transition'),
+    });
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['done']);
+    const provider = new DecisionAttentionProvider({ workItems: storage }, failedDecisionAttentionSpec);
+    expect(await provider.counts({ orgId: 'org-1', factoryProjectId: PROJECT_ID })).toMatchObject({ open: 0 });
+  });
+
   it('keeps an externally authored card from self-starting, even armed with auto-run on', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const item = (

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -21,7 +21,12 @@ import { FACTORY_RULE_MATERIALIZATION_KEY } from '../storage/domains/work-items/
 import { FactoryDispatchError, factoryDispatchFailureCode, factoryDispatchFailureMetadata } from './dispatch-errors.js';
 import type { FactoryTransitionService } from './transition-service.js';
 import type { FactoryCommitDecision, FactoryRuleActor, FactoryRuleCausalEntry } from './types.js';
-import { externallyAuthoredWorkItem, FACTORY_RULE_STAGES, isWorkingFactoryRuleStage } from './types.js';
+import {
+  externallyAuthoredWorkItem,
+  FACTORY_RULE_STAGES,
+  isTerminalFactoryRuleStage,
+  isWorkingFactoryRuleStage,
+} from './types.js';
 import { MAX_FACTORY_RULE_CAUSAL_DEPTH, validateFactoryRuleDecision } from './validation.js';
 
 const LEASE_MS = 30_000;
@@ -572,15 +577,39 @@ export class FactoryDecisionDispatcher {
       if (!completed) throw new Error('Factory decision lease was lost before completion.');
     } catch (error) {
       const failureCode = factoryDispatchFailureCode(error);
-      await this.#storage.failDeferredDecision({
+      const terminal = isTerminalFailure(record.attempts, failureCode);
+      const failed = await this.#storage.failDeferredDecision({
         ...leaseIdentity(record, this.#ownerId),
         now: new Date(),
         availableAt: retryAt(now, record.attempts),
         lastError: sanitizeDispatchError(error),
         failureCode,
-        terminal: isTerminalFailure(record.attempts, failureCode),
+        terminal,
         advanceDeliveryGeneration: !executionCompleted,
       });
+      if (terminal && failed) await this.#supersedeFailureOnSettledCard(failed);
+    }
+  }
+
+  /**
+   * Startup repair and terminal cleanup already settle a failed effect on a done or canceled
+   * card as superseded; a failure landing after the card settled would otherwise page a person
+   * until the next restart.
+   */
+  async #supersedeFailureOnSettledCard(record: FactoryDeferredDecisionRecord): Promise<void> {
+    if (!record.workItemId) return;
+    try {
+      const item = await this.#storage.get({ orgId: record.orgId, id: record.workItemId });
+      if (!item || !isTerminalFactoryRuleStage(item.stages)) return;
+      await this.#storage.supersedeDecisionsForWorkItem({
+        orgId: record.orgId,
+        factoryProjectId: record.factoryProjectId,
+        workItemId: record.workItemId,
+        supersededAt: new Date(),
+      });
+    } catch (error) {
+      // Best-effort: the row is already failed, and the next restart repairs it.
+      console.error('Factory settled-card supersede failed', sanitizeDispatchError(error));
     }
   }
 


### PR DESCRIPTION
**─────── TLDR ───────**
> An automation failing on a card already at Done or Canceled now settles as superseded, not as a Needs attention row that only a server restart cleared.

Seen on the review card for #23224. The PR closed after its review had already moved the card to Done, the closed-PR rule emitted `done → canceled`, the Review board refused it, and after five attempts the row went `failed`. A failed row is attention, so the session row wore the "waiting on you" marker for hours, and Retry could only be refused again.

The code already treats a failed or proposed effect on a settled card as moot: terminal cleanup after the move, the boot repair in `init`, and the closed-PR sweep all supersede such rows. None of the three runs when the failure lands after the card settled. The dispatcher now runs that same supersede the moment a terminal failure lands on a settled card.

### Behavior changed

an automation fails for good on a card at Done or Canceled
&nbsp;&nbsp;├─ **was** — `failed`; Needs attention and the session marker until the next restart
&nbsp;&nbsp;└─ **now** — `superseded` in the same dispatch; no attention, marker gone on the next poll

the same failure on a live card
&nbsp;&nbsp;└─ **unchanged** — `failed`, Needs attention, Retry on the card

### Decisions

- **the whole card settles, not only the failing row** — same call as the boot repair — one `decisionId` filter away if you disagree
- **no guard in `pullRequestClosed`** — the board already knows `done → canceled` is invalid — one line away if you want it

### Watch

on deploy: rows already stuck this way settle at the next boot through the existing repair; nothing to migrate. Retry on one of them now ends in `superseded` after its five attempts instead of back in `failed`.

---

> ██████████████████ **tests** `+58` — 61% of the additions
> ██████████ **source** `+32 −3`
> ██ **changeset** `+5`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an automation fails after a card is already finished, Factory now closes that failure instead of asking someone to fix it. Active cards still keep the failure so they can be retried.

## Changes

- Supersede terminal automation failures when the work item is already in `Done` or `Canceled`.
- Preserve the original `failed` result and log any supersede error.
- Keep failures on active cards unchanged.
- Add dispatcher coverage for this behavior.
- Add a patch changeset for `@mastra/factory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->