### PR TITLE
feat(cua): add Fleet computer-use sandbox provider

### DIFF
--- a/.changeset/lucky-mangos-do.md
+++ b/.changeset/lucky-mangos-do.md
@@ -1,0 +1,27 @@
+---
+'@mastra/cua': minor
+---
+
+Added Cua Cloud Fleet desktops for Mastra computer use.
+
+Attach a Linux desktop from an existing Fleet pool to a workspace. Each provider owns an independent claim; call `destroy()` to release it. Shell execution, pause/resume, and reconnecting by ID are not supported.
+
+```ts
+import { Workspace } from '@mastra/core/workspace';
+import { CuaFleetSandbox } from '@mastra/cua';
+
+const sandbox = new CuaFleetSandbox({
+  id: 'desktop-session',
+  poolName: 'existing-linux-pool',
+  clientId: process.env.CUA_CLIENT_ID!,
+  clientSecret: process.env.CUA_CLIENT_SECRET!,
+});
+const workspace = new Workspace({ sandbox });
+
+try {
+  await workspace.init();
+  await sandbox.computer.screenshot();
+} finally {
+  await workspace.destroy();
+}
+```

--- a/docs/src/content/en/integrations/sandboxes/cua.mdx
+++ b/docs/src/content/en/integrations/sandboxes/cua.mdx
@@ -1,0 +1,107 @@
+---
+title: "Cua | Sandbox"
+description: "Use Cua Fleet Linux desktops with Mastra computer tools for screenshots, mouse actions, keyboard input, and scrolling."
+packages:
+  - "@mastra/cua"
+---
+
+# Cua
+
+`CuaFleetSandbox` connects Mastra agents to a Linux desktop in [Cua Fleet](https://run.cua.ai). It implements the [WorkspaceSandbox interface](/reference/workspace/sandbox) and provides screenshot, mouse, and keyboard controls through Mastra's [computer capability](/docs/sandbox/computer).
+
+The provider acquires a claim from an existing pool. Your application owns the pool, its capacity, and its cleanup policy. This integration supports graphical desktop actions only: it doesn't provide shell execution, file operations, processes, storage mounts, or live viewing.
+
+## Package setup
+
+`@mastra/cua` is a proposed package and hasn't been published to npm. The examples on this page assume you've built and installed the package locally from the integration source.
+
+Before starting a session, configure:
+
+- An existing Linux pool with a compatible desktop image and computer-server exposed as the `server` service
+- Fleet client credentials in the `CUA_CLIENT_ID` and `CUA_CLIENT_SECRET` environment variables
+- The model provider API key required by your Mastra agent
+
+Keep Fleet credentials on the server. Pass them through `clientId` and `clientSecret`; the provider doesn't read environment variables automatically. It uses the Fleet OAuth endpoint and API at `run.cua.ai` and doesn't provision pools or install software.
+
+## Usage
+
+Pass a concrete sandbox instance to a workspace to register the `mastra_workspace_computer_*` tools. Use a separate sandbox and workspace for each concurrent application session:
+
+```typescript
+import { Agent } from '@mastra/core/agent'
+import { Workspace } from '@mastra/core/workspace'
+import { CuaFleetSandbox } from '@mastra/cua'
+
+const sandbox = new CuaFleetSandbox({
+  id: 'desktop-session',
+  poolName: 'existing-linux-pool',
+  clientId: process.env.CUA_CLIENT_ID!,
+  clientSecret: process.env.CUA_CLIENT_SECRET!,
+})
+
+const agent = new Agent({
+  id: 'desktop-agent',
+  name: 'Desktop Agent',
+  instructions: 'Use the computer tools to complete the requested task.',
+  model: '__GATEWAY_ANTHROPIC_MODEL_SONNET__',
+  workspace: new Workspace({ sandbox }),
+})
+
+try {
+  const response = await agent.generate('Take a screenshot and describe the desktop.', {
+    maxSteps: 10,
+  })
+  console.log(response.text)
+} finally {
+  await sandbox.destroy()
+}
+```
+
+The first computer operation starts the session. The agent can take screenshots, click, move the mouse, drag, type, press keys, scroll, and inspect the display and cursor position. Sharing one provider instance shares its desktop. Use a concrete `Workspace({ sandbox })` rather than a dynamic sandbox resolver so Mastra discovers the computer tools.
+
+### Direct desktop control
+
+Call the computer capability without an agent to verify that the pool supplies a working desktop. With a newly constructed sandbox, this example prints the screen dimensions and PNG byte count:
+
+```typescript
+try {
+  await sandbox.start()
+  const size = await sandbox.computer.getScreenSize()
+  const { data, mediaType } = await sandbox.computer.screenshot()
+  console.log({ size, mediaType, bytes: data.length })
+} finally {
+  await sandbox.destroy()
+}
+```
+
+Coordinates are integer display pixels measured from the top-left corner. Scrolling uses positive integer wheel ticks. Key input accepts names such as `Enter` and `ArrowDown`, or chords such as `['Control', 's']`. Single characters preserve case; unsupported named keys are rejected. Actions within one provider instance run in sequence, so screenshots, chords, and dragging don't overlap.
+
+## Constructor parameters
+
+| Parameter | Type | Description |
+| - | - | - |
+| `id` | `string` | Required application session identity. Reusing it doesn't reconnect to an existing claim. |
+| `poolName` | `string` | Required name of an existing compatible Linux pool. |
+| `clientId` | `string` | Required Fleet OAuth client ID. |
+| `clientSecret` | `string` | Required Fleet OAuth client secret. |
+| `claimTtlSeconds` | `number` | Claim time to live (TTL), measured from creation. Defaults to `3600`; maximum `86400`. |
+| `startupTimeoutMs` | `number` | Total acquisition and readiness timeout. Defaults to `900000`; maximum `3600000`. |
+| `requestTimeoutMs` | `number` | Per-request HTTP timeout. Defaults to `60000`; maximum `300000`. |
+
+Timeouts and TTL must be positive integers. The claim TTL must exceed the startup timeout after converting both to the same unit. Startup time counts toward the TTL; the claim doesn't renew automatically. The pool's own expiry can also end a session. TTL isn't a spending cap.
+
+## Lifecycle and cleanup
+
+Construction makes no network requests. `start()` or the first computer operation acquires a claim; concurrent starts on the same instance share one acquisition. Each new instance acquires an independent claim, even if it has the same `id`.
+
+Always call `destroy()` when the session ends. It rejects new actions, waits for active work, releases its owned claim, and verifies that the claim is absent. It leaves the application-owned pool intact. If cleanup fails, retain the instance and retry `destroy()`; the provider keeps the state needed for cleanup.
+
+`stop()` is not implemented. Calling `Workspace.stop()` leaves the claim active; call `destroy()` to release it. Pause/resume, reconnection, cloning, and checkpoints aren't supported. `supportsCheckpoints` is `false`, and `snapshot()` is a no-op compatibility hook. Create a new sandbox instance to start another desktop session after destruction.
+
+Requests have bounded timeouts and refuse redirects. The provider doesn't automatically replay graphical commands after ambiguous failures, because replaying a click or text entry can duplicate an action.
+
+## Related
+
+- [Computer-use tools](/docs/sandbox/computer#computer-tools)
+- [WorkspaceSandbox interface](/reference/workspace/sandbox)
+- [Sandbox overview](/docs/sandbox/overview)

--- a/docs/src/content/en/integrations/sandboxes/cua.mdx
+++ b/docs/src/content/en/integrations/sandboxes/cua.mdx
@@ -64,6 +64,15 @@ The first computer operation starts the session. The agent can take screenshots,
 Call the computer capability without an agent to verify that the pool supplies a working desktop. With a newly constructed sandbox, this example prints the screen dimensions and PNG byte count:
 
 ```typescript
+import { CuaFleetSandbox } from '@mastra/cua'
+
+const sandbox = new CuaFleetSandbox({
+  id: 'direct-desktop-session',
+  poolName: 'existing-linux-pool',
+  clientId: process.env.CUA_CLIENT_ID!,
+  clientSecret: process.env.CUA_CLIENT_SECRET!,
+})
+
 try {
   await sandbox.start()
   const size = await sandbox.computer.getScreenSize()

--- a/docs/src/content/en/integrations/sidebars.js
+++ b/docs/src/content/en/integrations/sidebars.js
@@ -200,6 +200,11 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'sandboxes/cua',
+          label: 'Cua',
+        },
+        {
+          type: 'doc',
           id: 'sandboxes/daytona',
           label: 'Daytona',
           customProps: { icon: '/img/integrations/daytona.svg', customCSS: 'dark:invert' },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9720,6 +9720,55 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0)(supports-color@10.2.2))(msw@2.14.6(@types/node@22.19.15)(typescript@7.0.2))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
 
+  workspaces/cua:
+    dependencies:
+      '@trycua/fleet':
+        specifier: 0.1.1
+        version: 0.1.1
+      pngjs:
+        specifier: 7.0.0
+        version: 7.0.0
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      '@types/pngjs':
+        specifier: 6.0.5
+        version: 6.0.5
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      '@vitest/ui':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      eslint:
+        specifier: ^10.7.0
+        version: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)
+      tsdown:
+        specifier: 0.22.9
+        version: 0.22.9(@volar/typescript@2.4.23(typescript@7.0.2))(oxc-resolver@11.20.0)(tsx@4.23.1)(typescript@7.0.2)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.23.1
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0)(supports-color@10.2.2))(msw@2.14.6(@types/node@22.19.15)(typescript@7.0.2))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
+
   workspaces/daytona:
     dependencies:
       '@daytonaio/sdk':
@@ -20972,6 +21021,9 @@ packages:
     resolution: {integrity: sha512-xQcPxVrKr3yT9+ZEM3skYXikJc/ocZlGDIcsBQ3mMwL3Weq1QL7jx/uGLXvrSO2Yh0DWUjWI6Q/oiRCEUM6P8w==}
     engines: {node: '>=14'}
 
+  '@trycua/fleet@0.1.1':
+    resolution: {integrity: sha512-a8pVRG0LZV/m6GEveBXpgUz64g1hjPEFw1HM5lnhB/wFBrc/JL3kXcewUcKNFpL8Rs1x1eS+rv7MRorhSSTC0w==}
+
   '@ts-graphviz/adapter@2.0.6':
     resolution: {integrity: sha512-kJ10lIMSWMJkLkkCG5gt927SnGZcBuG0s0HHswGzcHTgvtUe7yk5/3zTEr0bafzsodsOq5Gi6FhQeV775nC35Q==}
     engines: {node: '>=18'}
@@ -21429,6 +21481,9 @@ packages:
   '@types/pidusage@2.0.5':
     resolution: {integrity: sha512-MIiyZI4/MK9UGUXWt0jJcCZhVw7YdhBuTOuqP/BjuLDLZ2PmmViMIQgZiWxtaMicQfAz/kMrZ5T7PKxFSkTeUA==}
 
+  '@types/pngjs@6.0.5':
+    resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
+
   '@types/prismjs@1.26.5':
     resolution: {integrity: sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==}
 
@@ -21775,6 +21830,9 @@ packages:
   '@typespec/ts-http-runtime@0.3.1':
     resolution: {integrity: sha512-SnbaqayTVFEA6/tYumdF0UmybY0KHyKwGPBXnyckFlrrKdhWFrL3a2HIPXHjht5ZOElKGcXfD2D63P36btb+ww==}
     engines: {node: '>=20.0.0'}
+
+  '@ubjs/core@0.31.0-3':
+    resolution: {integrity: sha512-39XrJgUZ2VVb561sSnkXPhczNoeBsNiSRArecsV0JE7CJq69ajFkcn9/tBAUS2NpgHkLIDU+z6Ks2+1wXnboxg==}
 
   '@uiw/codemirror-extensions-basic-setup@4.25.11':
     resolution: {integrity: sha512-otyFa+n9IOYtEjaKOxPedHkj15fTPUF21wdR9pv0GpZPfuGl27cvmcv6+tognbRu9VvEcsHKE+ESoszeo3KfTw==}
@@ -29093,6 +29151,10 @@ packages:
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -45727,6 +45789,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@trycua/fleet@0.1.1':
+    dependencies:
+      '@ubjs/core': 0.31.0-3
+
   '@ts-graphviz/adapter@2.0.6':
     dependencies:
       '@ts-graphviz/common': 2.1.5
@@ -46264,6 +46330,10 @@ snapshots:
 
   '@types/pidusage@2.0.5': {}
 
+  '@types/pngjs@6.0.5':
+    dependencies:
+      '@types/node': 22.19.15
+
   '@types/prismjs@1.26.5': {}
 
   '@types/progress@2.0.7':
@@ -46638,6 +46708,8 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+
+  '@ubjs/core@0.31.0-3': {}
 
   '@uiw/codemirror-extensions-basic-setup@4.25.11(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.4)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.0)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)':
     dependencies:
@@ -55532,6 +55604,8 @@ snapshots:
       fsevents: 2.3.2
 
   pluralize@8.0.0: {}
+
+  pngjs@7.0.0: {}
 
   points-on-curve@0.2.0: {}
 

--- a/workspaces/cua/.gitignore
+++ b/workspaces/cua/.gitignore
@@ -1,0 +1,3 @@
+output/
+output-*/
+*.tgz

--- a/workspaces/cua/README.md
+++ b/workspaces/cua/README.md
@@ -1,0 +1,152 @@
+# Cua Fleet for Mastra
+
+`CuaFleetSandbox` gives a Mastra agent computer tools backed by a Linux desktop
+in Cua Fleet. It uses `@trycua/fleet` directly and implements Mastra's
+`WorkspaceSandbox` interface. The provider creates a claim from an existing pool;
+the application owns the pool's capacity and cleanup policy.
+
+This package is proposed in [Mastra #23283](https://github.com/mastra-ai/mastra/issues/23283)
+and has not been published to npm.
+
+## Develop locally
+
+From the Mastra repository root:
+
+```bash
+pnpm install
+pnpm turbo build --filter=@mastra/cua
+pnpm --filter @mastra/cua test:unit
+pnpm --filter @mastra/cua typecheck
+pnpm --filter @mastra/cua lint
+```
+
+Requires Node.js 22.13 or later. The package exports ESM, CommonJS, and TypeScript
+declarations from `dist` and uses `@trycua/fleet` 0.1.1.
+
+## Attach a Fleet desktop to an agent
+
+```ts
+import { Agent } from '@mastra/core/agent';
+import { Workspace } from '@mastra/core/workspace';
+import { CuaFleetSandbox } from '@mastra/cua';
+
+const sandbox = new CuaFleetSandbox({
+  id: 'unique-application-session',
+  poolName: 'existing-linux-pool',
+  clientId: process.env.CUA_CLIENT_ID!,
+  clientSecret: process.env.CUA_CLIENT_SECRET!,
+});
+
+const agent = new Agent({
+  id: 'desktop-agent',
+  name: 'Desktop Agent',
+  instructions: 'Use the computer tools to complete the requested task.',
+  model: process.env.MASTRA_MODEL!,
+  workspace: new Workspace({ sandbox }),
+});
+
+try {
+  const result = await agent.generate('Describe the desktop.', { maxSteps: 10 });
+  console.log(result.text);
+} finally {
+  await sandbox.destroy();
+}
+```
+
+Configure the API key required by the selected Mastra model separately. Keep
+Fleet client credentials server-side, in your secret manager or protected
+process environment. The SDK exchanges and refreshes OAuth credentials;
+credentials are not included in provider metadata or raw error messages.
+
+The pool must contain a compatible Linux desktop image with computer-server
+exposed as the `server` service. This provider is fixed to `run.cua.ai` and its
+Fleet OAuth endpoint. It does not install software or provision a pool.
+
+## Computer tools
+
+A concrete `Workspace({ sandbox })` automatically registers Mastra's computer
+tools for screenshots, left/right/double clicks, mouse movement, drag, typing,
+key presses, scrolling, screen information, and waiting. Screenshots are PNG
+bytes. Coordinates are integer display pixels from the top-left; scrolling
+uses positive integer wheel ticks.
+
+Examples: `press('Enter')`, `press('ArrowDown')`, and
+`press(['Control', 's'])`. Single characters preserve case. Unknown named keys
+are rejected instead of silently typing their names. Actions are serialized
+within one instance so chords, dragging, and screenshots do not overlap.
+
+Each concurrent application session needs a separate sandbox and workspace.
+Mastra 1.62.0 does not discover computer tools from a dynamic sandbox resolver.
+Sharing a provider instance shares its desktop.
+
+## Lifecycle and limits
+
+- Construction performs no network operations. `start()` or the first computer
+  operation acquires a claim. Concurrent starts share one acquisition.
+- `id` is an application identity, not a saved Fleet claim ID. Creating another
+  instance with the same `id` still creates an independent claim.
+- `destroy()` rejects new actions, waits for active work, releases only its
+  owned claim, and verifies claim absence. It leaves the caller's pool intact.
+  If cleanup fails, the instance retains cleanup state; retry `destroy()`.
+- `stop()` is not implemented. `Workspace.stop()` leaves the claim active;
+  call `destroy()` to release it. Pause and resume are unsupported.
+- The claim has a one-hour creation-age TTL by default. It is not an inactivity
+  timer or automatic renewal, and startup time counts toward it. Configure
+  `claimTtlSeconds` (maximum one day) for the intended session. A pool's own
+  expiry can also end the desktop. TTL is not a spending cap.
+- `startupTimeoutMs` defaults to 900000; `requestTimeoutMs` defaults to 60000.
+  Configure a claim TTL longer than startup. Requests refuse redirects and
+  have bounded HTTP timeouts. GUI commands are not replayed automatically on
+  ambiguous failures, since replay can duplicate clicks or text.
+- Shell execution, files, processes, live viewing, snapshots, cloning, and
+  other operating systems are not advertised. `snapshot()` is Mastra's no-op
+  compatibility hook and `supportsCheckpoints` is false.
+
+## Live example
+
+The example creates a temporary Linux pool, starts the provider, installs a
+synthetic guest-local webpage, and invokes an agent to enter a unique value and
+click its submit button. A separate authenticated guest command reads the
+fixture's recorded value; the agent's final text is not the success oracle.
+It then starts a second concurrent provider, checks that the two claims use
+different guests, and verifies that the second guest cannot see the first
+guest's fixture state. Both claims are released before pool cleanup.
+
+```bash
+# Set CUA_CLIENT_ID and CUA_CLIENT_SECRET securely first.
+# Select a vision-capable model and configure its provider API key.
+export MASTRA_MODEL='your-provider/your-model'
+pnpm --filter @mastra/cua example
+```
+
+For deterministic orchestration/GUI proof without a model API key:
+
+```bash
+pnpm --filter @mastra/cua example scripted
+```
+
+Scripted mode uses a fixed LanguageModelV2 fixture with the real Mastra agent
+loop and real desktop tools. It does not prove autonomous model reasoning.
+The fixture uses fixed geometry in a kiosk browser; model mode locates controls
+from screenshots. Screenshots and a small result record go to ignored `output/`.
+
+The live example incurs Fleet usage, provisions two pool slots with 4 CPU cores
+and 4 GiB RAM each, briefly holds two concurrent desktops, and uses
+one-hour pool and claim TTLs. Its `finally` blocks destroy the provider and
+delete only its exclusively reserved namespace. A successful namespace listing
+without that namespace is cleanup proof at the account API level, not an
+independent infrastructure termination check.
+
+If interrupted, keep `output/run.json`, restore credentials for the same
+account, and run:
+
+```bash
+pnpm --filter @mastra/cua example cleanup
+```
+
+Cleanup checks the namespace creation timestamp before deletion and never
+provisions resources. If reservation was not confirmed, the record has no
+creation timestamp and cleanup refuses deletion: inspect the recorded random
+namespace in Fleet before taking any manual action. A forbidden request is not
+proof of resource absence. After confirmed cleanup, archive `output/` before
+another run; the example refuses to overwrite a previous recovery record.

--- a/workspaces/cua/README.md
+++ b/workspaces/cua/README.md
@@ -148,5 +148,11 @@ Cleanup checks the namespace creation timestamp before deletion and never
 provisions resources. If reservation was not confirmed, the record has no
 creation timestamp and cleanup refuses deletion: inspect the recorded random
 namespace in Fleet before taking any manual action. A forbidden request is not
-proof of resource absence. After confirmed cleanup, archive `output/` before
-another run; the example refuses to overwrite a previous recovery record.
+proof of resource absence. After confirmed cleanup, the next run archives the
+record as `output/run-completed-<uuid>.json` and reserves a new `run.json`.
+Unfinished or malformed records block new runs. Archive screenshots and results
+before another run if you want to retain them.
+
+Record reservation uses `output/run.json.lock` to exclude simultaneous starts.
+If the process is interrupted during reservation, check that no example process
+is running before removing that lock file. Preserve `run.json` for cleanup.

--- a/workspaces/cua/THIRD_PARTY_NOTICES
+++ b/workspaces/cua/THIRD_PARTY_NOTICES
@@ -1,0 +1,23 @@
+Adapted from @trycua/mastra (https://github.com/trycua/cua/pull/3642).
+
+MIT License
+
+Copyright (c) 2025 Cua AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/workspaces/cua/THIRD_PARTY_NOTICES
+++ b/workspaces/cua/THIRD_PARTY_NOTICES
@@ -1,5 +1,3 @@
-Adapted from @trycua/mastra (https://github.com/trycua/cua/pull/3642).
-
 MIT License
 
 Copyright (c) 2025 Cua AI, Inc.

--- a/workspaces/cua/eslint.config.js
+++ b/workspaces/cua/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default config;

--- a/workspaces/cua/examples/agent.ts
+++ b/workspaces/cua/examples/agent.ts
@@ -7,6 +7,7 @@ import { Workspace } from '@mastra/core/workspace';
 import { CyclopsClient, CyclopsCredentials, uniffiInitAsync, type Sandbox } from '@trycua/fleet/node';
 import { CuaFleetSandbox } from '../src/index.js';
 import { FleetHttpClient, decodeGuestResponse } from '../src/fleet-session.js';
+import { reserveRunRecord } from './run-record.js';
 
 const require = createRequire(import.meta.url);
 const providerVersion = require('../package.json').version;
@@ -101,7 +102,7 @@ async function main() {
     const record: RecordFile = {
       name: `mastra-test-${randomUUID().replaceAll('-', '').slice(0, 20)}`,
     };
-    await writeFile(recordFile, JSON.stringify(record, null, 2), { flag: 'wx' });
+    await reserveRunRecord(recordFile, record);
     stage = 'namespace reservation';
     const ns = await client.createNamespace(record.name);
     record.createdAt = ns.createdAt;

--- a/workspaces/cua/examples/agent.ts
+++ b/workspaces/cua/examples/agent.ts
@@ -1,0 +1,307 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { Agent } from '@mastra/core/agent';
+import { Workspace } from '@mastra/core/workspace';
+import { CyclopsClient, CyclopsCredentials, uniffiInitAsync, type Sandbox } from '@trycua/fleet/node';
+import { CuaFleetSandbox } from '../src/index.js';
+import { FleetHttpClient, decodeGuestResponse } from '../src/fleet-session.js';
+
+const require = createRequire(import.meta.url);
+const providerVersion = require('../package.json').version;
+const mastraVersion = require('@mastra/core/package.json').version;
+const fleetVersion = require('@trycua/fleet/package.json').version;
+
+const output = new URL('../output/', import.meta.url);
+const recordFile = new URL('run.json', output);
+const image =
+  'public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04@sha256:c1e601dbb748fdc467c663136f7592e308a91a3c19c309b75261544432826a57';
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+type RecordFile = { name: string; createdAt?: string; cleanupConfirmed?: boolean };
+let stage = 'configuration';
+let failedStage: string | undefined;
+
+function env(name: string) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing ${name}`);
+  return value;
+}
+
+async function main() {
+  const mode = process.argv[2] ?? 'model';
+  assert.ok(['model', 'scripted', 'cleanup'].includes(mode));
+  const modelId = mode === 'model' ? env('MASTRA_MODEL') : undefined;
+  const clientId = env('CUA_CLIENT_ID'),
+    clientSecret = env('CUA_CLIENT_SECRET');
+  await uniffiInitAsync();
+  const credentials = new CyclopsCredentials(clientId, clientSecret);
+  const client = CyclopsClient.connect(
+    {
+      baseUrl: 'https://run.cua.ai',
+      tokenUrl: 'https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token',
+      credentials,
+      poolPollIntervalMs: 2_000n,
+      poolPollLimit: 450,
+      claimPollIntervalMs: 2_000n,
+      claimPollLimit: 450,
+    },
+    new FleetHttpClient(60_000),
+  );
+
+  async function cleanup(record: RecordFile) {
+    assert.match(record.name, /^mastra-test-[a-f0-9]{20}$/);
+    assert.ok(record.createdAt);
+    const current = (await client.listNamespaces()).find(item => item.name === record.name);
+    if (current) {
+      assert.equal(current.createdAt, record.createdAt, 'Refusing changed namespace identity');
+      await client.deleteNamespace(record.name);
+    }
+    for (let i = 0; i < 90; i++) {
+      if (!(await client.listNamespaces()).some(item => item.name === record.name)) {
+        record.cleanupConfirmed = true;
+        await writeFile(recordFile, JSON.stringify(record, null, 2) + '\n');
+        console.log('PASS: temporary namespace absent from account inventory');
+        return;
+      }
+      await delay(2_000);
+    }
+    throw new Error('Cleanup pending');
+  }
+
+  async function shell(sandbox: Sandbox, command: string) {
+    const response = await client.serviceRequest(sandbox, 'server', '/cmd', {
+      method: 'POST',
+      url: 'https://ignored.invalid/cmd',
+      headers: [{ name: 'content-type', value: 'application/json' }],
+      body: new TextEncoder().encode(JSON.stringify({ command: 'run_command', params: { command, timeout: 30 } }))
+        .buffer,
+      timeoutSecs: 60n,
+    });
+    assert.equal(response.status, 200);
+    const result = decodeGuestResponse(response.body);
+    if (result.success !== true || result.return_code !== 0) {
+      console.error('Guest fixture command failed', {
+        success: result.success,
+        exitCode: result.return_code,
+      });
+    }
+    assert.equal(result.success, true);
+    assert.equal(result.return_code, 0);
+    assert.equal(typeof result.stdout, 'string');
+    return result.stdout as string;
+  }
+
+  try {
+    if (mode === 'cleanup') {
+      await cleanup(JSON.parse(await readFile(recordFile, 'utf8')));
+      return;
+    }
+    await mkdir(output, { recursive: true });
+    const record: RecordFile = {
+      name: `mastra-test-${randomUUID().replaceAll('-', '').slice(0, 20)}`,
+    };
+    await writeFile(recordFile, JSON.stringify(record, null, 2), { flag: 'wx' });
+    stage = 'namespace reservation';
+    const ns = await client.createNamespace(record.name);
+    record.createdAt = ns.createdAt;
+    assert.ok(record.createdAt);
+    try {
+      await writeFile(recordFile, JSON.stringify(record, null, 2));
+      stage = 'pool provisioning';
+      console.log('Provisioning a temporary Linux Fleet pool (two slots, each 4 CPU / 4 GiB; one-hour TTL)...');
+      const templateName = `${record.name}-template`;
+      await client.createTemplate({
+        namespace: record.name,
+        name: templateName,
+        spec: {
+          vmTemplate: {
+            containerDiskImage: image,
+            cpuCores: 4,
+            memory: '4Gi',
+            services: [{ name: 'server', targetPort: 8000 }],
+          },
+        },
+      });
+      await client.createPool({
+        namespace: record.name,
+        spec: {
+          replicas: 2,
+          sandboxTemplateRef: { name: templateName },
+          ttlSecondsAfterCreated: 3600,
+        },
+      });
+      const sandbox = new CuaFleetSandbox({
+        id: randomUUID(),
+        poolName: record.name,
+        clientId,
+        clientSecret,
+      });
+      const workspace = new Workspace({ sandbox });
+      try {
+        stage = 'provider startup';
+        await sandbox.start();
+        const claims = await client.listClaims(record.name);
+        assert.equal(claims.length, 1);
+        const guest = await client.waitClaim(claims[0]!);
+        stage = 'fixture setup';
+        const fixture = (await readFile(new URL('./fixture.py', import.meta.url))).toString('base64');
+        const bootstrap = Buffer.from(
+          `import base64, pathlib, subprocess, shutil, time, urllib.request
+pathlib.Path('/tmp/mastra-fleet-fixture.py').write_bytes(base64.b64decode('${fixture}'))
+detached = dict(stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
+subprocess.Popen(['python3', '/tmp/mastra-fleet-fixture.py'], **detached)
+for attempt in range(30):
+    try:
+        urllib.request.urlopen('http://127.0.0.1:8765', timeout=1).close()
+        break
+    except Exception:
+        time.sleep(0.2)
+else:
+    raise RuntimeError('FIXTURE_SERVER_UNAVAILABLE')
+browser = next((shutil.which(name) for name in ['chromium', 'chromium-browser', 'google-chrome', 'google-chrome-stable'] if shutil.which(name)), None)
+if not browser:
+    raise RuntimeError('CHROMIUM_BROWSER_MISSING')
+subprocess.Popen([browser, '--no-sandbox', '--disable-dev-shm-usage', '--no-first-run', '--user-data-dir=/tmp/mastra-fleet-browser', '--kiosk', 'http://127.0.0.1:8765'], **detached)
+print('FIXTURE_STARTED')
+`,
+        ).toString('base64');
+        const setup = await shell(guest, `python3 -c "import base64; exec(base64.b64decode('${bootstrap}'))"`);
+        assert.match(setup, /FIXTURE_STARTED/);
+        await delay(5_000);
+        stage = 'initial fixture screenshot';
+        await writeFile(new URL('before.png', output), (await sandbox.computer.screenshot()).data);
+        const marker = `mastra-${randomUUID().slice(0, 8)}`;
+        const usage = { inputTokens: 1, outputTokens: 1, totalTokens: 2 };
+        const tool = (name: string, input: object, index: number) => ({
+          content: [
+            {
+              type: 'tool-call' as const,
+              toolCallId: `fixture-${index}`,
+              toolName: `mastra_workspace_computer_${name}`,
+              input: JSON.stringify(input),
+            },
+          ],
+          finishReason: 'tool-calls' as const,
+          usage,
+          warnings: [],
+        });
+        // Scripted mode tests the real Mastra tool loop, not autonomous model choice.
+        const responses = [
+          tool('screenshot', {}, 0),
+          tool('click', { x: 200, y: 205 }, 1),
+          tool('type', { text: marker }, 2),
+          tool('click', { x: 150, y: 280 }, 3),
+          {
+            content: [{ type: 'text' as const, text: 'Fixture submitted.' }],
+            finishReason: 'stop' as const,
+            usage,
+            warnings: [],
+          },
+        ];
+        let responseIndex = 0;
+        const model = modelId ?? {
+          specificationVersion: 'v2' as const,
+          provider: 'fixture',
+          modelId: 'scripted',
+          supportedUrls: {},
+          doGenerate: async () => {
+            const response = responses[responseIndex++];
+            if (!response) throw new Error('Scripted model exhausted');
+            return response;
+          },
+          doStream: async (): Promise<never> => {
+            throw new Error('Streaming is not used by this fixture');
+          },
+        };
+        const agent = new Agent({
+          id: 'fleet-fixture-agent',
+          name: 'Fleet Fixture Agent',
+          model,
+          workspace,
+          instructions:
+            'Use only computer tools to interact with the visible test page. Take a screenshot first. Type the requested value into Verification value and click Submit value. Confirm the displayed Submitted result. Do not use the terminal, address bar, developer tools, or other applications.',
+        });
+        stage = `${mode} Mastra agent`;
+        console.log(`Running ${mode} Mastra agent on the guest desktop...`);
+        const result = await agent.generate(`Submit exactly ${marker} using the test page.`, {
+          maxSteps: 15,
+        });
+        stage = 'independent fixture assertion';
+        const observed = JSON.parse(await shell(guest, 'cat /tmp/mastra-fleet-fixture-state.json'));
+        assert.equal(observed.value, marker);
+        await writeFile(new URL('after.png', output), (await sandbox.computer.screenshot()).data);
+        stage = 'session isolation';
+        console.log('Checking a second concurrent session has a separate desktop...');
+        const other = new CuaFleetSandbox({
+          id: sandbox.id,
+          poolName: record.name,
+          clientId,
+          clientSecret,
+        });
+        try {
+          await other.start();
+          const active = await client.listClaims(record.name);
+          assert.equal(active.length, 2);
+          const otherClaim = active.find(item => item.metadata.name !== claims[0]!.metadata.name);
+          assert.ok(otherClaim);
+          const otherGuest = await client.waitClaim(otherClaim);
+          assert.notEqual(otherGuest.name, guest.name);
+          assert.equal(
+            (await shell(otherGuest, 'test ! -e /tmp/mastra-fleet-fixture-state.json && printf isolated')).trim(),
+            'isolated',
+          );
+          assert.equal(JSON.parse(await shell(guest, 'cat /tmp/mastra-fleet-fixture-state.json')).value, marker);
+          console.log('PASS: simultaneous sessions have distinct guests and isolated fixture state');
+        } finally {
+          await other.destroy();
+        }
+        await writeFile(
+          new URL('result.json', output),
+          JSON.stringify(
+            {
+              mode,
+              model: modelId ?? 'scripted LanguageModelV2 fixture',
+              timestamp: new Date().toISOString(),
+              providerVersion,
+              mastraVersion,
+              fleetVersion,
+              fixtureVerified: true,
+              isolationVerified: true,
+              steps: result.steps.length,
+              image,
+            },
+            null,
+            2,
+          ) + '\n',
+        );
+        console.log('PASS: guest fixture independently recorded the exact submitted value');
+      } catch (error) {
+        failedStage = stage;
+        throw error;
+      } finally {
+        stage = 'claim cleanup';
+        await sandbox.destroy();
+        assert.equal((await client.listClaims(record.name)).length, 0);
+        console.log('PASS: provider released its claim and left the caller-owned pool intact');
+        assert.equal((await client.getPool(record.name)).metadata.name, record.name);
+      }
+    } catch (error) {
+      failedStage ??= stage;
+      throw error;
+    } finally {
+      stage = 'pool cleanup';
+      await cleanup(record);
+    }
+  } finally {
+    if (client instanceof CyclopsClient) client.uniffiDestroy();
+    credentials.uniffiDestroy();
+  }
+}
+
+main().catch(() => {
+  console.error(
+    `Example failed during ${failedStage ?? stage}. Raw SDK/model errors are withheld. Preserve output/run.json and run the cleanup command with the same account.`,
+  );
+  process.exitCode = 1;
+});

