### PR TITLE
fix(studio): refresh traces after resumed runs

### DIFF
--- a/.changeset/seven-poets-write.md
+++ b/.changeset/seven-poets-write.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed incomplete traces and subtraces after an agent resumes or more spans arrive. Selected details refresh on reopening, returning to Studio, or reconnecting, without periodic polling. Downloading a trace also updates its displayed data.

--- a/.changeset/slow-beds-tap.md
+++ b/.changeset/slow-beds-tap.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed Studio thread history downloading every historical trace on focus. Only selected trace details refresh automatically, while history rows share the updated data.

--- a/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { MastraReactProvider } from '@mastra/react';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render as renderUI, screen, waitFor } from '@testing-library/react';
 import { http } from 'msw';
 import { setupServer } from 'msw/node';
 import type { ReactNode } from 'react';
@@ -11,6 +12,15 @@ import type { TraceDataPanelViewProps } from '../trace-data-panel-view';
 import { deepTraceFixture, nestedSpanFixture, rootSpanFixture } from './fixtures/trace-data-panel-view';
 import { installHighlightApi } from '@/test/highlight-api';
 import type { HighlightApiHarness } from '@/test/highlight-api';
+
+let queryClient: QueryClient;
+beforeEach(() => {
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+});
+const render = (ui: ReactNode) =>
+  renderUI(ui, {
+    wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+  });
 
 const baseProps: TraceDataPanelViewProps = {
   traceId: 'trace-1',
@@ -27,6 +37,7 @@ Element.prototype.scrollIntoView = scrollIntoView;
 
 afterEach(() => {
   cleanup();
+  queryClient.clear();
   scrollIntoView.mockClear();
 });
 

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/fixtures/trace-spans.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/fixtures/trace-spans.ts
@@ -1,0 +1,36 @@
+import type { MastraClient } from '@mastra/client-js';
+import { SpanType } from '@mastra/core/observability';
+
+type TraceResponse = Awaited<ReturnType<MastraClient['getTrace']>>;
+
+const rootSpan: TraceResponse['spans'][number] = {
+  traceId: 'resumed-trace',
+  spanId: 'root',
+  parentSpanId: null,
+  name: 'agent run',
+  spanType: SpanType.AGENT_RUN,
+  isEvent: false,
+  startedAt: new Date('2026-09-02T19:13:00Z'),
+  endedAt: new Date('2026-09-02T19:14:00Z'),
+  createdAt: new Date('2026-09-02T19:13:00Z'),
+  updatedAt: null,
+};
+
+export const runningTrace: TraceResponse = { traceId: rootSpan.traceId, spans: [{ ...rootSpan, endedAt: null }] };
+export const suspendedTrace: TraceResponse = { traceId: rootSpan.traceId, spans: [rootSpan] };
+export const resumedTrace: TraceResponse = {
+  traceId: rootSpan.traceId,
+  spans: [
+    rootSpan,
+    {
+      ...rootSpan,
+      spanId: 'resumed',
+      parentSpanId: rootSpan.spanId,
+      name: 'agent run (resumed)',
+      startedAt: new Date('2026-09-02T19:15:00Z'),
+      endedAt: new Date('2026-09-02T19:16:00Z'),
+    },
+  ],
+};
+export const emptyTrace: TraceResponse = { traceId: rootSpan.traceId, spans: [] };
+export const otherTrace: TraceResponse = { traceId: 'other', spans: [] };

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-download-trace-json.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-download-trace-json.test.tsx
@@ -6,10 +6,12 @@ import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
 import type { ReactNode } from 'react';
-import { afterAll, afterEach, assert, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { server } from '../../../../test/msw-server';
 import { useDownloadTraceJson } from '../use-download-trace-json';
+import { useTraceSpans } from '../use-trace-spans';
+import { resumedTrace, suspendedTrace } from './fixtures/trace-spans';
 
 // jsdom's Blob exposes no `.text()`, and the global `Response` doesn't recognize it.
 function readBlobText(blob: Blob): Promise<string> {
@@ -42,7 +44,6 @@ vi.mock('@/lib/toast', () => ({
 
 const BASE_URL = 'http://localhost:4111';
 const TRACE_ID = '566f00c7d2e2';
-const server = setupServer();
 
 // Minimal full-trace payload. The download serializes whatever `getTrace` returns, so the
 // downloaded bytes must equal this fixture — including the heavy input/output fields that the
@@ -81,8 +82,6 @@ function makeWrapper() {
 let createObjectURL: ReturnType<typeof vi.spyOn>;
 let clickedDownloadAttr: string | undefined;
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
-
 beforeEach(() => {
   toastCalls.length = 0;
   clickedDownloadAttr = undefined;
@@ -99,9 +98,33 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-afterAll(() => server.close());
-
 describe('useDownloadTraceJson', () => {
+  describe('when downloading a trace that has gained spans', () => {
+    it('updates the displayed trace to match the download', async () => {
+      let response = suspendedTrace;
+      const requested = vi.fn();
+      server.use(
+        http.get(`${BASE_URL}/api/observability/traces/${suspendedTrace.traceId}`, () => {
+          requested();
+          return HttpResponse.json(response);
+        }),
+      );
+      const { result } = renderHook(
+        () => ({
+          trace: useTraceSpans(suspendedTrace.traceId),
+          download: useDownloadTraceJson(),
+        }),
+        { wrapper: makeWrapper() },
+      );
+      await waitFor(() => expect(result.current.trace.data?.spans).toHaveLength(1));
+      response = resumedTrace;
+      act(() => result.current.download.download(suspendedTrace.traceId));
+      await waitFor(() => expect(result.current.download.isPending).toBe(false));
+      await waitFor(() => expect(result.current.trace.data?.spans).toHaveLength(2));
+      expect(requested).toHaveBeenCalledTimes(2);
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+    });
+  });
   it('fetches the full trace and downloads it as trace-<id>.json', async () => {
     server.use(http.get(`${BASE_URL}/api/observability/traces/:traceId`, () => HttpResponse.json(traceFixture)));
 

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-spans.msw.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-spans.msw.test.tsx
@@ -1,0 +1,445 @@
+// @vitest-environment jsdom
+import { MastraReactProvider } from '@mastra/react';
+import { focusManager, onlineManager, QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { server } from '../../../../test/msw-server';
+import { useBranch } from '../use-branch';
+import { useTraceOrBranchSpans } from '../use-trace-or-branch-spans';
+import { useTraceSpans, useTraceSpansQueries } from '../use-trace-spans';
+import { emptyTrace, otherTrace, resumedTrace, runningTrace, suspendedTrace } from './fixtures/trace-spans';
+
+const BASE_URL = 'http://localhost:4111';
+const traceId = suspendedTrace.traceId;
+let queryClient: QueryClient;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+}
+
+beforeEach(() => {
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  cleanup();
+  queryClient.clear();
+  focusManager.setFocused(undefined);
+  onlineManager.setOnline(true);
+  vi.useRealTimers();
+});
+
+function serveTrace(initial = suspendedTrace) {
+  let response = initial;
+  const requested = vi.fn();
+  server.use(
+    http.get(`${BASE_URL}/api/observability/traces/${traceId}`, () => {
+      requested();
+      return HttpResponse.json(response);
+    }),
+  );
+  return { requested, resume: () => (response = resumedTrace) };
+}
+
+const expireCache = () => act(() => vi.advanceTimersByTimeAsync(10_000));
+const refocus = () =>
+  act(async () => {
+    focusManager.setFocused(false);
+    focusManager.setFocused(true);
+    await vi.advanceTimersByTimeAsync(1);
+  });
+const reconnect = () =>
+  act(async () => {
+    onlineManager.setOnline(false);
+    onlineManager.setOnline(true);
+    await vi.advanceTimersByTimeAsync(1);
+  });
+const waitFor = (assertion: () => void) =>
+  vi.waitFor(async () => {
+    await act(() => vi.advanceTimersByTimeAsync(1));
+    assertion();
+  });
+
+describe('Trace span refresh', () => {
+  describe.each([
+    ['running', runningTrace],
+    ['suspended', suspendedTrace],
+    ['empty', emptyTrace],
+  ] as const)('when a %s trace gains spans before ten seconds have passed', (_, initial) => {
+    it('refreshes immediately on reopening', async () => {
+      const api = serveTrace(initial);
+      const first = renderHook(() => useTraceSpans(traceId), { wrapper: Wrapper });
+      await waitFor(() => expect(first.result.current.isSuccess).toBe(true));
+      first.unmount();
+      api.resume();
+      const reopened = renderHook(() => useTraceSpans(traceId), { wrapper: Wrapper });
+      await waitFor(() => expect(reopened.result.current.data?.spans).toHaveLength(2));
+      expect(api.requested).toHaveBeenCalledTimes(2);
+    });
+
+    it('refreshes immediately on focus', async () => {
+      const api = serveTrace(initial);
+      const { result } = renderHook(() => useTraceSpans(traceId), { wrapper: Wrapper });
+      await waitFor(() => expect(result.current.data?.spans).toHaveLength(initial.spans.length));
+      api.resume();
+      await refocus();
+      await waitFor(() => expect(result.current.data?.spans).toHaveLength(2));
+    });
+  });
+
+  describe('when a trace resumes after all known spans have ended', () => {
+    it('updates the open trace when Studio regains focus', async () => {
+      const api = serveTrace();
+      const { result } = renderHook(() => useTraceSpans(traceId), { wrapper: Wrapper });
+      await waitFor(() => expect(result.current.data?.spans).toHaveLength(1));
+      api.resume();
+      await expireCache();
+      await refocus();
+      await waitFor(() => expect(result.current.data?.spans.map(s => s.spanId)).toEqual(['root', 'resumed']));
+    });
+
+    it('refreshes an expired snapshot when a trace is reopened', async () => {
+      const api = serveTrace();
+      const first = renderHook(() => useTraceSpans(traceId), { wrapper: Wrapper });
+      await waitFor(() => expect(first.result.current.data?.spans).toHaveLength(1));
+      first.unmount();
+      api.resume();
+      await expireCache();
+      const second = renderHook(() => useTraceSpans(traceId), { wrapper: Wrapper });
+      await waitFor(() => expect(second.result.current.data?.spans).toHaveLength(2));
+    });
+  });
+
+  describe('when a trace initially has no exported spans', () => {
+    it('discovers spans arriving later', async () => {
+      const api = serveTrace(emptyTrace);
+      const { result } = renderHook(() => useTraceSpans(traceId), { wrapper: Wrapper });
+      await waitFor(() => expect(result.current.data?.spans).toHaveLength(0));
+      api.resume();
+      await expireCache();
+      await refocus();
+      await waitFor(() => expect(result.current.data?.spans).toHaveLength(2));
+    });
+  });
+
+  describe('when the thread rail already observes the trace', () => {
+    it('shows cached data immediately and refreshes it for both the panel and rail', async () => {
+      const api = serveTrace();
+      const rail = renderHook(
+        () =>
+          useTraceSpansQueries(
+            [traceId],
+            (_, data) => data.spans.length,
+            () => 0,
+          ),
+        {
+          wrapper: Wrapper,
+        },
+      );
+      await waitFor(() => expect(rail.result.current).toEqual([1]));
+      api.resume();
+      const panel = renderHook(() => useTraceSpans(traceId), { wrapper: Wrapper });
+      expect(panel.result.current.data?.spans).toHaveLength(1);
+      await waitFor(() => expect(panel.result.current.data?.spans).toHaveLength(2));
+      await waitFor(() => expect(rail.result.current).toEqual([2]));
+      expect(api.requested).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not poll every trace in the rail', async () => {
+      const api = serveTrace();
+      const rail = renderHook(
+        () =>
+          useTraceSpansQueries(
+            [traceId],
+            (_, data) => data.spans.length,
+            () => 0,
+          ),
+        {
+          wrapper: Wrapper,
+        },
+      );
+      await waitFor(() => expect(rail.result.current).toEqual([1]));
+      await expireCache();
+      expect(api.requested).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when the trace detail panel is open', () => {
+    it('refreshes expired data on focus through the panel data source', async () => {
+      const api = serveTrace();
+      const { result } = renderHook(() => useTraceOrBranchSpans({ traceId, listMode: 'traces' }), { wrapper: Wrapper });
+      await waitFor(() => expect(result.current.spans).toHaveLength(1));
+      api.resume();
+      await expireCache();
+      await refocus();
+      await waitFor(() => expect(result.current.spans).toHaveLength(2));
+    });
+
+    it('refreshes immediately when connectivity returns', async () => {
+      const api = serveTrace();
+      const { result } = renderHook(() => useTraceSpans(traceId), { wrapper: Wrapper });
+      await waitFor(() => expect(result.current.data?.spans).toHaveLength(1));
+      api.resume();
+      await reconnect();
+      await waitFor(() => expect(result.current.data?.spans).toHaveLength(2));
+    });
+
+    it('does not poll while the panel remains open', async () => {
+      const api = serveTrace();
+      const { result } = renderHook(() => useTraceOrBranchSpans({ traceId, listMode: 'traces' }), {
+        wrapper: Wrapper,
+      });
+      await waitFor(() => expect(result.current.spans).toHaveLength(1));
+      api.resume();
+      await act(() => vi.advanceTimersByTimeAsync(60_000));
+      expect(api.requested).toHaveBeenCalledTimes(1);
+      expect(result.current.spans).toHaveLength(1);
+    });
+  });
+
+  describe('when a history row reads a trace', () => {
+    it('does not refetch on focus, remount, or a timer', async () => {
+      const api = serveTrace();
+      const first = renderHook(() => useTraceSpans(traceId, { passive: true }), { wrapper: Wrapper });
+      await waitFor(() => expect(first.result.current.data?.spans).toHaveLength(1));
+      await expireCache();
+      await refocus();
+      await reconnect();
+      first.unmount();
+      const second = renderHook(() => useTraceSpans(traceId, { passive: true }), { wrapper: Wrapper });
+      await expireCache();
+      expect(second.result.current.data?.spans).toHaveLength(1);
+      expect(api.requested).toHaveBeenCalledTimes(1);
+    });
+
+    it('receives updates from the active detail without scheduling its own requests', async () => {
+      const api = serveTrace();
+      const history = renderHook(() => useTraceSpans(traceId, { passive: true }), { wrapper: Wrapper });
+      await waitFor(() => expect(history.result.current.data?.spans).toHaveLength(1));
+      const detail = renderHook(() => useTraceSpans(traceId), { wrapper: Wrapper });
+      await waitFor(() => expect(api.requested).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(detail.result.current.isFetching).toBe(false));
+      api.resume();
+      await refocus();
+      await waitFor(() => expect(history.result.current.data?.spans).toHaveLength(2));
+      expect(api.requested).toHaveBeenCalledTimes(3);
+      detail.unmount();
+      await refocus();
+      expect(api.requested).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('when cached trace data is invalidated', () => {
+    it('refreshes the shared trace query', async () => {
+      const api = serveTrace();
+      const { result } = renderHook(() => useTraceSpans(traceId), { wrapper: Wrapper });
+      await waitFor(() => expect(result.current.data?.spans).toHaveLength(1));
+      api.resume();
+      await act(() => queryClient.invalidateQueries({ queryKey: ['trace-spans', traceId] }));
+      await waitFor(() => expect(result.current.data?.spans).toHaveLength(2));
+    });
+  });
+
+  describe('when a long thread rail is mounted', () => {
+    it('does not download historical traces on focus', async () => {
+      const ids = Array.from({ length: 100 }, (_, index) => `history-${index}`);
+      const requested = vi.fn();
+      server.use(
+        http.get(`${BASE_URL}/api/observability/traces/:traceId`, ({ params }) => {
+          requested(params.traceId);
+          return HttpResponse.json({ ...suspendedTrace, traceId: String(params.traceId) });
+        }),
+      );
+      const rail = renderHook(
+        () =>
+          useTraceSpansQueries(
+            ids,
+            (_, data) => data.spans.length,
+            () => 0,
+          ),
+        { wrapper: Wrapper },
+      );
+      await waitFor(() => expect(rail.result.current.every(count => count === 1)).toBe(true));
+      expect(requested).toHaveBeenCalledTimes(100);
+      await expireCache();
+      await refocus();
+      await reconnect();
+      rail.unmount();
+      renderHook(
+        () =>
+          useTraceSpansQueries(
+            ids,
+            (_, data) => data.spans.length,
+            () => 0,
+          ),
+        { wrapper: Wrapper },
+      );
+      await expireCache();
+      expect(requested).toHaveBeenCalledTimes(100);
+    });
+  });
+
+  describe('when the rail observes multiple traces', () => {
+    it('preserves trace order and per-trace loading fallbacks', async () => {
+      serveTrace();
+      server.use(http.get(`${BASE_URL}/api/observability/traces/other`, () => HttpResponse.json(otherTrace)));
+      const { result } = renderHook(
+        () =>
+          useTraceSpansQueries(
+            ['other', traceId],
+            (id, data) => `${id}:${data.spans.length}`,
+            id => `loading:${id}`,
+          ),
+        { wrapper: Wrapper },
+      );
+      expect(result.current).toEqual(['loading:other', `loading:${traceId}`]);
+      await waitFor(() => expect(result.current).toEqual(['other:0', `${traceId}:1`]));
+    });
+  });
+
+  describe('when the detail panel displays a branch', () => {
+    it('loads only the requested branch and retains its anchor', async () => {
+      const api = serveTrace();
+      server.use(
+        http.get(`${BASE_URL}/api/observability/traces/${traceId}/branches/root`, () =>
+          HttpResponse.json(suspendedTrace),
+        ),
+      );
+      const { result } = renderHook(
+        () => useTraceOrBranchSpans({ traceId, anchorSpanId: 'root', listMode: 'branches' }),
+        {
+          wrapper: Wrapper,
+        },
+      );
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.spans).toBeUndefined();
+      await waitFor(() => expect(result.current.spans).toHaveLength(1));
+      expect(result.current.anchorSpanId).toBe('root');
+      expect(result.current.isError).toBe(false);
+      expect(api.requested).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when a finished branch gains late spans', () => {
+    it('refreshes immediately on focus', async () => {
+      let response = suspendedTrace;
+      server.use(
+        http.get(`${BASE_URL}/api/observability/traces/${traceId}/branches/root`, () => HttpResponse.json(response)),
+      );
+      const { result } = renderHook(
+        () => useTraceOrBranchSpans({ traceId, anchorSpanId: 'root', listMode: 'branches' }),
+        { wrapper: Wrapper },
+      );
+      await waitFor(() => expect(result.current.spans).toHaveLength(1));
+      response = resumedTrace;
+      await refocus();
+      await waitFor(() => expect(result.current.spans).toHaveLength(2));
+    });
+
+    it('refreshes immediately on reopening', async () => {
+      let response = suspendedTrace;
+      server.use(
+        http.get(`${BASE_URL}/api/observability/traces/${traceId}/branches/root`, () => HttpResponse.json(response)),
+      );
+      const first = renderHook(() => useTraceOrBranchSpans({ traceId, anchorSpanId: 'root', listMode: 'branches' }), {
+        wrapper: Wrapper,
+      });
+      await waitFor(() => expect(first.result.current.spans).toHaveLength(1));
+      first.unmount();
+      response = resumedTrace;
+      const second = renderHook(() => useTraceOrBranchSpans({ traceId, anchorSpanId: 'root', listMode: 'branches' }), {
+        wrapper: Wrapper,
+      });
+      await waitFor(() => expect(second.result.current.spans).toHaveLength(2));
+    });
+  });
+
+  describe.each([
+    { traceId: null, spanId: 'root' },
+    { traceId, spanId: null },
+    { traceId: null, spanId: null },
+  ])('when branch identifiers are incomplete ($traceId, $spanId)', args => {
+    it('does not start a request on mount or focus', async () => {
+      const { result } = renderHook(() => useBranch(args), { wrapper: Wrapper });
+      await refocus();
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(result.current.isError).toBe(false);
+      expect(result.current.data).toBeUndefined();
+    });
+
+    it('reports the missing identifiers on explicit refetch', async () => {
+      const { result } = renderHook(() => useBranch(args), { wrapper: Wrapper });
+      await act(async () => {
+        const refreshed = await result.current.refetch();
+        expect(refreshed.error?.message).toBe('traceId and spanId are required');
+      });
+    });
+  });
+
+  describe('when the same branch is requested at different depths', () => {
+    it('keeps independent results and supports targeted invalidation', async () => {
+      const requested = vi.fn();
+      server.use(
+        http.get(`${BASE_URL}/api/observability/traces/${traceId}/branches/root`, ({ request }) => {
+          const depth = new URL(request.url).searchParams.get('depth');
+          requested(depth);
+          return HttpResponse.json(depth === '1' ? suspendedTrace : resumedTrace);
+        }),
+      );
+      const { result } = renderHook(
+        () => ({
+          shallow: useBranch({ traceId, spanId: 'root', depth: 1 }),
+          deep: useBranch({ traceId, spanId: 'root', depth: 2 }),
+        }),
+        { wrapper: Wrapper },
+      );
+      await waitFor(() => {
+        expect(result.current.shallow.data?.spans).toHaveLength(1);
+        expect(result.current.deep.data?.spans).toHaveLength(2);
+      });
+      requested.mockClear();
+      await act(() => queryClient.invalidateQueries({ queryKey: ['branch', traceId, 'root', 1] }));
+      expect(requested.mock.calls).toEqual([['1']]);
+    });
+  });
+
+  describe('when a branch has no anchor', () => {
+    it('disables fetching and returns no anchor', async () => {
+      const { result } = renderHook(
+        () => useTraceOrBranchSpans({ traceId, anchorSpanId: null, listMode: 'branches' }),
+        {
+          wrapper: Wrapper,
+        },
+      );
+      await expireCache();
+      expect(result.current.anchorSpanId).toBeUndefined();
+      expect(result.current.spans).toBeUndefined();
+    });
+  });
+
+  describe('when a disabled trace is manually refetched', () => {
+    it('reports the missing trace ID', async () => {
+      const { result } = renderHook(() => useTraceSpans(undefined), { wrapper: Wrapper });
+      await act(async () => {
+        const refreshed = await result.current.refetch();
+        expect(refreshed.error?.message).toBe('Trace ID is required');
+      });
+    });
+  });
+
+  describe('when no trace is selected', () => {
+    it('does not fetch or poll', async () => {
+      const api = serveTrace();
+      const { result } = renderHook(() => useTraceSpans(undefined), { wrapper: Wrapper });
+      await expireCache();
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(api.requested).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/playground-ui/src/domains/traces/hooks/use-branch.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-branch.ts
@@ -4,8 +4,6 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import type { SearchableSpan } from '../types';
 import { selectSearchableSpans } from '../utils';
 
-const IMMUTABLE_CACHE_TIME = 1000 * 60 * 60 * 24 * 30; // 30 days, massive cache, span data is immutable
-
 export interface UseBranchArgs {
   traceId: string | null | undefined;
   spanId: string | null | undefined;
@@ -30,10 +28,7 @@ export function useBranch({
     // Builds each span's search haystack once per fetch, cached with the query.
     select: selectSearchableSpans,
     enabled: !!traceId && !!spanId,
-    staleTime: query => {
-      const data = query.state.data;
-      const isFinished = data?.spans.every(s => Boolean(s.endedAt));
-      return isFinished ? IMMUTABLE_CACHE_TIME : 0;
-    },
+    // A finished subtree can still gain spans from a resumed run or delayed export.
+    staleTime: 0,
   });
 }

--- a/packages/playground-ui/src/domains/traces/hooks/use-download-trace-json.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-download-trace-json.ts
@@ -1,19 +1,22 @@
 import { useMastraClient } from '@mastra/react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { traceSpansQueryOptions } from './use-trace-spans';
 import { downloadJson } from '@/lib/file';
 import { toast } from '@/lib/toast';
 
 export function useDownloadTraceJson() {
   const client = useMastraClient();
+  const queryClient = useQueryClient();
   const [isPending, setIsPending] = useState(false);
 
   const download = (traceId: string) => {
     if (isPending) return;
     setIsPending(true);
 
-    // getTrace returns the full payload (heavy input/output), unlike the light spans the panel renders.
-    const task = client
-      .getTrace(traceId)
+    // Fetch the full payload into the shared cache so the panel matches the downloaded trace.
+    const task = queryClient
+      .fetchQuery(traceSpansQueryOptions(client, traceId))
       .then(trace => downloadJson(`trace-${traceId}.json`, trace))
       .finally(() => setIsPending(false));
 

--- a/packages/playground-ui/src/domains/traces/hooks/use-trace-spans.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-trace-spans.ts
@@ -5,8 +5,6 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import type { SearchableSpan } from '../types';
 import { selectSearchableSpans } from '../utils';
 
-const IMMUTABLE_CACHE_TIME = 1000 * 60 * 60 * 24 * 30; // 30 days, massive cache, span data is immutable
-
 /**
  * Key, fetcher and stale policy of the `trace-spans` query. Every observer of this key must
  * share these (rather than only the key) so one observer with a stricter `staleTime` does not
@@ -23,11 +21,8 @@ export const traceSpansQueryOptions = (client: MastraClient, traceId: string | n
       return res;
     },
     enabled: !!traceId,
-    staleTime: query => {
-      const data = query.state.data;
-      const isFinished = data?.spans.every(span => Boolean(span.endedAt));
-      return isFinished ? IMMUTABLE_CACHE_TIME : 0;
-    },
+    // Resumed runs and delayed exports can append spans even when every known span has ended.
+    staleTime: 0,
   });
 
 /**
@@ -41,11 +36,16 @@ export const traceSpansQueryOptions = (client: MastraClient, traceId: string | n
  */
 export function useTraceSpans(
   traceId: string | null | undefined,
+  { passive = false }: { passive?: boolean } = {},
 ): UseQueryResult<{ traceId: string; spans: SearchableSpan[] } | null> {
   const client = useMastraClient();
 
   return useQuery({
     ...traceSpansQueryOptions(client, traceId),
+    // History rows share updates but leave automatic refreshes to the selected detail.
+    refetchOnMount: !passive,
+    refetchOnWindowFocus: !passive,
+    refetchOnReconnect: !passive,
     // Builds each span's search haystack once per fetch, cached with the query.
     select: selectSearchableSpans,
   });
@@ -67,6 +67,9 @@ export function useTraceSpansQueries<T>(
   return useQueries({
     queries: traceIds.map(traceId => ({
       ...traceSpansQueryOptions(client, traceId),
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
       select: (data: TraceSpansData) => select(traceId, data),
     })),
     combine: results =>

--- a/packages/playground/src/domains/traces/components/__tests__/thread-view-by-trace.msw.test.tsx
+++ b/packages/playground/src/domains/traces/components/__tests__/thread-view-by-trace.msw.test.tsx
@@ -1,3 +1,4 @@
+import { focusManager } from '@tanstack/react-query';
 import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -95,6 +96,46 @@ const renderView = ({ search = '' }: { search?: string } = {}) =>
   );
 
 describe('ThreadViewByTrace', () => {
+  describe('when the thread contains historical traces', () => {
+    afterEach(() => focusManager.setFocused(undefined));
+
+    it('refreshes only the selected trace on focus and stops after its detail closes', async () => {
+      installHandlers();
+      const requested = vi.fn();
+      server.use(
+        ...['trace-a', 'trace-b'].map(traceId =>
+          http.get(`${TEST_BASE_URL}/api/observability/traces/${traceId}`, () => {
+            requested(traceId);
+            return HttpResponse.json(traceId === 'trace-b' ? traceBSpans : traceASpans);
+          }),
+        ),
+      );
+      const { queryClient } = renderView();
+      await screen.findByText('Chef agent follow-up');
+      await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+      expect(requested.mock.calls.map(([id]) => id).sort()).toEqual(['trace-a', 'trace-b']);
+      requested.mockClear();
+      const refocus = () =>
+        act(async () => {
+          focusManager.setFocused(false);
+          focusManager.setFocused(true);
+          await new Promise(resolve => setTimeout(resolve, 100));
+        });
+      await refocus();
+      expect(requested).not.toHaveBeenCalled();
+      fireEvent.click(screen.getByText('Chef agent run'));
+      await screen.findByRole('button', { name: /close/i });
+      await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+      expect(requested.mock.calls).toEqual([['trace-a']]);
+      requested.mockClear();
+      await refocus();
+      expect(requested.mock.calls).toEqual([['trace-a']]);
+      fireEvent.click(screen.getByRole('button', { name: /close/i }));
+      requested.mockClear();
+      await refocus();
+      expect(requested).not.toHaveBeenCalled();
+    });
+  });
   it('renders one row per trace, oldest first', async () => {
     installHandlers();
     const { queryClient } = renderView();

--- a/packages/playground/src/domains/traces/components/thread-view-by-trace.tsx
+++ b/packages/playground/src/domains/traces/components/thread-view-by-trace.tsx
@@ -225,7 +225,7 @@ function TraceThreadRow({
   onHighlightSpans,
 }: TraceThreadRowProps) {
   // Deduped with the fetch inside TraceThreadItemView (same query key).
-  const { data, isLoading } = useTraceSpans(traceId);
+  const { data, isLoading } = useTraceSpans(traceId, { passive: true });
 
   const hierarchicalSpans = useMemo(() => formatHierarchicalSpans(data?.spans ?? []), [data]);
 

--- a/packages/playground/src/domains/traces/components/trace-thread-item-view.tsx
+++ b/packages/playground/src/domains/traces/components/trace-thread-item-view.tsx
@@ -21,7 +21,7 @@ export interface TraceThreadItemViewProps {
 const noop = () => {};
 
 export function TraceThreadItemView({ traceId, onHighlightSpans, className }: TraceThreadItemViewProps) {
-  const { data, isLoading, error } = useTraceSpans(traceId);
+  const { data, isLoading, error } = useTraceSpans(traceId, { passive: true });
 
   if (isLoading) {
     return (


### PR DESCRIPTION
Studio could keep showing an incomplete trace after an agent resumed because snapshots with all known spans ended stayed fresh for 30 days. Selected trace and subtrace details now refresh on reopening, focus, or reconnect, without periodic polling.

The cache policy changes from:

```ts
// Before: ended spans were treated as an immutable trace.
staleTime: query => query.state.data?.spans.every(span => Boolean(span.endedAt)) ? IMMUTABLE_CACHE_TIME : 0

// After: selected details remain eligible for event-driven refresh.
staleTime: 0
```

History rows and the thread rail share refreshed data without downloading every historical trace on focus. Downloading a trace updates the same cache used by the display.

Verified with 5,428 passing tests across both packages, both typechecks and builds, and targeted lint. In real Studio, a trace updated from 232 to 404 spans on reopen, tab return, and download; idle waiting made no full-trace requests. Subtrace refresh is covered by real-client/MSW tests because the local reproduction store does not support subtrace listing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Studio now shows new trace spans when a run continues after you reopen Studio, return to the tab, reconnect, or download the trace. It refreshes only the selected trace instead of repeatedly fetching every historical trace.

## Changes

- Set trace and subtrace queries to `staleTime: 0`.
- Refresh selected trace details on mount, focus, reconnect, expiration, and invalidation.
- Add passive queries for history rows and thread rails.
- Share downloaded trace data with the display cache.
- Add coverage for resumed runs, delayed spans, subtraces, downloads, and refresh behavior.
- Add patch changesets for `@mastra/playground-ui` and `mastra`.

## Validation

- 5,428 tests passed.
- Typechecks, builds, and targeted lint passed.
- Studio testing confirmed updates from 232 to 404 spans without idle full-trace requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->