### PR TITLE
feat(mastracode): make subagents opt-in in the TUI

### DIFF
--- a/.changeset/gold-aliens-read.md
+++ b/.changeset/gold-aliens-read.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Added a persisted preference for Mastra Code interfaces to opt into native subagents.

--- a/.changeset/ready-candles-bake.md
+++ b/.changeset/ready-candles-bake.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Disabled native subagents by default and added enable, disable, and model configuration controls to the /subagents command.

--- a/mastracode/sdk/src/onboarding/__tests__/settings.test.ts
+++ b/mastracode/sdk/src/onboarding/__tests__/settings.test.ts
@@ -50,7 +50,14 @@ function createSettings(overrides?: Partial<GlobalSettings>): GlobalSettings {
       goalJudgeModel: null,
       goalMaxTurns: null,
     },
-    preferences: { yolo: null, theme: 'auto', thinkingLevel: 'off', quietMode: false, quietModeMaxToolPreviewLines: 2 },
+    preferences: {
+      yolo: null,
+      theme: 'auto',
+      thinkingLevel: 'off',
+      subagentsEnabled: false,
+      quietMode: false,
+      quietModeMaxToolPreviewLines: 2,
+    },
     storage,
     customProviders: [],
     customModelPacks: [
@@ -294,8 +301,27 @@ describe('customProviders parsing/persistence', () => {
 
       expect(settings.customProviders).toEqual([]);
       expect(settings.preferences.thinkingLevel).toBe('off');
+      expect(settings.preferences.subagentsEnabled).toBe(false);
       expect(settings.preferences.quietModeMaxToolPreviewLines).toBe(2);
       expect(settings.shellPassthrough).toEqual({ mode: 'default' });
+    });
+  });
+
+  it('parses subagent enablement as an explicit boolean preference', () => {
+    withTempSettingsFile(filePath => {
+      writeFileSync(
+        filePath,
+        JSON.stringify({ onboarding: {}, models: {}, preferences: { subagentsEnabled: true }, storage: {} }),
+        'utf-8',
+      );
+      expect(loadSettings(filePath).preferences.subagentsEnabled).toBe(true);
+
+      writeFileSync(
+        filePath,
+        JSON.stringify({ onboarding: {}, models: {}, preferences: { subagentsEnabled: 'true' }, storage: {} }),
+        'utf-8',
+      );
+      expect(loadSettings(filePath).preferences.subagentsEnabled).toBe(false);
     });
   });
 

