### PR TITLE
feat(factory): supervisor creates and drives work items (COR-1207)

### DIFF
--- a/.changeset/quiet-doors-open.md
+++ b/.changeset/quiet-doors-open.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+The factory supervisor can now file work items on a person's behalf. A new approval-free, audited `factory_create_work_item` tool takes a title and a brief, enters the card through intake like the board does (the brief lands as the card's first comment for the worker to read), and records who asked. On an authenticated turn the card is filed as that person; on a notification-woken turn it is filed as the supervisor's agent identity with no requester. The supervisor then drives the item the way it drives everything else: watching its findings, answering its worker's questions, and escalating what needs a person. It never assigns, schedules, or codes the work itself.

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -597,7 +597,7 @@ describe('MastraFactory.prepare', () => {
     'factory_list_attention',
     'factory_read_session',
   ];
-  const SUPERVISOR_ACTION_TOOLS = ['factory_escalate_finding', 'factory_answer_suspension'];
+  const SUPERVISOR_ACTION_TOOLS = ['factory_escalate_finding', 'factory_answer_suspension', 'factory_create_work_item'];
   const SUPERVISOR_HUMAN_WRITE_TOOLS = [
     'factory_retry_decision',
     'factory_dismiss_decision',

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -828,6 +828,8 @@ export class MastraFactory {
                                 id: `agent:${supervisorThreadId ?? supervisorResourceId(supervisorScope.factoryProjectId)}`,
                               },
                         workItems: workItemsStorage,
+                        comments: workItemCommentsStorage,
+                        transitionService,
                         audit: auditStorage,
                         controller: prepared.base.controller,
                         notifySupervisor: input =>

--- a/mastracode/factory/src/routes/work-items.ts
+++ b/mastracode/factory/src/routes/work-items.ts
@@ -46,6 +46,7 @@ import {
   WorkItemRelationError,
 } from '../storage/domains/work-items/base.js';
 import { computeFactoryMetrics, parseMetricsRange } from '../storage/domains/work-items/metrics.js';
+import { createFactoryWorkItem } from '../work-item-create.js';
 import { buildAttentionRoutes, factoryDecisionType } from './attention.js';
 import type { RouteDependencies } from './route.js';
 import { Route } from './route.js';
@@ -711,36 +712,22 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
 
           await workItems.ensureReady();
           try {
-            const result = await workItems.upsert({
+            const result = await createFactoryWorkItem({
+              workItems,
+              transitionService,
               orgId: resolved.orgId,
-              userId: resolved.userId,
               factoryProjectId: resolved.factoryProjectId,
+              userId: resolved.userId,
+              actor: { type: 'human', id: resolved.userId },
+              ingressType: 'human',
               input,
-              reuseMode: 'non-stage',
             });
-            let item = result.item;
-            if (result.created) {
-              if (!transitionService) {
-                await workItems.delete({ orgId: resolved.orgId, id: item.id });
-                return c.json({ error: 'factory_transitions_unavailable' }, 503);
-              }
-              const entered = await transitionService.transition({
-                orgId: resolved.orgId,
-                factoryProjectId: resolved.factoryProjectId,
-                workItemId: item.id,
-                board: item.externalSource?.type === 'pull-request' ? 'review' : 'work',
-                stage: 'intake',
-                expectedRevision: item.revision,
-                actor: { type: 'human', id: resolved.userId },
-                ingress: { type: 'human', identity: `work-item:${item.id}:initial-entry` },
-                cause: 'work_item_created',
-                initialEntry: true,
-              });
-              if (entered.status === 'rejected') {
-                await workItems.delete({ orgId: resolved.orgId, id: item.id });
-                return c.json({ status: 'rejected', code: entered.code, reason: entered.reason }, 422);
-              }
-              item = (await workItems.getForProject(resolved.orgId, resolved.factoryProjectId, item.id)) ?? item;
+            if (result.status === 'unavailable') return c.json({ error: 'factory_transitions_unavailable' }, 503);
+            if (result.status === 'rejected') {
+              return c.json({ status: 'rejected', code: result.code, reason: result.reason }, 422);
+            }
+            const item = result.item;
+            if (result.status === 'created') {
               await audit.emit({
                 context: loose(c),
                 input: {

--- a/mastracode/factory/src/supervisor/action-tools.test.ts
+++ b/mastracode/factory/src/supervisor/action-tools.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { builtInFactoryRules } from '../rules/defaults.js';
+import { FactoryTransitionService } from '../rules/transition-service.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
 import { createFactorySupervisorActionTools } from './action-tools.js';
 import { computeFactoryHealth } from './health.js';
@@ -34,6 +36,8 @@ async function setup(actor: { type: 'human' | 'agent'; id: string } = { type: 'a
     scope: SCOPE,
     actor,
     workItems: seed.workItems,
+    comments: seed.comments,
+    transitionService: new FactoryTransitionService({ rules: builtInFactoryRules(), storage: seed.workItems }),
     audit: seed.audit,
     controller: noSessions,
     now: () => NOW,
@@ -984,5 +988,118 @@ describe('factory_answer_suspension', () => {
     expect(after.occurrence).toBe(published.occurrence);
     expect(after.lastNotifiedAt?.getTime()).toBe(published.lastNotifiedAt?.getTime());
     expect(notify).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('factory_create_work_item', () => {
+  const listAudit = (audit: Awaited<ReturnType<typeof setup>>['audit']) =>
+    audit.list({ orgId: 'org-1', factoryProjectId: PROJECT_ID, limit: 10 });
+
+  it('is approval-free and takes no stage: every card enters through intake', async () => {
+    const { tools } = await setup();
+    const tool = tools.factory_create_work_item as { requireApproval?: boolean; inputSchema: { shape: object } };
+    expect(tool.requireApproval).toBeFalsy();
+    expect(Object.keys(tool.inputSchema.shape).sort()).toEqual(['brief', 'title']);
+  });
+
+  it('files the card in intake for the human who asked, with the brief on its feed', async () => {
+    const { tools, workItems, comments, audit } = await setup({ type: 'human', id: 'user-7' });
+
+    const result = await execute<any>(tools.factory_create_work_item, {
+      title: 'Add a retry budget to the dispatcher',
+      brief: 'Runs give up after one failure; we want three attempts with backoff.',
+    });
+
+    expect(result).toMatchObject({
+      title: 'Add a retry budget to the dispatcher',
+      stages: ['intake'],
+      requestedBy: 'user-7',
+      createdBy: 'user-7',
+      briefPosted: true,
+      audited: true,
+    });
+    const item = await workItems.getForProject('org-1', PROJECT_ID, result.workItemId);
+    expect(item).toMatchObject({ stages: ['intake'], createdBy: 'user-7', externalSource: null });
+    // The governed initial entry ran, not a bare insert.
+    expect(item?.stageHistory.map(entry => entry.stage)).toEqual(['intake']);
+    expect(
+      await workItems.getTransitionResultByIngress('org-1', PROJECT_ID, `work-item:${item!.id}:initial-entry`),
+    ).toMatchObject({ status: 'accepted' });
+
+    const feed = await comments.list({ orgId: 'org-1', factoryProjectId: PROJECT_ID, workItemId: item!.id });
+    expect(feed.comments.map(comment => ({ body: comment.body, author: comment.author }))).toEqual([
+      {
+        body: 'Runs give up after one failure; we want three attempts with backoff.',
+        author: expect.objectContaining({ kind: 'user', id: 'user-7' }),
+      },
+    ]);
+
+    const event = (await listAudit(audit)).events.find(entry => entry.action === 'factory.work_item.created');
+    expect(event).toMatchObject({
+      actorType: 'human',
+      actorId: 'user-7',
+      targets: [{ type: 'work_item', id: item!.id }],
+      metadata: { cause: 'supervisor', requestedBy: 'user-7', stages: ['intake'], briefPosted: true },
+    });
+  });
+
+  it('on a signal turn files as the agent with no requester, never a human-shaped attribution', async () => {
+    const { tools, workItems, comments, audit } = await setup();
+
+    const result = await execute<any>(tools.factory_create_work_item, {
+      title: 'Follow up on the flaky fixture',
+      brief: 'The worker kept asking which database the fixture uses; pin it in the README.',
+    });
+
+    expect(result).toMatchObject({ requestedBy: null, createdBy: 'agent:thread-1', stages: ['intake'] });
+    const item = await workItems.getForProject('org-1', PROJECT_ID, result.workItemId);
+    expect(item?.createdBy).toBe('agent:thread-1');
+    const feed = await comments.list({ orgId: 'org-1', factoryProjectId: PROJECT_ID, workItemId: item!.id });
+    expect(feed.comments[0]?.author).toMatchObject({ kind: 'agent', id: 'agent:thread-1' });
+    const event = (await listAudit(audit)).events.find(entry => entry.action === 'factory.work_item.created');
+    expect(event).toMatchObject({ actorType: 'agent', actorId: 'agent:thread-1', metadata: { requestedBy: null } });
+  });
+
+  it('creates nothing when the factory cannot enter intake', async () => {
+    const seed = await createFactoryStorageForTests();
+    const tools = createFactorySupervisorActionTools({
+      scope: SCOPE,
+      actor: { type: 'human', id: 'user-7' },
+      workItems: seed.workItems,
+      comments: seed.comments,
+      transitionService: undefined,
+      audit: seed.audit,
+      controller: noSessions,
+      now: () => NOW,
+    });
+
+    await expect(execute(tools.factory_create_work_item, { title: 'Card', brief: 'Brief' })).rejects.toThrow(
+      'cannot accept new work items',
+    );
+    expect((await seed.workItems.list({ orgId: 'org-1', factoryProjectId: PROJECT_ID })).length).toBe(0);
+  });
+
+  it('reports a brief that failed to post without unfiling the card', async () => {
+    const seed = await createFactoryStorageForTests();
+    const tools = createFactorySupervisorActionTools({
+      scope: SCOPE,
+      actor: { type: 'human', id: 'user-7' },
+      workItems: seed.workItems,
+      comments: {
+        create: async () => {
+          throw new Error('comments down');
+        },
+      },
+      transitionService: new FactoryTransitionService({ rules: builtInFactoryRules(), storage: seed.workItems }),
+      audit: seed.audit,
+      controller: noSessions,
+      now: () => NOW,
+    });
+
+    const result = await execute<any>(tools.factory_create_work_item, { title: 'Card', brief: 'Brief' });
+    expect(result).toMatchObject({ briefPosted: false, briefError: expect.stringContaining('Filed') });
+    expect(await seed.workItems.getForProject('org-1', PROJECT_ID, result.workItemId)).toMatchObject({
+      stages: ['intake'],
+    });
   });
 });

--- a/mastracode/factory/src/supervisor/action-tools.test.ts
+++ b/mastracode/factory/src/supervisor/action-tools.test.ts
@@ -1079,7 +1079,7 @@ describe('factory_create_work_item', () => {
     expect((await seed.workItems.list({ orgId: 'org-1', factoryProjectId: PROJECT_ID })).length).toBe(0);
   });
 
-  it('reports a brief that failed to post without unfiling the card', async () => {
+  it('files no card at all when the brief cannot be posted', async () => {
     const seed = await createFactoryStorageForTests();
     const tools = createFactorySupervisorActionTools({
       scope: SCOPE,
@@ -1096,10 +1096,42 @@ describe('factory_create_work_item', () => {
       now: () => NOW,
     });
 
-    const result = await execute<any>(tools.factory_create_work_item, { title: 'Card', brief: 'Brief' });
-    expect(result).toMatchObject({ briefPosted: false, briefError: expect.stringContaining('Filed') });
-    expect(await seed.workItems.getForProject('org-1', PROJECT_ID, result.workItemId)).toMatchObject({
-      stages: ['intake'],
+    await expect(execute(tools.factory_create_work_item, { title: 'Card', brief: 'Brief' })).rejects.toThrow(
+      /brief could not be posted, so no work item was filed: comments down/,
+    );
+    // No orphan card, nothing entered intake, nothing audited as created.
+    const items = await seed.workItems.list({ orgId: 'org-1', factoryProjectId: PROJECT_ID });
+    expect(items.filter(i => i.title === 'Card')).toEqual([]);
+    const { events } = await seed.audit.list({ orgId: 'org-1', factoryProjectId: PROJECT_ID, limit: 10 });
+    expect(events.filter(e => e.action === 'factory.work_item.created')).toEqual([]);
+  });
+
+  it('posts the brief before the card enters intake', async () => {
+    const seed = await createFactoryStorageForTests();
+    const order: string[] = [];
+    const transitionService = new FactoryTransitionService({ rules: builtInFactoryRules(), storage: seed.workItems });
+    const tools = createFactorySupervisorActionTools({
+      scope: SCOPE,
+      actor: { type: 'human', id: 'user-7' },
+      workItems: seed.workItems,
+      comments: {
+        create: async input => {
+          order.push('brief');
+          return seed.comments.create(input);
+        },
+      },
+      transitionService: {
+        transition: async input => {
+          order.push('intake');
+          return transitionService.transition(input);
+        },
+      },
+      audit: seed.audit,
+      controller: noSessions,
+      now: () => NOW,
     });
+
+    await execute<any>(tools.factory_create_work_item, { title: 'Card', brief: 'Brief' });
+    expect(order).toEqual(['brief', 'intake']);
   });
 });

--- a/mastracode/factory/src/supervisor/action-tools.ts
+++ b/mastracode/factory/src/supervisor/action-tools.ts
@@ -559,35 +559,33 @@ export function createFactorySupervisorActionTools(deps: SupervisorActionDepende
           actor: requestedBy ? { type: 'human', id: requestedBy } : { type: 'system', id: deps.actor.id },
           ingressType: requestedBy ? 'human' : 'agent',
           input: { title, stages: ['intake'] },
+          // The kickoff reads the card's feed, so the brief goes on as the
+          // card's first comment before the card enters intake: the worker
+          // can never pick up a card that has no brief yet. A failure here
+          // means no card is filed at all.
+          beforeEntry: item =>
+            deps.comments.create({
+              orgId: deps.scope.orgId,
+              factoryProjectId: deps.scope.factoryProjectId,
+              workItemId: item.id,
+              author: requestedBy ? { kind: 'user', id: requestedBy } : { kind: 'agent', id: deps.actor.id },
+              body: brief,
+            }),
         });
         if (created.status === 'unavailable') throw new Error('This factory cannot accept new work items right now.');
         if (created.status === 'rejected') {
-          throw new Error(`Intake refused the work item (${created.code}): ${created.reason}`);
+          throw new Error(
+            created.code === 'entry_preparation_failed'
+              ? `The brief could not be posted, so no work item was filed: ${created.reason}`
+              : `Intake refused the work item (${created.code}): ${created.reason}`,
+          );
         }
         const item = created.item;
-        // The kickoff reads the card's feed, so the brief reaches the worker as
-        // the card's first comment, attributed to whoever the turn acts as.
-        let briefPosted = true;
-        try {
-          await deps.comments.create({
-            orgId: deps.scope.orgId,
-            factoryProjectId: deps.scope.factoryProjectId,
-            workItemId: item.id,
-            author: requestedBy ? { kind: 'user', id: requestedBy } : { kind: 'agent', id: deps.actor.id },
-            body: brief,
-          });
-        } catch (error) {
-          briefPosted = false;
-          deps.logger?.warn('Factory supervisor could not post the brief on a new work item', {
-            workItemId: item.id,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
         const audited = await auditAfter(
           'audited',
           'factory.work_item.created',
           { type: 'work_item', id: item.id },
-          { title: item.title, stages: item.stages, requestedBy, briefPosted },
+          { title: item.title, stages: item.stages, requestedBy, briefPosted: true },
         );
         return {
           workItemId: item.id,
@@ -595,8 +593,7 @@ export function createFactorySupervisorActionTools(deps: SupervisorActionDepende
           stages: item.stages,
           requestedBy,
           createdBy: item.createdBy,
-          briefPosted,
-          ...(briefPosted ? {} : { briefError: 'Filed, but posting the brief failed. Add it as a comment instead.' }),
+          briefPosted: true,
           ...audited,
         };
       },

--- a/mastracode/factory/src/supervisor/action-tools.ts
+++ b/mastracode/factory/src/supervisor/action-tools.ts
@@ -4,13 +4,16 @@ import { z } from 'zod';
 
 import type { IntegrationTools } from '../integrations/base.js';
 import { describeParkedTool, FACTORY_DISPATCH_CONSTANTS } from '../rules/dispatcher.js';
+import type { FactoryTransitionService } from '../rules/transition-service.js';
 import type { AuditActorType, AuditStorage } from '../storage/domains/audit/base.js';
+import type { WorkItemCommentsStorage } from '../storage/domains/comments/base.js';
 import type {
   FactoryDeferredDecisionRecord,
   FactoryParkedSuspension,
   FactoryRunBindingRecord,
   WorkItemsStorage,
 } from '../storage/domains/work-items/base.js';
+import { createFactoryWorkItem } from '../work-item-create.js';
 import {
   decisionFailedFinding,
   decisionIdFromFindingKey,
@@ -66,7 +69,12 @@ interface SupervisorActionDependencies {
     | 'openSupervisorFinding'
     | 'markSupervisorFindingNotified'
     | 'get'
+    | 'upsert'
+    | 'delete'
+    | 'getForProject'
   >;
+  comments: Pick<WorkItemCommentsStorage, 'create'>;
+  transitionService: Pick<FactoryTransitionService, 'transition'> | undefined;
   audit: Pick<AuditStorage, 'record'>;
   /** Session lookup by resource id, the join key persisted with a parked suspension. */
   controller: { getSessionByResource(resourceId: string): Promise<SuspendableSession | undefined> };
@@ -528,6 +536,68 @@ export function createFactorySupervisorActionTools(deps: SupervisorActionDepende
           answer: resumeData,
           ...audited,
           ...settled,
+        };
+      },
+    }),
+
+    factory_create_work_item: createTool({
+      id: 'factory_create_work_item',
+      description:
+        'File a new work item in this factory on behalf of the person asking, and let the factory drive it: the card enters intake, where the normal lifecycle (triage, approval, work) takes over. Give a short title and a brief that says what is wanted and why; the brief is posted on the card so the worker reads it. Before filing, check the board for an existing item or session covering the same request and point to that instead of creating a duplicate. You never assign, schedule, run, or write code yourself: after filing, you watch the item, answer its questions, and escalate what needs a person.',
+      inputSchema: z.object({
+        title: z.string().trim().min(1).max(200),
+        brief: z.string().trim().min(1).max(4000),
+      }),
+      execute: async ({ title, brief }) => {
+        const requestedBy = deps.actor.type === 'human' ? deps.actor.id : null;
+        const created = await createFactoryWorkItem({
+          workItems: deps.workItems,
+          transitionService: deps.transitionService,
+          orgId: deps.scope.orgId,
+          factoryProjectId: deps.scope.factoryProjectId,
+          userId: deps.actor.id,
+          actor: requestedBy ? { type: 'human', id: requestedBy } : { type: 'system', id: deps.actor.id },
+          ingressType: requestedBy ? 'human' : 'agent',
+          input: { title, stages: ['intake'] },
+        });
+        if (created.status === 'unavailable') throw new Error('This factory cannot accept new work items right now.');
+        if (created.status === 'rejected') {
+          throw new Error(`Intake refused the work item (${created.code}): ${created.reason}`);
+        }
+        const item = created.item;
+        // The kickoff reads the card's feed, so the brief reaches the worker as
+        // the card's first comment, attributed to whoever the turn acts as.
+        let briefPosted = true;
+        try {
+          await deps.comments.create({
+            orgId: deps.scope.orgId,
+            factoryProjectId: deps.scope.factoryProjectId,
+            workItemId: item.id,
+            author: requestedBy ? { kind: 'user', id: requestedBy } : { kind: 'agent', id: deps.actor.id },
+            body: brief,
+          });
+        } catch (error) {
+          briefPosted = false;
+          deps.logger?.warn('Factory supervisor could not post the brief on a new work item', {
+            workItemId: item.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+        const audited = await auditAfter(
+          'audited',
+          'factory.work_item.created',
+          { type: 'work_item', id: item.id },
+          { title: item.title, stages: item.stages, requestedBy, briefPosted },
+        );
+        return {
+          workItemId: item.id,
+          title: item.title,
+          stages: item.stages,
+          requestedBy,
+          createdBy: item.createdBy,
+          briefPosted,
+          ...(briefPosted ? {} : { briefError: 'Filed, but posting the brief failed. Add it as a comment instead.' }),
+          ...audited,
         };
       },
     }),

--- a/mastracode/factory/src/supervisor/instructions.ts
+++ b/mastracode/factory/src/supervisor/instructions.ts
@@ -77,6 +77,20 @@ cap exists so a plan-looping worker reaches a person, and you never approve
 the plan past it. The tool escalates those cases for you rather than
 guessing; if it reports the question was already handled, do nothing more.
 
+## Filing work
+
+When a person asks you to get something built, fixed, or looked into, file
+it with \`factory_create_work_item\`: a short title and a brief that says
+what they want and why. The card enters intake and the factory's own
+lifecycle takes it from there. The tool needs no confirmation and records
+who asked. Before filing, check the board (\`factory_overview\`,
+\`factory_inspect_work_item\`) for a card or session already covering the
+request and point the person to it instead of duplicating it. Filing is the
+whole of your part: you never assign, schedule, start, or code the work
+yourself. After that you drive it the way you drive everything else: watch
+its findings, answer its worker's questions, and escalate what needs the
+person.
+
 ## Escalating
 
 Findings in the supervisor-actionable kinds (\`decision-failed\`,

--- a/mastracode/factory/src/work-item-create.ts
+++ b/mastracode/factory/src/work-item-create.ts
@@ -34,6 +34,13 @@ export interface CreateFactoryWorkItemInput {
   actor: FactoryRuleActor;
   ingressType: 'human' | 'agent';
   input: CreateWorkItemInput;
+  /**
+   * Runs once the card exists and before it enters intake, for anything the
+   * worker must find on the card the moment the lifecycle starts (a brief on
+   * the feed). If it throws, the card is deleted again and the outcome is
+   * `rejected`: a card never enters the lifecycle without its brief.
+   */
+  beforeEntry?: (item: WorkItemRow) => Promise<unknown>;
 }
 
 export async function createFactoryWorkItem({
@@ -45,6 +52,7 @@ export async function createFactoryWorkItem({
   actor,
   ingressType,
   input,
+  beforeEntry,
 }: CreateFactoryWorkItemInput): Promise<CreateFactoryWorkItemOutcome> {
   const result = await workItems.upsert({ orgId, userId, factoryProjectId, input, reuseMode: 'non-stage' });
   let item = result.item;
@@ -53,6 +61,18 @@ export async function createFactoryWorkItem({
   if (!transitionService) {
     await workItems.delete({ orgId, id: item.id });
     return { status: 'unavailable' };
+  }
+  if (beforeEntry) {
+    try {
+      await beforeEntry(item);
+    } catch (error) {
+      await workItems.delete({ orgId, id: item.id });
+      return {
+        status: 'rejected',
+        code: 'entry_preparation_failed',
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
   }
   const entered = await transitionService.transition({
     orgId,

--- a/mastracode/factory/src/work-item-create.ts
+++ b/mastracode/factory/src/work-item-create.ts
@@ -1,0 +1,75 @@
+/**
+ * The one way a new work item enters a factory: upsert the card, then walk it
+ * through the governed `intake` initial entry so the board's entry rules run.
+ * The HTTP route and the supervisor's `factory_create_work_item` both create
+ * through here; a card written any other way skips the lifecycle.
+ */
+
+import type { FactoryTransitionService } from './rules/transition-service.js';
+import type { FactoryRuleActor } from './rules/types.js';
+import type {
+  CreateWorkItemInput,
+  WorkItemPriorState,
+  WorkItemRow,
+  WorkItemsStorage,
+} from './storage/domains/work-items/base.js';
+
+export type CreateFactoryWorkItemOutcome =
+  | { status: 'created'; item: WorkItemRow }
+  /** The source key matched an existing card, which the input updated instead. */
+  | { status: 'reused'; item: WorkItemRow; previous: WorkItemPriorState }
+  /** Intake entry refused the card; it has been deleted again. */
+  | { status: 'rejected'; code: string; reason: string }
+  /** No transition service is mounted, so nothing can enter intake; the card has been deleted again. */
+  | { status: 'unavailable' };
+
+export interface CreateFactoryWorkItemInput {
+  workItems: Pick<WorkItemsStorage, 'upsert' | 'delete' | 'getForProject'>;
+  transitionService: Pick<FactoryTransitionService, 'transition'> | undefined;
+  orgId: string;
+  factoryProjectId: string;
+  /** Stamped as the card's creator (`created_by`, stage history). */
+  userId: string;
+  /** Who the initial-entry transition acts as. */
+  actor: FactoryRuleActor;
+  ingressType: 'human' | 'agent';
+  input: CreateWorkItemInput;
+}
+
+export async function createFactoryWorkItem({
+  workItems,
+  transitionService,
+  orgId,
+  factoryProjectId,
+  userId,
+  actor,
+  ingressType,
+  input,
+}: CreateFactoryWorkItemInput): Promise<CreateFactoryWorkItemOutcome> {
+  const result = await workItems.upsert({ orgId, userId, factoryProjectId, input, reuseMode: 'non-stage' });
+  let item = result.item;
+  if (!result.created) return { status: 'reused', item, previous: result.previous };
+
+  if (!transitionService) {
+    await workItems.delete({ orgId, id: item.id });
+    return { status: 'unavailable' };
+  }
+  const entered = await transitionService.transition({
+    orgId,
+    factoryProjectId,
+    workItemId: item.id,
+    board: item.externalSource?.type === 'pull-request' ? 'review' : 'work',
+    stage: 'intake',
+    expectedRevision: item.revision,
+    actor,
+    ingress: { type: ingressType, identity: `work-item:${item.id}:initial-entry` },
+    cause: 'work_item_created',
+    initialEntry: true,
+  });
+  if (entered.status === 'rejected') {
+    await workItems.delete({ orgId, id: item.id });
+    return { status: 'rejected', code: entered.code, reason: entered.reason };
+  }
+  item = (await workItems.getForProject(orgId, factoryProjectId, item.id)) ?? item;
+  return { status: 'created', item };
+}


### PR DESCRIPTION
Part of COR-1183 (Improved Supervisor v1). Stacked on #23103 (COR-1197). Segment 5 of 5. Draft until the whole stack is reviewed.

## What this does

The supervisor can now file work on a person's behalf. A person chats "file this for the worker" to the supervisor and it creates a card without a human touching the board; the card enters through intake exactly as a hand-filed card would, and the card records who asked.

- New approval-free, audited tool `factory_create_work_item({ title, brief })`, registered on authenticated turns and on notification-woken (signal) turns.
- No `stage` parameter: every card enters through intake via the same governed entry transition the HTTP create route uses. The route's inline create chain was extracted into `work-item-create.ts` and the route now delegates to it, so there is one creation path.
- `created_by` records the requester: the authenticated person on a human turn; the supervisor's agent identity (`agent:<thread>`) on a signal turn, never a human-shaped stand-in. The audit row carries `cause: 'supervisor'` and the turn's actual actor.
- The brief is posted as the first comment on the card's feed (manual cards have no description field; kickoff reads the feed). It is posted before the card enters intake, and if it cannot be posted no card is filed at all: the worker can never pick up a card without its brief.
- Signal turns register the read tools plus exactly the three v1 tools (`factory_escalate_finding`, `factory_answer_suspension`, `factory_create_work_item`); `factory.test.ts` asserts the exact set. The seven pre-existing `requireApproval` repair tools stay human-turn only.
- `SUPERVISOR_INSTRUCTIONS` gains the filing policy: check existing cards and sessions with the read tools first and link rather than duplicate; driving means watch, wake, answer and nudge, never assign, schedule, run or write code.

## Approval posture: proposed, decide on this PR

This tool is **approval-free** (like the other two v1 tools). Reasoning: the supervisor files on request from a person who is already in the conversation, the action is reversible (a card in intake can be deleted or dismissed), and an approval prompt on a signal turn would have nobody to answer it, which defeats the point of a front door. Guardrails are the audit trail and the instructions.

Alternative: `requireApproval: true` for human-initiated filings only (the prompt goes to the person asking) while keeping it approval-free on signal turns. That is a one-flag change if the reviewer prefers it. Please state a preference on this PR.

## Proof

- Real-rig finale (HTTP-driven, no browser, isolated local DB): person asks the supervisor over HTTP → `factory_create_work_item` files the card in intake with the requester stamped → person moves it to planning → worker parks on `ask_user` → dispatcher opens the finding and rings the supervisor before any sweep (delivered, `idle-high`) → woken supervisor calls `factory_answer_suspension` in its own turn → worker resumes, decision succeeds → nothing hit the human Attention rail. Then a second card whose brief asks a question nothing in context answers: the worker parks, the finding stays off the rail, and the woken supervisor escalates it in its own turn so it appears on the rail with the supervisor's note. Verdict: `PROOF: GREEN — front door to resumed worker; the answerable question stayed off Attention, the unanswerable one was escalated onto it`. Transcript is a local proof artifact (not committed).

## Test plan

- `cd mastracode/factory && pnpm vitest run src/supervisor src/rules/dispatcher.test.ts src/storage/domains/work-items/base.test.ts src/routes src/factory.test.ts` — 697 passed (23 files). `workspace.test.ts` has one pre-existing failure on `main` (skill-handoff text), untouched.
- `pnpm check` (tsc) exit 0; `oxfmt --check` clean.