--- a/workspaces/cua/examples/fixture.py
+++ b/workspaces/cua/examples/fixture.py
@@ -1,0 +1,39 @@
+"""Synthetic guest-local GUI fixture. No external network requests."""
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+STATE = Path('/tmp/mastra-fleet-fixture-state.json')
+HTML = b'''<!doctype html><html><head><title>Fleet Mastra Test</title>
+<style>body{font:24px sans-serif;margin:0;background:#f3f5f6;color:#18232d}
+h1{position:absolute;left:48px;top:24px}label{position:absolute;left:48px;top:125px}
+input,button{font:24px sans-serif;padding:16px;position:absolute;box-sizing:border-box}
+input{left:48px;top:170px;width:480px;height:64px}
+button{left:48px;top:260px;height:64px;background:#135f4b;color:white;border:0}
+#result{position:absolute;left:48px;top:350px;font-weight:bold}</style></head><body><h1>Fleet Mastra Test</h1>
+<label for="value">Verification value</label><input id="value" autofocus>
+<button id="submit">Submit value</button><p id="result">Waiting for submission</p>
+<script>document.querySelector('#submit').onclick=async()=>{
+const value=document.querySelector('#value').value;
+const r=await fetch('/submit',{method:'POST',body:JSON.stringify({value})});
+if(r.ok)document.querySelector('#result').textContent='Submitted: '+value;
+};</script></body></html>'''
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html')
+        self.end_headers()
+        self.wfile.write(HTML)
+
+    def do_POST(self):
+        data = json.loads(self.rfile.read(int(self.headers['Content-Length'])))
+        STATE.write_text(json.dumps(data))
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b'ok')
+
+    def log_message(self, *args):
+        pass
+
+HTTPServer(('127.0.0.1', 8765), Handler).serve_forever()

