### PR TITLE
feat(playground): bulk tag experiment results and color tags by value

### DIFF
--- a/.changeset/bulk-add-tag-experiment-results.md
+++ b/.changeset/bulk-add-tag-experiment-results.md
@@ -1,9 +1,0 @@
----
-'@mastra/playground': patch
----
-
-Experiment results tagging in Studio:
-
-- Add an "Add tag" action to the selected-results row on the experiment page. Selecting an existing tag or creating a new one applies it to every selected experiment result, mirroring the dataset tag editor.
-- Add a "Tags" column to the experiment results list and cap the "Input" column width so it no longer takes the whole table.
-- In the result panel, replace the "Review" section with "Status" and "Tags" metadata rows; tags can now be added or removed directly on the result.

--- a/.changeset/bulk-add-tag-experiment-results.md
+++ b/.changeset/bulk-add-tag-experiment-results.md
@@ -1,0 +1,9 @@
+---
+'@mastra/playground': patch
+---
+
+Experiment results tagging in Studio:
+
+- Add an "Add tag" action to the selected-results row on the experiment page. Selecting an existing tag or creating a new one applies it to every selected experiment result, mirroring the dataset tag editor.
+- Add a "Tags" column to the experiment results list and cap the "Input" column width so it no longer takes the whole table.
+- In the result panel, replace the "Review" section with "Status" and "Tags" metadata rows; tags can now be added or removed directly on the result.

--- a/.changeset/computed-tag-colors.md
+++ b/.changeset/computed-tag-colors.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground': patch
+---
+
+Render dataset, experiment result and review tags with a `ComputedTag` whose background and foreground colors are derived from the tag value, so the same tag looks identical everywhere it appears.

--- a/.changeset/computed-tag-colors.md
+++ b/.changeset/computed-tag-colors.md
@@ -1,5 +1,0 @@
----
-'@mastra/playground': patch
----
-
-Render dataset, experiment result and review tags with a `ComputedTag` whose background and foreground colors are derived from the tag value, so the same tag looks identical everywhere it appears.

--- a/packages/playground/src/domains/datasets/components/dataset-detail/__tests__/dataset-tags-editor.msw.test.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/__tests__/dataset-tags-editor.msw.test.tsx
@@ -5,7 +5,7 @@ import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { DatasetTagsEditor } from '../dataset-tags-editor';
 import { buildDataset, buildListDatasetsResponse } from '@/domains/datasets/components/__tests__/fixtures/datasets';
-import { expectComputedTag } from '@/test/computed-tag';
+import { expectComputedTag, expectInheritsTagForeground } from '@/test/computed-tag';
 import { server } from '@/test/msw-server';
 import { renderWithProviders, TEST_BASE_URL } from '@/test/render';
 
