### PR TITLE
fix(mastracode): restore goal startup and resume details in the TUI

### DIFF
--- a/.changeset/full-streets-chew.md
+++ b/.changeset/full-streets-chew.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed missing goal startup and resume details in the terminal transcript, including goals started from approved plans.

--- a/mastracode/tui/e2e/tui/plan-approval-goal-handoff.ts
+++ b/mastracode/tui/e2e/tui/plan-approval-goal-handoff.ts
@@ -92,13 +92,13 @@ export const planApprovalGoalHandoffScenario: McE2eScenario = {
     terminal.write('\r');
 
     await runtime.waitForScreenText(/Resumed plan output before goal startup\./i, terminal, 10_000);
-    if (readGoalObjective(dbPath) || /Goal \(judge:/.test(terminal.serialize().view)) {
+    if (readGoalObjective(dbPath) || /Goal \(3 max attempts, judge:/.test(terminal.serialize().view)) {
       throw new Error('Goal started before the resumed plan run finished');
     }
     releaseResume();
 
     await runtime.waitForScreenText(/✓\s+Set as goal/i, terminal, 10_000);
-    await runtime.waitForScreenText(/Goal \(judge: openai\/gpt-5\.4-mini\)/i, terminal, 10_000);
+    await runtime.waitForScreenText(/Goal \(3 max attempts, judge: openai\/gpt-5\.4-mini\)/i, terminal, 10_000);
     await runtime.waitForScreenText(/# E2E Goal Plan/i, terminal, 10_000);
     await runtime.waitForScreenText(/Plan goal handoff e2e goal run started\./i, terminal, 15_000);
     const expectedObjective =

--- a/mastracode/tui/src/tui/commands/__tests__/goal.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/goal.test.ts
@@ -207,6 +207,7 @@ describe('handleGoalCommand', () => {
     const showInfo = vi.fn();
     const ctx = {
       state: createMockState({ session: { sendSignal }, extra: { goalManager } }),
+      addUserMessage: vi.fn(),
       showInfo,
       showError: vi.fn(),
       updateStatusLine: vi.fn(),
@@ -216,7 +217,14 @@ describe('handleGoalCommand', () => {
 
     expect(goalManager.resume).toHaveBeenCalledTimes(1);
     expect(goalManager.saveToThread).toHaveBeenCalledTimes(1);
-    // No showInfo — only the signal renders the goal box (avoids duplicate).
+    expect(ctx.addUserMessage).toHaveBeenCalledTimes(1);
+    expect(getReminderView(ctx.addUserMessage.mock.calls[0][0])).toMatchObject({
+      reminderType: 'goal',
+      message: goal.objective,
+      goalMaxTurns: goal.maxTurns,
+      judgeModelId: goal.judgeModelId,
+    });
+    expect(ctx.addUserMessage.mock.invocationCallOrder[0]).toBeLessThan(sendSignal.mock.invocationCallOrder[0]);
     expect(showInfo).not.toHaveBeenCalled();
     expect(sendSignal).toHaveBeenCalledWith({
       type: 'system-reminder',
@@ -542,6 +550,14 @@ describe('handleGoalCommand', () => {
     expect(goalManager.saveToThread).toHaveBeenCalledTimes(1);
     expect(goalManager.saveToThread.mock.invocationCallOrder[0]).toBeLessThan(sendSignal.mock.invocationCallOrder[0]);
     expect(goalManager.isActive()).toBe(true);
+    expect(ctx.addUserMessage).toHaveBeenCalledTimes(1);
+    expect(getReminderView(ctx.addUserMessage.mock.calls[0][0])).toMatchObject({
+      reminderType: 'goal',
+      message: objective,
+      goalMaxTurns: 50,
+      judgeModelId: '__GATEWAY_OPENAI_MODEL__',
+    });
+    expect(ctx.addUserMessage.mock.invocationCallOrder[0]).toBeLessThan(sendSignal.mock.invocationCallOrder[0]);
 
     expect(sendSignal).toHaveBeenCalledTimes(1);
     expect(sendSignal).toHaveBeenCalledWith({
@@ -638,6 +654,13 @@ describe('handleGoalCommand', () => {
 
     expect(goalManager.isActive()).toBe(true);
     expect(goalManager.getGoal()).toMatchObject({ activeDurationMs: 0 });
+    expect(ctx.addUserMessage).toHaveBeenCalledTimes(1);
+    expect(getReminderView(ctx.addUserMessage.mock.calls[0][0])).toMatchObject({
+      reminderType: 'goal',
+      message: '# Ship it\n\n1. Build\n2. Test',
+      goalMaxTurns: 50,
+      judgeModelId: '__GATEWAY_OPENAI_MODEL__',
+    });
     expect(sendMessage).not.toHaveBeenCalled();
     vi.useRealTimers();
   });
@@ -838,6 +861,7 @@ describe('handleGoalCommand', () => {
     const showError = vi.fn();
     const ctx = {
       state,
+      addUserMessage: vi.fn(),
       showInfo,
       showError,
       updateStatusLine: vi.fn(),

--- a/mastracode/tui/src/tui/commands/goal.ts
+++ b/mastracode/tui/src/tui/commands/goal.ts
@@ -86,6 +86,14 @@ export async function handleGoalCommand(ctx: SlashCommandContext, args: string[]
     // startGoal, so the model receives a structured system-reminder rather than
     // a plain user message.
     const resumedGoal = goalManager.getGoal();
+    ctx.addUserMessage(
+      createGoalReminderMessage(
+        resumedGoal!.id,
+        resumedGoal!.objective,
+        resumedGoal!.maxTurns,
+        resumedGoal!.judgeModelId,
+      ),
+    );
     try {
       await state.session.sendSignal(createGoalReminderSignal(resumedGoal!)).accepted;
     } catch (err) {
@@ -369,6 +377,10 @@ async function startGoal(
   state.planStartedGoalId = undefined;
   await goalManager.saveToThread(state);
   ctx.updateStatusLine();
+
+  // Model-only reminders are not echoed to the live stream. Render the goal
+  // locally, including plan handoffs that start their run separately.
+  ctx.addUserMessage(createGoalReminderMessage(goal.id, goal.objective, goal.maxTurns, goal.judgeModelId));
 
   if (options.trigger === 'none') {
     return;


### PR DESCRIPTION
## Summary
Goal startup and resume relied on system-reminder signals being echoed into the live transcript. Those signals are now model-only, so the goal details disappeared even though execution continued correctly.

Render the canonical goal box locally before sending the model reminder, including approved-plan handoffs. Preserve a single model reminder and assert the full configured header in the E2E test. No timing gates or relaxed regex assertions.

## Test plan
- 261 command tests passed, including startup/resume rendering and ordering coverage.
- Goal-handoff E2E passed five consecutive runs (four on the standalone branch).
- TUI TypeScript check and lint passed.
- Prettier and git diff --check passed.

Independent of Factory PR #23266.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Goal details disappeared from the terminal when a goal started or resumed. This change displays those details locally, including goals started from approved plans, while keeping model reminders from being duplicated.

## Changes

- Render the canonical goal reminder before sending the continuation signal.
- Include the goal ID, objective, turn limit, and judge model.
- Cover initial starts, resumes, plan-based starts, and triggerless activation.
- Update unit tests to verify database-native user messages.
- Update the plan-approval E2E test to verify the complete goal header.
- Add a patch changeset for `mastracode`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->