### PR TITLE
feat(cli): add deploy diagnose command

### DIFF
--- a/.changeset/eager-tools-cough.md
+++ b/.changeset/eager-tools-cough.md
@@ -1,0 +1,5 @@
+---
+'mastra': minor
+---
+
+Added the deploy diagnose command for Studio and Server deployments. The existing deploy suggestions command remains available as an alias.

--- a/packages/cli/src/commands/dev/DevBundler.test.ts
+++ b/packages/cli/src/commands/dev/DevBundler.test.ts
@@ -18,6 +18,7 @@ vi.mock('commander', () => {
     version: any;
     addHelpText: any;
     action: any;
+    alias: any;
     argument: any;
     command: any;
     description: any;
@@ -31,6 +32,7 @@ vi.mock('commander', () => {
       this.version = vi.fn().mockReturnThis();
       this.addHelpText = vi.fn().mockReturnThis();
       this.action = vi.fn().mockReturnThis();
+      this.alias = vi.fn().mockReturnThis();
       this.argument = vi.fn().mockReturnThis();
       this.command = vi.fn().mockReturnThis();
       this.description = vi.fn().mockReturnThis();

--- a/packages/cli/src/commands/server/deploy-suggestions.test.ts
+++ b/packages/cli/src/commands/server/deploy-suggestions.test.ts
@@ -175,7 +175,7 @@ describe('serverSuggestionsAction', () => {
     await expect(serverSuggestionsAction(undefined, {})).rejects.toThrow('exit:1');
 
     expect(mockLogError).toHaveBeenCalledWith(
-      'No deploys found for linked Server project Server App. The suggestions command helps debug failed deployments, and you can run it after a deployment fails with `mastra server deploy suggestions <deploy-id>` or `mastra server deploy suggestions`.',
+      'No deploys found for linked Server project Server App. The diagnose command helps debug failed deployments, and you can run it after a deployment fails with `mastra server deploy diagnose <deploy-id>` or `mastra server deploy diagnose`.',
     );
     expect(mockFetchServerDeployDiagnosis).not.toHaveBeenCalled();
     mockExit.mockRestore();

--- a/packages/cli/src/commands/server/deploy-suggestions.ts
+++ b/packages/cli/src/commands/server/deploy-suggestions.ts
@@ -18,7 +18,7 @@ async function resolveDeployId(
   const { project } = await fetchServerProjectDetail(token, orgId, projectId);
   if (!project.latestDeployId) {
     throw new Error(
-      `No deploys found for linked Server project ${project.name}. The suggestions command helps debug failed deployments, and you can run it after a deployment fails with \`mastra server deploy suggestions <deploy-id>\` or \`mastra server deploy suggestions\`.`,
+      `No deploys found for linked Server project ${project.name}. The diagnose command helps debug failed deployments, and you can run it after a deployment fails with \`mastra server deploy diagnose <deploy-id>\` or \`mastra server deploy diagnose\`.`,
     );
   }
 
@@ -32,7 +32,7 @@ function buildLogsUrl(orgId: string, projectId: string | undefined, deployId: st
 }
 
 export async function serverSuggestionsAction(deployId: string | undefined, opts: { org?: string }) {
-  p.intro('mastra server deploy suggestions');
+  p.intro('mastra server deploy diagnose');
   try {
     const { token, orgId } = await resolveAuth(opts.org);
     const resolved = await resolveDeployId(token, orgId, deployId);

--- a/packages/cli/src/commands/studio/deploy-commands.test.ts
+++ b/packages/cli/src/commands/studio/deploy-commands.test.ts
@@ -366,7 +366,7 @@ describe('suggestionsAction', () => {
     await expect(suggestionsAction()).rejects.toThrow('process.exit');
 
     expect(mockClackLogError).toHaveBeenCalledWith(
-      'No deploys found for linked Studio project App 2. The suggestions command helps debug failed deployments, and you can run it after a deployment fails with `mastra studio deploy suggestions <deploy-id>` or `mastra studio deploy suggestions`.',
+      'No deploys found for linked Studio project App 2. The diagnose command helps debug failed deployments, and you can run it after a deployment fails with `mastra studio deploy diagnose <deploy-id>` or `mastra studio deploy diagnose`.',
     );
     expect(mockFetchDeployDiagnosis).not.toHaveBeenCalled();
     mockExit.mockRestore();

--- a/packages/cli/src/commands/studio/deploy-suggestions.ts
+++ b/packages/cli/src/commands/studio/deploy-suggestions.ts
@@ -15,7 +15,7 @@ function getLatestProjectDeploy(projects: Project[], linkedProjectId?: string) {
     }
 
     throw new Error(
-      `No deploys found for linked Studio project ${linkedProject.name}. The suggestions command helps debug failed deployments, and you can run it after a deployment fails with \`mastra studio deploy suggestions <deploy-id>\` or \`mastra studio deploy suggestions\`.`,
+      `No deploys found for linked Studio project ${linkedProject.name}. The diagnose command helps debug failed deployments, and you can run it after a deployment fails with \`mastra studio deploy diagnose <deploy-id>\` or \`mastra studio deploy diagnose\`.`,
     );
   }
 
@@ -66,7 +66,7 @@ async function resolveDeployId(
 }
 
 export async function suggestionsAction(deployId?: string) {
-  p.intro('mastra studio deploy suggestions');
+  p.intro('mastra studio deploy diagnose');
 
   try {
     const token = await getToken();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -309,8 +309,9 @@ deployCommand
 
 if (coreFeatures.has('deploy-diagnosis')) {
   deployCommand
-    .command('suggestions [deploy-id]')
-    .description('Show deploy suggestions for a failed deploy')
+    .command('diagnose [deploy-id]')
+    .alias('suggestions')
+    .description('Diagnose a failed deploy')
     .action(wrapAction(suggestionsAction));
 }
 
@@ -387,8 +388,9 @@ const serverDeployCommand = serverCommand
 
 if (coreFeatures.has('deploy-diagnosis')) {
   serverDeployCommand
-    .command('suggestions [deploy-id]')
-    .description('Show deploy suggestions for a failed deploy')
+    .command('diagnose [deploy-id]')
+    .alias('suggestions')
+    .description('Diagnose a failed deploy')
     .option('--org <id>', 'Organization ID')
     .action(wrapAction(serverSuggestionsAction));
 }


### PR DESCRIPTION
## Description

Adds `mastra studio deploy diagnose` and `mastra server deploy diagnose` as the primary commands. The existing `deploy suggestions` spelling remains available as an alias.

## Related issue(s)

Internal: PLTFRM-1609

## Type of change

- [x] New feature
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (not applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

Verified: CLI tests pass (1,120 tests); CLI typecheck and lint pass; both Studio and Server help output list `diagnose|suggestions`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The CLI now uses `diagnose` as the main command for deployment problems. The older `suggestions` command still works as an alias.

## Changes

- Added `mastra studio deploy diagnose`.
- Added `mastra server deploy diagnose`.
- Kept `suggestions` as a compatible alias.
- Updated command descriptions and error messages.
- Updated tests for the new command name.
- Added a changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->