### PR TITLE
fix(playground): paginate the Studio experiments list with infinite scroll

### DIFF
--- a/.changeset/experiments-list-infinite-scroll.md
+++ b/.changeset/experiments-list-infinite-scroll.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+The Studio experiments list now loads more experiments as you scroll to the bottom, instead of stopping at the first 100. Older runs are reachable again, both on the global list and when the list is filtered by dataset.

--- a/.changeset/experiments-list-infinite-scroll.md
+++ b/.changeset/experiments-list-infinite-scroll.md
@@ -1,5 +1,5 @@
 ---
-'mastra': patch
+'@internal/playground': patch
 ---
 
-The Studio experiments list now loads more experiments as you scroll to the bottom, instead of stopping at the first 100. Older runs are reachable again, both on the global list and when the list is filtered by dataset.
+Fixed the Studio experiments list stopping at the first 100 experiments. The list now loads more as you scroll to the bottom, so older runs are reachable again, both on the global list and when it is filtered by dataset. Fixes [#22984](https://github.com/mastra-ai/mastra/issues/22984).

--- a/packages/playground/src/domains/experiments/components/experiments-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiments-list.tsx
@@ -26,6 +26,10 @@ export interface ExperimentsListProps {
   datasetFilter?: string;
   /** When provided, rows toggle selection (for comparison) instead of navigating. */
   selection?: ExperimentsListSelection;
+  isFetchingNextPage?: boolean;
+  hasNextPage?: boolean;
+  /** Ref for the end-of-list sentinel that triggers loading the next page. */
+  setEndOfListElement?: (element: HTMLDivElement | null) => void;
 }
 
 export interface ExperimentsListSelection {
@@ -57,6 +61,9 @@ export function ExperimentsList({
   statusFilter = 'all',
   datasetFilter = 'all',
   selection,
+  isFetchingNextPage,
+  hasNextPage,
+  setEndOfListElement,
 }: ExperimentsListProps) {
   const isSelectionActive = selection !== undefined;
   const { paths, Link } = useLinkComponent();
@@ -150,6 +157,12 @@ export function ExperimentsList({
           </EntityList.RowWrapper>
         );
       })}
+
+      <EntityList.NextPageLoading
+        isLoading={isFetchingNextPage}
+        hasMore={hasNextPage}
+        setEndOfListElement={setEndOfListElement}
+      />
     </EntityList>
   );
 }

