### PR TITLE
fix(core): stop the durable loop at a client-executed tool call

### DIFF
--- a/.changeset/durable-loop-pending-client-tool.md
+++ b/.changeset/durable-loop-pending-client-tool.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the durable agent loop continuing past a client-executed tool call. A tool with no `execute` is answered by the client on a follow-up request, and the non-durable loop ends the turn at the call for that reason (`hasPendingHITL`). The durable mapping step had no such check: it recorded a result for the call it never got and ran the model again. It now leaves a pending client-side call unanswered and ends the turn, matching the non-durable loop.

--- a/packages/core/src/agent/durable/__tests__/durable-agent-client-tool-pending.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-client-tool-pending.test.ts
@@ -1,0 +1,163 @@
+/**
+ * A client-executed tool (no `execute`) must end the durable run at the call
+ * so the client can answer, exactly as the non-durable loop does. The durable
+ * mapping step used to record a result for the call it never got and run the
+ * model again.
+ */
+import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { z } from 'zod';
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import { Mastra } from '../../../mastra';
+import { InMemoryStore } from '../../../storage';
+import { createTool } from '../../../tools';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../create-durable-agent';
+
+/** First call: a tool call. Second call: a text answer. */
+function createClientToolModel(toolName: string) {
+  let callCount = 0;
+  const model = new MockLanguageModelV2({
+    doStream: async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'resp-1', modelId: 'mock', timestamp: new Date(0) },
+            {
+              type: 'tool-call',
+              toolCallType: 'function',
+              toolCallId: 'tc-1',
+              toolName,
+              args: '{"label":"Done"}',
+            },
+            {
+              type: 'finish',
+              finishReason: 'tool-calls',
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      }
+      return {
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'resp-2', modelId: 'mock', timestamp: new Date(0) },
+          { type: 'text-delta', textDelta: 'Done' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+          },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      };
+    },
+  }) as unknown as LanguageModelV2;
+  return { model, calls: () => callCount };
+}
+
+describe('DurableAgent with a client-executed tool', () => {
+  let _mastra: Mastra;
+  let pubsub: EventEmitterPubSub;
+
+  beforeEach(() => {
+    pubsub = new EventEmitterPubSub();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await _mastra?.close?.();
+    pubsub?.removeAllListeners?.();
+  });
+
+  it('ends the run at the client tool call and leaves it unanswered', async () => {
+    const { model, calls } = createClientToolModel('client-tool');
+    const baseAgent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'You are a test agent',
+      model,
+      tools: {
+        // Execute-less: the tool runs on the client; the server only observes.
+        'client-tool': createTool({
+          id: 'client-tool',
+          description: 'A client-side tool',
+          inputSchema: z.object({ label: z.string() }),
+        }),
+      },
+    });
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+    _mastra = new Mastra({
+      agents: { 'test-agent': durableAgent },
+      storage: new InMemoryStore(),
+    });
+
+    const { output } = await durableAgent.stream('test prompt', { maxSteps: 3 });
+    const chunkTypes: string[] = [];
+    for await (const chunk of output.fullStream) {
+      chunkTypes.push(chunk.type);
+    }
+
+    // One model call, one step: the loop stopped for the client to answer.
+    expect(calls()).toBe(1);
+    expect(chunkTypes.filter(type => type === 'step-start')).toHaveLength(1);
+    expect(chunkTypes).toContain('tool-call');
+    // Nothing answered it on the server.
+    expect(chunkTypes).not.toContain('tool-result');
+    expect(await output.finishReason).toBe('tool-calls');
+  });
+
+  it('continues when the client result arrives on a follow-up request', async () => {
+    const { model, calls } = createClientToolModel('client-tool');
+    const baseAgent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'You are a test agent',
+      model,
+      tools: {
+        'client-tool': createTool({
+          id: 'client-tool',
+          description: 'A client-side tool',
+          inputSchema: z.object({ label: z.string() }),
+        }),
+      },
+    });
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+    _mastra = new Mastra({
+      agents: { 'test-agent': durableAgent },
+      storage: new InMemoryStore(),
+    });
+
+    const first = await durableAgent.stream('test prompt', { maxSteps: 3 });
+    await first.output.consumeStream();
+    expect(calls()).toBe(1);
+
+    const second = await durableAgent.stream(
+      [
+        { role: 'user', content: 'test prompt' },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'tool-call', toolCallId: 'tc-1', toolName: 'client-tool', args: { label: 'Done' } },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            { type: 'tool-result', toolCallId: 'tc-1', toolName: 'client-tool', result: 'ok' },
+          ],
+        },
+      ],
+      { maxSteps: 3 },
+    );
+    const text = await second.output.text;
+    expect(calls()).toBe(2);
+    expect(text).toBe('Done');
+  });
+});

