### PR TITLE
fix(playground-ui): keep HorizontalBars labels readable on bright fills

### DIFF
--- a/.changeset/horizontal-bars-label-contrast.md
+++ b/.changeset/horizontal-bars-label-contrast.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed unreadable row labels in `HorizontalBars` when a bar has a bright fill in dark mode. The label now uses a dark tone over yellow, orange, red and green fills, so dataset names in the Studio "Experiments by Dataset" and "Review Pipeline" cards are readable again.

--- a/packages/playground-ui/src/ds/components/HorizontalBars/horizontal-bars.stories.tsx
+++ b/packages/playground-ui/src/ds/components/HorizontalBars/horizontal-bars.stories.tsx
@@ -19,6 +19,20 @@ const singleData = [
   { name: 'moderation-agent', values: [400] },
 ];
 
+const statusSegments = [
+  { label: 'Completed', color: 'var(--neutral3)' },
+  { label: 'Running', color: '#facc15' },
+  { label: 'Pending', color: '#fb923c' },
+  { label: 'Failed', color: '#f87171' },
+];
+
+const statusData = [
+  { name: 'travel-questions', values: [0, 10, 0, 0] },
+  { name: 'geo-questions', values: [2, 0, 5, 0] },
+  { name: 'support-tickets', values: [0, 0, 0, 4] },
+  { name: 'billing-faq', values: [3, 0, 0, 0] },
+];
+
 const stackedData = [
   { name: 'chef-agent', values: [2800, 1400] },
   { name: 'eval-agent', values: [1900, 1200] },
@@ -57,6 +71,15 @@ export const Stacked: Story = {
   render: () => (
     <div style={{ width: '30rem', height: 300 }}>
       <HorizontalBars data={stackedData} segments={stackedSegments} maxVal={4200} fmt={fmt} />
+    </div>
+  ),
+};
+
+/** Bright fills (yellow, orange, red) render at full opacity in dark mode; the label must stay readable on them. */
+export const BrightSegments: Story = {
+  render: () => (
+    <div style={{ width: '30rem', height: 300 }}>
+      <HorizontalBars data={statusData} segments={statusSegments} maxVal={10} fmt={fmt} />
     </div>
   ),
 };

--- a/packages/playground-ui/src/ds/components/HorizontalBars/horizontal-bars.tsx
+++ b/packages/playground-ui/src/ds/components/HorizontalBars/horizontal-bars.tsx
@@ -1,8 +1,26 @@
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { ScrollArea } from '@/ds/components/ScrollArea/scroll-area';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/ds/components/Tooltip';
 import type { LinkComponent } from '@/ds/types/link-component';
 import { cn } from '@/lib/utils';
+
+/** Relative luminance (WCAG) of a hex color, or `undefined` for anything else (e.g. `var(--token)`). */
+function hexLuminance(color: string): number | undefined {
+  const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(color.trim())?.[1];
+  if (!hex) return undefined;
+  const full = hex.length === 3 ? [...hex].map(c => c + c).join('') : hex;
+  const linear = (offset: number) => {
+    const channel = parseInt(full.slice(offset, offset + 2), 16) / 255;
+    return channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * linear(0) + 0.7152 * linear(2) + 0.0722 * linear(4);
+}
+
+/** Bright fills (yellow, orange, green, red) swallow the light label; dark text reads better on them. */
+function needsDarkLabel(color: string | undefined): boolean {
+  const luminance = color ? hexLuminance(color) : undefined;
+  return luminance !== undefined && luminance > 0.25;
+}
 
 type Segment = { label: string; color: string };
 
@@ -58,14 +76,18 @@ export function HorizontalBars({
       <div className="grid gap-3.5">
         {sorted.map(d => {
           const total = d.values.reduce((s, v) => s + v, 0);
+          const barWidth = `${maxVal > 0 ? (total / maxVal) * 100 : 0}%`;
+          // The label starts over the first filled segment; that fill decides the label tone in dark mode.
+          // Light mode fades every fill to 40% (see below), so the default label already reads there.
+          const darkLabelOnFill = needsDarkLabel(segments[d.values.findIndex(v => v > 0)]?.color);
           const rowBody = (
             <>
-              <div className="relative h-full min-w-0 flex-1">
+              <div className="relative h-full min-w-0 flex-1" style={{ '--bar-width': barWidth } as CSSProperties}>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <div
                       className={cn('absolute inset-y-0 left-0', d.href ? 'cursor-pointer' : 'cursor-default')}
-                      style={{ width: `${maxVal > 0 ? (total / maxVal) * 100 : 0}%` }}
+                      style={{ width: barWidth }}
                     >
                       {segments.map((seg, si) => {
                         const val = d.values[si] ?? 0;
@@ -120,9 +142,26 @@ export function HorizontalBars({
                     </div>
                   </TooltipContent>
                 </Tooltip>
-                <span className="text-ui-sm text-neutral4 pointer-events-none absolute inset-y-0 left-2.5 z-10 flex items-center truncate">
-                  {d.name}
-                </span>
+                <div
+                  className={cn(
+                    'pointer-events-none absolute inset-0 z-10',
+                    darkLabelOnFill && 'dark:[clip-path:inset(0_0_0_var(--bar-width))]',
+                  )}
+                >
+                  <span className="text-ui-sm text-neutral4 absolute inset-y-0 left-2.5 flex items-center truncate">
+                    {d.name}
+                  </span>
+                </div>
+                {darkLabelOnFill && (
+                  <div
+                    aria-hidden
+                    className="pointer-events-none absolute inset-y-0 left-0 z-10 hidden w-(--bar-width) overflow-hidden dark:block"
+                  >
+                    <span className="text-ui-sm text-neutral1 absolute inset-y-0 left-2.5 flex items-center whitespace-nowrap">
+                      {d.name}
+                    </span>
+                  </div>
+                )}
               </div>
               <span className="text-ui-md text-neutral4 shrink-0 pr-3 tabular-nums">{fmt(total)}</span>
             </>


### PR DESCRIPTION
## Description

In dark mode, `HorizontalBars` draws its light row label over the bar fill at full opacity. When a row starts with a bright fill (yellow, orange, red, green) the dataset name is unreadable. This shows in the Studio "Experiments by Dataset" and "Review Pipeline" cards.

## Before
<img width="467" height="299" alt="image" src="https://github.com/user-attachments/assets/60e8f98b-5442-4199-9dd9-7fb7c1a0a250" />

## After
<img width="613" height="329" alt="image" src="https://github.com/user-attachments/assets/f3c0aaf2-a994-4f17-a0c7-aeb22a4c2ef9" />

- The label now checks the luminance of the first filled segment and switches to a dark tone over bright hex fills.
- The dark copy is clipped to the bar width, so the label stays light past the end of a short bar.
- Light mode is unchanged (fills are already faded to 40% there).
- Added a `BrightSegments` story covering yellow, orange, red and gray fills.

## Related Issue(s)

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

In dark mode, bright bars could hide dataset names. This change makes the labels switch to a dark color on bright bars while keeping them readable on short bars.

## Changes

- Updated `HorizontalBars` to:
  - Detect the luminance of the first filled segment.
  - Use dark labels on bright fills.
  - Clip dark labels to the bar width.
  - Keep light labels outside short bars.
  - Preserve light-mode behavior.
- Added the `BrightSegments` Storybook story for yellow, orange, red, and gray fills.
- Added a patch changeset for `@mastra/playground-ui`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->