### PR TITLE
fix(server): let PATCH /memory/threads/:threadId clear a thread title

### DIFF
--- a/.changeset/loud-pandas-listen.md
+++ b/.changeset/loud-pandas-listen.md
@@ -1,0 +1,13 @@
+---
+'@mastra/server': patch
+---
+
+Let `PATCH /memory/threads/:threadId` clear a thread title.
+
+The handler distinguished "field absent" from "field present" with a falsy check
+(`title: title || thread.title`), so `{ "title": "" }` returned 200 with the old
+title still stored, and callers had no way to tell that apart from a successful
+write. It now checks for `undefined`, which is already how the body schema says
+"leave this field alone" — both fields are `.optional()`. Callers that omit a
+field are unaffected. `metadata` gets the same treatment for consistency; its
+behavior is unchanged, since `{}` is truthy.

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -2272,6 +2272,88 @@ describe('Memory Handlers', () => {
       });
     });
 
+    describe('UPDATE_THREAD_ROUTE - absent vs. empty', () => {
+      const mastraWithAgent = () =>
+        new Mastra({
+          logger: false,
+          agents: { 'test-agent': mockAgent },
+        });
+
+      it('should clear the title when given an empty string', async () => {
+        const mastra = mastraWithAgent();
+        await mockMemory.createThread({ threadId: 'thread-1', resourceId: 'user-a', title: 'Old Title' });
+
+        const result = await UPDATE_THREAD_ROUTE.handler({
+          ...createTestContextWithReservedKeys({ mastra, resourceId: 'user-a' }),
+          agentId: 'test-agent',
+          threadId: 'thread-1',
+          title: '',
+        });
+
+        expect(result.title).toBe('');
+        const stored = await mockMemory.getThreadById({ threadId: 'thread-1' });
+        expect(stored?.title).toBe('');
+      });
+
+      it('should clear the metadata when given an empty object', async () => {
+        const mastra = mastraWithAgent();
+        await mockMemory.createThread({
+          threadId: 'thread-2',
+          resourceId: 'user-a',
+          metadata: { pinned: true },
+        });
+
+        const result = await UPDATE_THREAD_ROUTE.handler({
+          ...createTestContextWithReservedKeys({ mastra, resourceId: 'user-a' }),
+          agentId: 'test-agent',
+          threadId: 'thread-2',
+          metadata: {},
+        });
+
+        expect(result.metadata).toEqual({});
+      });
+
+      it('should keep the existing title when the field is absent', async () => {
+        const mastra = mastraWithAgent();
+        await mockMemory.createThread({
+          threadId: 'thread-3',
+          resourceId: 'user-a',
+          title: 'Keep Me',
+          metadata: { pinned: true },
+        });
+
+        const result = await UPDATE_THREAD_ROUTE.handler({
+          ...createTestContextWithReservedKeys({ mastra, resourceId: 'user-a' }),
+          agentId: 'test-agent',
+          threadId: 'thread-3',
+          metadata: { pinned: false },
+        });
+
+        expect(result.title).toBe('Keep Me');
+        expect(result.metadata).toEqual({ pinned: false });
+      });
+
+      it('should keep the existing metadata when the field is absent', async () => {
+        const mastra = mastraWithAgent();
+        await mockMemory.createThread({
+          threadId: 'thread-4',
+          resourceId: 'user-a',
+          title: 'Old Title',
+          metadata: { pinned: true },
+        });
+
+        const result = await UPDATE_THREAD_ROUTE.handler({
+          ...createTestContextWithReservedKeys({ mastra, resourceId: 'user-a' }),
+          agentId: 'test-agent',
+          threadId: 'thread-4',
+          title: 'New Title',
+        });
+
+        expect(result.title).toBe('New Title');
+        expect(result.metadata).toEqual({ pinned: true });
+      });
+    });
+
     describe('SAVE_MESSAGES_ROUTE - resourceId validation', () => {
       it('should return 403 when saving messages for different resource', async () => {
         const mastra = new Mastra({

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -1510,8 +1510,14 @@ export const UPDATE_THREAD_ROUTE = createRoute({
 
       const updatedThread = {
         ...thread,
-        title: title || thread.title,
-        metadata: metadata || thread.metadata,
+        // Absent means "leave it alone"; present means "use this", including an
+        // empty string or an empty object. A falsy check here cannot express
+        // "clear this field": `{ title: '' }` would return 200 with the old
+        // title still in place, and the caller has no way to tell that apart
+        // from a successful write. Both fields are optional in the body schema,
+        // so `undefined` is already the documented way to skip one.
+        title: title !== undefined ? title : thread.title,
+        metadata: metadata !== undefined ? metadata : thread.metadata,
         // Don't allow changing resourceId if effectiveResourceId is set (prevents reassigning threads)
         resourceId: effectiveResourceId || resourceId || thread.resourceId,
         createdAt: thread.createdAt,


### PR DESCRIPTION
Fixes #23344

Bug fix, not a feature request — the linked issue is a report that a documented-optional field can't be written with an empty value.

## Problem

`UPDATE_THREAD_ROUTE` told "field absent" apart from "field present" with a falsy check:

```ts
title: title || thread.title,
metadata: metadata || thread.metadata,
```

`''` is falsy, so `PATCH /memory/threads/:threadId { "title": "" }` returned **200 with the previous title still stored**. There is no way to clear a thread title through the route, and — worse for a client — no way to tell "stored an empty title" apart from "ignored my write".

## Fix

Check for `undefined` instead. That is already how the body schema expresses "leave this field alone": `title` and `metadata` are both `.optional()` in `updateThreadBodySchema`, so callers that omit a field behave exactly as before, and nothing about the wire format changes.

```ts
title: title !== undefined ? title : thread.title,
metadata: metadata !== undefined ? metadata : thread.metadata,
```

## One correction to the issue I filed

The issue says `metadata: {}` is affected too. **That is wrong, and I'm sorry for the noise** — `{}` is truthy in JS, so an empty object already replaced the stored value. `metadata` is only in this diff so both fields read the same way; its behavior does not change. The single behavioral change here is the empty title.

I found the mistake because the metadata test I wrote passed against the *unfixed* handler.

## Tests

Four cases in `memory.test.ts`, covering both fields in both directions:

| Test | On old code |
|---|---|
| empty string clears the title | **fails** (`expected 'Old Title' to be ''`) |
| empty object clears the metadata | passes (`{}` was already truthy) |
| absent title keeps the stored one | passes |
| absent metadata keeps the stored one | passes |

Only the first one is the bug. The other three exist so the `!== undefined` rewrite can't quietly regress the absent-field path, which is the path every current caller uses.

```
✓ packages/server/src/server/handlers/memory.test.ts (83 tests) 42ms
  Tests  83 passed (83)
```

I ran the file against the published `@mastra/core@1.52.1` rather than a full workspace build, since `@mastra/server`'s only runtime needs here are `core`, `zod` and `hono`. Happy to re-run any other suite you'd like to see, or to drop the `metadata` line if you prefer the minimal diff.

## Why it matters downstream

We ship a "rename conversation" affordance in a chat sidebar, where clearing the name should fall back to a label derived from the first user message. A 200 that changes nothing makes that path fail silently: the UI shows the fallback optimistically and the next poll brings the old title back. Our workaround is to write a single space, which passes the `||` and reads as blank on the client because we compare with `.trim()` — it works, but it stores a value nobody wants stored, purely because the route can't say "clear this".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This change lets clients clear a thread title by sending an empty string. If a field is not sent, the existing value remains unchanged.

## Changes

- Updated `PATCH /memory/threads/:threadId` to check for `undefined` instead of using falsy fallbacks.
- Empty `title` values now replace the stored title.
- Applied the same presence check to `metadata`.
- Added tests for clearing fields and preserving omitted fields.
- Added a patch changeset for `@mastra/server`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->