### PR TITLE
chore(factory): mark the sidebar stage chip Beta

### DIFF
--- a/.changeset/sidebar-beta-badge.md
+++ b/.changeset/sidebar-beta-badge.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+The sidebar stage chip next to the Mastra logo now reads Beta instead of Alpha.

--- a/mastracode/factory-ui/src/ui/Sidebar.tsx
+++ b/mastracode/factory-ui/src/ui/Sidebar.tsx
@@ -20,34 +20,34 @@ function useSettingsOpen() {
 }
 
 /**
- * Alpha status tag rendered as a dashed-outline chip (Clerk-style), so it reads
+ * Beta status tag rendered as a dashed-outline chip (Clerk-style), so it reads
  * as a subtle stage marker rather than a solid pill competing with the nav items.
  * Tinted with the Mastra brand green (#7aff78, `--color-ds-green` on the website).
  *
- * The tint is centralised in the `--alpha-green` custom property so it can flip
+ * The tint is centralised in the `--beta-green` custom property so it can flip
  * per theme: the neon brand green only reads on dark surfaces, so light mode uses
  * a darker brand-green shade that keeps enough contrast against the pale sidebar.
  */
-function AlphaBadge() {
+function BetaBadge() {
   return (
-    <span className="relative bg-[var(--alpha-green)]/10 px-[0.1875rem] text-[0.625rem]/[0.875rem] font-medium tracking-wide text-[var(--alpha-green)] uppercase [--alpha-green:oklch(48%_0.17_142)] dark:[--alpha-green:#7aff78]">
-      Alpha
-      <span className="absolute inset-x-[-0.1875rem] -top-px block transform-gpu text-[var(--alpha-green)]/40">
+    <span className="relative bg-[var(--beta-green)]/10 px-[0.1875rem] text-[0.625rem]/[0.875rem] font-medium tracking-wide text-[var(--beta-green)] uppercase [--beta-green:oklch(48%_0.17_142)] dark:[--beta-green:#7aff78]">
+      Beta
+      <span className="absolute inset-x-[-0.1875rem] -top-px block transform-gpu text-[var(--beta-green)]/40">
         <svg aria-hidden="true" height="1" stroke="currentColor" strokeDasharray="3.3 1" width="100%">
           <line x1="0" x2="100%" y1="0.5" y2="0.5" />
         </svg>
       </span>
-      <span className="absolute inset-x-[-0.1875rem] -bottom-px block transform-gpu text-[var(--alpha-green)]/40">
+      <span className="absolute inset-x-[-0.1875rem] -bottom-px block transform-gpu text-[var(--beta-green)]/40">
         <svg aria-hidden="true" height="1" stroke="currentColor" strokeDasharray="3.3 1" width="100%">
           <line x1="0" x2="100%" y1="0.5" y2="0.5" />
         </svg>
       </span>
-      <span className="absolute inset-y-[-0.1875rem] -left-px block transform-gpu text-[var(--alpha-green)]/40">
+      <span className="absolute inset-y-[-0.1875rem] -left-px block transform-gpu text-[var(--beta-green)]/40">
         <svg aria-hidden="true" height="100%" stroke="currentColor" strokeDasharray="3.3 1" width="1">
           <line x1="0.5" x2="0.5" y1="0" y2="100%" />
         </svg>
       </span>
-      <span className="absolute inset-y-[-0.1875rem] -right-px block transform-gpu text-[var(--alpha-green)]/40">
+      <span className="absolute inset-y-[-0.1875rem] -right-px block transform-gpu text-[var(--beta-green)]/40">
         <svg aria-hidden="true" height="100%" stroke="currentColor" strokeDasharray="3.3 1" width="1">
           <line x1="0.5" x2="0.5" y1="0" y2="100%" />
         </svg>
@@ -68,7 +68,7 @@ export function Sidebar() {
       <MainSidebar.Nav aria-label={settingsOpen ? 'Settings sections' : 'Main'}>
         <div className="mt-1 mb-2 flex items-center gap-2 pt-1 pl-3">
           <LogoWithoutText aria-label="Mastra" role="img" className="text-icon6 h-4 w-auto" />
-          <AlphaBadge />
+          <BetaBadge />
           <SidebarGlobalSearchButton />
         </div>
         {settingsOpen ? (


### PR DESCRIPTION
**─────── TLDR ───────**
> The stage chip next to the Mastra logo in the factory sidebar now reads Beta.

Same chip, same dashed outline, same brand green. Only the word and the custom property behind the tint moved, so nothing else in the sidebar shifts.

the sidebar header, under the Mastra logo
&nbsp;&nbsp;├─ **was** — a green dashed chip reading `Alpha`
&nbsp;&nbsp;└─ **now** — the same chip reading `Beta`

`AlphaBadge` becomes `BetaBadge` and `--alpha-green` becomes `--beta-green`; both are local to `Sidebar.tsx` and nothing outside it referenced either.

---

> ██████████████████ **source** `+10 −10` — one file, the chip
> █████████ **changeset** `+5`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The factory sidebar now shows “Beta” instead of “Alpha” next to the Mastra logo. The change keeps the existing styling and layout.

## Changes

- Renamed `AlphaBadge` to `BetaBadge`.
- Renamed `--alpha-green` to `--beta-green`.
- Added a patch changeset for `@mastra/factory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->