--- a/workspaces/cua/examples/run-record.ts
+++ b/workspaces/cua/examples/run-record.ts
@@ -1,0 +1,26 @@
+import { randomUUID } from 'node:crypto';
+import { open, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+
+/** Reserve the shared recovery record without overwriting a run that still needs cleanup. */
+export async function reserveRunRecord(recordFile: URL, record: { name: string }): Promise<void> {
+  const lockFile = new URL(`${recordFile.href}.lock`);
+  const lock = await open(lockFile, 'wx');
+  try {
+    let previous: string | undefined;
+    try {
+      previous = await readFile(recordFile, 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    if (previous !== undefined) {
+      if (JSON.parse(previous)?.cleanupConfirmed !== true) {
+        throw new Error('Previous run still requires cleanup; preserve run.json');
+      }
+      await rename(recordFile, new URL(`run-completed-${randomUUID()}.json`, recordFile));
+    }
+    await writeFile(recordFile, JSON.stringify(record, null, 2), { flag: 'wx' });
+  } finally {
+    await lock.close();
+    await unlink(lockFile);
+  }
+}

--- a/workspaces/cua/package.json
+++ b/workspaces/cua/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@mastra/cua",
+  "version": "0.0.0",
+  "description": "Cua Cloud Fleet computer-use sandbox provider for Mastra workspaces",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsdown --silent --config tsdown.config.ts",
+    "build:lib": "pnpm build",
+    "build:watch": "pnpm build --watch",
+    "test:unit": "vitest run --exclude '**/*.integration.test.ts'",
+    "test:watch": "vitest watch",
+    "test": "vitest run",
+    "test:cloud": "tsx examples/agent.ts scripted",
+    "lint": "oxlint . && eslint .",
+    "lint:fix": "oxlint --fix . && eslint --fix .",
+    "typecheck": "tsc --noEmit",
+    "example": "tsx examples/agent.ts",
+    "test:exports": "node --test tests/exports.mjs"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@trycua/fleet": "0.1.1",
+    "pngjs": "7.0.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "@types/node": "22.20.1",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "dotenv": "^17.4.2",
+    "eslint": "^10.7.0",
+    "tsdown": "0.22.9",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "@types/pngjs": "6.0.5",
+    "tsx": "catalog:"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.62.0-0 <2.0.0-0"
+  },
+  "files": [
+    "dist",
+    "THIRD_PARTY_NOTICES"
+  ],
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "workspaces/cua"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/workspaces/cua/src/fleet-session.test.ts
+++ b/workspaces/cua/src/fleet-session.test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { CyclopsClient, SdkError } from '@trycua/fleet/node';
+import { afterEach, test, vi } from 'vitest';
+import { CloudFleetSession, type SessionOptions } from './fleet-session.js';
+
+const options: SessionOptions = {
+  poolName: 'fake-pool',
+  clientId: 'fake-client',
+  clientSecret: 'fake-secret',
+  claimTtlSeconds: 3600,
+  startupTimeoutMs: 1000,
+  requestTimeoutMs: 5,
+};
+
+function fakeClient(createError: unknown = new Error('response lost')) {
+  let name = '';
+  let present = false;
+  let lists = 0;
+  const deleted: string[] = [];
+  const client = {
+    async getPool() {
+      return {
+        metadata: { namespace: 'owned-namespace' },
+        spec: { sandboxTemplateRef: { name: 'template' } },
+      };
+    },
+    async createClaim(request: { name: string }) {
+      name = request.name;
+      throw createError;
+    },
+    async listClaims(namespace: string) {
+      assert.equal(namespace, 'owned-namespace');
+      lists++;
+      return present ? [{ metadata: { name, namespace } }] : [];
+    },
+    async deleteClaim(claim: { metadata: { name: string } }) {
+      assert.equal(claim.metadata.name, name);
+      deleted.push(claim.metadata.name);
+      present = false;
+    },
+  };
+  return {
+    client: client as unknown as CyclopsClient,
+    appear: () => {
+      present = true;
+    },
+    get lists() {
+      return lists;
+    },
+    get name() {
+      return name;
+    },
+    deleted,
+  };
+}
+
+test('ambiguous creation retains ownership and retries cleanup when the late claim appears', async () => {
+  const fake = fakeClient();
+  vi.spyOn(CyclopsClient, 'connect').mockImplementation(() => fake.client);
+  const session = new CloudFleetSession(options);
+  await assert.rejects(session.start(), /response lost/);
+  assert.match(fake.name, /^mastra-[a-f0-9-]+$/);
+  await assert.rejects(session.close(), /CLAIM_CREATION_OUTCOME_UNKNOWN/);
+  assert.equal(fake.deleted.length, 0);
+  assert.ok(fake.lists >= 2, 'absence is rechecked during recovery');
+  fake.appear();
+  await session.close();
+  assert.deepEqual(fake.deleted, [fake.name]);
+  const completedLists = fake.lists;
+  await session.close();
+  assert.equal(fake.lists, completedLists, 'completed cleanup is idempotent');
+});
+
+test('claim appearing during recovery is deleted and its absence verified', async () => {
+  const fake = fakeClient();
+  const originalList = fake.client.listClaims.bind(fake.client);
+  let reads = 0;
+  vi.spyOn(fake.client, 'listClaims').mockImplementation(async (namespace: string) => {
+    if (++reads === 2) fake.appear();
+    return originalList(namespace);
+  });
+  vi.spyOn(CyclopsClient, 'connect').mockImplementation(() => fake.client);
+  const session = new CloudFleetSession({ ...options, requestTimeoutMs: 20 });
+  await assert.rejects(session.start(), /response lost/);
+  await session.close();
+  assert.deepEqual(fake.deleted, [fake.name]);
+  assert.equal(reads, 3, 'one absent read, one recovered claim, one deletion verification');
+});
+
+test('definitive create rejection does not search for or delete claims', async () => {
+  const rejection = new SdkError.Status({
+    operation: 'createClaim',
+    status: 403,
+    body: 'withheld',
+  });
+  const fake = fakeClient(rejection);
+  vi.spyOn(CyclopsClient, 'connect').mockImplementation(() => fake.client);
+  const session = new CloudFleetSession(options);
+  await assert.rejects(session.start(), error => error === rejection);
+  await session.close();
+  assert.equal(fake.lists, 0);
+  assert.deepEqual(fake.deleted, []);
+});
+
+test('failed deletion verification keeps confirmed identity for a safe retry', async () => {
+  const fake = fakeClient();
+  const originalList = fake.client.listClaims.bind(fake.client);
+  let failVerification = true;
+  vi.spyOn(fake.client, 'listClaims').mockImplementation(async (namespace: string) => {
+    if (fake.deleted.length && failVerification) throw new Error('inventory unavailable');
+    return originalList(namespace);
+  });
+  vi.spyOn(CyclopsClient, 'connect').mockImplementation(() => fake.client);
+  const session = new CloudFleetSession(options);
+  await assert.rejects(session.start(), /response lost/);
+  fake.appear();
+  await assert.rejects(session.close(), /inventory unavailable/);
+  failVerification = false;
+  await session.close();
+  assert.deepEqual(fake.deleted, [fake.name], 'confirmed deleted claim is not deleted again');
+});
+
+afterEach(() => vi.restoreAllMocks());

--- a/workspaces/cua/src/fleet-session.ts
+++ b/workspaces/cua/src/fleet-session.ts
@@ -1,0 +1,206 @@
+import { randomUUID } from 'node:crypto';
+import type {
+  CyclopsCredentials,
+  CyclopsClientLike,
+  HttpClient,
+  HttpRequest,
+  HttpResponse,
+  Claim,
+  Sandbox,
+} from '@trycua/fleet/node';
+
+export interface FleetSession {
+  start(): Promise<void>;
+  command(name: string, params: Record<string, unknown>): Promise<Record<string, unknown>>;
+  close(): Promise<void>;
+}
+
+export interface SessionOptions {
+  poolName: string;
+  clientId: string;
+  clientSecret: string;
+  claimTtlSeconds: number;
+  startupTimeoutMs: number;
+  requestTimeoutMs: number;
+}
+
+export class CuaFleetError extends Error {
+  constructor(public readonly code: string) {
+    super(`Cua Fleet: ${code}`);
+    this.name = 'CuaFleetError';
+  }
+}
+
+// Never forward raw SDK exceptions: they can include authenticated HTTP details.
+export function safeError(error: unknown, fallback: string): CuaFleetError {
+  return error instanceof CuaFleetError ? error : new CuaFleetError(fallback);
+}
+
+export class FleetHttpClient implements HttpClient {
+  constructor(private readonly timeoutMs: number) {}
+  async execute(request: HttpRequest, options?: { signal: AbortSignal }): Promise<HttpResponse> {
+    const { HttpError } = await import('@trycua/fleet/node');
+    try {
+      const timeout = AbortSignal.timeout(this.timeoutMs);
+      const response = await fetch(request.url, {
+        method: request.method,
+        headers: request.headers.map(({ name, value }) => [name, value]),
+        body: request.body,
+        redirect: 'error',
+        signal: options?.signal ? AbortSignal.any([options.signal, timeout]) : timeout,
+      });
+      return {
+        status: response.status,
+        headers: [...response.headers].map(([name, value]) => ({ name, value })),
+        body: await response.arrayBuffer(),
+      };
+    } catch {
+      // UniFFI callbacks require typed errors; raw exceptions can panic and log request details.
+      throw new HttpError.Transport({ reason: 'Fleet HTTP transport failed' });
+    }
+  }
+}
+
+export function decodeGuestResponse(bytes: ArrayBuffer): Record<string, unknown> {
+  const text = new TextDecoder().decode(bytes).trim();
+  const data = text.startsWith('data:')
+    ? text
+        .split(/\r?\n/)
+        .filter(line => line.startsWith('data:'))
+        .map(line => line.slice(5).trim())
+        .join('\n')
+    : text;
+  try {
+    const result: unknown = JSON.parse(data);
+    if (!result || typeof result !== 'object' || Array.isArray(result)) throw new Error();
+    return result as Record<string, unknown>;
+  } catch {
+    throw new CuaFleetError('INVALID_GUEST_RESPONSE');
+  }
+}
+
+export class CloudFleetSession implements FleetSession {
+  #sdk?: typeof import('@trycua/fleet/node');
+  #options: SessionOptions;
+  #client?: CyclopsClientLike;
+  #credentials?: CyclopsCredentials;
+  #claim?: Claim;
+  #sandbox?: Sandbox;
+  #namespace?: string;
+  #claimName = `mastra-${randomUUID()}`;
+  #createAttempted = false;
+
+  constructor(options: SessionOptions) {
+    this.#options = options;
+  }
+
+  async start(): Promise<void> {
+    const options = this.#options;
+    // Fleet's Node entry is ESM-only; defer it so CommonJS consumers can load the provider.
+    this.#sdk = await import('@trycua/fleet/node');
+    const { CyclopsClient, CyclopsCredentials, SdkError, uniffiInitAsync } = this.#sdk;
+    await uniffiInitAsync();
+    this.#credentials = new CyclopsCredentials(options.clientId, options.clientSecret);
+    this.#client = CyclopsClient.connect(
+      {
+        baseUrl: 'https://run.cua.ai',
+        tokenUrl: 'https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token',
+        credentials: this.#credentials,
+        poolPollIntervalMs: 2_000n,
+        poolPollLimit: Math.ceil(options.startupTimeoutMs / 2_000),
+        claimPollIntervalMs: 2_000n,
+        claimPollLimit: Math.ceil(options.startupTimeoutMs / 2_000),
+      },
+      new FleetHttpClient(options.requestTimeoutMs),
+    );
+    const signal = AbortSignal.timeout(options.startupTimeoutMs);
+    const pool = await this.#client.getPool(options.poolName, { signal });
+    this.#namespace = pool.metadata.namespace;
+    this.#createAttempted = true;
+    try {
+      this.#claim = await this.#client.createClaim(
+        {
+          pool,
+          name: this.#claimName,
+          spec: {
+            sandboxTemplateRef: pool.spec.sandboxTemplateRef,
+            bindDeadline: Math.ceil(options.startupTimeoutMs / 1000),
+            ttlSecondsAfterCreated: options.claimTtlSeconds,
+          },
+        },
+        { signal },
+      );
+    } catch (error) {
+      if (SdkError.Status.instanceOf(error) && [400, 401, 403, 404, 409, 422].includes(error.inner.status)) {
+        this.#createAttempted = false;
+      }
+      throw error;
+    }
+    this.#sandbox = await this.#client.waitClaim(this.#claim, { signal });
+    while (!signal.aborted) {
+      try {
+        await this.#request('/status', undefined, signal);
+        return;
+      } catch (error) {
+        if (signal.aborted) break;
+        if (error instanceof CuaFleetError && ['GUEST_HTTP_401', 'GUEST_HTTP_403'].includes(error.code)) throw error;
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+    throw new CuaFleetError('STARTUP_TIMEOUT');
+  }
+
+  async #request(path: string, body?: object, signal?: AbortSignal) {
+    if (!this.#client || !this.#sandbox) throw new CuaFleetError('NOT_RUNNING');
+    const response = await this.#client.serviceRequest(
+      this.#sandbox,
+      'server',
+      path,
+      {
+        method: body ? 'POST' : 'GET',
+        url: `https://ignored.invalid${path}`,
+        headers: body ? [{ name: 'content-type', value: 'application/json' }] : [],
+        body: body ? new TextEncoder().encode(JSON.stringify(body)).buffer : undefined,
+        timeoutSecs: BigInt(Math.ceil(this.#options.requestTimeoutMs / 1000)),
+      },
+      signal ? { signal } : undefined,
+    );
+    if (response.status !== 200) throw new CuaFleetError(`GUEST_HTTP_${response.status}`);
+    return decodeGuestResponse(response.body);
+  }
+
+  async command(name: string, params: Record<string, unknown>) {
+    const response = await this.#request('/cmd', { command: name, params });
+    if (response.success !== true) throw new CuaFleetError('GUEST_COMMAND_FAILED');
+    return response;
+  }
+
+  async close(): Promise<void> {
+    const client = this.#client;
+    if (client && this.#createAttempted && this.#namespace) {
+      // Recover an owned named claim even if its create response was lost.
+      const deadline = Date.now() + this.#options.requestTimeoutMs;
+      let claim = (await client.listClaims(this.#namespace)).find(item => item.metadata.name === this.#claimName);
+      // Absence is not conclusive when a timed-out create may still complete.
+      while (!claim && !this.#claim && Date.now() < deadline) {
+        await new Promise(resolve => setTimeout(resolve, Math.min(1000, this.#options.requestTimeoutMs)));
+        claim = (await client.listClaims(this.#namespace)).find(item => item.metadata.name === this.#claimName);
+      }
+      if (!claim && !this.#claim) throw new CuaFleetError('CLAIM_CREATION_OUTCOME_UNKNOWN');
+      if (claim) await client.deleteClaim(claim);
+      // Retain confirmed identity for a retry if deletion succeeded but verification failed.
+      if (claim) this.#claim = claim;
+      while ((await client.listClaims(this.#namespace)).some(item => item.metadata.name === this.#claimName)) {
+        if (Date.now() >= deadline) throw new CuaFleetError('CLAIM_CLEANUP_PENDING');
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+    this.#claim = undefined;
+    this.#sandbox = undefined;
+    this.#createAttempted = false;
+    if (this.#sdk && client instanceof this.#sdk.CyclopsClient) client.uniffiDestroy();
+    this.#client = undefined;
+    this.#credentials?.uniffiDestroy();
+    this.#credentials = undefined;
+  }
+}

--- a/workspaces/cua/src/index.ts
+++ b/workspaces/cua/src/index.ts
@@ -1,0 +1,254 @@
+import type { ProviderStatus, SandboxComputer, WorkspaceSandbox } from '@mastra/core/workspace';
+import { PNG } from 'pngjs';
+import {
+  CloudFleetSession,
+  CuaFleetError,
+  safeError,
+  type FleetSession,
+  type SessionOptions,
+} from './fleet-session.js';
+
+export { CuaFleetError } from './fleet-session.js';
+
+export interface CuaFleetSandboxOptions {
+  /** Logical session identity, not a reconnectable Fleet sandbox identifier. */
+  id: string;
+  /** Existing Linux pool with a computer-server service named `server`. */
+  poolName: string;
+  clientId: string;
+  clientSecret: string;
+  /** Creation-age deadline; does not renew automatically. Default: 3600. */
+  claimTtlSeconds?: number;
+  /** Total acquisition/readiness deadline. Default: 900000. */
+  startupTimeoutMs?: number;
+  /** Per-HTTP-request deadline. Default: 60000. */
+  requestTimeoutMs?: number;
+}
+
+function integer(value: number, min = 0, max = 100_000): number {
+  if (!Number.isSafeInteger(value) || value < min || value > max) throw new CuaFleetError('INVALID_ARGUMENT');
+  return value;
+}
+
+const aliases: Record<string, string> = {
+  enter: 'enter',
+  return: 'enter',
+  escape: 'esc',
+  esc: 'esc',
+  space: 'space',
+  spacebar: 'space',
+  control: 'ctrl',
+  ctrl: 'ctrl',
+  alt: 'alt',
+  shift: 'shift',
+  meta: 'cmd',
+  super: 'cmd',
+  win: 'cmd',
+  arrowup: 'up',
+  arrowdown: 'down',
+  arrowleft: 'left',
+  arrowright: 'right',
+  pageup: 'page_up',
+  pagedown: 'page_down',
+  backspace: 'backspace',
+  delete: 'delete',
+  tab: 'tab',
+  home: 'home',
+  end: 'end',
+  insert: 'insert',
+  capslock: 'caps_lock',
+};
+
+function keyName(key: string): string {
+  if (typeof key !== 'string' || !key.length) throw new CuaFleetError('INVALID_KEY');
+  if (key.length === 1) return key;
+  const lower = key.toLowerCase();
+  if (aliases[lower]) return aliases[lower];
+  if (/^(f([1-9]|1[0-9]|2[0-4])|up|down|left|right|page_up|page_down|caps_lock)$/.test(lower)) return lower;
+  throw new CuaFleetError('UNSUPPORTED_KEY');
+}
+
+/** Linux-only Mastra computer capability; each instance owns a separate Fleet claim. */
+export class CuaFleetSandbox implements WorkspaceSandbox {
+  readonly id: string;
+  readonly name = 'Cua Fleet Linux';
+  readonly provider = 'cua-fleet';
+  readonly supportsCheckpoints = false;
+  readonly computer: SandboxComputer;
+  #status: ProviderStatus = 'pending';
+  #options: SessionOptions;
+  #session?: FleetSession;
+  #startPromise?: Promise<void>;
+  #destroyPromise?: Promise<void>;
+  #closing = false;
+  #queue: Promise<unknown> = Promise.resolve();
+
+  constructor(options: CuaFleetSandboxOptions) {
+    if (!options.id || !options.poolName || !options.clientId || !options.clientSecret)
+      throw new CuaFleetError('MISSING_CONFIGURATION');
+    this.id = options.id;
+    this.#options = {
+      poolName: options.poolName,
+      clientId: options.clientId,
+      clientSecret: options.clientSecret,
+      claimTtlSeconds: integer(options.claimTtlSeconds ?? 3600, 1, 86_400),
+      startupTimeoutMs: integer(options.startupTimeoutMs ?? 900_000, 1, 3_600_000),
+      requestTimeoutMs: integer(options.requestTimeoutMs ?? 60_000, 1, 300_000),
+    };
+    if (this.#options.claimTtlSeconds * 1000 <= this.#options.startupTimeoutMs)
+      throw new CuaFleetError('TTL_SHORTER_THAN_STARTUP');
+    const point = (x: number, y: number) => ({ x: integer(x), y: integer(y) });
+    const action = async (command: string, params: Record<string, unknown>) => {
+      await this.#command(command, params);
+    };
+    this.computer = {
+      screenshot: async () => {
+        const result = await this.#command('screenshot', { format: 'png' });
+        if (typeof result.image_data !== 'string') throw new CuaFleetError('INVALID_SCREENSHOT');
+        const data = Buffer.from(result.image_data, 'base64');
+        if (
+          data.length < 24 ||
+          data.length > 20 * 1024 * 1024 ||
+          data.subarray(0, 8).toString('hex') !== '89504e470d0a1a0a' ||
+          !data.readUInt32BE(16) ||
+          !data.readUInt32BE(20) ||
+          data.readUInt32BE(16) * data.readUInt32BE(20) > 16_000_000
+        )
+          throw new CuaFleetError('INVALID_SCREENSHOT');
+        try {
+          PNG.sync.read(data, { checkCRC: true });
+        } catch {
+          throw new CuaFleetError('INVALID_SCREENSHOT');
+        }
+        return { data: new Uint8Array(data), mediaType: 'image/png' };
+      },
+      leftClick: (x, y) => action('left_click', point(x, y)),
+      rightClick: (x, y) => action('right_click', point(x, y)),
+      doubleClick: (x, y) => action('double_click', point(x, y)),
+      moveMouse: (x, y) => action('move_cursor', point(x, y)),
+      drag: (from, to) => {
+        point(from.x, from.y);
+        point(to.x, to.y);
+        return action('drag', {
+          path: [
+            [from.x, from.y],
+            [to.x, to.y],
+          ],
+          button: 'left',
+        });
+      },
+      scroll: (direction, amount) => {
+        if (direction !== 'up' && direction !== 'down') throw new CuaFleetError('INVALID_ARGUMENT');
+        return action(`scroll_${direction}`, { clicks: integer(amount, 1, 1000) });
+      },
+      type: text => {
+        if (typeof text !== 'string') throw new CuaFleetError('INVALID_ARGUMENT');
+        return action('type_text', { text });
+      },
+      press: key => {
+        if (Array.isArray(key)) {
+          if (!key.length || key.length > 8) throw new CuaFleetError('INVALID_KEY');
+          return action('hotkey', { keys: key.map(keyName) });
+        }
+        return action('press_key', { key: keyName(key) });
+      },
+      getScreenSize: async () => {
+        const { size } = await this.#command('get_screen_size', {});
+        const result = size as { width?: number; height?: number } | undefined;
+        return {
+          width: integer(result?.width ?? NaN, 1),
+          height: integer(result?.height ?? NaN, 1),
+        };
+      },
+      getCursorPosition: async () => {
+        const { position } = await this.#command('get_cursor_position', {});
+        const result = position as { x?: number; y?: number } | undefined;
+        return point(result?.x ?? NaN, result?.y ?? NaN);
+      },
+    };
+  }
+
+  get status(): ProviderStatus {
+    return this.#status;
+  }
+  protected createSession(): FleetSession {
+    return new CloudFleetSession(this.#options);
+  }
+  isReady(): boolean {
+    return this.#status === 'running' && !this.#closing;
+  }
+  getInstructions(): string {
+    return 'Control an isolated Linux desktop. Coordinates are display pixels. This session has no persistent pause/resume, shell tool, or live viewer.';
+  }
+  async snapshot(): Promise<void> {
+    /* Mastra's no-checkpoint contract. */
+  }
+
+  start(): Promise<void> {
+    if (this.#closing) return Promise.reject(new CuaFleetError('DESTROYED'));
+    if (this.#startPromise) return this.#startPromise;
+    if (this.#status === 'running') return Promise.resolve();
+    this.#status = 'starting';
+    this.#startPromise = (async () => {
+      try {
+        if (this.#session) {
+          await this.#session.close();
+          this.#session = undefined;
+        }
+        this.#session = this.createSession();
+        await this.#session.start();
+        this.#status = 'running';
+        // Claims can bind to warm pool desktops; no VM creation outcome is implied.
+      } catch (error) {
+        this.#status = 'error';
+        try {
+          await this.#session?.close();
+          this.#session = undefined;
+        } catch {
+          throw new CuaFleetError('START_FAILED_CLEANUP_PENDING');
+        }
+        throw safeError(error, 'START_FAILED');
+      } finally {
+        this.#startPromise = undefined;
+      }
+    })();
+    return this.#startPromise;
+  }
+
+  destroy(): Promise<void> {
+    this.#closing = true;
+    if (this.#destroyPromise) return this.#destroyPromise;
+    if (this.#status === 'destroyed') return Promise.resolve();
+    this.#destroyPromise = (async () => {
+      await this.#startPromise?.catch(() => {});
+      await this.#queue.catch(() => {});
+      this.#status = 'destroying';
+      try {
+        await this.#session?.close();
+        this.#session = undefined;
+        this.#status = 'destroyed';
+      } catch (error) {
+        this.#status = 'error';
+        throw safeError(error, 'CLEANUP_PENDING');
+      } finally {
+        this.#destroyPromise = undefined;
+      }
+    })();
+    return this.#destroyPromise;
+  }
+
+  #command(name: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    if (this.#closing) return Promise.reject(new CuaFleetError('DESTROYED'));
+    const result = this.#queue.then(async () => {
+      try {
+        await this.start();
+        if (!this.#session || this.#closing) throw new CuaFleetError('DESTROYED');
+        return await this.#session.command(name, params);
+      } catch (error) {
+        throw safeError(error, 'COMMAND_FAILED');
+      }
+    });
+    this.#queue = result.catch(() => {});
+    return result;
+  }
+}

--- a/workspaces/cua/src/run-record.test.ts
+++ b/workspaces/cua/src/run-record.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { test } from 'vitest';
+import { reserveRunRecord } from '../examples/run-record.js';
+
+async function recordLocation() {
+  return pathToFileURL(join(await mkdtemp(join(tmpdir(), 'mastra-cua-record-')), 'run.json'));
+}
+
+test('a completed run is archived before reserving the next run', async () => {
+  const file = await recordLocation();
+  const previous = JSON.stringify({ name: 'old', cleanupConfirmed: true });
+  await writeFile(file, previous);
+  await reserveRunRecord(file, { name: 'next' });
+  assert.deepEqual(JSON.parse(await readFile(file, 'utf8')), { name: 'next' });
+  const archived = (await readdir(new URL('.', file))).find(name => name.startsWith('run-completed-'));
+  assert.ok(archived);
+  assert.equal(await readFile(new URL(archived, file), 'utf8'), previous);
+  await assert.rejects(reserveRunRecord(file, { name: 'third' }), /requires cleanup/);
+});
+
+test('unfinished and malformed records remain unchanged', async () => {
+  for (const previous of ['{"name":"active"}', '{"cleanupConfirmed":"true"}', 'invalid']) {
+    const file = await recordLocation();
+    await writeFile(file, previous);
+    await assert.rejects(reserveRunRecord(file, { name: 'next' }));
+    assert.equal(await readFile(file, 'utf8'), previous);
+    assert.deepEqual(await readdir(new URL('.', file)), ['run.json']);
+  }
+});
+
+test('simultaneous starts reserve only one record', async () => {
+  const file = await recordLocation();
+  await writeFile(file, JSON.stringify({ name: 'old', cleanupConfirmed: true }));
+  const results = await Promise.allSettled([
+    reserveRunRecord(file, { name: 'first' }),
+    reserveRunRecord(file, { name: 'second' }),
+  ]);
+  assert.equal(results.filter(result => result.status === 'fulfilled').length, 1);
+  const saved = JSON.parse(await readFile(file, 'utf8'));
+  assert.ok(['first', 'second'].includes(saved.name));
+  assert.equal(saved.cleanupConfirmed, undefined);
+});

--- a/workspaces/cua/src/sandbox.test.ts
+++ b/workspaces/cua/src/sandbox.test.ts
@@ -1,0 +1,354 @@
+import assert from 'node:assert/strict';
+import { Agent } from '@mastra/core/agent';
+import { Workspace, createWorkspaceTools } from '@mastra/core/workspace';
+import { PNG } from 'pngjs';
+import { test } from 'vitest';
+import { decodeGuestResponse, type FleetSession } from './fleet-session.js';
+import { CuaFleetSandbox } from './index.js';
+
+const png = PNG.sync.write(new PNG({ width: 1, height: 1 }));
+const options = {
+  id: 'test',
+  poolName: 'test-pool',
+  clientId: 'private-client',
+  clientSecret: 'private-secret',
+};
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(r => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+class Session implements FleetSession {
+  starts = 0;
+  closes = 0;
+  calls: { name: string; params: Record<string, unknown> }[] = [];
+  startImpl = async () => {};
+  closeImpl = async () => {};
+  commandImpl = async (name: string): Promise<Record<string, unknown>> => {
+    if (name === 'screenshot') return { image_data: png.toString('base64') };
+    if (name === 'get_screen_size') return { size: { width: 1280, height: 720 } };
+    if (name === 'get_cursor_position') return { position: { x: 10, y: 20 } };
+    return { success: true };
+  };
+  async start() {
+    this.starts++;
+    await this.startImpl();
+  }
+  async close() {
+    this.closes++;
+    await this.closeImpl();
+  }
+  async command(name: string, params: Record<string, unknown>) {
+    this.calls.push({ name, params });
+    return this.commandImpl(name);
+  }
+}
+class Sandbox extends CuaFleetSandbox {
+  sessions: Session[];
+  allocations = 0;
+  constructor(...sessions: Session[]) {
+    super(options);
+    this.sessions = sessions;
+  }
+  protected override createSession() {
+    return this.sessions[this.allocations++]!;
+  }
+}
+
+test('computer surface maps commands and normalizes images, dimensions, and keys', async () => {
+  const session = new Session();
+  const sandbox = new Sandbox(session);
+  const c = sandbox.computer;
+  const image = await c.screenshot();
+  assert.equal(image.mediaType, 'image/png');
+  assert.deepEqual(image.data, new Uint8Array(png));
+  await c.leftClick(1, 2);
+  await c.rightClick(3, 4);
+  await c.doubleClick(5, 6);
+  await c.moveMouse(7, 8);
+  await c.drag({ x: 9, y: 10 }, { x: 11, y: 12 });
+  await c.scroll('up', 2);
+  await c.scroll('down', 3);
+  await c.type('hello\nworld');
+  await c.press('Enter');
+  await c.press(['Control', 'Shift', 's']);
+  await c.press('ArrowUp');
+  await c.press('F12');
+  await c.press('Escape');
+  assert.deepEqual(await c.getScreenSize(), { width: 1280, height: 720 });
+  assert.deepEqual(await c.getCursorPosition(), { x: 10, y: 20 });
+  assert.deepEqual(session.calls, [
+    { name: 'screenshot', params: { format: 'png' } },
+    { name: 'left_click', params: { x: 1, y: 2 } },
+    { name: 'right_click', params: { x: 3, y: 4 } },
+    { name: 'double_click', params: { x: 5, y: 6 } },
+    { name: 'move_cursor', params: { x: 7, y: 8 } },
+    {
+      name: 'drag',
+      params: {
+        path: [
+          [9, 10],
+          [11, 12],
+        ],
+        button: 'left',
+      },
+    },
+    { name: 'scroll_up', params: { clicks: 2 } },
+    { name: 'scroll_down', params: { clicks: 3 } },
+    { name: 'type_text', params: { text: 'hello\nworld' } },
+    { name: 'press_key', params: { key: 'enter' } },
+    { name: 'hotkey', params: { keys: ['ctrl', 'shift', 's'] } },
+    { name: 'press_key', params: { key: 'up' } },
+    { name: 'press_key', params: { key: 'f12' } },
+    { name: 'press_key', params: { key: 'esc' } },
+    { name: 'get_screen_size', params: {} },
+    { name: 'get_cursor_position', params: {} },
+  ]);
+  assert.equal(session.starts, 1);
+  await sandbox.destroy();
+});
+
+test('invalid arguments fail before allocating or sending a command', async () => {
+  const session = new Session();
+  const sandbox = new Sandbox(session);
+  const c = sandbox.computer;
+  for (const action of [
+    () => c.leftClick(-1, 2),
+    () => c.moveMouse(NaN, 2),
+    () => c.scroll('up', 0),
+    () => c.scroll('down', 1.5),
+    () => c.press([]),
+    () => c.press(''),
+    () => c.press('not-a-key'),
+    () => c.drag({ x: 0, y: 0 }, { x: Infinity, y: 2 }),
+  ]) {
+    await assert.rejects(async () => action(), /INVALID_|UNSUPPORTED_KEY/);
+  }
+  assert.equal(session.starts, 0);
+  assert.equal(session.calls.length, 0);
+});
+
+test('malformed guest results are rejected', async () => {
+  const session = new Session();
+  const sandbox = new Sandbox(session);
+  const truncated = Buffer.alloc(24);
+  Buffer.from('89504e470d0a1a0a', 'hex').copy(truncated);
+  truncated.writeUInt32BE(1, 16);
+  truncated.writeUInt32BE(1, 20);
+  const invalidCrc = Buffer.from(png);
+  invalidCrc[29] = invalidCrc[29]! ^ 1;
+  for (const response of [
+    {},
+    { image_data: 'not an image' },
+    { image_data: Buffer.alloc(24).toString('base64') },
+    { image_data: truncated.toString('base64') },
+    { image_data: invalidCrc.toString('base64') },
+  ]) {
+    session.commandImpl = async () => response;
+    await assert.rejects(sandbox.computer.screenshot(), /INVALID_SCREENSHOT/);
+  }
+  session.commandImpl = async () => ({
+    size: { width: 0, height: 720 },
+    position: { x: '1', y: 2 },
+  });
+  await assert.rejects(sandbox.computer.getScreenSize(), /INVALID_ARGUMENT/);
+  await assert.rejects(sandbox.computer.getCursorPosition(), /INVALID_ARGUMENT/);
+  await sandbox.destroy();
+});
+
+test('concurrent start coalesces and destroy waits for acquisition', async () => {
+  const gate = deferred();
+  const session = new Session();
+  session.startImpl = () => gate.promise;
+  const sandbox = new Sandbox(session);
+  const first = sandbox.start();
+  const second = sandbox.start();
+  assert.equal(first, second);
+  assert.equal(session.starts, 1);
+  const destroy = sandbox.destroy();
+  assert.equal(session.closes, 0);
+  await assert.rejects(sandbox.start(), /DESTROYED/);
+  gate.resolve();
+  await first;
+  await destroy;
+  assert.equal(session.closes, 1);
+  assert.equal(sandbox.status, 'destroyed');
+  await assert.rejects(sandbox.computer.screenshot(), /DESTROYED/);
+  await sandbox.destroy();
+  assert.equal(session.closes, 1);
+});
+
+test('destroy drains an active command and rejects queued or new operations', async () => {
+  const entered = deferred();
+  const gate = deferred();
+  const session = new Session();
+  session.commandImpl = async () => {
+    entered.resolve();
+    await gate.promise;
+    return {};
+  };
+  const sandbox = new Sandbox(session);
+  const active = sandbox.computer.type('first');
+  await entered.promise;
+  const queued = sandbox.computer.type('second');
+  const queuedRejected = assert.rejects(queued, /DESTROYED/);
+  const destroy = sandbox.destroy();
+  assert.equal(session.closes, 0);
+  await assert.rejects(sandbox.computer.type('third'), /DESTROYED/);
+  gate.resolve();
+  await active;
+  await queuedRejected;
+  await destroy;
+  assert.equal(session.calls.length, 1);
+  assert.equal(session.closes, 1);
+});
+
+test('failed startup releases its session and permits a clean retry', async () => {
+  const failed = new Session();
+  failed.startImpl = async () => {
+    throw new Error(options.clientSecret);
+  };
+  const next = new Session();
+  const sandbox = new Sandbox(failed, next);
+  await assert.rejects(sandbox.start(), { message: 'Cua Fleet: START_FAILED' });
+  assert.equal(failed.closes, 1);
+  assert.equal(sandbox.status, 'error');
+  assert.equal(await sandbox.start(), undefined);
+  assert.equal(await sandbox.start(), undefined);
+  assert.equal(next.starts, 1);
+  await sandbox.destroy();
+});
+
+test('failed cleanup remains retryable and blocks further use', async () => {
+  const session = new Session();
+  let fail = true;
+  session.closeImpl = async () => {
+    if (fail) throw new Error(options.clientSecret);
+  };
+  const sandbox = new Sandbox(session);
+  await sandbox.start();
+  await assert.rejects(sandbox.destroy(), { message: 'Cua Fleet: CLEANUP_PENDING' });
+  assert.equal(sandbox.status, 'error');
+  await assert.rejects(sandbox.start(), /DESTROYED/);
+  fail = false;
+  await sandbox.destroy();
+  assert.equal(session.closes, 2);
+  assert.equal(sandbox.status, 'destroyed');
+});
+
+test('startup cleanup failure retains session for explicit destruction', async () => {
+  const session = new Session();
+  let fail = true;
+  session.startImpl = async () => {
+    throw new Error('failed');
+  };
+  session.closeImpl = async () => {
+    if (fail) throw new Error('release failed');
+  };
+  const sandbox = new Sandbox(session);
+  await assert.rejects(sandbox.start(), /START_FAILED_CLEANUP_PENDING/);
+  fail = false;
+  await sandbox.destroy();
+  assert.equal(session.closes, 2);
+});
+
+test('workspace stop leaves the claim active and errors remain private', async () => {
+  const session = new Session();
+  const sandbox = new Sandbox(session);
+  await sandbox.start();
+  const workspace = new Workspace({ sandbox });
+  await workspace.init();
+  await workspace.stop();
+  assert.equal('stop' in sandbox, false);
+  assert.equal(sandbox.status, 'running');
+  assert.equal(session.closes, 0);
+  session.commandImpl = async () => {
+    throw new Error(`Authorization: ${options.clientSecret}`);
+  };
+  await assert.rejects(sandbox.computer.type('hello'), { message: 'Cua Fleet: COMMAND_FAILED' });
+  const serialized = JSON.stringify(new CuaFleetSandbox(options));
+  assert.ok(!serialized.includes(options.clientSecret));
+  assert.ok(!serialized.includes(options.clientId));
+  assert.equal(sandbox.supportsCheckpoints, false);
+  await sandbox.snapshot();
+  await sandbox.destroy();
+});
+
+test('Mastra discovers computer tools and Agent.generate executes a model tool call offline', async () => {
+  const session = new Session();
+  const sandbox = new Sandbox(session);
+  const workspace = new Workspace({ sandbox });
+  const tools = await createWorkspaceTools(workspace);
+  assert.equal(Object.keys(tools).filter(name => name.startsWith('mastra_workspace_computer_')).length, 11);
+  assert.ok(!('mastra_workspace_execute_command' in tools));
+  const usage = { inputTokens: 1, outputTokens: 1, totalTokens: 2 };
+  const calls: unknown[] = [];
+  const responses = [
+    {
+      content: [
+        {
+          type: 'tool-call' as const,
+          toolCallId: 'screen-1',
+          toolName: 'mastra_workspace_computer_screenshot',
+          input: '{}',
+        },
+      ],
+      finishReason: 'tool-calls' as const,
+      usage,
+      warnings: [],
+    },
+    {
+      content: [{ type: 'text' as const, text: 'Desktop screenshot received.' }],
+      finishReason: 'stop' as const,
+      usage,
+      warnings: [],
+    },
+  ];
+  const model = {
+    specificationVersion: 'v2' as const,
+    provider: 'fixture',
+    modelId: 'scripted',
+    supportedUrls: {},
+    async doGenerate(input: unknown) {
+      calls.push(input);
+      const response = responses[calls.length - 1];
+      assert.ok(response, 'unexpected extra model call');
+      return response;
+    },
+    async doStream(): Promise<never> {
+      throw new Error('Streaming not used');
+    },
+  };
+  const agent = new Agent({
+    id: 'offline-desktop',
+    name: 'Offline Desktop',
+    instructions: 'Inspect the desktop.',
+    model,
+    workspace,
+  });
+  const result = await agent.generate('Inspect the desktop.', { maxSteps: 3 });
+  assert.equal(result.text, 'Desktop screenshot received.');
+  assert.deepEqual(session.calls, [{ name: 'screenshot', params: { format: 'png' } }]);
+  assert.equal(calls.length, 2);
+  const prompt = calls[1] as { prompt: { content: unknown }[] };
+  const modelInput = JSON.stringify(prompt.prompt);
+  assert.ok(modelInput.includes('tool-result'));
+  assert.ok(modelInput.includes('image/png'), 'the model receives a successful image result');
+  assert.ok(modelInput.includes(png.toString('base64')), 'the model receives the screenshot bytes');
+  assert.ok(!modelInput.includes('INVALID_SCREENSHOT'));
+  await workspace.destroy();
+  assert.equal(session.closes, 1);
+});
+
+test('guest decoder accepts JSON and SSE JSON but rejects malformed or scalar responses', () => {
+  const bytes = (text: string) => new TextEncoder().encode(text).buffer;
+  assert.deepEqual(decodeGuestResponse(bytes('{"success":true}')), { success: true });
+  assert.deepEqual(decodeGuestResponse(bytes('data: {"success":true}\n\n')), { success: true });
+  for (const value of ['invalid private-secret', 'null', '[]', '42', 'data: invalid']) {
+    assert.throws(() => decodeGuestResponse(bytes(value)), {
+      message: 'Cua Fleet: INVALID_GUEST_RESPONSE',
+    });
+  }
+});

--- a/workspaces/cua/tests/exports.mjs
+++ b/workspaces/cua/tests/exports.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { test } from 'node:test';
+
+const require = createRequire(import.meta.url);
+
+for (const format of ['esm', 'cjs']) {
+  test(`${format} package export loads Fleet and preserves sanitized errors`, async t => {
+    const { CuaFleetSandbox } = format === 'esm' ? await import('@mastra/cua') : require('@mastra/cua');
+    let requests = 0;
+    t.mock.method(globalThis, 'fetch', async () => {
+      requests++;
+      throw new Error('private transport detail');
+    });
+    const sandbox = new CuaFleetSandbox({
+      id: 'export-test',
+      poolName: 'fake-pool',
+      clientId: 'fake-client',
+      clientSecret: 'fake-secret',
+    });
+    await assert.rejects(sandbox.start(), { message: 'Cua Fleet: START_FAILED' });
+    assert.ok(requests > 0, 'the built export loads and initializes the ESM Fleet SDK');
+    await sandbox.destroy();
+  });
+}

--- a/workspaces/cua/tsconfig.build.json
+++ b/workspaces/cua/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/workspaces/cua/tsconfig.json
+++ b/workspaces/cua/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsdown.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/workspaces/cua/tsdown.config.ts
+++ b/workspaces/cua/tsdown.config.ts
@@ -1,0 +1,19 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  fixedExtension: false,
+  nodeProtocol: 'strip',
+  clean: true,
+  dts: false,
+  treeshake: true,
+  sourcemap: true,
+  deps: {
+    neverBundle: ['@mastra/core', '@trycua/fleet', 'pngjs'],
+  },
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/workspaces/cua/vitest.config.ts
+++ b/workspaces/cua/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.integration.test.ts'],
+    setupFiles: ['dotenv/config'],
+    testTimeout: 60000,
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
Closes https://github.com/mastra-ai/mastra/issues/23283

Adds `@mastra/cua` under `workspaces/cua`, so Mastra agents can use computer tools on Linux desktops acquired from an existing Cua Fleet pool through `@trycua/fleet`. Includes ESM/CommonJS exports, lifecycle and transport tests, a runnable live example, integration docs, and a minor changeset. Refs #23283.

Each instance owns an independent claim. `id` is a logical application identity, not a reconnect key; `start()` returns no acquisition outcome because a claim can bind to a warm desktop. `Workspace.stop()` leaves the claim active; `destroy()` drains actions, releases the owned claim, and verifies absence. Shell/files/processes, pause/resume, live viewing, and checkpoints are unsupported. The pool remains caller-owned. The package is proposed and unpublished.

Validated against Mastra main at `f97fd227` (`@mastra/core` 1.65.0-alpha.8): provider build/declarations, typecheck, lint, 18 Vitest tests, and 2 built-package ESM/CommonJS export tests pass. Frozen lockfile installation, package-content inspection, and ESM/CommonJS smoke tests from an independently installed tarball pass. Docs validation, focused formatting/Remark/Vale checks, production build, and rendered-page inspection pass. The live example passed with a real Mastra agent loop and scripted model decisions: screenshot/type/click submission was independently verified inside the guest, concurrent instances had distinct guests and isolated fixture state, both claims were released, and a separate fresh account listing confirmed zero namespaces. Autonomous vision-model behavior has not been tested.

Salvaged from trycua/cua#3642, with the original MIT notice retained in THIRD_PARTY_NOTICES. This ports the prototype into Mastra's provider layout rather than publishing a separate Cua adapter.

Hosted Vercel previews require authorization by a Mastra team member for this fork. Local production docs build and browser verification pass; the hosted preview checks have not run successfully. CodeRabbit review feedback has been addressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a package that lets Mastra agents control Linux desktops from an existing Cua Fleet pool. Each sandbox gets its own desktop, and `destroy()` releases it safely.

## What changed

- Added the proposed `@mastra/cua` workspace package.
- Added ESM and CommonJS exports.
- Added `CuaFleetSandbox` with screenshot, mouse, keyboard, typing, scrolling, screen-size, and cursor controls.
- Added independent Fleet claim management for each sandbox.
- Added startup polling, request timeouts, error sanitization, and cleanup recovery.
- Added lifecycle, transport, command-mapping, validation, decoder, and export tests.
- Added integration documentation, a package README, a changeset, and a runnable live example.
- Preserved the original MIT notice from the salvaged implementation.
- Added run-record safeguards for repeated and concurrent reservations.

## Limitations

- Linux is required.
- Shell, file, process, pause/resume, live viewing, checkpoint, and reconnect-by-ID features are unsupported.
- `Workspace.stop()` leaves the Fleet claim active.
- The Fleet pool remains caller-owned.
- Autonomous vision-model behavior and hosted Vercel preview checks were not completed.

## Validation

Build, typecheck, lint, Vitest, package exports, installation, documentation, formatting, production build, and live-example checks passed. The live example verified screenshots, typing, clicking, concurrent instance isolation, and claim release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Review update: the standalone docs example now constructs its own sandbox, and the live example archives confirmed-cleanup records before reserving the next run. New local filesystem tests cover repeat runs and concurrent reservation. The previously recorded live Fleet evidence applies to provider code, which is unchanged; no new cloud resources were needed to test this recovery-record change.
