### PR TITLE
fix(core): close live text and reasoning spans on their end chunks

### DIFF
--- a/.changeset/core-live-message-span-end.md
+++ b/.changeset/core-live-message-span-end.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+The agent controller's live message now closes a text or reasoning span on `text-end` / `reasoning-end`. A later step that reuses the provider's block id opens a new part instead of appending to the earlier one, so the live message keeps the same part order as the persisted one.

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -558,6 +558,11 @@ export class SessionRunEngine {
         break;
       }
 
+      case 'text-end': {
+        state.textContentById.delete(getString(getPayload(chunk).id) ?? '');
+        break;
+      }
+
       case 'reasoning-start': {
         // Mirror text-start: a late start for an already-seeded id is a no-op.
         if (state.thinkingContentById.has(getString(getPayload(chunk).id) ?? '')) break;
@@ -586,6 +591,11 @@ export class SessionRunEngine {
           thinkingContent.details = [{ type: 'text', text: thinkingState.text }];
         }
         this.#session.emit({ type: 'message_update', message: state.currentMessage });
+        break;
+      }
+
+      case 'reasoning-end': {
+        state.thinkingContentById.delete(getString(getPayload(chunk).id) ?? '');
         break;
       }
 

--- a/packages/core/src/agent-controller/signal-messages.test.ts
+++ b/packages/core/src/agent-controller/signal-messages.test.ts
@@ -1426,6 +1426,64 @@ describe('AgentController signal messages', () => {
     ]);
   });
 
+  it('opens a new reasoning part when a later step reuses a block id after reasoning-end', async () => {
+    const { session } = await createController(new InMemoryStore());
+    const events: AgentControllerEvent[] = [];
+    session.subscribe(event => {
+      events.push(event);
+    });
+    const state = session.runEngine.createStreamState();
+    const requestContext = new RequestContext();
+    const chunks: Parameters<typeof session.runEngine.processStreamChunk>[1][] = [
+      { type: 'reasoning-start', payload: { id: '0' } },
+      { type: 'reasoning-delta', payload: { id: '0', text: 'step one' } },
+      { type: 'reasoning-end', payload: { id: '0' } },
+      { type: 'reasoning-start', payload: { id: '0' } },
+      { type: 'reasoning-delta', payload: { id: '0', text: 'step two' } },
+    ];
+
+    for (const chunk of chunks) {
+      await session.runEngine.processStreamChunk(state, chunk, requestContext);
+    }
+
+    const updates = events.filter(
+      (event): event is Extract<AgentControllerEvent, { type: 'message_update' }> => event.type === 'message_update',
+    );
+    expect(updates.at(-1)?.message.content.parts).toEqual([
+      { type: 'reasoning', reasoning: 'step one', details: [{ type: 'text', text: 'step one' }] },
+      { type: 'reasoning', reasoning: 'step two', details: [{ type: 'text', text: 'step two' }] },
+    ]);
+  });
+
+  it('opens a new text part when a later step reuses a block id after text-end', async () => {
+    const { session } = await createController(new InMemoryStore());
+    const events: AgentControllerEvent[] = [];
+    session.subscribe(event => {
+      events.push(event);
+    });
+    const state = session.runEngine.createStreamState();
+    const requestContext = new RequestContext();
+    const chunks: Parameters<typeof session.runEngine.processStreamChunk>[1][] = [
+      { type: 'text-start', payload: { id: '1' } },
+      { type: 'text-delta', payload: { id: '1', text: 'step one' } },
+      { type: 'text-end', payload: { id: '1' } },
+      { type: 'text-start', payload: { id: '1' } },
+      { type: 'text-delta', payload: { id: '1', text: 'step two' } },
+    ];
+
+    for (const chunk of chunks) {
+      await session.runEngine.processStreamChunk(state, chunk, requestContext);
+    }
+
+    const updates = events.filter(
+      (event): event is Extract<AgentControllerEvent, { type: 'message_update' }> => event.type === 'message_update',
+    );
+    expect(updates.at(-1)?.message.content.parts).toEqual([
+      { type: 'text', text: 'step one' },
+      { type: 'text', text: 'step two' },
+    ]);
+  });
+
   it('emits generic reactive signal data parts as renderable message updates', async () => {
     const storage = new InMemoryStore();
     const { session } = await createController(storage);


### PR DESCRIPTION
**─────── TLDR ───────**
> The live message of a running session now ends a text or reasoning span on its end chunk, so each step's thinking is its own part instead of gluing onto the first one.

Watching a multi-step run in the factory, the thinking above the first tool kept growing with sentences from later steps ("sandbox.test.ts.With CI mostly passing"), and every tool row under it blinked and replayed its entrance on each token. Anthropic numbers content blocks per response, so every step's first reasoning block is id `0`; the live engine kept `0` in its map for the whole run and appended step two into step one's part. The persisted builder already ends a span on `text-end` / `reasoning-end`; the live engine now does the same, so a run looks the same live and after reload.

### Behavior changed

a multi-step run watched live
&nbsp;&nbsp;├─ **was** — one reasoning part glued from every step, rows below re-animate on each token
&nbsp;&nbsp;└─ **now** — reasoning, tool, reasoning, tool… in order, the shape the thread shows after reload

the live message id across steps
&nbsp;&nbsp;└─ **unchanged** — one message per run, as #21185 set it

### Decisions

- **end chunks rather than clearing the maps on `step-start`** — mirrors `build-messages-from-chunks.ts`, the persisted shape, and covers two spans inside one step; one case each if you would rather rotate per step

### Not verified

- [ ] the factory transcript live — the fix ran only in the engine test, the symptom was traced from a screenshot and the two engines

---

> ██████████████████ **tests** `+58` — 79% of the additions
> ███ **source** `+10`
> ██ **changeset** `+5`
