### PR TITLE
ci: route call-external-mastra-workflow.yml inputs through env:

### DIFF
--- a/.github/workflows/call-external-mastra-workflow.yml
+++ b/.github/workflows/call-external-mastra-workflow.yml
@@ -25,11 +25,27 @@ jobs:
     runs-on: starsling-ubuntu-24.04
     steps:
       - name: Create and execute workflow run
+        # Route all workflow_call inputs through env: instead of interpolating
+        # ${{ inputs.* }} directly into the script below. Direct interpolation
+        # inserts the raw value into the script text before the shell ever
+        # runs, so a value containing shell metacharacters (backticks, `$()`,
+        # quotes) executes as part of the script rather than as inert data —
+        # the WORKFLOW_NAME format check further down only inspects the
+        # variable *after* that substitution already happened, so it cannot
+        # catch an injection in the substitution itself. All current callers
+        # only ever pass static, hardcoded strings (see cron-every-2h.yml), so
+        # this isn't reachable today, but the workflow_call inputs are
+        # documented as generic ("Name of the external workflow to execute",
+        # "JSON input data for the workflow") with nothing here stopping a
+        # future caller from wiring in issue/PR-derived text. env: keeps the
+        # same values available to the script as plain data, closing that off
+        # regardless of what future callers pass.
+        env:
+          WORKFLOW_NAME: ${{ inputs.workflow_name }}
+          BASE_URL: ${{ inputs.base_url }}
+          INPUT_DATA: ${{ inputs.input_data }}
         run: |
           set -e
-
-          WORKFLOW_NAME="${{ inputs.workflow_name }}"
-          BASE_URL="${{ inputs.base_url }}"
 
           # Validate workflow_name to prevent unsafe characters in URL paths
           if ! echo "$WORKFLOW_NAME" | grep -Eq '^[a-zA-Z0-9_-]+$'; then
@@ -73,7 +89,7 @@ jobs:
           echo "Starting workflow with runId: $runId"
 
           # Use jq to properly escape and validate the input data
-          echo '${{ inputs.input_data }}' | jq -c . > /tmp/input_data.json
+          printf '%s' "$INPUT_DATA" | jq -c . > /tmp/input_data.json
 
           http_code=$(curl -w "%{http_code}" -o /tmp/start_response.json -s \
             --max-time 300 \


### PR DESCRIPTION
Fixes #23298

## Description

`.github/workflows/call-external-mastra-workflow.yml` interpolated `${{ inputs.workflow_name }}`, `${{ inputs.base_url }}`, and `${{ inputs.input_data }}` directly into the `run:` script text instead of passing them through `env:`. GitHub Actions substitutes `${{ }}` expressions into the script *before* the shell runs it, so a value containing shell metacharacters would execute as part of the script rather than be treated as inert data (see GitHub's [script injection guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)).

The existing `WORKFLOW_NAME` regex check (`^[a-zA-Z0-9_-]+$`) ran *after* that substitution already happened, so it couldn't catch an injection in the substitution itself. `BASE_URL` and `input_data` had no check at all.

As noted in the linked issue, this isn't reachable today — the three current call sites in `cron-every-2h.yml` all pass static, hardcoded strings — so this is a hardening fix, not a report of an active exploit. It brings this file in line with how every other workflow here handles `github.event.*`/`inputs.*` values in a `run:` step (`env:` first, e.g. `changed-test-gate.yml`, `major-version-check.yml`, `test-suite.yml`).

## Changes

- Add an `env:` block on the step mapping `WORKFLOW_NAME`, `BASE_URL`, `INPUT_DATA` to the three `inputs.*` values.
- Reference `$WORKFLOW_NAME` / `$BASE_URL` / `$INPUT_DATA` in the script instead of the raw `${{ inputs.* }}` expressions.
- Replace `echo '${{ inputs.input_data }}' | jq -c .` with `printf '%s' "$INPUT_DATA" | jq -c .`, which also sidesteps `echo` treating a value that starts with `-` as a flag.

No behavior change for the existing callers: `WORKFLOW_NAME`/`BASE_URL`/`INPUT_DATA` hold the exact same values as before, the regex validation is untouched, and the two `curl` calls and their URLs are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable) — not applicable, workflow-internal only
- [ ] I have added tests that prove my fix is effective or that my feature works — GitHub Actions workflow YAML; verified with `bash -n` against the extracted script and a manual YAML structure review (no test harness exists for these workflows in this repo)

## Verification

- Extracted the `run:` script with representative values substituted and checked it with `bash -n` (syntax OK).
- Manually diffed the new script logic against the old one line-by-line to confirm no functional change: same regex check, same two `curl` requests, same URLs, same `jq` piping.
- Confirmed the three current callers (`cron-every-2h.yml`) only ever pass static literals, so this PR does not change any real workflow run's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The workflow now treats caller-provided values as data instead of shell commands. This prevents future inputs from running unintended commands while keeping current behavior unchanged.

## Changes

- Pass `workflow_name`, `base_url`, and `input_data` through `env:`.
- Read these values from environment variables in the shell script.
- Use `printf` to pass `INPUT_DATA` to `jq`.
- Preserve existing validation and behavior for current static callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->