### PR TITLE
Set moduleResolution: bundler in factory template tsconfig so deploy preflight passes

### DIFF
--- a/mastracode/mastra-factory/scripts/sync-template.mjs
+++ b/mastracode/mastra-factory/scripts/sync-template.mjs
@@ -206,6 +206,7 @@ function writeTsconfig() {
       declaration: true,
       declarationMap: true,
       module: 'Preserve',
+      moduleResolution: 'bundler',
       noEmit: true,
       lib: ['ES2023'],
       types: ['node'],


### PR DESCRIPTION
## Summary

Deploying a factory project through the Platform fails at the preflight lint step because the generated template's `tsconfig.json` sets `module: "Preserve"` but leaves `moduleResolution` implicit. The preflight lint doesn't accept that combination and rejects the project before it can be deployed.

## What changed

`mastracode/mastra-factory/scripts/sync-template.mjs`'s `writeTsconfig()` now writes `moduleResolution: "bundler"` alongside `module: "Preserve"`. Once this lands and the `sync-softwarefactory-template` workflow runs, `mastra-ai/softwarefactory-template` picks up the new tsconfig and new factory projects created from the template deploy cleanly.

## Test plan

- Ran `node scripts/sync-template.mjs --out /tmp/factory-template-verify` and confirmed the generated `tsconfig.json` includes `"moduleResolution": "bundler"` next to `"module": "Preserve"`.
- No runtime resolution semantics change for existing users: `Preserve` already implies bundler-style resolution; this just makes it explicit for the preflight lint.

## Notes

- The template repo is regenerated by the `sync-softwarefactory-template` workflow — no manual push to `mastra-ai/softwarefactory-template` is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

New factory projects now use the correct TypeScript module settings. This prevents lint failures during platform checks.

## Changes

- Added `moduleResolution: "bundler"` beside `module: "Preserve"` in the generated `tsconfig.json`.
- Updated `mastracode/mastra-factory/scripts/sync-template.mjs`.

## Verification

- Verified the generated configuration with the sync script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->