### PR TITLE
test(memory): isolate reminder ownership transports between stores

### DIFF
--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-owner.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-owner.test.ts
@@ -1,9 +1,10 @@
 import type { LanguageModelV2StreamPart } from '@internal/ai-sdk-v5';
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { Agent } from '@mastra/core/agent';
 import { EventEmitterPubSub } from '@mastra/core/events';
 import { RequestContext } from '@mastra/core/request-context';
 import { InMemoryStore } from '@mastra/core/storage';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Memory } from '../../..';
 import { applyExtractorHooks } from '../extracted-values';
@@ -227,6 +228,30 @@ async function runScenario(knowledgeResourceId: string | undefined, completionGa
 }
 
 describe('Subconscious remind thread ownership', () => {
+  const pendingWakeOutputs: Promise<unknown>[] = [];
+  const sendMessage = Agent.prototype.sendMessage;
+
+  beforeEach(() => {
+    vi.spyOn(Agent.prototype, 'sendMessage').mockImplementation(function (this: Agent, ...args) {
+      const delivery = sendMessage.apply(this, args);
+      pendingWakeOutputs.push(
+        delivery.accepted.then(accepted => {
+          if (accepted.action === 'wake') return accepted.output.consumeStream();
+        }),
+      );
+      return delivery;
+    });
+  });
+
+  afterEach(async () => {
+    try {
+      await Promise.all(pendingWakeOutputs);
+    } finally {
+      pendingWakeOutputs.length = 0;
+      vi.restoreAllMocks();
+    }
+  });
+
   // Control first: the package vitest config bails after the first failure.
   it('accepts ask_memory after a passive reminder without override', async () => {
     await runScenario(undefined);
@@ -246,6 +271,7 @@ describe('Subconscious remind thread ownership', () => {
       await runScenario(PROJECT);
     } finally {
       release();
+      await Promise.all(pendingWakeOutputs);
     }
   });
 });

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-owner.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-owner.test.ts
@@ -1,5 +1,6 @@
 import type { LanguageModelV2StreamPart } from '@internal/ai-sdk-v5';
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { EventEmitterPubSub } from '@mastra/core/events';
 import { RequestContext } from '@mastra/core/request-context';
 import { InMemoryStore } from '@mastra/core/storage';
 import { describe, expect, it, vi } from 'vitest';
@@ -59,7 +60,7 @@ function textStopStream(text: string) {
   return { stream: convertArrayToReadableStream(parts), rawCall: { rawPrompt: null, rawSettings: {} }, warnings: [] };
 }
 
-function createHarness(options: { knowledgeResourceId?: string }) {
+function createHarness(options: { knowledgeResourceId?: string; completionGate?: Promise<void> }) {
   const storage = new InMemoryStore();
   const memory = new Memory({ storage });
   const requestContext = new RequestContext();
@@ -96,16 +97,18 @@ function createHarness(options: { knowledgeResourceId?: string }) {
           'reminder-call',
         );
       }
+      if (emitted.reply > 0) await options.completionGate;
       return textStopStream('Done.');
     },
   });
 
   const signals: Array<{ signal: any; options: any }> = [];
+  const pubsub = new EventEmitterPubSub();
   const mainAgent = {
     id: 'main-agent',
     getModel: vi.fn(async () => model),
     getMastraInstance: vi.fn(),
-    getPubSub: vi.fn(),
+    getPubSub: vi.fn(() => pubsub),
     sendSignal: vi.fn((signal: unknown, sendOptions: { ifActive: { behavior: string } }) => {
       signals.push({ signal, options: sendOptions });
       if (sendOptions.ifActive.behavior === 'persist') {
@@ -138,8 +141,8 @@ function createHarness(options: { knowledgeResourceId?: string }) {
   };
 }
 
-async function runScenario(knowledgeResourceId: string | undefined) {
-  const harness = createHarness({ knowledgeResourceId });
+async function runScenario(knowledgeResourceId: string | undefined, completionGate?: Promise<void>) {
+  const harness = createHarness({ knowledgeResourceId, completionGate });
   const scopeResource = knowledgeResourceId ?? SESSION;
   const scope = [`org:${ORG}`, `resource:${scopeResource}`];
 
@@ -231,5 +234,18 @@ describe('Subconscious remind thread ownership', () => {
 
   it('accepts ask_memory after a passive reminder with a knowledgeResourceId override', async () => {
     await runScenario(PROJECT);
+  });
+
+  it('isolates passive delivery from an unfinished sidekick in another store', async () => {
+    let release!: () => void;
+    const completionGate = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    try {
+      await runScenario(undefined, completionGate);
+      await runScenario(PROJECT);
+    } finally {
+      release();
+    }
   });
 });

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-owner.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-owner.test.ts
@@ -270,8 +270,9 @@ describe('Subconscious remind thread ownership', () => {
       await runScenario(undefined, completionGate);
       await runScenario(PROJECT);
     } finally {
+      // Only unblock the stalled sidekick here. Draining is afterEach's job: awaiting the
+      // drain inside this finally would replace a failed assertion with the drain's error.
       release();
-      await Promise.all(pendingWakeOutputs);
     }
   });
 });


### PR DESCRIPTION
Isolates each reminder ownership test harness with its own EventEmitterPubSub so an unfinished sidekick in another store cannot interfere with delivery assertions. Adds a gated overlapping-store regression; production ownership and delivery behavior are unchanged.

Verification: the overlapping scenario reproduced expected-one/received-zero with shared transport; isolated harnesses passed all three ownership tests. The prerequisite full memory suite passed 1,536 tests with one existing todo; build, typecheck and lint passed. This is the prerequisite for the stacked passive-reminder context fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Each test store now has its own message system. This prevents unfinished background work in one test from affecting another test’s results.

## Changes

- Updated `subconscious-remind-owner.test.ts` to use a real `EventEmitterPubSub` for each store.
- Added gated sidekick scenarios to test overlapping stores and delivery isolation.
- Added cleanup that waits for all tracked wake outputs to finish.
- Aggregated cleanup failures with `AggregateError` without hiding assertion failures.
- Added regression coverage for multiple pending outputs and late background errors.
- Production ownership and delivery behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->