@@ -76,6 +76,12 @@ describe('DatasetTagsEditor', () => {
 
       const remove = await screen.findByRole('button', { name: 'Remove tag alpha' });
       expectComputedTag(remove.parentElement, 'alpha');
+    });
+
+    it('renders the remove action in the tag foreground color', async () => {
+      renderEditor();
+
+      expectInheritsTagForeground(await screen.findByRole('button', { name: 'Remove tag alpha' }));
     });
 
     it('lists every known tag and marks the ones already on the dataset', async () => {

--- a/packages/playground/src/domains/datasets/components/dataset-detail/__tests__/dataset-tags-editor.msw.test.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/__tests__/dataset-tags-editor.msw.test.tsx
@@ -78,7 +78,7 @@ describe('DatasetTagsEditor', () => {
       expectComputedTag(remove.parentElement, 'alpha');
     });
 
-    it('renders the remove action in the tag foreground color', async () => {
+    it('renders the remove action in the tag foreground color with a pointer cursor', async () => {
       renderEditor();
 
       expectInheritsTagForeground(await screen.findByRole('button', { name: 'Remove tag alpha' }));

--- a/packages/playground/src/domains/datasets/components/dataset-detail/__tests__/dataset-tags-editor.msw.test.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/__tests__/dataset-tags-editor.msw.test.tsx
@@ -5,6 +5,7 @@ import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { DatasetTagsEditor } from '../dataset-tags-editor';
 import { buildDataset, buildListDatasetsResponse } from '@/domains/datasets/components/__tests__/fixtures/datasets';
+import { expectComputedTag } from '@/test/computed-tag';
 import { server } from '@/test/msw-server';
 import { renderWithProviders, TEST_BASE_URL } from '@/test/render';
 
@@ -68,6 +69,13 @@ describe('DatasetTagsEditor', () => {
       const editor = screen.getByTestId('dataset-tags-editor');
       expect(editor.contains(remove)).toBe(true);
       expect(editor.textContent).toContain('alpha');
+    });
+
+    it('renders each current tag with colors computed from its value', async () => {
+      renderEditor();
+
+      const remove = await screen.findByRole('button', { name: 'Remove tag alpha' });
+      expectComputedTag(remove.parentElement, 'alpha');
     });
 
     it('lists every known tag and marks the ones already on the dataset', async () => {

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-tags-editor.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-tags-editor.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Combobox } from '@mastra/playground-ui/components/Combobox';
 import type { ComboboxOption } from '@mastra/playground-ui/components/Combobox';
 import { toast } from '@mastra/playground-ui/utils/toast';
@@ -8,6 +7,7 @@ import { useMemo, useState } from 'react';
 import { getAllDatasetTags } from '../datasets-list/helpers';
 import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
 import { useDataset, useDatasets } from '@/domains/datasets/hooks/use-datasets';
+import { ComputedTag } from '@/domains/observability/components/computed-tag';
 
 const CREATE_TAG_VALUE = '__create_tag__';
 
@@ -58,7 +58,7 @@ export function DatasetTagsEditor({ datasetId }: DatasetTagsEditorProps) {
   return (
     <div data-testid="dataset-tags-editor" className="flex flex-wrap items-center gap-2 px-4 py-2">
       {currentTags.map(tag => (
-        <Badge key={tag} size="md" className="gap-1 pr-1">
+        <ComputedTag key={tag} value={tag} size="md" className="gap-1 pr-1">
           {tag}
           <button
             type="button"
@@ -69,7 +69,7 @@ export function DatasetTagsEditor({ datasetId }: DatasetTagsEditorProps) {
           >
             <X className="size-3" />
           </button>
-        </Badge>
+        </ComputedTag>
       ))}
       <Combobox
         options={options}

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-tags-editor.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-tags-editor.tsx
@@ -65,7 +65,7 @@ export function DatasetTagsEditor({ datasetId }: DatasetTagsEditorProps) {
             aria-label={`Remove tag ${tag}`}
             disabled={updateDataset.isPending}
             onClick={() => handleRemove(tag)}
-            className="text-neutral3 hover:text-neutral6 rounded-sm disabled:opacity-50"
+            className="rounded-sm hover:opacity-70 disabled:opacity-50"
           >
             <X className="size-3" />
           </button>

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-tags-editor.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-tags-editor.tsx
@@ -65,7 +65,7 @@ export function DatasetTagsEditor({ datasetId }: DatasetTagsEditorProps) {
             aria-label={`Remove tag ${tag}`}
             disabled={updateDataset.isPending}
             onClick={() => handleRemove(tag)}
-            className="rounded-sm hover:opacity-70 disabled:opacity-50"
+            className="cursor-pointer rounded-sm hover:opacity-70 disabled:opacity-50"
           >
             <X className="size-3" />
           </button>

--- a/packages/playground/src/domains/datasets/components/datasets-list/__tests__/datasets-list.test.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/__tests__/datasets-list.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { DatasetsList } from '../datasets-list';
 import type { DatasetsListProps } from '../datasets-list';
 import { datasets, experiments, mixedExperiments } from './fixtures/datasets';
+import { expectComputedTag } from '@/test/computed-tag';
 import { TestLinkProvider } from '@/test/link-provider';
 import { renderWithProviders } from '@/test/render';
 
@@ -57,6 +58,13 @@ describe('DatasetsList', () => {
       expect(within(row).queryByText('reviewed')).toBeNull();
       expect(within(row).getByText('+1')).toBeTruthy();
       expect(within(row).getByTitle('support, english, reviewed')).toBeTruthy();
+    });
+
+    it('renders each visible tag with colors computed from its value', () => {
+      renderList();
+      const row = screen.getByRole('link', { name: /Dataset A/ });
+      expectComputedTag(within(row).getByText('support'), 'support');
+      expectComputedTag(within(row).getByText('english'), 'english');
     });
   });
 

--- a/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
@@ -8,6 +8,7 @@ import {
   useDataListKeyboard,
 } from '@mastra/playground-ui/components/DataList';
 import { useMemo } from 'react';
+import { ComputedTag } from '@/domains/observability/components/computed-tag';
 import { useLinkComponent } from '@/lib/framework';
 
 export interface DatasetsListProps {
@@ -108,9 +109,7 @@ export function DatasetsList({
                 {tags.length > 0 ? (
                   <div className="flex max-w-48 items-center gap-1 overflow-hidden" title={tags.join(', ')}>
                     {tags.slice(0, 2).map(tag => (
-                      <Badge key={tag} size="xs" className="shrink-0">
-                        {tag}
-                      </Badge>
+                      <ComputedTag key={tag} value={tag} className="shrink-0" />
                     ))}
                     {tags.length > 2 && <span className="text-neutral2 shrink-0 text-[10px]">+{tags.length - 2}</span>}
                   </div>

--- a/packages/playground/src/domains/experiments/__tests__/experiment-item-route.msw.test.tsx
+++ b/packages/playground/src/domains/experiments/__tests__/experiment-item-route.msw.test.tsx
@@ -173,6 +173,121 @@ describe('experiment item sub-route', () => {
     });
   });
 
+  describe('when the user selects results to tag', () => {
+    const patches: Array<{ resultId: string; body: unknown }> = [];
+
+    beforeEach(() => {
+      patches.length = 0;
+      server.use(
+        http.patch(
+          `${TEST_BASE_URL}/api/datasets/${DATASET_ID}/experiments/${EXPERIMENT_ID}/results/:resultId`,
+          async ({ params, request }) => {
+            const body = await request.json();
+            patches.push({ resultId: String(params.resultId), body });
+            const original = resultsResponse.results.find(r => r.id === params.resultId)!;
+            return HttpResponse.json({ ...original, ...(body as object) });
+          },
+        ),
+      );
+    });
+
+    async function openTagPicker() {
+      const trigger = await screen.findByRole('combobox');
+      expect(trigger.textContent).toContain('Add tag');
+      fireEvent.click(trigger);
+      return screen.findByPlaceholderText('Search or create tag...');
+    }
+
+    function selectOption(option: HTMLElement) {
+      fireEvent.pointerDown(option, { pointerType: 'mouse' });
+      fireEvent.click(option, { detail: 1 });
+    }
+
+    it('only shows the "Add tag" picker once something is selected', async () => {
+      renderExperimentRoute();
+
+      await screen.findByRole('checkbox', { name: 'Select result item-1' });
+      expect(screen.queryByRole('combobox')).toBeNull();
+
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Select result item-1' }));
+
+      expect((await screen.findByRole('combobox')).textContent).toContain('Add tag');
+    });
+
+    it('lists tags already present on results as existing options', async () => {
+      renderExperimentRoute();
+
+      fireEvent.click(await screen.findByRole('checkbox', { name: 'Select result item-1' }));
+      await openTagPicker();
+
+      expect(await screen.findByRole('option', { name: 'alpha' })).toBeDefined();
+    });
+
+    it('creates a new tag on every selected result and keeps the selection', async () => {
+      renderExperimentRoute();
+
+      fireEvent.click(await screen.findByRole('checkbox', { name: 'Select result item-1' }));
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Select result item-2' }));
+
+      const search = await openTagPicker();
+      fireEvent.input(search, { target: { value: 'smoke' }, inputType: 'insertText' });
+      selectOption(await screen.findByRole('option', { name: 'Create "smoke"' }));
+
+      await waitFor(() => {
+        expect(patches).toEqual([
+          { resultId: 'res-1', body: { tags: ['smoke'] } },
+          { resultId: 'res-2', body: { tags: ['alpha', 'smoke'] } },
+        ]);
+      });
+      expect(screen.getByRole('checkbox', { name: 'Select result item-1' }).getAttribute('aria-checked')).toBe('true');
+      expect(screen.getByRole('checkbox', { name: 'Select result item-2' }).getAttribute('aria-checked')).toBe('true');
+    });
+  });
+
+  describe('when the user edits tags from the open result panel', () => {
+    const patches: Array<{ resultId: string; body: unknown }> = [];
+
+    beforeEach(() => {
+      patches.length = 0;
+      server.use(
+        http.patch(
+          `${TEST_BASE_URL}/api/datasets/${DATASET_ID}/experiments/${EXPERIMENT_ID}/results/:resultId`,
+          async ({ params, request }) => {
+            const body = await request.json();
+            patches.push({ resultId: String(params.resultId), body });
+            const original = resultsResponse.results.find(r => r.id === params.resultId)!;
+            return HttpResponse.json({ ...original, ...(body as object) });
+          },
+        ),
+      );
+    });
+
+    it('removes a tag from the metadata row', async () => {
+      renderExperimentRoute(`/experiments/${EXPERIMENT_ID}/items/item-2`);
+      const dialog = await screen.findByRole('dialog');
+
+      fireEvent.click(await within(dialog).findByRole('button', { name: 'Remove tag alpha' }));
+
+      await waitFor(() => {
+        expect(patches).toEqual([{ resultId: 'res-2', body: { tags: [] } }]);
+      });
+    });
+
+    it('adds a known tag from the metadata row picker', async () => {
+      renderExperimentRoute(`/experiments/${EXPERIMENT_ID}/items/item-1`);
+      const dialog = await screen.findByRole('dialog');
+
+      fireEvent.click(await within(dialog).findByRole('combobox'));
+      const option = await screen.findByRole('option', { name: 'alpha' });
+      fireEvent.pointerDown(option, { pointerType: 'mouse' });
+      fireEvent.click(option, { detail: 1 });
+
+      await waitFor(() => {
+        expect(patches).toEqual([{ resultId: 'res-1', body: { tags: ['alpha'] } }]);
+      });
+    });
+  });
+
   describe('when visiting the item URL directly', () => {
     it('renders the results list with the panel open', async () => {
       renderExperimentRoute(`/experiments/${EXPERIMENT_ID}/items/item-3`);

--- a/packages/playground/src/domains/experiments/__tests__/fixtures/experiment-item-route.ts
+++ b/packages/playground/src/domains/experiments/__tests__/fixtures/experiment-item-route.ts
@@ -119,7 +119,14 @@ const baseResult: DatasetExperimentResult = {
 /** Three results, itemIds item-1..item-3, result ids res-1..res-3. */
 export const results: DatasetExperimentResult[] = [
   baseResult,
-  { ...baseResult, id: 'res-2', itemId: 'item-2', input: { q: 'second question' }, output: { a: 'second answer' } },
+  {
+    ...baseResult,
+    id: 'res-2',
+    itemId: 'item-2',
+    input: { q: 'second question' },
+    output: { a: 'second answer' },
+    tags: ['alpha'],
+  },
   {
     ...baseResult,
     id: 'res-3',

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-result-panel.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-result-panel.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import type { DatasetExperimentResult } from '@mastra/client-js';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { ExperimentResultPanel } from '../experiment-result-panel';
+
+const makeResult = (overrides: Partial<DatasetExperimentResult> = {}): DatasetExperimentResult => ({
+  id: 'res-1',
+  experimentId: 'exp-1',
+  itemId: 'item-1',
+  input: 'hello',
+  output: 'world',
+  groundTruth: null,
+  scores: {},
+  error: null,
+  status: null,
+  tags: null,
+  comment: null,
+  traceId: null,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  ...overrides,
+});
+
+beforeAll(() => {
+  if (typeof window.PointerEvent === 'undefined') {
+    window.PointerEvent = window.MouseEvent as unknown as typeof PointerEvent;
+  }
+});
+
+afterEach(() => cleanup());
+
+function selectOption(option: HTMLElement) {
+  fireEvent.pointerDown(option, { pointerType: 'mouse' });
+  fireEvent.click(option, { detail: 1 });
+}
+
+function renderPanel(
+  result: DatasetExperimentResult,
+  props: Partial<Parameters<typeof ExperimentResultPanel>[0]> = {},
+) {
+  const onTagsChange = vi.fn();
+  render(
+    <ExperimentResultPanel
+      result={result}
+      onClose={() => {}}
+      onTagsChange={onTagsChange}
+      tagVocabulary={['alpha', 'beta']}
+      {...props}
+    />,
+  );
+  return { onTagsChange };
+}
+
+describe('ExperimentResultPanel metadata', () => {
+  describe('given a result with a status and tags', () => {
+    const result = makeResult({ status: 'needs-review', tags: ['alpha'] });
+
+    it('shows the status and the tags as metadata rows instead of a "Review" section', () => {
+      renderPanel(result);
+
+      expect(screen.queryByText('Review')).toBeNull();
+      expect(screen.getByText('Status')).toBeDefined();
+      expect(screen.getByText('needs-review')).toBeDefined();
+      expect(screen.getByText('Tags')).toBeDefined();
+      expect(screen.getByText('alpha')).toBeDefined();
+    });
+
+    it('removes a tag from the badge', () => {
+      const { onTagsChange } = renderPanel(result);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Remove tag alpha' }));
+
+      expect(onTagsChange).toHaveBeenCalledWith([]);
+    });
+
+    it('adds an existing tag from the picker', async () => {
+      const { onTagsChange } = renderPanel(result);
+
+      fireEvent.click(screen.getByRole('combobox'));
+      selectOption(await screen.findByRole('option', { name: 'beta' }));
+
+      expect(onTagsChange).toHaveBeenCalledWith(['alpha', 'beta']);
+    });
+
+    it('creates a new tag from the picker', async () => {
+      const { onTagsChange } = renderPanel(result);
+
+      fireEvent.click(screen.getByRole('combobox'));
+      const search = await screen.findByPlaceholderText('Search or create tag...');
+      fireEvent.input(search, { target: { value: 'fresh' }, inputType: 'insertText' });
+      selectOption(await screen.findByRole('option', { name: 'Create "fresh"' }));
+
+      expect(onTagsChange).toHaveBeenCalledWith(['alpha', 'fresh']);
+    });
+  });
+
+  describe('given a result without status or tags', () => {
+    it('hides the status row but still offers the tag picker', () => {
+      renderPanel(makeResult());
+
+      expect(screen.queryByText('Status')).toBeNull();
+      expect(screen.getByText('Tags')).toBeDefined();
+      expect(screen.getByRole('combobox').textContent).toContain('Add tag');
+    });
+  });
+
+  describe('given no onTagsChange handler', () => {
+    it('renders tags read-only without picker or remove buttons', () => {
+      render(<ExperimentResultPanel result={makeResult({ tags: ['alpha'] })} onClose={() => {}} />);
+
+      expect(screen.getByText('alpha')).toBeDefined();
+      expect(screen.queryByRole('combobox')).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Remove tag alpha' })).toBeNull();
+    });
+  });
+});

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-result-panel.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-result-panel.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { ExperimentResultPanel } from '../experiment-result-panel';
-import { expectComputedTag } from '@/test/computed-tag';
+import { expectComputedTag, expectInheritsTagForeground } from '@/test/computed-tag';
 
 const makeResult = (overrides: Partial<DatasetExperimentResult> = {}): DatasetExperimentResult => ({
   id: 'res-1',
@@ -74,6 +74,12 @@ describe('ExperimentResultPanel metadata', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Remove tag alpha' }));
 
       expect(onTagsChange).toHaveBeenCalledWith([]);
+    });
+
+    it('renders the remove action in the tag foreground color', () => {
+      renderPanel(result);
+
+      expectInheritsTagForeground(screen.getByRole('button', { name: 'Remove tag alpha' }));
     });
 
     it('adds an existing tag from the picker', async () => {

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-result-panel.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-result-panel.test.tsx
@@ -76,7 +76,7 @@ describe('ExperimentResultPanel metadata', () => {
       expect(onTagsChange).toHaveBeenCalledWith([]);
     });
 
-    it('renders the remove action in the tag foreground color', () => {
+    it('renders the remove action in the tag foreground color with a pointer cursor', () => {
       renderPanel(result);
 
       expectInheritsTagForeground(screen.getByRole('button', { name: 'Remove tag alpha' }));

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-result-panel.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-result-panel.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { ExperimentResultPanel } from '../experiment-result-panel';
+import { expectComputedTag } from '@/test/computed-tag';
 
 const makeResult = (overrides: Partial<DatasetExperimentResult> = {}): DatasetExperimentResult => ({
   id: 'res-1',
@@ -113,6 +114,12 @@ describe('ExperimentResultPanel metadata', () => {
       expect(screen.getByText('alpha')).toBeDefined();
       expect(screen.queryByRole('combobox')).toBeNull();
       expect(screen.queryByRole('button', { name: 'Remove tag alpha' })).toBeNull();
+    });
+
+    it('renders each tag with colors computed from its value', () => {
+      render(<ExperimentResultPanel result={makeResult({ tags: ['alpha'] })} onClose={() => {}} />);
+
+      expectComputedTag(screen.getByText('alpha'), 'alpha');
     });
   });
 });

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-results-list.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-results-list.test.tsx
@@ -59,6 +59,40 @@ describe('ExperimentResultsList', () => {
     });
   });
 
+  describe('tags column', () => {
+    const tagColumns = [...columns, { name: 'tags', label: 'Tags', size: '10rem' }];
+
+    it('renders each tag of the result in the tags cell', () => {
+      renderWithProviders(
+        <ExperimentResultsList
+          results={[{ ...makeResult('r-1'), tags: ['alpha', 'beta'] }]}
+          isLoading={false}
+          featuredResultId={null}
+          onResultClick={() => {}}
+          columns={tagColumns}
+        />,
+      );
+
+      expect(screen.getByText('alpha')).toBeDefined();
+      expect(screen.getByText('beta')).toBeDefined();
+    });
+
+    it('renders an empty tags cell when the result has no tags', () => {
+      renderWithProviders(
+        <ExperimentResultsList
+          results={[makeResult('r-1')]}
+          isLoading={false}
+          featuredResultId={null}
+          onResultClick={() => {}}
+          columns={tagColumns}
+        />,
+      );
+
+      expect(screen.getByText('Tags')).toBeDefined();
+      expect(screen.getByTestId('result-tags-r-1').textContent).toBe('');
+    });
+  });
+
   describe('scorer columns', () => {
     it('links the column header to the scorer page in the same tab', () => {
       renderWithProviders(

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-results-list.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-results-list.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { ExperimentResultsList } from '../experiment-results-list';
+import { expectComputedTag } from '@/test/computed-tag';
 import { TestLinkProvider } from '@/test/link-provider';
 import { renderWithProviders } from '@/test/render';
 
@@ -75,6 +76,21 @@ describe('ExperimentResultsList', () => {
 
       expect(screen.getByText('alpha')).toBeDefined();
       expect(screen.getByText('beta')).toBeDefined();
+    });
+
+    it('renders each tag with colors computed from its value', () => {
+      renderWithProviders(
+        <ExperimentResultsList
+          results={[{ ...makeResult('r-1'), tags: ['alpha', 'beta'] }]}
+          isLoading={false}
+          featuredResultId={null}
+          onResultClick={() => {}}
+          columns={tagColumns}
+        />,
+      );
+
+      expectComputedTag(screen.getByText('alpha'), 'alpha');
+      expectComputedTag(screen.getByText('beta'), 'beta');
     });
 
     it('renders an empty tags cell when the result has no tags', () => {

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-results-tag-picker.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-results-tag-picker.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import type { DatasetExperimentResult } from '@mastra/client-js';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { ExperimentResultsTagPicker } from '../experiment-results-tag-picker';
+
+const makeResult = (id: string, tags: string[] | null): DatasetExperimentResult => ({
+  id,
+  experimentId: 'exp-1',
+  itemId: `item-${id}`,
+  input: {},
+  output: {},
+  groundTruth: null,
+  scores: {},
+  error: null,
+  status: null,
+  tags,
+  comment: null,
+  traceId: null,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+});
+
+beforeAll(() => {
+  if (typeof window.PointerEvent === 'undefined') {
+    window.PointerEvent = window.MouseEvent as unknown as typeof PointerEvent;
+  }
+});
+
+afterEach(() => cleanup());
+
+async function openCombobox() {
+  const trigger = await screen.findByRole('combobox');
+  expect(trigger.textContent).toContain('Add tag');
+  fireEvent.click(trigger);
+  return screen.findByPlaceholderText('Search or create tag...');
+}
+
+function selectOption(option: HTMLElement) {
+  fireEvent.pointerDown(option, { pointerType: 'mouse' });
+  fireEvent.click(option, { detail: 1 });
+}
+
+function renderPicker(selectedResults: DatasetExperimentResult[], onAddTag = vi.fn()) {
+  render(
+    <ExperimentResultsTagPicker selectedResults={selectedResults} vocabulary={['beta', 'alpha']} onAddTag={onAddTag} />,
+  );
+  return onAddTag;
+}
+
+describe('ExperimentResultsTagPicker', () => {
+  describe('given a vocabulary of "alpha" and "beta" and two selected results both tagged "alpha"', () => {
+    const selected = [makeResult('res-1', ['alpha']), makeResult('res-2', ['alpha', 'x'])];
+
+    it('lists the vocabulary sorted and marks tags applied to every selected result', async () => {
+      renderPicker(selected);
+      await openCombobox();
+
+      await screen.findByRole('option', { name: 'beta' });
+      const options = screen.getAllByRole('option');
+      expect(options.map(o => o.textContent)).toEqual(['alpha', 'beta']);
+      expect(within(options[0]).queryByTestId('tag-applied')).not.toBeNull();
+      expect(within(options[1]).queryByTestId('tag-applied')).toBeNull();
+    });
+
+    it('calls onAddTag when an unapplied tag is selected', async () => {
+      const onAddTag = renderPicker(selected);
+      await openCombobox();
+
+      selectOption(await screen.findByRole('option', { name: 'beta' }));
+
+      expect(onAddTag).toHaveBeenCalledWith('beta');
+    });
+
+    it('does nothing when a tag already applied to every selected result is selected', async () => {
+      const onAddTag = renderPicker(selected);
+      await openCombobox();
+
+      selectOption(await screen.findByRole('option', { name: 'alpha' }));
+
+      await waitFor(() => expect(screen.queryByRole('option')).toBeNull());
+      expect(onAddTag).not.toHaveBeenCalled();
+    });
+
+    it('offers to create an unknown tag as the first option and calls onAddTag with it', async () => {
+      const onAddTag = renderPicker(selected);
+      const search = await openCombobox();
+
+      fireEvent.input(search, { target: { value: 'new-tag' }, inputType: 'insertText' });
+      const create = await screen.findByRole('option', { name: 'Create "new-tag"' });
+      expect(screen.getAllByRole('option')[0]).toBe(create);
+
+      selectOption(create);
+
+      expect(onAddTag).toHaveBeenCalledWith('new-tag');
+    });
+
+    it('does not offer to create a tag that already exists in the vocabulary', async () => {
+      renderPicker(selected);
+      const search = await openCombobox();
+
+      fireEvent.input(search, { target: { value: 'beta' }, inputType: 'insertText' });
+
+      await screen.findByRole('option', { name: 'beta' });
+      expect(screen.queryByRole('option', { name: /^Create/ })).toBeNull();
+    });
+  });
+
+  describe('given only one of two selected results is tagged "alpha"', () => {
+    it('does not mark "alpha" as applied', async () => {
+      renderPicker([makeResult('res-1', ['alpha']), makeResult('res-2', null)]);
+      await openCombobox();
+
+      const alpha = await screen.findByRole('option', { name: 'alpha' });
+      expect(within(alpha).queryByTestId('tag-applied')).toBeNull();
+    });
+  });
+});

--- a/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
@@ -15,6 +15,7 @@ import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import { ExperimentResultsTagPicker } from './experiment-results-tag-picker';
 import { ToolMockReportSection } from './tool-mock-report-section';
+import { ComputedTag } from '@/domains/observability/components/computed-tag';
 
 export type ExperimentResultPanelProps = {
   result: DatasetExperimentResult;
@@ -141,7 +142,7 @@ export function ExperimentResultPanel({
                     <DataKeysAndValues.Value>
                       <div className="flex flex-wrap items-center gap-1.5">
                         {tags.map(tag => (
-                          <Badge key={tag} size="xs" className={onTagsChange ? 'gap-1 pr-1' : undefined}>
+                          <ComputedTag key={tag} value={tag} className={onTagsChange ? 'gap-1 pr-1' : undefined}>
                             {tag}
                             {onTagsChange && (
                               <button
@@ -154,7 +155,7 @@ export function ExperimentResultPanel({
                                 <X className="size-3" />
                               </button>
                             )}
-                          </Badge>
+                          </ComputedTag>
                         ))}
                         {onTagsChange && (
                           <ExperimentResultsTagPicker

--- a/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
@@ -150,7 +150,7 @@ export function ExperimentResultPanel({
                                 aria-label={`Remove tag ${tag}`}
                                 disabled={isUpdatingTags}
                                 onClick={() => onTagsChange(tags.filter(t => t !== tag))}
-                                className="rounded-sm hover:opacity-70 disabled:opacity-50"
+                                className="cursor-pointer rounded-sm hover:opacity-70 disabled:opacity-50"
                               >
                                 <X className="size-3" />
                               </button>

--- a/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
@@ -150,7 +150,7 @@ export function ExperimentResultPanel({
                                 aria-label={`Remove tag ${tag}`}
                                 disabled={isUpdatingTags}
                                 onClick={() => onTagsChange(tags.filter(t => t !== tag))}
-                                className="text-neutral3 hover:text-neutral6 rounded-sm disabled:opacity-50"
+                                className="rounded-sm hover:opacity-70 disabled:opacity-50"
                               >
                                 <X className="size-3" />
                               </button>

--- a/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { ClientScoreRowData, DatasetExperimentResult } from '@mastra/client-js';
+import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { DataKeysAndValues } from '@mastra/playground-ui/components/DataKeysAndValues';
@@ -9,8 +10,10 @@ import { DataPanel } from '@mastra/playground-ui/components/DataPanel';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { TraceIcon } from '@mastra/playground-ui/icons/TraceIcon';
 import { format } from 'date-fns/format';
-import { ClipboardCheck, ExternalLinkIcon, FileCodeIcon, FileOutputIcon, TagIcon, TargetIcon } from 'lucide-react';
+import { ClipboardCheck, ExternalLinkIcon, FileCodeIcon, FileOutputIcon, TargetIcon, X } from 'lucide-react';
 import type { ReactNode } from 'react';
+import { useMemo } from 'react';
+import { ExperimentResultsTagPicker } from './experiment-results-tag-picker';
 import { ToolMockReportSection } from './tool-mock-report-section';
 
 export type ExperimentResultPanelProps = {
@@ -32,6 +35,11 @@ export type ExperimentResultPanelProps = {
    * result content on the left, this slot (typically the score detail) on the right.
    */
   scorePanelSlot?: ReactNode;
+  /** When provided, tags become editable in the metadata block (add via picker, remove via badge). */
+  onTagsChange?: (tags: string[]) => void;
+  /** Known tags offered by the tag picker. */
+  tagVocabulary?: string[];
+  isUpdatingTags?: boolean;
 };
 
 export function ExperimentResultPanel({
@@ -47,6 +55,9 @@ export function ExperimentResultPanel({
   onFlagForReview,
   collapsed = false,
   scorePanelSlot,
+  onTagsChange,
+  tagVocabulary = [],
+  isUpdatingTags = false,
 }: ExperimentResultPanelProps) {
   const hasError = Boolean(result?.error);
   const inputStr = formatValue(result?.input);
@@ -54,6 +65,8 @@ export function ExperimentResultPanel({
   const groundTruthStr = formatValue(result?.groundTruth);
   const canFlag = onFlagForReview && result.status !== 'needs-review' && result.status !== 'complete';
   const tags = Array.isArray(result.tags) ? result.tags : [];
+  const selectedResults = useMemo(() => [result], [result]);
+  const showTagsRow = Boolean(onTagsChange) || tags.length > 0;
 
   return (
     <DataPanel collapsed={collapsed}>
@@ -103,6 +116,59 @@ export function ExperimentResultPanel({
                 <DataKeysAndValues.Value>
                   {format(new Date(result.createdAt), "MMM d, yyyy 'at' h:mm a")}
                 </DataKeysAndValues.Value>
+                {result.status && (
+                  <>
+                    <DataKeysAndValues.Key>Status</DataKeysAndValues.Key>
+                    <DataKeysAndValues.Value>
+                      <Badge
+                        size="xs"
+                        variant={
+                          result.status === 'needs-review'
+                            ? 'orange'
+                            : result.status === 'complete'
+                              ? 'green'
+                              : 'neutral'
+                        }
+                      >
+                        {result.status}
+                      </Badge>
+                    </DataKeysAndValues.Value>
+                  </>
+                )}
+                {showTagsRow && (
+                  <>
+                    <DataKeysAndValues.Key>Tags</DataKeysAndValues.Key>
+                    <DataKeysAndValues.Value>
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        {tags.map(tag => (
+                          <Badge key={tag} size="xs" className={onTagsChange ? 'gap-1 pr-1' : undefined}>
+                            {tag}
+                            {onTagsChange && (
+                              <button
+                                type="button"
+                                aria-label={`Remove tag ${tag}`}
+                                disabled={isUpdatingTags}
+                                onClick={() => onTagsChange(tags.filter(t => t !== tag))}
+                                className="text-neutral3 hover:text-neutral6 rounded-sm disabled:opacity-50"
+                              >
+                                <X className="size-3" />
+                              </button>
+                            )}
+                          </Badge>
+                        ))}
+                        {onTagsChange && (
+                          <ExperimentResultsTagPicker
+                            appearance="inline"
+                            selectedResults={selectedResults}
+                            vocabulary={tagVocabulary}
+                            onAddTag={tag => onTagsChange([...tags, tag])}
+                            disabled={isUpdatingTags}
+                          />
+                        )}
+                      </div>
+                    </DataKeysAndValues.Value>
+                  </>
+                )}
               </DataKeysAndValues>
 
               {hasError && (
@@ -137,34 +203,6 @@ export function ExperimentResultPanel({
               )}
 
               {result.toolMockReport && <ToolMockReportSection report={result.toolMockReport} />}
-
-              {(result.status || tags.length > 0) && (
-                <div className="grid gap-2">
-                  <DataPanel.SectionHeading icon={<TagIcon />} className="mb-2">
-                    Review
-                  </DataPanel.SectionHeading>
-                  <div className="flex flex-wrap items-center gap-2">
-                    {result.status && (
-                      <span
-                        className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                          result.status === 'needs-review'
-                            ? 'bg-orange-500/10 text-orange-400'
-                            : result.status === 'complete'
-                              ? 'bg-accent1/10 text-accent1'
-                              : 'bg-neutral3/10 text-neutral4'
-                        }`}
-                      >
-                        {result.status}
-                      </span>
-                    )}
-                    {tags.map(tag => (
-                      <span key={tag} className="bg-surface4 text-neutral4 rounded px-2 py-0.5 text-xs">
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              )}
             </div>
 
             <div className="grid gap-3">

--- a/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
@@ -1,9 +1,9 @@
 import type { ClientScoreRowData, DatasetExperimentResult } from '@mastra/client-js';
-import { Badge } from '@mastra/playground-ui/components/Badge';
 import { DataList, DataListSkeleton, useDataListKeyboard } from '@mastra/playground-ui/components/DataList';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { ScorersIcon } from '@mastra/playground-ui/icons/ScorersIcon';
 import { AlertCircleIcon } from 'lucide-react';
+import { ComputedTag } from '@/domains/observability/components/computed-tag';
 import { useLinkComponent } from '@/lib/framework';
 
 export type ExperimentResultsListProps = {
@@ -111,9 +111,7 @@ export function ExperimentResultsList({
                     data-testid={`result-tags-${result.id}`}
                   >
                     {result.tags?.map(tag => (
-                      <Badge key={tag} size="xs" className="shrink-0">
-                        {tag}
-                      </Badge>
+                      <ComputedTag key={tag} value={tag} className="shrink-0" />
                     ))}
                   </DataList.Cell>
                 )}

--- a/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
@@ -1,4 +1,5 @@
 import type { ClientScoreRowData, DatasetExperimentResult } from '@mastra/client-js';
+import { Badge } from '@mastra/playground-ui/components/Badge';
 import { DataList, DataListSkeleton, useDataListKeyboard } from '@mastra/playground-ui/components/DataList';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { ScorersIcon } from '@mastra/playground-ui/icons/ScorersIcon';
@@ -41,6 +42,7 @@ export function ExperimentResultsList({
   const hasSelection = Boolean(selectedIds && onToggleSelect);
   const gridColumns = [hasSelection ? '2rem' : '', ...columns.map(c => c.size)].filter(Boolean).join(' ');
   const hasInputColumn = columns.some(col => col.name === 'input');
+  const hasTagsColumn = columns.some(col => col.name === 'tags');
 
   const { containerRef, getRowProps } = useDataListKeyboard({ count: results.length });
 
@@ -101,6 +103,19 @@ export function ExperimentResultsList({
 
                 {hasInputColumn && (
                   <DataList.TextCell font="mono">{truncate(formatValue(result.input), 200)}</DataList.TextCell>
+                )}
+
+                {hasTagsColumn && (
+                  <DataList.Cell
+                    className="flex items-center gap-1 overflow-hidden"
+                    data-testid={`result-tags-${result.id}`}
+                  >
+                    {result.tags?.map(tag => (
+                      <Badge key={tag} size="xs" className="shrink-0">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </DataList.Cell>
                 )}
 
                 {scorerIds?.map(scorerId => {

--- a/packages/playground/src/domains/experiments/components/experiment-results-section.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-results-section.tsx
@@ -10,7 +10,10 @@ import { ClipboardCheck } from 'lucide-react';
 import { useState, useMemo, useCallback } from 'react';
 
 import { useExperimentItemPanel } from '../context/experiment-item-panel-context';
+import { useAddTagToResults } from '../hooks/use-add-tag-to-results';
+import { useExperimentTagVocabulary } from '../hooks/use-experiment-tag-vocabulary';
 import { ExperimentResultsList } from './experiment-results-list';
+import { ExperimentResultsTagPicker } from './experiment-results-tag-picker';
 import { ExperimentScorerSummary } from './experiment-scorer-summary';
 import { useScoresByExperimentId } from '@/domains/datasets/hooks/use-dataset-experiments';
 import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
@@ -47,6 +50,10 @@ export function ExperimentResultsSection({
   const [isFlagging, setIsFlagging] = useState(false);
 
   const { updateExperimentResult } = useDatasetMutations();
+  const { addTag, isPending: isTagging } = useAddTagToResults({ datasetId, experimentId });
+  const tagVocabulary = useExperimentTagVocabulary(datasetId, results);
+
+  const selectedResults = useMemo(() => results.filter(r => selectedIds.has(r.id)), [results, selectedIds]);
 
   const toggleSelect = useCallback((resultId: string) => {
     setSelectedIds(prev => {
@@ -135,7 +142,8 @@ export function ExperimentResultsSection({
   const resultsListColumns = useMemo(
     () => [
       { name: 'itemId', label: 'Item ID', size: '7rem' },
-      { name: 'input', label: 'Input', size: 'minmax(10rem,1fr)' },
+      { name: 'input', label: 'Input', size: 'minmax(200px,1fr)' },
+      { name: 'tags', label: 'Tags', size: 'max-content' },
       ...scorerIds.map(id => ({ name: id, label: id, size: '12rem' })),
     ],
     [scorerIds],
@@ -153,12 +161,23 @@ export function ExperimentResultsSection({
 
       {selectedIds.size > 0 && (
         <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" disabled={isFlagging} onClick={() => flagForReview([...selectedIds])}>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={isFlagging || isTagging}
+            onClick={() => flagForReview([...selectedIds])}
+          >
             <Icon size="sm">
               <ClipboardCheck />
             </Icon>
             Flag {selectedIds.size} to review
           </Button>
+          <ExperimentResultsTagPicker
+            selectedResults={selectedResults}
+            vocabulary={tagVocabulary}
+            onAddTag={tag => addTag(tag, selectedResults)}
+            disabled={isTagging || isFlagging}
+          />
           <Button variant="ghost" size="sm" onClick={clearSelection}>
             Clear
           </Button>

--- a/packages/playground/src/domains/experiments/components/experiment-results-tag-picker.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-results-tag-picker.tsx
@@ -1,0 +1,80 @@
+import type { DatasetExperimentResult } from '@mastra/client-js';
+import { Combobox } from '@mastra/playground-ui/components/Combobox';
+import type { ComboboxOption } from '@mastra/playground-ui/components/Combobox';
+import { Check, Tag } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+const CREATE_TAG_VALUE = '__create_tag__';
+
+export interface ExperimentResultsTagPickerProps {
+  selectedResults: DatasetExperimentResult[];
+  vocabulary: string[];
+  onAddTag: (tag: string) => void;
+  disabled?: boolean;
+  /** `toolbar` (default) for the selection row; `inline` for the compact editor in the result panel. */
+  appearance?: 'toolbar' | 'inline';
+}
+
+/**
+ * "Add tag" combobox for a selection of experiment results. Lists every known
+ * tag (checked when already on every selected result) with a first-row
+ * `Create "<input>"` option for new ones. Selecting a tag that is already
+ * applied to every selected result is a no-op.
+ */
+export function ExperimentResultsTagPicker({
+  selectedResults,
+  vocabulary,
+  onAddTag,
+  disabled,
+  appearance = 'toolbar',
+}: ExperimentResultsTagPickerProps) {
+  const [search, setSearch] = useState('');
+
+  const sortedVocabulary = useMemo(() => [...vocabulary].sort(), [vocabulary]);
+
+  // Tags present on every selected result: selecting them again is a no-op.
+  const appliedToAll = useMemo(() => {
+    if (selectedResults.length === 0) return new Set<string>();
+    const [first, ...rest] = selectedResults;
+    return new Set((first.tags ?? []).filter(tag => rest.every(r => (r.tags ?? []).includes(tag))));
+  }, [selectedResults]);
+
+  const options = useMemo<ComboboxOption[]>(() => {
+    const existing = sortedVocabulary.map(tag => ({
+      label: tag,
+      value: tag,
+      end: appliedToAll.has(tag) ? <Check data-testid="tag-applied" className="size-3.5" /> : undefined,
+    }));
+    const trimmed = search.trim();
+    const canCreate = trimmed.length > 0 && !sortedVocabulary.includes(trimmed);
+    return canCreate ? [{ label: `Create "${trimmed}"`, value: CREATE_TAG_VALUE }, ...existing] : existing;
+  }, [sortedVocabulary, appliedToAll, search]);
+
+  const handleSelect = (value: string) => {
+    const tag = value === CREATE_TAG_VALUE ? search.trim() : value;
+    if (!tag || appliedToAll.has(tag)) return;
+    onAddTag(tag);
+  };
+
+  return (
+    <Combobox
+      data-testid="experiment-results-tag-picker"
+      options={options}
+      value={undefined}
+      onValueChange={handleSelect}
+      onInputValueChange={setSearch}
+      placeholder={
+        <span className="flex items-center gap-1.5">
+          <Tag className="size-3.5" />
+          Add tag
+        </span>
+      }
+      searchPlaceholder="Search or create tag..."
+      emptyText="Type to create a tag"
+      variant={appearance === 'inline' ? 'ghost' : 'outline'}
+      size={appearance === 'inline' ? 'xs' : 'sm'}
+      className="w-auto min-w-0"
+      disabled={disabled}
+    />
+  );
+}

--- a/packages/playground/src/domains/experiments/hooks/__tests__/use-add-tag-to-results.msw.test.tsx
+++ b/packages/playground/src/domains/experiments/hooks/__tests__/use-add-tag-to-results.msw.test.tsx
@@ -87,6 +87,39 @@ describe('useAddTagToResults', () => {
     });
   });
 
+  describe('given several results to tag', () => {
+    it('sends every update concurrently instead of one after the other', async () => {
+      patches.length = 0;
+      let inFlight = 0;
+      let maxInFlight = 0;
+      server.use(
+        http.patch(
+          `${BASE_URL}/api/datasets/${DATASET_ID}/experiments/${EXPERIMENT_ID}/results/:resultId`,
+          async ({ params, request }) => {
+            inFlight++;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            const body = (await request.json()) as { tags: string[] };
+            // Hold the response so overlapping requests can be observed.
+            await new Promise(resolve => setTimeout(resolve, 20));
+            inFlight--;
+            return HttpResponse.json({ ...makeResult(String(params.resultId), body.tags) });
+          },
+        ),
+      );
+      const { result } = renderTagHook();
+
+      await act(async () => {
+        await result.current.addTag('beta', [
+          makeResult('res-1', null),
+          makeResult('res-2', null),
+          makeResult('res-3', null),
+        ]);
+      });
+
+      expect(maxInFlight).toBe(3);
+    });
+  });
+
   describe('given one of the updates fails', () => {
     it('still applies the tag to the other results and resets isPending', async () => {
       setupPatchHandler('res-1');

--- a/packages/playground/src/domains/experiments/hooks/__tests__/use-add-tag-to-results.msw.test.tsx
+++ b/packages/playground/src/domains/experiments/hooks/__tests__/use-add-tag-to-results.msw.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import type { DatasetExperimentResult } from '@mastra/client-js';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { useAddTagToResults } from '../use-add-tag-to-results';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+const DATASET_ID = 'ds-1';
+const EXPERIMENT_ID = 'exp-1';
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+};
+
+const makeResult = (id: string, tags: string[] | null): DatasetExperimentResult => ({
+  id,
+  experimentId: EXPERIMENT_ID,
+  itemId: `item-${id}`,
+  input: {},
+  output: {},
+  groundTruth: null,
+  scores: {},
+  error: null,
+  status: null,
+  tags,
+  comment: null,
+  traceId: null,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+});
+
+afterEach(() => cleanup());
+
+describe('useAddTagToResults', () => {
+  const patches: Array<{ resultId: string; body: unknown }> = [];
+
+  const setupPatchHandler = (failFor?: string) => {
+    patches.length = 0;
+    server.use(
+      http.patch(
+        `${BASE_URL}/api/datasets/${DATASET_ID}/experiments/${EXPERIMENT_ID}/results/:resultId`,
+        async ({ params, request }) => {
+          const resultId = String(params.resultId);
+          const body = await request.json();
+          patches.push({ resultId, body });
+          if (resultId === failFor) return HttpResponse.json({ error: 'boom' }, { status: 500 });
+          return HttpResponse.json({ ...makeResult(resultId, (body as { tags: string[] }).tags) });
+        },
+      ),
+    );
+  };
+
+  const renderTagHook = () =>
+    renderHook(() => useAddTagToResults({ datasetId: DATASET_ID, experimentId: EXPERIMENT_ID }), {
+      wrapper: makeWrapper(),
+    });
+
+  describe('given selected results with mixed existing tags', () => {
+    it('merges the tag into each result that does not already have it', async () => {
+      setupPatchHandler();
+      const { result } = renderTagHook();
+
+      await act(async () => {
+        await result.current.addTag('beta', [
+          makeResult('res-1', ['alpha']),
+          makeResult('res-2', null),
+          makeResult('res-3', ['beta']),
+        ]);
+      });
+
+      expect(patches).toEqual([
+        { resultId: 'res-1', body: { tags: ['alpha', 'beta'] } },
+        { resultId: 'res-2', body: { tags: ['beta'] } },
+      ]);
+      expect(result.current.isPending).toBe(false);
+    });
+  });
+
+  describe('given one of the updates fails', () => {
+    it('still applies the tag to the other results and resets isPending', async () => {
+      setupPatchHandler('res-1');
+      const { result } = renderTagHook();
+
+      await act(async () => {
+        await result.current.addTag('beta', [makeResult('res-1', null), makeResult('res-2', null)]);
+      });
+
+      // The client retries failed requests, so only assert which results were targeted.
+      expect([...new Set(patches.map(p => p.resultId))]).toEqual(['res-1', 'res-2']);
+      await waitFor(() => expect(result.current.isPending).toBe(false));
+    });
+  });
+
+  describe('given every selected result already has the tag', () => {
+    it('does not send any request', async () => {
+      setupPatchHandler();
+      const { result } = renderTagHook();
+
+      await act(async () => {
+        await result.current.addTag('beta', [makeResult('res-1', ['beta']), makeResult('res-2', ['x', 'beta'])]);
+      });
+
+      expect(patches).toEqual([]);
+    });
+  });
+});

--- a/packages/playground/src/domains/experiments/hooks/use-add-tag-to-results.ts
+++ b/packages/playground/src/domains/experiments/hooks/use-add-tag-to-results.ts
@@ -26,19 +26,17 @@ export function useAddTagToResults({ datasetId, experimentId }: UseAddTagToResul
       setIsPending(true);
       let added = 0;
       try {
-        for (const result of targets) {
-          try {
-            await updateExperimentResult.mutateAsync({
+        const outcomes = await Promise.allSettled(
+          targets.map(result =>
+            updateExperimentResult.mutateAsync({
               datasetId,
               experimentId,
               resultId: result.id,
               tags: [...(result.tags ?? []), tag],
-            });
-            added++;
-          } catch {
-            // continue on individual failures
-          }
-        }
+            }),
+          ),
+        );
+        added = outcomes.filter(o => o.status === 'fulfilled').length;
       } finally {
         setIsPending(false);
       }

--- a/packages/playground/src/domains/experiments/hooks/use-add-tag-to-results.ts
+++ b/packages/playground/src/domains/experiments/hooks/use-add-tag-to-results.ts
@@ -1,0 +1,56 @@
+import type { DatasetExperimentResult } from '@mastra/client-js';
+import { toast } from '@mastra/playground-ui/utils/toast';
+import { useCallback, useState } from 'react';
+
+import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
+
+type UseAddTagToResultsArgs = {
+  datasetId: string;
+  experimentId: string;
+};
+
+/**
+ * Applies a tag to a batch of experiment results (union with each result's
+ * existing tags). Results that already carry the tag are skipped; individual
+ * failures do not stop the remaining updates.
+ */
+export function useAddTagToResults({ datasetId, experimentId }: UseAddTagToResultsArgs) {
+  const [isPending, setIsPending] = useState(false);
+  const { updateExperimentResult } = useDatasetMutations();
+
+  const addTag = useCallback(
+    async (tag: string, results: DatasetExperimentResult[]) => {
+      const targets = results.filter(r => !(r.tags ?? []).includes(tag));
+      if (isPending || targets.length === 0) return;
+
+      setIsPending(true);
+      let added = 0;
+      try {
+        for (const result of targets) {
+          try {
+            await updateExperimentResult.mutateAsync({
+              datasetId,
+              experimentId,
+              resultId: result.id,
+              tags: [...(result.tags ?? []), tag],
+            });
+            added++;
+          } catch {
+            // continue on individual failures
+          }
+        }
+      } finally {
+        setIsPending(false);
+      }
+
+      if (added > 0) {
+        toast(`Tag "${tag}" added to ${added} result${added > 1 ? 's' : ''}`);
+      } else {
+        toast.error('Failed to add tag');
+      }
+    },
+    [datasetId, experimentId, isPending, updateExperimentResult],
+  );
+
+  return { addTag, isPending };
+}

--- a/packages/playground/src/domains/experiments/hooks/use-experiment-tag-vocabulary.ts
+++ b/packages/playground/src/domains/experiments/hooks/use-experiment-tag-vocabulary.ts
@@ -1,0 +1,17 @@
+import type { DatasetExperimentResult } from '@mastra/client-js';
+import { useMemo } from 'react';
+
+import { useDataset } from '@/domains/datasets/hooks/use-datasets';
+
+/**
+ * Every tag known for an experiment: the dataset's own tags (when the dataset
+ * still exists) plus every tag already applied to a loaded result, sorted.
+ */
+export function useExperimentTagVocabulary(datasetId: string, results: DatasetExperimentResult[]) {
+  const { data: dataset } = useDataset(datasetId);
+
+  return useMemo(
+    () => [...new Set([...(dataset?.tags ?? []), ...results.flatMap(r => r.tags ?? [])])].sort(),
+    [dataset?.tags, results],
+  );
+}

--- a/packages/playground/src/domains/observability/components/__tests__/computed-tag.test.tsx
+++ b/packages/playground/src/domains/observability/components/__tests__/computed-tag.test.tsx
@@ -1,0 +1,80 @@
+import { stringToColor } from '@mastra/playground-ui/utils/colors';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ComputedTag } from '../computed-tag';
+
+afterEach(() => {
+  cleanup();
+});
+
+// jsdom normalizes inline colors to rgb(...); feed a probe element the same hsl() to get the expected value.
+function normalizeColor(color: string) {
+  const probe = document.createElement('div');
+  probe.style.color = color;
+  return probe.style.color;
+}
+
+describe('ComputedTag', () => {
+  describe('when given a value', () => {
+    it('renders the value as the tag label', () => {
+      render(<ComputedTag value="alpha" />);
+
+      expect(screen.getByTestId('computed-tag').textContent).toBe('alpha');
+    });
+
+    it('derives the background color from the value (lightness 90)', () => {
+      render(<ComputedTag value="alpha" />);
+
+      expect(screen.getByTestId('computed-tag').style.backgroundColor).toBe(normalizeColor(stringToColor('alpha')));
+    });
+
+    it('derives the foreground color from the value (lightness 25)', () => {
+      render(<ComputedTag value="alpha" />);
+
+      expect(screen.getByTestId('computed-tag').style.color).toBe(normalizeColor(stringToColor('alpha', 25)));
+    });
+  });
+
+  describe('when the same value is rendered twice', () => {
+    it('produces identical colors', () => {
+      render(
+        <>
+          <ComputedTag value="alpha" data-testid="first" />
+          <ComputedTag value="alpha" data-testid="second" />
+        </>,
+      );
+
+      expect(screen.getByTestId('first').getAttribute('style')).toBe(
+        screen.getByTestId('second').getAttribute('style'),
+      );
+    });
+  });
+
+  describe('when two different values are rendered', () => {
+    it('produces different colors', () => {
+      render(
+        <>
+          <ComputedTag value="alpha" data-testid="first" />
+          <ComputedTag value="beta" data-testid="second" />
+        </>,
+      );
+
+      expect(screen.getByTestId('first').getAttribute('style')).not.toBe(
+        screen.getByTestId('second').getAttribute('style'),
+      );
+    });
+  });
+
+  describe('when children are provided', () => {
+    it('renders the children instead of the raw value while keeping value-derived colors', () => {
+      render(
+        <ComputedTag value="alpha">
+          alpha <button type="button">x</button>
+        </ComputedTag>,
+      );
+
+      expect(screen.getByRole('button', { name: 'x' })).toBeTruthy();
+      expect(screen.getByTestId('computed-tag').style.backgroundColor).toBe(normalizeColor(stringToColor('alpha')));
+    });
+  });
+});

--- a/packages/playground/src/domains/observability/components/computed-tag.tsx
+++ b/packages/playground/src/domains/observability/components/computed-tag.tsx
@@ -3,7 +3,8 @@ import type { BadgeProps } from '@mastra/playground-ui/components/Badge';
 import { stringToColor } from '@mastra/playground-ui/utils/colors';
 import { useMemo } from 'react';
 
-export type ComputedTagProps = Omit<BadgeProps, 'variant' | 'emphasis' | 'style'> & {
+// `BadgeProps` is a union on icon/indicator; tags never use a leading visual, so drop both.
+export type ComputedTagProps = Omit<BadgeProps, 'variant' | 'emphasis' | 'style' | 'icon' | 'indicator'> & {
   /** Tag value the colors are derived from. Rendered as label unless children are provided. */
   value: string;
 };

--- a/packages/playground/src/domains/observability/components/computed-tag.tsx
+++ b/packages/playground/src/domains/observability/components/computed-tag.tsx
@@ -1,0 +1,23 @@
+import { Badge } from '@mastra/playground-ui/components/Badge';
+import type { BadgeProps } from '@mastra/playground-ui/components/Badge';
+import { stringToColor } from '@mastra/playground-ui/utils/colors';
+import { useMemo } from 'react';
+
+export type ComputedTagProps = Omit<BadgeProps, 'variant' | 'emphasis' | 'style'> & {
+  /** Tag value the colors are derived from. Rendered as label unless children are provided. */
+  value: string;
+};
+
+/**
+ * Tag badge whose background/foreground colors are deterministically computed
+ * from its value, so the same tag looks the same everywhere it is displayed.
+ */
+export function ComputedTag({ value, children, size = 'xs', ...props }: ComputedTagProps) {
+  const style = useMemo(() => ({ backgroundColor: stringToColor(value), color: stringToColor(value, 25) }), [value]);
+
+  return (
+    <Badge data-testid="computed-tag" size={size} style={style} {...props}>
+      {children ?? value}
+    </Badge>
+  );
+}

--- a/packages/playground/src/domains/review/components/__tests__/review-item-panel.test.tsx
+++ b/packages/playground/src/domains/review/components/__tests__/review-item-panel.test.tsx
@@ -69,7 +69,7 @@ describe('ReviewItemPanel', () => {
       expectComputedTag(screen.getByRole('button', { name: 'Remove tag alpha' }).parentElement, 'alpha');
     });
 
-    it('renders the remove action in the tag foreground color', () => {
+    it('renders the remove action in the tag foreground color with a pointer cursor', () => {
       renderPanel({ item: { ...baseItem, tags: ['alpha'] } });
 
       expectInheritsTagForeground(screen.getByRole('button', { name: 'Remove tag alpha' }));

--- a/packages/playground/src/domains/review/components/__tests__/review-item-panel.test.tsx
+++ b/packages/playground/src/domains/review/components/__tests__/review-item-panel.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ReviewItem } from '../review-item-card';
 import type { ReviewItemPanelProps } from '../review-item-panel';
 import { ReviewItemPanel } from '../review-item-panel';
+import { expectComputedTag } from '@/test/computed-tag';
 
 const baseItem: ReviewItem = {
   id: 'item-1',
@@ -53,5 +54,19 @@ describe('ReviewItemPanel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Rate positive' }));
     expect(props.onRate).toHaveBeenCalledWith(undefined);
+  });
+
+  describe('given an item with tags', () => {
+    it('renders read-only tags with colors computed from their value when completed', () => {
+      renderPanel({ item: { ...baseItem, tags: ['alpha'] }, isCompleted: true });
+
+      expectComputedTag(screen.getByText('alpha'), 'alpha');
+    });
+
+    it('renders editable tag chips with colors computed from their value', () => {
+      renderPanel({ item: { ...baseItem, tags: ['alpha'] } });
+
+      expectComputedTag(screen.getByRole('button', { name: 'Remove tag alpha' }).parentElement, 'alpha');
+    });
   });
 });

--- a/packages/playground/src/domains/review/components/__tests__/review-item-panel.test.tsx
+++ b/packages/playground/src/domains/review/components/__tests__/review-item-panel.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ReviewItem } from '../review-item-card';
 import type { ReviewItemPanelProps } from '../review-item-panel';
 import { ReviewItemPanel } from '../review-item-panel';
-import { expectComputedTag } from '@/test/computed-tag';
+import { expectComputedTag, expectInheritsTagForeground } from '@/test/computed-tag';
 
 const baseItem: ReviewItem = {
   id: 'item-1',
@@ -67,6 +67,12 @@ describe('ReviewItemPanel', () => {
       renderPanel({ item: { ...baseItem, tags: ['alpha'] } });
 
       expectComputedTag(screen.getByRole('button', { name: 'Remove tag alpha' }).parentElement, 'alpha');
+    });
+
+    it('renders the remove action in the tag foreground color', () => {
+      renderPanel({ item: { ...baseItem, tags: ['alpha'] } });
+
+      expectInheritsTagForeground(screen.getByRole('button', { name: 'Remove tag alpha' }));
     });
   });
 });

--- a/packages/playground/src/domains/review/components/review-item-card.tsx
+++ b/packages/playground/src/domains/review/components/review-item-card.tsx
@@ -8,6 +8,7 @@ import { cn } from '@mastra/playground-ui/utils/cn';
 import { ThumbsUp, ThumbsDown, Trash2, CheckCircle, GaugeIcon } from 'lucide-react';
 import { useState } from 'react';
 import { TagPicker } from './tag-picker';
+import { ComputedTag } from '@/domains/observability/components/computed-tag';
 
 export interface ReviewItem {
   id: string;
@@ -150,7 +151,7 @@ export function ReviewItemCard({
             {isCompleted ? (
               <div className="flex flex-wrap gap-1">
                 {item.tags.map(tag => (
-                  <Badge key={tag}>{tag}</Badge>
+                  <ComputedTag key={tag} value={tag} size="sm" />
                 ))}
               </div>
             ) : (

--- a/packages/playground/src/domains/review/components/review-item-panel.tsx
+++ b/packages/playground/src/domains/review/components/review-item-panel.tsx
@@ -11,6 +11,7 @@ import { CheckCircle, FileInputIcon, FileOutputIcon, GaugeIcon, ThumbsDown, Thum
 import { useState, useEffect, useRef } from 'react';
 import type { ReviewItem } from './review-item-card';
 import { TagPicker } from './tag-picker';
+import { ComputedTag } from '@/domains/observability/components/computed-tag';
 function formatUnknown(value: unknown): string {
   if (typeof value === 'string') return value;
   try {
@@ -151,7 +152,7 @@ export function ReviewItemPanel({
               {isCompleted ? (
                 <div className="flex flex-wrap gap-1">
                   {item.tags.length > 0 ? (
-                    item.tags.map(tag => <Badge key={tag}>{tag}</Badge>)
+                    item.tags.map(tag => <ComputedTag key={tag} value={tag} size="sm" />)
                   ) : (
                     <Txt variant="ui-sm" className="text-neutral2">
                       No tags

--- a/packages/playground/src/domains/review/components/tag-picker.tsx
+++ b/packages/playground/src/domains/review/components/tag-picker.tsx
@@ -3,6 +3,7 @@ import { Popover, PopoverTrigger, PopoverContent } from '@mastra/playground-ui/c
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { X, Plus } from 'lucide-react';
 import { useState, useRef } from 'react';
+import { ComputedTag } from '@/domains/observability/components/computed-tag';
 
 export function TagPicker({
   tags,
@@ -40,15 +41,17 @@ export function TagPicker({
   return (
     <div className="flex flex-wrap items-center gap-1">
       {tags.map(tag => (
-        <span
-          key={tag}
-          className="bg-accent1/10 text-accent1 inline-flex items-center gap-0.5 rounded-md px-1.5 py-0.5 text-[10px] font-medium"
-        >
+        <ComputedTag key={tag} value={tag} className="gap-0.5 pr-1">
           {tag}
-          <button type="button" onClick={() => removeTag(tag)} className="hover:text-accent1/70">
+          <button
+            type="button"
+            aria-label={`Remove tag ${tag}`}
+            onClick={() => removeTag(tag)}
+            className="hover:opacity-70"
+          >
             <X className="h-2.5 w-2.5" />
           </button>
-        </span>
+        </ComputedTag>
       ))}
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>

--- a/packages/playground/src/domains/review/components/tag-picker.tsx
+++ b/packages/playground/src/domains/review/components/tag-picker.tsx
@@ -47,7 +47,7 @@ export function TagPicker({
             type="button"
             aria-label={`Remove tag ${tag}`}
             onClick={() => removeTag(tag)}
-            className="hover:opacity-70"
+            className="cursor-pointer hover:opacity-70"
           >
             <X className="h-2.5 w-2.5" />
           </button>

--- a/packages/playground/src/pages/experiments/experiment/item/index.tsx
+++ b/packages/playground/src/pages/experiments/experiment/item/index.tsx
@@ -12,6 +12,7 @@ import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutati
 import { ExperimentResultPanel } from '@/domains/experiments/components/experiment-result-panel';
 import { ExperimentScorePanel } from '@/domains/experiments/components/experiment-score-panel';
 import { useExperimentItemPanel } from '@/domains/experiments/context/experiment-item-panel-context';
+import { useExperimentTagVocabulary } from '@/domains/experiments/hooks/use-experiment-tag-vocabulary';
 import { useExperimentTrace } from '@/domains/experiments/hooks/use-experiment-trace';
 import { useTraceSpanScores } from '@/domains/scores/hooks/use-trace-span-scores';
 import { SpanFeedbackTab } from '@/domains/traces/components/span-feedback-tab';
@@ -57,6 +58,18 @@ function ExperimentItemPageContent({ itemId }: { itemId: string }) {
         toast('Result flagged for review');
       } catch {
         toast.error('Failed to flag result for review');
+      }
+    },
+    [datasetId, experimentId, updateExperimentResult],
+  );
+  const tagVocabulary = useExperimentTagVocabulary(datasetId, results);
+
+  const updateTags = useCallback(
+    async (resultId: string, tags: string[]) => {
+      try {
+        await updateExperimentResult.mutateAsync({ datasetId, experimentId, resultId, tags });
+      } catch {
+        toast.error('Failed to update tags');
       }
     },
     [datasetId, experimentId, updateExperimentResult],
@@ -149,6 +162,9 @@ function ExperimentItemPageContent({ itemId }: { itemId: string }) {
             }}
             onOpenInReview={() => openInReview(result.id)}
             onFlagForReview={() => void flagForReview(result.id)}
+            onTagsChange={tags => void updateTags(result.id, tags)}
+            tagVocabulary={tagVocabulary}
+            isUpdatingTags={updateExperimentResult.isPending}
             collapsed={resultCollapsed}
             scorePanelSlot={
               featuredScore ? (

--- a/packages/playground/src/test/computed-tag.ts
+++ b/packages/playground/src/test/computed-tag.ts
@@ -17,3 +17,11 @@ export function expectComputedTag(element: HTMLElement | null, value: string) {
   expect(tag.style.backgroundColor).toBe(probe.style.backgroundColor);
   expect(tag.style.color).toBe(probe.style.color);
 }
+
+/**
+ * Asserts that a remove button inside a `ComputedTag` inherits the tag foreground color
+ * (no own `text-*` color utility) instead of overriding it with a neutral color.
+ */
+export function expectInheritsTagForeground(button: HTMLElement) {
+  expect(button.className).not.toMatch(/(^|\s)(hover:)?text-(neutral|accent)\d/);
+}

--- a/packages/playground/src/test/computed-tag.ts
+++ b/packages/playground/src/test/computed-tag.ts
@@ -24,4 +24,5 @@ export function expectComputedTag(element: HTMLElement | null, value: string) {
  */
 export function expectInheritsTagForeground(button: HTMLElement) {
   expect(button.className).not.toMatch(/(^|\s)(hover:)?text-(neutral|accent)\d/);
+  expect(button.className).toMatch(/(^|\s)cursor-pointer(\s|$)/);
 }

--- a/packages/playground/src/test/computed-tag.ts
+++ b/packages/playground/src/test/computed-tag.ts
@@ -1,0 +1,19 @@
+import { stringToColor } from '@mastra/playground-ui/utils/colors';
+import { expect } from 'vitest';
+
+/**
+ * Asserts that `element` is a `ComputedTag` whose colors are derived from `value`.
+ * jsdom normalizes inline colors to rgb(...), so the expected hsl() is fed through a probe element.
+ */
+export function expectComputedTag(element: HTMLElement | null, value: string) {
+  expect(element, `expected a computed tag for "${value}"`).not.toBeNull();
+  const tag = element as HTMLElement;
+  expect(tag.getAttribute('data-testid')).toBe('computed-tag');
+
+  const probe = document.createElement('div');
+  probe.style.backgroundColor = stringToColor(value);
+  probe.style.color = stringToColor(value, 25);
+
+  expect(tag.style.backgroundColor).toBe(probe.style.backgroundColor);
+  expect(tag.style.color).toBe(probe.style.color);
+}


### PR DESCRIPTION
Adds an "Add tag" combobox to the selected-results row on the experiment page, so you can apply an existing tag or create a new one on every selected result at once (union with each result's existing tags, already-tagged results are skipped, selection stays active so you can add several in a row). The results list gains a Tags column and the result panel shows status/tags as metadata with inline add/remove.

Tags are now rendered with a new `ComputedTag` that derives background/foreground from the tag string via the shared `stringToColor` utility, so the same tag looks identical wherever it shows up across datasets, experiment results and review.

```tsx
<ComputedTag value="regression" />
```

Test plan: MSW/RTL tests cover the bulk-tag hook, the picker, the experiment route wiring, `ComputedTag` and each tag call site; `pnpm --filter @mastra/playground test`, typecheck and lint are green. Manually: open an experiment, tick a couple of rows, add a tag and check both rows (and the datasets list) show the same colored tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Users can add tags to several experiment results at once. Existing tags stay in place, and users can add more tags without losing their selection.

## Summary

- Added bulk tagging with the “Add tag” combobox.
- Added support for existing and newly created tags.
- Skipped results that already have the selected tag.
- Applied updates concurrently with `Promise.allSettled`.
- Added editable tags to the experiment result panel.
- Added a Tags column to experiment results.
- Added tag vocabulary from dataset tags and loaded results.
- Added `ComputedTag` for consistent value-based colors across datasets, experiments, and review views.
- Updated tag removal controls with correct foreground color and pointer styling.
- Added coverage for bulk tagging, tag picking, result panels, experiment routes, `ComputedTag`, and tag call sites.
- Typecheck and lint pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->