### PR TITLE
test(playground): match the dataset empty state's Add Item label

### DIFF
--- a/packages/playground/e2e/tests/datasets/dataset-items-list.spec.ts
+++ b/packages/playground/e2e/tests/datasets/dataset-items-list.spec.ts
@@ -104,7 +104,7 @@ test.describe('Dataset items list', () => {
       await page.goto(`/datasets/${dataset.id}`);
 
       await expect(page.getByText('No items yet')).toBeVisible();
-      await expect(page.getByRole('button', { name: /Add Single Item/i })).toBeVisible();
+      await expect(page.getByRole('button', { name: /Add Item/i })).toBeVisible();
       await expect(page.getByRole('button', { name: /Import CSV/i })).toBeVisible();
     });
   });


### PR DESCRIPTION
**─────── TLDR ───────**
> The dataset empty-state e2e spec waits on the button label the page actually renders, unblocking `kitchen-sink (3/4)` on every open PR.

#23304 renamed that button from **Add Single Item** to **Add Item** when it restyled the empty state, and the Playwright spec kept the old name. It has been red on `main` since that merge, so every branch based on it inherits the failure.

the empty dataset page, in `dataset-items-list.spec.ts`
&nbsp;&nbsp;├─ **was** — waited for `/Add Single Item/i`, element never found, 3 retries, job red
&nbsp;&nbsp;└─ **now** — waits for `/Add Item/i`, the label the empty state renders

The toolbar has an **Add Item** button too, but it is behind `hasItems || searchQuery`, so on an empty dataset only one button matches and the unanchored regex stays unambiguous.

---

> ██████████████████ **tests** `+1 −1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The test now looks for the button label that the application displays. This fixes the failing test and allows the `kitchen-sink (3/4)` check to pass.

## Changes

- Updated `dataset-items-list.spec.ts` to expect `"Add Item"` instead of `"Add Single Item"` in the empty-dataset test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->