--- a/mastracode/sdk/src/onboarding/settings.ts
+++ b/mastracode/sdk/src/onboarding/settings.ts
@@ -295,6 +295,8 @@ export interface GlobalSettings {
     theme: 'auto' | 'dark' | 'light';
     /** Default reasoning effort level used for all threads/models unless overridden in-session. */
     thinkingLevel: ThinkingLevelSetting;
+    /** Whether native subagents are enabled for Mastra Code TUI sessions. */
+    subagentsEnabled: boolean;
     /** When true, components like subagent output collapse to compact summaries on completion. */
     quietMode: boolean;
     /** Maximum quiet-mode detail preview lines for compact tool calls. Set to 0 to hide previews. */
@@ -413,6 +415,7 @@ const DEFAULTS: GlobalSettings = {
     yolo: null,
     theme: 'auto',
     thinkingLevel: 'off',
+    subagentsEnabled: false,
     quietMode: false,
     quietModeMaxToolPreviewLines: 2,
     webSearchProvider: 'auto',
@@ -512,6 +515,8 @@ function parsePreferences(rawPreferences: unknown): GlobalSettings['preferences'
     ...DEFAULTS.preferences,
     ...raw,
     thinkingLevel: parseThinkingLevel(raw.thinkingLevel),
+    subagentsEnabled:
+      typeof raw.subagentsEnabled === 'boolean' ? raw.subagentsEnabled : DEFAULTS.preferences.subagentsEnabled,
     quietModeMaxToolPreviewLines: parseQuietModeMaxToolPreviewLines(raw.quietModeMaxToolPreviewLines),
     webSearchProvider: parseWebSearchProvider(raw.webSearchProvider),
   };

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -158,6 +158,7 @@ import { streamingToolArgsScenario } from './streaming-tool-args.js';
 import { subagentDelegationScenario } from './subagent-delegation.js';
 import { subagentModelStartupRestoreScenario } from './subagent-model-startup-restore.js';
 import { subagentPlanExecuteToolsScenario } from './subagent-plan-execute-tools.js';
+import { subagentsCommandScenario } from './subagents-command.js';
 import { subconsciousActivityRenderingScenario } from './subconscious-activity-rendering.js';
 import { taskInlineTransitionsScenario } from './task-inline-transitions.js';
 import { taskPatchToolsScenario } from './task-patch-tools.js';
@@ -342,6 +343,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'stream-error-retry': streamErrorRetryScenario,
   'streaming-render-stability': streamingRenderStabilityScenario,
   'streaming-tool-args': streamingToolArgsScenario,
+  'subagents-command': subagentsCommandScenario,
   'subagent-delegation': subagentDelegationScenario,
   'subagent-plan-execute-tools': subagentPlanExecuteToolsScenario,
   'subagent-model-startup-restore': subagentModelStartupRestoreScenario,

--- a/mastracode/tui/e2e/tui/subagents-command.ts
+++ b/mastracode/tui/e2e/tui/subagents-command.ts
@@ -1,0 +1,69 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { McE2eScenario } from './types.js';
+
+export const subagentsCommandScenario = {
+  name: 'subagents-command',
+  description: 'Enables, configures, and disables subagents through the /subagents TUI command.',
+  testName: 'persists subagent enablement and model configuration from the TUI',
+  prepare({ appDataDir }) {
+    const settingsPath = join(appDataDir, 'settings.json');
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as any;
+    settings.preferences = {
+      ...settings.preferences,
+      subagentsEnabled: false,
+    };
+    settings.models = {
+      ...settings.models,
+      subagentModels: {},
+    };
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    await runtime.waitForScreenText(/Project:\s+mastra/i, terminal);
+
+    terminal.submit('/subagents');
+    await runtime.waitForScreenText(/Manage subagents/i, terminal);
+    await runtime.waitForScreenText(/Enable subagents/i, terminal);
+    terminal.write('\r');
+    await runtime.waitForScreenText(/Subagents enabled\. Restart MastraCode for this to take effect\./i, terminal);
+
+    terminal.submit(
+      `!node -e 'const fs=require("fs"); const s=JSON.parse(fs.readFileSync(process.env.MASTRA_APP_DATA_DIR+"/settings.json","utf8")); console.log("SUBAGENTS_ENABLED="+s.preferences.subagentsEnabled);'`,
+    );
+    await runtime.waitForScreenText(/SUBAGENTS_ENABLED=true/i, terminal, 8_000);
+
+    terminal.submit('/subagents');
+    await runtime.waitForScreenText(/Disable subagents/i, terminal);
+    terminal.write('\x1b[B');
+    terminal.write('\r');
+    await runtime.waitForScreenText(/Select subagent type/i, terminal);
+    await runtime.waitForScreenText(/Explore/i, terminal);
+    terminal.write('\r');
+    await runtime.waitForScreenText(/Select scope for Explore subagents/i, terminal);
+    terminal.write('\x1b[B');
+    terminal.write('\r');
+    await runtime.waitForScreenText(/Select subagent model \(Explore · Global\)/i, terminal);
+    terminal.write('\r');
+    await runtime.waitForScreenText(/Subagent model set for Explore · Global:/i, terminal, 8_000);
+
+    terminal.submit(
+      `!node -e 'const fs=require("fs"); const s=JSON.parse(fs.readFileSync(process.env.MASTRA_APP_DATA_DIR+"/settings.json","utf8")); console.log("SUBAGENT_EXPLORE_MODEL="+(s.models.subagentModels.explore||"missing"));'`,
+    );
+    await runtime.waitForScreenText(/SUBAGENT_EXPLORE_MODEL=(?!missing)\S+/i, terminal, 8_000);
+
+    terminal.submit('/subagents');
+    await runtime.waitForScreenText(/Disable subagents/i, terminal);
+    terminal.write('\r');
+    await runtime.waitForScreenText(/Subagents disabled\. Restart MastraCode for this to take effect\./i, terminal);
+
+    terminal.submit(
+      `!node -e 'const fs=require("fs"); const s=JSON.parse(fs.readFileSync(process.env.MASTRA_APP_DATA_DIR+"/settings.json","utf8")); console.log("SUBAGENTS_ENABLED_AFTER_DISABLE="+s.preferences.subagentsEnabled);'`,
+    );
+    await runtime.waitForScreenText(/SUBAGENTS_ENABLED_AFTER_DISABLE=false/i, terminal, 8_000);
+
+    terminal.keyCtrlC();
+  },
+} satisfies McE2eScenario;

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -155,6 +155,7 @@ export type ScenarioName =
   | 'stream-error-retry'
   | 'streaming-render-stability'
   | 'streaming-tool-args'
+  | 'subagents-command'
   | 'subagent-delegation'
   | 'subagent-plan-execute-tools'
   | 'subagent-model-startup-restore'

--- a/mastracode/tui/src/__tests__/subagent-settings.test.ts
+++ b/mastracode/tui/src/__tests__/subagent-settings.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveTuiSubagents } from '../subagent-settings.js';
+
+describe('resolveTuiSubagents', () => {
+  it('disables SDK default subagents unless the TUI preference is enabled', () => {
+    expect(resolveTuiSubagents(false)).toEqual([]);
+  });
+
+  it('allows the SDK to register native defaults after opt-in', () => {
+    expect(resolveTuiSubagents(true)).toBeUndefined();
+  });
+});

--- a/mastracode/tui/src/main.ts
+++ b/mastracode/tui/src/main.ts
@@ -22,6 +22,7 @@ import {
   createShutdownCoordinator,
   startTuiProcessMemoryDiagnostics,
 } from './process-memory-diagnostics-lifecycle.js';
+import { resolveTuiSubagents } from './subagent-settings.js';
 import { detectTerminalTheme } from './tui/detect-theme.js';
 import { MastraTUI } from './tui/index.js';
 import { applyThemeMode, restoreTerminalForeground } from './tui/theme.js';
@@ -82,6 +83,7 @@ async function tuiMain(pipedInput?: string | null) {
     unixSocketPubSub: !isTruthyEnv('MASTRACODE_DISABLE_UNIX_SOCKET_PUBSUB'),
     disableMcp: isTruthyEnv('MASTRACODE_DISABLE_MCP'),
     disableHooks: isTruthyEnv('MASTRACODE_DISABLE_HOOKS'),
+    subagents: resolveTuiSubagents(settings.preferences.subagentsEnabled),
     ...(isTruthyEnv('MASTRACODE_DISABLE_MEMORY') ? { memory: false as never } : {}),
     ...(initialState ? { initialState: initialState as never } : {}),
   });

