### PR TITLE
test(clickhouse): guard feedback review-status preservation

### DIFF
--- a/stores/_test-utils/src/domains/observability-vnext/index.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/index.ts
@@ -3,7 +3,12 @@ export * from './trace-query';
 import { coreFeatures } from '@mastra/core/features';
 import { EntityType, SpanType } from '@mastra/core/observability';
 import { parseTraceQueryRequest, planTraceQuery } from '@mastra/core/storage';
-import type { CreateSpanRecord, ObservabilityStorage, TraceQueryRequest } from '@mastra/core/storage';
+import type {
+  CreateFeedbackRecord,
+  CreateSpanRecord,
+  ObservabilityStorage,
+  TraceQueryRequest,
+} from '@mastra/core/storage';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { VNEXT_BASE_DATE, makeSpan } from './data';
 import {
@@ -3695,25 +3700,71 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
         expect(reviewed.feedback.map(fb => fb.feedbackId)).toEqual(['feedback-review-filter-2']);
       });
 
-      it('updates reviewStatus and returns the updated record', async () => {
-        await storage.createFeedback({
-          feedback: { ...baseFeedback, feedbackId: 'feedback-review-update', traceId: 'trace-review-update' },
-        });
+      it.each([0, 'Corrected answer'])(
+        'preserves all feedback fields when updating reviewStatus (value: %j)',
+        async value => {
+          const feedback = {
+            feedbackId: 'feedback-review-update',
+            timestamp: new Date('2026-01-01T12:34:56.789Z'),
+            traceId: 'trace-review-update',
+            spanId: 'span-review-update',
+            experimentId: 'experiment-review-update',
+            entityType: EntityType.TOOL,
+            entityId: 'tool-id',
+            entityName: 'Tool',
+            entityVersionId: 'tool-version',
+            parentEntityType: EntityType.AGENT,
+            parentEntityId: 'agent-id',
+            parentEntityName: 'Agent',
+            parentEntityVersionId: 'agent-version',
+            rootEntityType: EntityType.WORKFLOW_RUN,
+            rootEntityId: 'workflow-id',
+            rootEntityName: 'Workflow',
+            rootEntityVersionId: 'workflow-version',
+            userId: 'reviewer-id',
+            organizationId: 'organization-id',
+            resourceId: 'resource-id',
+            runId: 'run-id',
+            sessionId: 'session-id',
+            threadId: 'thread-id',
+            requestId: 'request-id',
+            environment: 'test',
+            executionSource: 'api',
+            serviceName: 'feedback-service',
+            feedbackUserId: 'reviewer-id',
+            sourceId: 'dataset-item-id',
+            feedbackSource: 'reviewer',
+            feedbackType: 'correction',
+            value,
+            comment: 'Preserve this comment when marking the feedback reviewed.',
+            tags: ['quality', 'review'],
+            metadata: { reviewer: { team: 'quality' }, confidence: 0, approved: false },
+            scope: { tenant: 'tenant-id', groups: ['reviewers', 'editors'] },
+            reviewStatus: 'needs-review',
+          } satisfies Omit<Required<CreateFeedbackRecord>, 'source'>;
 
-        const updated = await storage.updateFeedbackReviewStatus({
-          feedbackId: 'feedback-review-update',
-          reviewStatus: 'reviewed',
-        });
-        expect(updated.feedbackId).toBe('feedback-review-update');
-        expect(updated.reviewStatus).toBe('reviewed');
+          await storage.createFeedback({
+            feedback: structuredClone(feedback),
+          });
 
-        // Append-only stores (ClickHouse) implement the update as a replacement
-        // row; the read side must still expose a single, latest version.
-        const result = await storage.listFeedback({ filters: { traceId: 'trace-review-update' } });
-        expect(result.feedback).toHaveLength(1);
-        expect(result.pagination?.total).toBe(1);
-        expect(result.feedback[0]!.reviewStatus).toBe('reviewed');
-      });
+          // Compare against the input so a lossy read mapper cannot hide missing fields.
+          const before = await storage.listFeedback({ filters: { traceId: feedback.traceId } });
+          expect(before.feedback).toMatchObject([feedback]);
+
+          const updated = await storage.updateFeedbackReviewStatus({
+            feedbackId: feedback.feedbackId,
+            reviewStatus: 'reviewed',
+          });
+          const expected = { ...feedback, reviewStatus: 'reviewed' };
+          expect(updated).toMatchObject(expected);
+
+          // Append-only stores (ClickHouse) implement the update as a replacement
+          // row; the read side must still expose a single, latest version.
+          const result = await storage.listFeedback({ filters: { traceId: feedback.traceId } });
+          expect(result.feedback).toMatchObject([expected]);
+          expect(result.pagination?.total).toBe(1);
+        },
+      );
 
       it('throws when updating reviewStatus of a missing feedback record', async () => {
         await expect(

--- a/stores/clickhouse/src/storage/domains/observability/v-next/helpers.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/helpers.ts
@@ -528,6 +528,8 @@ export function scoreRecordToRow(score: CreateScoreRecord): Record<string, unkno
   };
 }
 
+// Keep both feedback mappers lossless: updateFeedbackReviewStatus uses them
+// to reinsert the entire row, so an omitted column would reset to its default.
 export function rowToFeedbackRecord(row: Record<string, any>): FeedbackRecord {
   const hasNumber = row.valueNumber != null;
   const feedbackSource = nullableString(row.feedbackSource);
@@ -574,6 +576,8 @@ export function rowToFeedbackRecord(row: Record<string, any>): FeedbackRecord {
   };
 }
 
+// Keep both feedback mappers lossless: updateFeedbackReviewStatus uses them
+// to reinsert the entire row, so an omitted column would reset to its default.
 export function feedbackRecordToRow(feedback: CreateFeedbackRecord): Record<string, unknown> {
   const metadata = feedback.metadata ?? null;
   const feedbackSource = feedback.feedbackSource ?? feedback.source ?? '';

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
@@ -30,10 +30,12 @@ import {
   TABLE_DISCOVERY_PAIRS,
   TABLE_DELETION_REQUESTS,
   TABLE_DISCOVERY_VALUES,
+  TABLE_FEEDBACK_EVENTS,
   TABLE_SCORE_EVENTS,
   TABLE_SPAN_EVENTS,
   TABLE_TRACE_ROOTS,
 } from './ddl';
+import { feedbackRecordToRow } from './helpers';
 import { isReplacingMergeTreeEngine } from './migration';
 import { compileClickHouseTraceQuery, runWithClickHouseTraceQueryTimeout } from './trace-query';
 import { ObservabilityStorageClickhouseVNext } from '.';
@@ -2530,6 +2532,34 @@ LIMIT 1`,
   // ==========================================================================
 
   describe('feedback', () => {
+    it('maps every persisted feedback column', async () => {
+      const client = createClient({
+        url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+        username: process.env.CLICKHOUSE_USERNAME || 'default',
+        password: process.env.CLICKHOUSE_PASSWORD || 'password',
+      });
+
+      try {
+        const result = await client.query({
+          query: 'SELECT name FROM system.columns WHERE database = currentDatabase() AND table = {table:String}',
+          query_params: { table: TABLE_FEEDBACK_EVENTS },
+          format: 'JSONEachRow',
+        });
+        const columns = await result.json<{ name: string }>();
+        const row = feedbackRecordToRow({
+          feedbackId: 'feedback-column-parity',
+          timestamp: new Date('2026-01-01T00:00:00Z'),
+          feedbackSource: 'user',
+          feedbackType: 'rating',
+          value: 0,
+        });
+
+        expect(Object.keys(row).sort()).toEqual(columns.map(column => column.name).sort());
+      } finally {
+        await client.close();
+      }
+    });
+
     it('feedbackUserId round-trips through CH userId column', async () => {
       await storage.createFeedback({
         feedback: {


### PR DESCRIPTION
## What

Expand the shared review-status test to populate every canonical feedback field and verify the input, update result, and persisted reread for numeric and string values. Add a ClickHouse mapper-key check against the initialized table's `system.columns`, plus a short invariant comment on both mappers.

## Why

ClickHouse replaces the complete feedback row when changing `reviewStatus`. The current mappings are correct; these tests protect against future field loss without changing storage behavior or public APIs.

Closes #22880

## Testing

- ClickHouse review-status and column-parity tests: 8 passed against ClickHouse 26.6.1.1193.
- InMemory and DuckDB review-status tests: 7 passed each. Full DuckDB observability suite: 175 passed.
- Temporarily removed a read-mapper field, discarded it only during replacement, and removed a write-mapper key. Each defect failed the new tests; restored the code and reran the ClickHouse checks successfully.
- Relevant Turbo builds, ClickHouse lint/typecheck, shared-file typecheck/oxlint, and formatting passed.
- Broader ClickHouse run: 239 passed, 1 failed (legacy discovery-MV migration, `UNKNOWN_TABLE`). Broader InMemory run: 741 passed, 4 failed, 3 skipped. The identical failures reproduce on unchanged base `685616780e`. An additional test-inclusive typecheck reports the same 7 existing ClickHouse test errors on both revisions.

PostgreSQL conformance was not run locally because its shared suite requires TimescaleDB. This is a test/comment-only change, with no release behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When ClickHouse updates a review status, it rewrites the entire feedback record. This PR tests that no feedback data is lost and checks that both mappers include every database column.

## Changes

- Expanded shared review-status tests to populate and verify all canonical feedback fields.
- Tested numeric and string feedback values across ClickHouse, InMemory, and DuckDB.
- Verified input, update-result, and persisted reread values.
- Added a ClickHouse check that mapper keys match the initialized feedback table columns.
- Documented the lossless round-trip requirement for both feedback mappers.
- Added invariant checks for append-only stores.

## Validation

- Ran ClickHouse column-parity and review-status tests.
- Ran relevant builds, linting, typechecking, and formatting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->