### PR TITLE
fix(cli): stop polling retries on cancellation

### DIFF
--- a/.changeset/stop-polling-on-cancel.md
+++ b/.changeset/stop-polling-on-cancel.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Stopped command-line polling retries immediately when requests are canceled.

--- a/packages/cli/src/utils/polling.test.ts
+++ b/packages/cli/src/utils/polling.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { isRetryablePollingError } from './polling';
+import { isRetryablePollingError, withPollingRetries } from './polling';
 
 describe('isRetryablePollingError', () => {
   const retryableCodes = ['ECONNRESET', 'ETIMEDOUT', 'ECONNREFUSED', 'ENOTFOUND'];
@@ -15,5 +15,60 @@ describe('isRetryablePollingError', () => {
 
   it('rejects unsupported error codes', () => {
     expect(isRetryablePollingError({ code: 'EINVAL' })).toBe(false);
+  });
+
+  it('rejects explicit cancellation errors', () => {
+    expect(isRetryablePollingError(new DOMException('Cancelled', 'AbortError'))).toBe(false);
+  });
+});
+
+describe('withPollingRetries', () => {
+  it('continues retrying transient network errors', async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('Connection reset'), { code: 'ECONNRESET' }))
+      .mockResolvedValue('result');
+
+    await expect(withPollingRetries(operation, 1)).resolves.toBe('result');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry explicit cancellation errors', async () => {
+    const cancellation = new DOMException('Cancelled', 'AbortError');
+    const operation = vi.fn().mockRejectedValue(cancellation);
+
+    await expect(withPollingRetries(operation, 1)).rejects.toBe(cancellation);
+    expect(operation).toHaveBeenCalledOnce();
+  });
+
+  it('does not start an operation when its signal is already aborted', async () => {
+    const controller = new AbortController();
+    const cancellation = new Error('Cancelled by caller');
+    const operation = vi.fn().mockResolvedValue('result');
+    controller.abort(cancellation);
+
+    await expect(withPollingRetries(operation, 1, controller.signal)).rejects.toBe(cancellation);
+    expect(operation).not.toHaveBeenCalled();
+  });
+
+  it('interrupts retry backoff when its signal is aborted', async () => {
+    const controller = new AbortController();
+    const cancellation = new Error('Cancelled during backoff');
+    let markAttempted!: () => void;
+    const attempted = new Promise<void>(resolve => {
+      markAttempted = resolve;
+    });
+    const operation = vi.fn(async () => {
+      markAttempted();
+      throw Object.assign(new Error('Connection reset'), { code: 'ECONNRESET' });
+    });
+
+    const result = withPollingRetries(operation, 1, controller.signal);
+    await attempted;
+    await new Promise(resolve => setTimeout(resolve, 0));
+    controller.abort(cancellation);
+
+    await expect(result).rejects.toBe(cancellation);
+    expect(operation).toHaveBeenCalledOnce();
   });
 });

--- a/packages/cli/src/utils/polling.ts
+++ b/packages/cli/src/utils/polling.ts
@@ -1,3 +1,5 @@
+import { setTimeout as delay } from 'node:timers/promises';
+
 const RETRYABLE_NETWORK_ERROR_CODES = new Set(['ECONNRESET', 'ETIMEDOUT', 'ECONNREFUSED', 'ENOTFOUND']);
 
 export function isRetryablePollingError(error: unknown): boolean {
@@ -6,7 +8,7 @@ export function isRetryablePollingError(error: unknown): boolean {
   }
 
   if ('name' in error && error.name === 'AbortError') {
-    return true;
+    return false;
   }
 
   const cause = 'cause' in error && error.cause && typeof error.cause === 'object' ? error.cause : undefined;
@@ -23,18 +25,27 @@ export function isRetryablePollingError(error: unknown): boolean {
   return error instanceof TypeError && error.message.toLowerCase().includes('fetch failed');
 }
 
-export async function withPollingRetries<T>(fn: () => Promise<T>, maxRetries = 3): Promise<T> {
+export async function withPollingRetries<T>(fn: () => Promise<T>, maxRetries = 3, signal?: AbortSignal): Promise<T> {
   let retryCount = 0;
 
   while (true) {
+    signal?.throwIfAborted();
+
     try {
       return await fn();
     } catch (error) {
+      signal?.throwIfAborted();
+
       if (!isRetryablePollingError(error) || retryCount >= maxRetries) {
         throw error;
       }
 
-      await new Promise(resolve => setTimeout(resolve, 500 * Math.pow(2, retryCount)));
+      try {
+        await delay(500 * Math.pow(2, retryCount), undefined, { signal });
+      } catch (error) {
+        signal?.throwIfAborted();
+        throw error;
+      }
       retryCount += 1;
     }
   }


### PR DESCRIPTION
## Description

Stop command-line polling retries immediately when a request is explicitly canceled.

`AbortError` is now terminal instead of retryable. `withPollingRetries()` also accepts an optional `AbortSignal`, checks it before starting or repeating an operation, and uses it to interrupt exponential backoff while preserving the caller's abort reason. Supported transient network errors retain the existing retry behavior.

Regression coverage verifies thrown abort errors, pre-aborted signals, cancellation during backoff, and successful retries after transient network failures.

Validation:

- Four cancellation regression cases failed against the original implementation
- Targeted `polling.test.ts`: 14 tests passed
- Strict TypeScript check for the changed source and test passed
- Formatter check passed
- `git diff --check` passed

## Related issue(s)

Fixes #23305

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (not applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a user cancels CLI polling, it now stops immediately instead of trying again. Temporary network failures still retry as before.

## Changes

- Treat `AbortError` as terminal.
- Add optional `AbortSignal` support to `withPollingRetries()`.
- Stop before attempts when the signal is already aborted.
- Check cancellation before attempts and after failures.
- Interrupt retry backoff when cancellation occurs.
- Preserve the caller’s abort reason.
- Retain existing retry behavior for supported transient network errors.
- Add regression tests for cancellation and retry scenarios.
- Add a patch changeset for `mastra`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->