--- a/mastracode/tui/src/subagent-settings.ts
+++ b/mastracode/tui/src/subagent-settings.ts
@@ -1,0 +1,3 @@
+export function resolveTuiSubagents(enabled: boolean): undefined | [] {
+  return enabled ? undefined : [];
+}

--- a/mastracode/tui/src/tui/commands/__tests__/subagents.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/subagents.test.ts
@@ -1,111 +1,114 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { handleSubagentsCommand } from '../subagents.js';
-import type { SlashCommandContext } from '../types.js';
 
-const askQuestionMock = vi.fn();
-
-vi.mock('../../modal-question.js', () => ({
-  askModalQuestion: vi.fn(async (_ui, props) => {
-    askQuestionMock(props);
-    return null;
-  }),
+const { askModalQuestion, loadSettings, saveSettings } = vi.hoisted(() => ({
+  askModalQuestion: vi.fn(),
+  loadSettings: vi.fn(),
+  saveSettings: vi.fn(),
 }));
 
-function createContext(subagents?: Array<{ id: string; name: string; description: string }>) {
-  const chatContainer = {
-    addChild: vi.fn(),
-    invalidate: vi.fn(),
-  };
+vi.mock('@mariozechner/pi-tui', () => ({
+  matchesKey: vi.fn(() => false),
+  Key: {},
+}));
 
-  const ctx = {
+vi.mock('@mastra/code-sdk/onboarding/settings', () => ({
+  loadSettings,
+  saveSettings,
+}));
+
+vi.mock('../../modal-question.js', () => ({ askModalQuestion }));
+
+import { handleSubagentsCommand } from '../subagents.js';
+
+function createCtx(subagents: unknown[] = []) {
+  return {
     state: {
-      controller: {
-        config: {
-          subagents,
-        },
-      },
-      ui: {
-        requestRender: vi.fn(),
-      },
-      chatContainer,
-      activeInlineQuestion: undefined,
+      session: { subagents: { model: {} } },
+      controller: { config: { subagents } },
+      ui: { requestRender: vi.fn() },
     },
-    authStorage: {},
-    showError: vi.fn(),
     showInfo: vi.fn(),
-  } as unknown as SlashCommandContext;
+    showError: vi.fn(),
+  } as any;
+}
 
-  return { ctx, chatContainer };
+function createSettings(subagentsEnabled = false) {
+  return {
+    preferences: { subagentsEnabled },
+    models: { subagentModels: {} },
+  } as any;
 }
 
 describe('handleSubagentsCommand', () => {
   beforeEach(() => {
-    askQuestionMock.mockReset();
+    vi.clearAllMocks();
+    loadSettings.mockReturnValue(createSettings());
   });
 
-  it('falls back to built-in subagent types when no custom subagents are configured', async () => {
-    const { ctx, chatContainer } = createContext();
+  it('enables subagents globally and asks for a restart', async () => {
+    const settings = createSettings(false);
+    loadSettings.mockReturnValue(settings);
+    askModalQuestion.mockResolvedValue('Enable subagents');
+    const ctx = createCtx();
 
     await handleSubagentsCommand(ctx);
 
-    expect(askQuestionMock).toHaveBeenCalledTimes(1);
-    const question = askQuestionMock.mock.calls[0]?.[0];
-    expect(question.question).toBe('Select subagent type');
-    expect(question.options).toEqual([
-      { label: 'Explore', description: 'Read-only codebase exploration' },
-      { label: 'Plan', description: 'Read-only analysis and planning' },
-      { label: 'Execute', description: 'Task execution with write access' },
-    ]);
-    expect(chatContainer.addChild).not.toHaveBeenCalled();
+    expect(askModalQuestion).toHaveBeenCalledWith(
+      ctx.state.ui,
+      expect.objectContaining({ allowCustomResponse: false }),
+    );
+    expect(settings.preferences.subagentsEnabled).toBe(true);
+    expect(saveSettings).toHaveBeenCalledWith(settings);
+    expect(ctx.showInfo).toHaveBeenCalledWith('Subagents enabled. Restart MastraCode for this to take effect.');
   });
 
-  it('falls back to built-in subagent types when subagents is an empty array', async () => {
-    const { ctx } = createContext([]);
+  it('disables subagents globally and asks for a restart', async () => {
+    const settings = createSettings(true);
+    loadSettings.mockReturnValue(settings);
+    askModalQuestion.mockResolvedValue('Disable subagents');
+    const ctx = createCtx();
 
     await handleSubagentsCommand(ctx);
 
-    expect(askQuestionMock).toHaveBeenCalledTimes(1);
-    const question = askQuestionMock.mock.calls[0]?.[0];
-    expect(question.options).toEqual([
-      { label: 'Explore', description: 'Read-only codebase exploration' },
-      { label: 'Plan', description: 'Read-only analysis and planning' },
-      { label: 'Execute', description: 'Task execution with write access' },
-    ]);
+    expect(settings.preferences.subagentsEnabled).toBe(false);
+    expect(saveSettings).toHaveBeenCalledWith(settings);
+    expect(ctx.showInfo).toHaveBeenCalledWith('Subagents disabled. Restart MastraCode for this to take effect.');
   });
 
-  it('renders configured subagents from the controller config', async () => {
-    const { ctx } = createContext([
-      {
-        id: 'explore',
-        name: 'Explore',
-        description: 'Read-only codebase exploration',
-      },
-      {
-        id: 'plan',
-        name: 'Plan',
-        description: 'Read-only analysis and planning',
-      },
-      {
-        id: 'execute',
-        name: 'Execute',
-        description: 'Task execution with write access',
-      },
-      {
-        id: 'test-writer',
-        name: 'Test Writer',
-        description: 'Write tests for the specified module',
-      },
-    ]);
+  it('uses built-in types when configuring models without explicit subagents', async () => {
+    askModalQuestion.mockResolvedValueOnce('Configure models').mockResolvedValueOnce(null);
+    const ctx = createCtx();
 
     await handleSubagentsCommand(ctx);
 
-    expect(askQuestionMock).toHaveBeenCalledTimes(1);
-    const question = askQuestionMock.mock.calls[0]?.[0];
-    expect(question.options).toEqual([
-      { label: 'Explore', description: 'Read-only codebase exploration' },
-      { label: 'Plan', description: 'Read-only analysis and planning' },
-      { label: 'Execute', description: 'Task execution with write access' },
-      { label: 'Test Writer', description: 'Write tests for the specified module' },
-    ]);
+    expect(askModalQuestion).toHaveBeenNthCalledWith(
+      2,
+      ctx.state.ui,
+      expect.objectContaining({
+        question: 'Select subagent type',
+        allowCustomResponse: false,
+        options: expect.arrayContaining([
+          expect.objectContaining({ label: 'Explore' }),
+          expect.objectContaining({ label: 'Plan' }),
+          expect.objectContaining({ label: 'Execute' }),
+        ]),
+      }),
+    );
+  });
+
+  it('uses configured subagent types when configuring models', async () => {
+    askModalQuestion.mockResolvedValueOnce('Configure models').mockResolvedValueOnce(null);
+    const ctx = createCtx([{ id: 'custom', name: 'Custom agent', description: 'Custom desc' }]);
+
+    await handleSubagentsCommand(ctx);
+
+    expect(askModalQuestion).toHaveBeenNthCalledWith(
+      2,
+      ctx.state.ui,
+      expect.objectContaining({
+        allowCustomResponse: false,
+        options: [expect.objectContaining({ label: 'Custom agent', description: 'Custom desc' })],
+      }),
+    );
   });
 });

--- a/mastracode/tui/src/tui/commands/subagents.ts
+++ b/mastracode/tui/src/tui/commands/subagents.ts
@@ -128,21 +128,53 @@ function getConfiguredSubagentTypes(
     : BUILT_IN_SUBAGENT_TYPES;
 }
 
-export async function handleSubagentsCommand(ctx: SlashCommandContext): Promise<void> {
+async function configureSubagentModels(ctx: SlashCommandContext): Promise<void> {
   const agentTypes = getConfiguredSubagentTypes(ctx);
-
   const answer = await askModalQuestion(ctx.state.ui, {
     question: 'Select subagent type',
+    allowCustomResponse: false,
     options: agentTypes.map(t => ({
       label: t.label,
       description: t.description,
     })),
   });
 
+  const selected = agentTypes.find(t => t.label === answer);
+  if (selected) {
+    await showSubagentScopeThenList(ctx, selected.id, selected.label);
+  }
+}
+
+function setSubagentsEnabled(ctx: SlashCommandContext, enabled: boolean): void {
+  const settings = loadSettings();
+  settings.preferences.subagentsEnabled = enabled;
+  saveSettings(settings);
+  ctx.showInfo(`Subagents ${enabled ? 'enabled' : 'disabled'}. Restart MastraCode for this to take effect.`);
+}
+
+export async function handleSubagentsCommand(ctx: SlashCommandContext): Promise<void> {
+  const settings = loadSettings();
+  const toggleLabel = settings.preferences.subagentsEnabled ? 'Disable subagents' : 'Enable subagents';
+  const answer = await askModalQuestion(ctx.state.ui, {
+    question: 'Manage subagents',
+    allowCustomResponse: false,
+    options: [
+      {
+        label: toggleLabel,
+        description: `${toggleLabel} for future MastraCode sessions`,
+      },
+      {
+        label: 'Configure models',
+        description: 'Choose the default model for each subagent type',
+      },
+    ],
+  });
+
   try {
-    const selected = agentTypes.find(t => t.label === answer);
-    if (selected) {
-      await showSubagentScopeThenList(ctx, selected.id, selected.label);
+    if (answer === toggleLabel) {
+      setSubagentsEnabled(ctx, !settings.preferences.subagentsEnabled);
+    } else if (answer === 'Configure models') {
+      await configureSubagentModels(ctx);
     }
   } catch (err) {
     ctx.showError(`Subagent selection failed: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
Mastra Code now keeps native subagents disabled by default in the TUI while preserving the SDK's existing defaults for other consumers. Users can enable or disable subagents from `/subagents`, and the preference is persisted and applied on startup.\n\nWhen enabled, the existing per-subagent model configuration remains available.\n\nVerified with the SDK settings tests, focused TUI subagent tests, SDK and TUI typechecks, lint, formatting, git diff checks, and a full workspace build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Mastra Code users can turn native subagents on or off with `/subagents`. The choice is saved and applied when Mastra Code starts, while other SDK users keep the existing default behavior.

## Changes

- Added the persisted `preferences.subagentsEnabled` setting.
- Disabled native subagents by default in the TUI.
- Added `/subagents` controls to enable, disable, and configure subagent models.
- Applied the saved preference at TUI startup.
- Preserved SDK native subagent defaults for other consumers.
- Added unit and end-to-end tests for settings validation, command behavior, persistence, model configuration, and startup resolution.
- Added patch changesets for `@mastra/code-sdk` and Mastra Code.

## Verification

- SDK settings tests
- TUI subagent tests
- SDK and TUI typechecks
- Linting and formatting checks
- Git diff checks
- Full workspace build
<!-- end of auto-generated comment: release notes by coderabbit.ai -->