### PR TITLE
fix(cli): skip unresolved peer dependency versions

### DIFF
--- a/.changeset/skip-unresolved-peer-versions.md
+++ b/.changeset/skip-unresolved-peer-versions.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed peer dependency checks crashing when installed package versions cannot be resolved to exact versions.

--- a/packages/cli/src/utils/check-peer-deps.test.ts
+++ b/packages/cli/src/utils/check-peer-deps.test.ts
@@ -185,6 +185,25 @@ describe('checkMastraPeerDeps', () => {
     const mismatches = await checkMastraPeerDeps(packages);
     expect(mismatches).toHaveLength(0);
   });
+
+  it.each(['workspace:^', 'catalog:', '^1.0.0'])(
+    'should skip unresolved installed version %s',
+    async installedVersion => {
+      const packages: MastraPackageInfo[] = [
+        { name: '@mastra/core', version: installedVersion },
+        { name: '@mastra/memory', version: '1.0.0' },
+      ];
+
+      mockGetPackageInfo.mockImplementation(async (name: string) => ({
+        name,
+        version: packages.find(pkg => pkg.name === name)?.version ?? '0.0.0',
+        rootPath: `/node_modules/${name}`,
+        packageJson: name === '@mastra/memory' ? { peerDependencies: { '@mastra/core': '^1.0.0' } } : {},
+      }));
+
+      await expect(checkMastraPeerDeps(packages)).resolves.toEqual([]);
+    },
+  );
 });
 
 describe('workspace package manager detection', () => {
@@ -284,6 +303,27 @@ describe('workspace package manager detection', () => {
     const aboveRange = { ...mismatch, installedVersion: '2.0.0' };
     expect(getUpdateCommand([aboveRange, aboveRange, mismatch, mismatch])).toBe(
       'pnpm add @mastra/memory@latest @mastra/core@latest',
+    );
+  });
+
+  it.each(['workspace:^', 'catalog:', '^1.0.0'])(
+    'does not generate a command or warning for unresolved installed version %s',
+    installedVersion => {
+      const unresolvedMismatch = { ...mismatch, installedVersion };
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      expect(getUpdateCommand([unresolvedMismatch])).toBeNull();
+      expect(logPeerDepWarnings([unresolvedMismatch])).toBe(false);
+      expect(warn).not.toHaveBeenCalled();
+    },
+  );
+
+  it('ignores unresolved versions while generating commands for comparable mismatches', () => {
+    fs.writeFileSync(join(workspace, 'pnpm-lock.yaml'), '');
+    vi.spyOn(process, 'cwd').mockReturnValue(app);
+
+    expect(getUpdateCommand([{ ...mismatch, installedVersion: 'workspace:^' }, mismatch])).toBe(
+      'pnpm add @mastra/core@latest',
     );
   });
 

--- a/packages/cli/src/utils/check-peer-deps.ts
+++ b/packages/cli/src/utils/check-peer-deps.ts
@@ -3,7 +3,7 @@ import { dirname, join, resolve } from 'node:path';
 
 import { getPackageInfo } from 'local-pkg';
 import pc from 'picocolors';
-import { satisfies, gtr, validRange } from 'semver';
+import { satisfies, gtr, valid, validRange } from 'semver';
 
 import type { MastraPackageInfo } from './mastra-packages.js';
 
@@ -56,10 +56,10 @@ export async function checkMastraPeerDeps(packages: MastraPackageInfo[]): Promis
           continue;
         }
 
-        // Skip non-semver ranges like `workspace:^` or `catalog:` (seen when the
-        // package resolves to monorepo source) - they can't be compared and would
-        // make getUpdateCommand's gtr() throw.
-        if (!validRange(requiredRange)) {
+        // Skip unresolved versions and non-semver ranges like `workspace:^` or
+        // `catalog:`. They can't be compared and would make getUpdateCommand's
+        // gtr() call throw.
+        if (!valid(installedVersion) || !validRange(requiredRange)) {
           continue;
         }
 
@@ -112,10 +112,13 @@ export function getUpdateCommand(mismatches: PeerDepMismatch[]): string | null {
     return null;
   }
 
-  const pm = detectPackageManager();
   const packagesToUpdate = new Set<string>();
 
   for (const m of mismatches) {
+    if (!valid(m.installedVersion) || !validRange(m.requiredRange)) {
+      continue;
+    }
+
     // Check if installed version is above the range (too new) or below (too old)
     const isAboveRange = gtr(m.installedVersion, m.requiredRange, { includePrerelease: true });
 
@@ -128,6 +131,11 @@ export function getUpdateCommand(mismatches: PeerDepMismatch[]): string | null {
     }
   }
 
+  if (packagesToUpdate.size === 0) {
+    return null;
+  }
+
+  const pm = detectPackageManager();
   const packagesWithLatest = [...packagesToUpdate].map(pkg => `${pkg}@latest`);
   return `${pm} add ${packagesWithLatest.join(' ')}`;
 }


### PR DESCRIPTION
## Description

Prevent peer dependency diagnostics from passing unresolved installed-version specifiers to semver comparisons.

Installed versions must now be exact semantic versions before the checker records a mismatch. Command generation applies the same validation defensively, skips non-comparable entries, continues handling valid mismatches, and returns no command when none can be compared. Regression coverage includes `workspace:^`, `catalog:`, ordinary ranges, rendered-warning behavior, and mixed valid/invalid mismatches.

Validation:

- Seven regression cases failed against the original implementation
- Targeted `check-peer-deps.test.ts`: 33 tests passed
- Formatter check passed
- `git diff --check` passed
- Package-wide typecheck was not run because this partial checkout does not contain all CLI dependencies and built workspace packages

## Related issue(s)

Fixes #23302

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (not applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The CLI no longer crashes when it cannot determine an exact installed package version. It skips unsafe comparisons and still reports valid peer dependency mismatches.

## Changes

- Validate installed versions before semantic-version comparisons.
- Skip unresolved values such as `workspace:^`, `catalog:`, and version ranges.
- Make `getUpdateCommand()` ignore invalid entries and process valid mismatches.
- Return no update command when no comparable mismatches exist.
- Add regression tests for unresolved, valid, and mixed mismatch cases.
- Add a patch changeset for `mastra`.

## Verification

- Targeted tests passed.
- Formatting checks passed.
- `git diff --check` passed.
- Package-wide typechecking was not run because dependencies were missing in the partial checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->