--- a/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
@@ -146,6 +146,18 @@ export function createDurableLLMMappingStep() {
             continue;
           }
 
+          // A pending client-side / HITL call: no result, no error, not aborted,
+          // not provider-executed. Leave it as `call` for the client to answer —
+          // mirrors the non-durable llm-mapping-step.
+          if (
+            toolResult.result === undefined &&
+            !toolResult.error &&
+            !toolResult.aborted &&
+            !toolResult.providerExecuted
+          ) {
+            continue;
+          }
+
           const result = toolResult.error ? toolResult.error.message : toolResult.result;
 
           // Compute toModelOutput for successful tool results (Bug 9 parity).
@@ -263,7 +275,13 @@ export function createDurableLLMMappingStep() {
       // self-correct. This matches the regular agent's behaviour where both
       // ToolNotFoundError and generic tool execution errors are recoverable.
       const hasToolErrors = toolResults.some(r => r.error !== undefined);
-      const isContinued = hasToolErrors ? true : llmOutput.stepResult.isContinued;
+      // A pending client-side / HITL call ends the turn so the client can answer
+      // (the non-durable llm-mapping-step's `hasPendingHITL`). Without this the
+      // durable loop ran the model again on a result nobody produced.
+      const hasPendingHITL = toolResults.some(
+        r => r.result === undefined && !r.error && !r.aborted && !r.providerExecuted && !isDeniedApproval(r),
+      );
+      const isContinued = hasPendingHITL ? false : hasToolErrors ? true : llmOutput.stepResult.isContinued;
 
       // Check if any delegation hook called ctx.bail(). The bail flag is
       // communicated via requestContext because Zod output validation strips


### PR DESCRIPTION
Fixes #23295

## What

A tool with no `execute` is a client-executed tool: the client runs it and sends the result back on a follow-up request. The non-durable loop ends the turn at such a call (`hasPendingHITL` in `llm-mapping-step.ts`). The durable mapping step (`agent/durable/workflows/steps/llm-mapping.ts`) had no equivalent: it wrote a result for the call it never got (`updateToolInvocation` with `result: undefined` → state `result`) and set `isContinued` from the model's `tool-calls` reason, so the loop ran the model again on nothing.

This mirrors the non-durable step into the durable one:

- skip a pending client-side call (no result, no error, not aborted, not provider-executed) when writing tool results, so it stays a `call`;
- end the turn when one is pending.

## How it was found

A production assistant whose UI tools (highlight, navigate, render a view) are all client-executed. With `durable: true` every one of them was "answered" server-side with nothing and the model spoke again, whichever way the tool was declared (on the agent, as a per-request `clientTools` entry, or both). Measured on `@mastra/core` 1.64.0 and reproduced against `main`.

## Test

`durable-agent-client-tool-pending.test.ts`: a durable agent with an execute-less tool ends the run after one model call with the call unanswered (`finishReason: 'tool-calls'`, no `tool-result` chunk), and the client's result on a follow-up request continues to the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGQK7FmhCFtERQzA3sH6iQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a client must run a tool, the durable agent now pauses and waits for the result. It does not create a fake result or continue early.

## Changes

- Updated durable LLM mapping to preserve unanswered client-side tool calls.
- Ends the turn with `finishReason: 'tool-calls'` while a client result is pending.
- Added tests for the initial paused run and the follow-up request that supplies the tool result.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