--- a/packages/playground/src/domains/experiments/hooks/__tests__/use-infinite-experiments.msw.test.tsx
+++ b/packages/playground/src/domains/experiments/hooks/__tests__/use-infinite-experiments.msw.test.tsx
@@ -1,0 +1,64 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it, vi } from 'vitest';
+import { buildListExperimentsResponse, experiments } from '../../components/__tests__/fixtures/experiments';
+import { EXPERIMENTS_LIST_PAGE_SIZE, useInfiniteExperiments } from '../use-infinite-experiments';
+import { server } from '@/test/msw-server';
+import { makeWrapper, TEST_BASE_URL } from '@/test/render';
+
+/** One experiment per page; the first page reports more. */
+function pagedResponse(page: number) {
+  const experiment = experiments[page];
+  const response = buildListExperimentsResponse(experiment ? [experiment] : []);
+  return { ...response, pagination: { ...response.pagination, page, hasMore: page === 0 } };
+}
+
+describe('useInfiniteExperiments', () => {
+  it('loads the global list page by page while the server reports more', async () => {
+    const onRequest = vi.fn<(url: URL) => void>();
+    server.use(
+      http.get(`${TEST_BASE_URL}/api/experiments`, ({ request }) => {
+        const url = new URL(request.url);
+        onRequest(url);
+        return HttpResponse.json(pagedResponse(Number(url.searchParams.get('page'))));
+      }),
+    );
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useInfiniteExperiments(undefined), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(onRequest.mock.calls[0][0].searchParams.get('page')).toBe('0');
+    expect(onRequest.mock.calls[0][0].searchParams.get('perPage')).toBe(String(EXPERIMENTS_LIST_PAGE_SIZE));
+    expect(result.current.data?.map(exp => exp.id)).toEqual([experiments[0].id]);
+    expect(result.current.hasNextPage).toBe(true);
+
+    await act(() => result.current.fetchNextPage());
+
+    await waitFor(() =>
+      expect(result.current.data?.map(exp => exp.id)).toEqual([experiments[0].id, experiments[1].id]),
+    );
+    expect(onRequest.mock.calls[1][0].searchParams.get('page')).toBe('1');
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it('reads the dataset-scoped list when a dataset is given', async () => {
+    const urls: string[] = [];
+    server.use(
+      http.get(`${TEST_BASE_URL}/api/datasets/:datasetId/experiments`, ({ request }) => {
+        urls.push(request.url);
+        return HttpResponse.json(buildListExperimentsResponse([experiments[0]]));
+      }),
+    );
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useInfiniteExperiments('dataset-1'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.hasNextPage).toBe(false);
+    expect(urls).toEqual([
+      `${TEST_BASE_URL}/api/datasets/dataset-1/experiments?page=0&perPage=${EXPERIMENTS_LIST_PAGE_SIZE}`,
+    ]);
+  });
+});

--- a/packages/playground/src/domains/experiments/hooks/use-infinite-experiments.ts
+++ b/packages/playground/src/domains/experiments/hooks/use-infinite-experiments.ts
@@ -1,0 +1,41 @@
+import { useInView } from '@mastra/playground-ui/hooks/use-in-view';
+import { useMastraClient } from '@mastra/react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+export const EXPERIMENTS_LIST_PAGE_SIZE = 20;
+
+/**
+ * Experiments for the list page, loaded page by page as the end of the list scrolls into view.
+ * Reads the global list, or the dataset-scoped list when a dataset filter is active: a dataset's
+ * runs may not be in the first pages of the global list, so filtering client-side is not enough.
+ */
+export function useInfiniteExperiments(datasetId: string | undefined) {
+  const client = useMastraClient();
+  const { inView: isEndOfListInView, setRef: setEndOfListElement } = useInView();
+
+  const query = useInfiniteQuery({
+    // Prefixes match the keys invalidated by dataset/experiment mutations.
+    queryKey: datasetId ? ['dataset-experiments', datasetId, 'infinite'] : ['experiments', 'infinite'],
+    queryFn: ({ pageParam }) => {
+      const pagination = { page: pageParam, perPage: EXPERIMENTS_LIST_PAGE_SIZE };
+      return datasetId ? client.listDatasetExperiments(datasetId, pagination) : client.listExperiments(pagination);
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _, lastPageParam) => {
+      if (!lastPage?.experiments?.length || !lastPage.pagination?.hasMore) {
+        return undefined;
+      }
+      return lastPageParam + 1;
+    },
+    select: data => data.pages.flatMap(page => page?.experiments ?? []),
+  });
+
+  useEffect(() => {
+    if (isEndOfListInView && query.hasNextPage && !query.isFetchingNextPage) {
+      void query.fetchNextPage();
+    }
+  }, [isEndOfListInView, query]);
+
+  return { ...query, setEndOfListElement };
+}

--- a/packages/playground/src/domains/experiments/hooks/use-infinite-experiments.ts
+++ b/packages/playground/src/domains/experiments/hooks/use-infinite-experiments.ts
@@ -32,7 +32,9 @@ export function useInfiniteExperiments(datasetId: string | undefined) {
   });
 
   useEffect(() => {
-    if (isEndOfListInView && query.hasNextPage && !query.isFetchingNextPage) {
+    // Stop after a failed page: the page shows its error state, and re-firing on every
+    // render while the sentinel stays in view would hammer the server in a loop.
+    if (isEndOfListInView && query.hasNextPage && !query.isFetchingNextPage && !query.isFetchNextPageError) {
       void query.fetchNextPage();
     }
   }, [isEndOfListInView, query]);

--- a/packages/playground/src/pages/experiments/__tests__/experiments-dataset-filter.msw.test.tsx
+++ b/packages/playground/src/pages/experiments/__tests__/experiments-dataset-filter.msw.test.tsx
@@ -16,7 +16,7 @@ import {
   noScorers,
   noWorkflows,
 } from '@/domains/experiments/components/__tests__/fixtures/target-registries';
-import { EXPERIMENTS_PAGE_SIZE } from '@/domains/experiments/hooks/use-experiments-for-dataset-filter';
+import { EXPERIMENTS_LIST_PAGE_SIZE } from '@/domains/experiments/hooks/use-infinite-experiments';
 import { TestLinkProvider } from '@/test/link-provider';
 import { server } from '@/test/msw-server';
 import { renderWithProviders, TEST_BASE_URL } from '@/test/render';
@@ -97,7 +97,7 @@ describe('Experiments page — dataset filter from URL', () => {
     renderPage('/experiments?dataset=dataset-1');
 
     await screen.findByText('entity-extraction / model-a');
-    expect(calls.datasetPerPage).toBe(String(EXPERIMENTS_PAGE_SIZE));
+    expect(calls.datasetPerPage).toBe(String(EXPERIMENTS_LIST_PAGE_SIZE));
     expect(calls.global).toBe(0);
   });
 

--- a/packages/playground/src/pages/experiments/__tests__/experiments-infinite-scroll.msw.test.tsx
+++ b/packages/playground/src/pages/experiments/__tests__/experiments-infinite-scroll.msw.test.tsx
@@ -61,7 +61,12 @@ const dataset = buildDataset({ id: 'dataset-1', name: 'Dataset One' });
 /** Two pages: the first holds `experiments[0]` and reports more, the second holds `experiments[1]`. */
 const pages: DatasetExperiment[][] = [[experiments[0]], [experiments[1]]];
 
-function setupHandlers() {
+interface HandlerOptions {
+  /** Page index the server answers with a 500 instead of data. */
+  failPage?: number;
+}
+
+function setupHandlers({ failPage }: HandlerOptions = {}) {
   const requestedPages: string[] = [];
 
   server.use(
@@ -75,6 +80,9 @@ function setupHandlers() {
       const url = new URL(request.url);
       requestedPages.push(`${url.searchParams.get('page')}:${url.searchParams.get('perPage')}`);
       const page = Number(url.searchParams.get('page'));
+      if (page === failPage) {
+        return HttpResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+      }
       const response = buildListExperimentsResponse(pages[page] ?? []);
       return HttpResponse.json({
         ...response,
@@ -126,5 +134,21 @@ describe('Experiments page — infinite scroll', () => {
     await scrollToEndOfList();
 
     await waitFor(() => expect(requestedPages).toHaveLength(2));
+  });
+
+  it('does not keep re-requesting a page that failed while the sentinel stays in view', async () => {
+    const requestedPages = setupHandlers({ failPage: 1 });
+    renderPage();
+
+    await screen.findByText('entity-extraction / model-a');
+    await scrollToEndOfList();
+
+    expect(await screen.findByText('Failed to load experiments')).toBeDefined();
+    // The client SDK retries a 5xx a few times before surfacing the error; those are one fetch.
+    // After that, the sentinel is unmounted but still counts as "in view", so the hook must not refire.
+    const requestsWhenErrorShown = requestedPages.length;
+    await act(() => new Promise(resolve => setTimeout(resolve, 300)));
+    expect(requestedPages).toHaveLength(requestsWhenErrorShown);
+    expect(requestedPages.filter(page => page.startsWith('0:'))).toHaveLength(1);
   });
 });

--- a/packages/playground/src/pages/experiments/__tests__/experiments-infinite-scroll.msw.test.tsx
+++ b/packages/playground/src/pages/experiments/__tests__/experiments-infinite-scroll.msw.test.tsx
@@ -1,0 +1,130 @@
+import type { DatasetExperiment } from '@mastra/client-js';
+import { act, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ExperimentsPage from '..';
+import { buildDataset, buildListDatasetsResponse } from '@/domains/datasets/components/__tests__/fixtures/datasets';
+import {
+  buildListExperimentsResponse,
+  emptyReviewSummary,
+  experiments,
+} from '@/domains/experiments/components/__tests__/fixtures/experiments';
+import {
+  noAgents,
+  noProcessors,
+  noScorers,
+  noWorkflows,
+} from '@/domains/experiments/components/__tests__/fixtures/target-registries';
+import { EXPERIMENTS_LIST_PAGE_SIZE } from '@/domains/experiments/hooks/use-infinite-experiments';
+import { TestLinkProvider } from '@/test/link-provider';
+import { server } from '@/test/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '@/test/render';
+
+/** Lets a test scroll the end-of-list sentinel "into view" by hand. */
+class MockIntersectionObserver implements IntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  readonly root: Element | Document | null;
+  readonly rootMargin = '0px';
+  readonly thresholds: ReadonlyArray<number> = [0];
+  readonly observed: Element[] = [];
+  readonly disconnect = vi.fn();
+  readonly unobserve = vi.fn();
+  readonly takeRecords = vi.fn(() => []);
+
+  constructor(
+    private readonly callback: IntersectionObserverCallback,
+    options?: IntersectionObserverInit,
+  ) {
+    this.root = options?.root ?? null;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(element: Element) {
+    this.observed.push(element);
+  }
+
+  intersect(element: Element) {
+    this.callback([{ isIntersecting: true, target: element } as IntersectionObserverEntry], this);
+  }
+}
+
+const scrollToEndOfList = () =>
+  act(() => {
+    for (const observer of MockIntersectionObserver.instances) {
+      for (const element of observer.observed) observer.intersect(element);
+    }
+  });
+
+const dataset = buildDataset({ id: 'dataset-1', name: 'Dataset One' });
+
+/** Two pages: the first holds `experiments[0]` and reports more, the second holds `experiments[1]`. */
+const pages: DatasetExperiment[][] = [[experiments[0]], [experiments[1]]];
+
+function setupHandlers() {
+  const requestedPages: string[] = [];
+
+  server.use(
+    http.get(`${TEST_BASE_URL}/api/agents`, () => HttpResponse.json(noAgents)),
+    http.get(`${TEST_BASE_URL}/api/workflows`, () => HttpResponse.json(noWorkflows)),
+    http.get(`${TEST_BASE_URL}/api/processors`, () => HttpResponse.json(noProcessors)),
+    http.get(`${TEST_BASE_URL}/api/scores/scorers`, () => HttpResponse.json(noScorers)),
+    http.get(`${TEST_BASE_URL}/api/experiments/review-summary`, () => HttpResponse.json(emptyReviewSummary)),
+    http.get(`${TEST_BASE_URL}/api/datasets`, () => HttpResponse.json(buildListDatasetsResponse([dataset]))),
+    http.get(`${TEST_BASE_URL}/api/experiments`, ({ request }) => {
+      const url = new URL(request.url);
+      requestedPages.push(`${url.searchParams.get('page')}:${url.searchParams.get('perPage')}`);
+      const page = Number(url.searchParams.get('page'));
+      const response = buildListExperimentsResponse(pages[page] ?? []);
+      return HttpResponse.json({
+        ...response,
+        pagination: { ...response.pagination, page, hasMore: page < pages.length - 1 },
+      });
+    }),
+  );
+
+  return requestedPages;
+}
+
+const renderPage = () =>
+  renderWithProviders(
+    <TestLinkProvider>
+      <ExperimentsPage />
+    </TestLinkProvider>,
+    { router: { initialEntries: ['/experiments'] } },
+  );
+
+describe('Experiments page — infinite scroll', () => {
+  beforeEach(() => {
+    MockIntersectionObserver.instances = [];
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  });
+
+  it('loads the next page when the end of the list scrolls into view', async () => {
+    const requestedPages = setupHandlers();
+    renderPage();
+
+    expect(await screen.findByText('entity-extraction / model-a')).toBeDefined();
+    expect(screen.queryByText('entity-extraction / model-b')).toBeNull();
+    expect(requestedPages).toEqual([`0:${EXPERIMENTS_LIST_PAGE_SIZE}`]);
+
+    await scrollToEndOfList();
+
+    expect(await screen.findByText('entity-extraction / model-b')).toBeDefined();
+    expect(screen.getByText('entity-extraction / model-a')).toBeDefined();
+    expect(requestedPages).toEqual([`0:${EXPERIMENTS_LIST_PAGE_SIZE}`, `1:${EXPERIMENTS_LIST_PAGE_SIZE}`]);
+  });
+
+  it('stops requesting once the server reports no more pages', async () => {
+    const requestedPages = setupHandlers();
+    renderPage();
+
+    await screen.findByText('entity-extraction / model-a');
+    await scrollToEndOfList();
+    await screen.findByText('entity-extraction / model-b');
+
+    await scrollToEndOfList();
+
+    await waitFor(() => expect(requestedPages).toHaveLength(2));
+  });
+});

--- a/packages/playground/src/pages/experiments/index.tsx
+++ b/packages/playground/src/pages/experiments/index.tsx
@@ -13,7 +13,7 @@ import {
   getExperimentDatasetOptions,
   NoExperimentsInfo,
 } from '@/domains/experiments';
-import { useExperimentsForDatasetFilter } from '@/domains/experiments/hooks/use-experiments-for-dataset-filter';
+import { useInfiniteExperiments } from '@/domains/experiments/hooks/use-infinite-experiments';
 import { useReviewSummary } from '@/domains/review';
 import { buildReviewByExperimentMap } from '@/domains/review/review-maps';
 
@@ -50,11 +50,14 @@ export default function Experiments() {
     data: experimentsData,
     isLoading: isLoadingExperiments,
     error: errorExperiments,
-  } = useExperimentsForDatasetFilter(datasetFilter === 'all' ? undefined : datasetFilter);
+    isFetchingNextPage,
+    hasNextPage,
+    setEndOfListElement,
+  } = useInfiniteExperiments(datasetFilter === 'all' ? undefined : datasetFilter);
   const { data: reviewSummary } = useReviewSummary();
 
   const datasets = useMemo(() => datasetsData?.datasets ?? [], [datasetsData?.datasets]);
-  const experiments = useMemo(() => experimentsData?.experiments ?? [], [experimentsData?.experiments]);
+  const experiments = useMemo(() => experimentsData ?? [], [experimentsData]);
   const experimentDatasetOptions = useMemo(() => getExperimentDatasetOptions(datasets), [datasets]);
   const reviewByExperiment = useMemo(() => buildReviewByExperimentMap(reviewSummary), [reviewSummary]);
 
@@ -194,6 +197,9 @@ export default function Experiments() {
             ? { selectedExperimentIds: selectedIds, onToggleSelection: toggleExperimentSelection }
             : undefined
         }
+        isFetchingNextPage={isFetchingNextPage}
+        hasNextPage={hasNextPage}
+        setEndOfListElement={setEndOfListElement}
       />
 
       {runDialog}


### PR DESCRIPTION
## Description

The Studio experiments list loaded a single page of 100 runs and rendered no way to reach the rest: no scroll sentinel, no pager, no hint that older experiments exist. Once a project passed 100 experiments, the older ones were silently unreachable and unsearchable. This PR switches the list to the same sentinel-based infinite scroll the Datasets page uses (#22981), so every experiment is reachable on both the global list and the dataset-filtered list.

- Added `useInfiniteExperiments(datasetId)` in `packages/playground/src/domains/experiments/hooks/use-infinite-experiments.ts`, mirroring `useInfiniteDatasets`: `useInfiniteQuery` + `useInView` sentinel, 20 per page, reads `pagination.hasMore` to stop. It hits `GET /api/experiments` or `GET /api/datasets/:id/experiments` depending on the dataset filter, and keeps the `experiments` / `dataset-experiments` query-key prefixes so existing mutation invalidations still refresh it.
- `ExperimentsList` now renders `EntityList.NextPageLoading` after the rows and accepts `isFetchingNextPage` / `hasNextPage` / `setEndOfListElement`.
- The Experiments page uses the new hook. The existing `useExperimentsForDatasetFilter` (100 per page) is untouched and still backs the experiment combobox and the review queue, which need the flat list, the same split as `useDatasets` / `useInfiniteDatasets`.
- MSW tests: hook paging for the global and dataset-scoped endpoints, and a page-level test that scrolls the sentinel into view (mock `IntersectionObserver`) and asserts page 2 loads and no further request happens once `hasMore` is false.
- Verified in a running Studio against a project with 48 experiments across two datasets: first render shows 20 rows, scrolling to the bottom loads pages 1 and 2 until all 48 show; filtering by a dataset with 22 runs loads them in two requests from the per-dataset endpoint. `pnpm --filter ./packages/playground vitest run`: 336 files, 2280 tests green; typecheck and lint clean.

Known limitation (unchanged by this PR): the search box still filters client-side over the rows loaded so far, because `GET /api/experiments` has no `search` param. Scrolling loads more rows into the search; server-side search would be a separate change.

## Related issue(s)

Fixes #22984

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The experiments list now loads more experiments when you scroll to the bottom. This lets users find older experiments in global and dataset-filtered lists.

## Changes

- Added `useInfiniteExperiments(datasetId)` with 20 experiments per page.
- Added sentinel-based loading and next-page indicators to `ExperimentsList`.
- Updated the experiments page to use infinite scrolling.
- Preserved the existing flat-list hook for the combobox and review queue.
- Added MSW tests for pagination, scroll loading, final-page handling, and failed-page retry prevention.
- Added a patch changeset for `@internal/playground`.
- Search continues to filter only loaded experiments because the API has no search parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->