### PR TITLE
feat(factory): track authenticated web usage and platform attribution

### DIFF
--- a/.changeset/deep-sheep-push.md
+++ b/.changeset/deep-sheep-push.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Updated the bundled Factory web app to report visible page views and throttled interactions when the server enables telemetry. Older servers and telemetry opt-out remain supported.

--- a/.changeset/open-pillows-rescue.md
+++ b/.changeset/open-pillows-rescue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': minor
+---
+
+Added authenticated Factory web usage telemetry with account, project, deployment, and region attribution. Set `MASTRA_TELEMETRY_DISABLED=true` on the Factory Server to opt out.

--- a/mastracode/factory-ui/src/ui/domains/auth/components/RootGuards.tsx
+++ b/mastracode/factory-ui/src/ui/domains/auth/components/RootGuards.tsx
@@ -1,4 +1,5 @@
 import { BrandLoader } from '@mastra/playground-ui/components/BrandLoader';
+import { FactoryWebTelemetry } from '../../telemetry/FactoryWebTelemetry';
 import { useFactoryAuth } from '../../../../hooks/useFactoryAuth';
 import { useFactoriesQuery } from '../../../../hooks/useFactories';
 import { hasResumableFactoryOnboarding } from '../../workspaces/services/onboardingFlow';
@@ -44,7 +45,12 @@ const OnboardingGuard = () => {
     return <Navigate to={`/factories/${factories[0].id}`} replace />;
   }
 
-  return <Outlet />;
+  return (
+    <>
+      <FactoryWebTelemetry />
+      <Outlet />
+    </>
+  );
 };
 
 function AuthNotConfiguredScreen() {

--- a/mastracode/factory-ui/src/ui/domains/auth/services/auth.ts
+++ b/mastracode/factory-ui/src/ui/domains/auth/services/auth.ts
@@ -19,6 +19,8 @@ export interface FactoryAuthState {
   /** Whether the server has web auth configured (any provider). */
   authEnabled: boolean;
   authenticated: boolean;
+  /** Explicit server capability; absent on older servers. */
+  telemetryEnabled?: boolean;
   user?: { userId?: string; email?: string; name?: string; avatarUrl?: string; organizationId?: string };
   /** Active identity provider: 'workos' | 'better-auth' | custom adapter kind. */
   provider?: string;
@@ -128,6 +130,7 @@ export async function fetchAuthState(baseUrl: string): Promise<FactoryAuthState>
   }
   const data = (await res.json()) as {
     authenticated?: boolean;
+    telemetryEnabled?: boolean;
     user?: { userId?: string; email?: string; name?: string; organizationId?: string } | null;
     provider?: string;
     signUpDisabled?: boolean;
@@ -135,6 +138,7 @@ export async function fetchAuthState(baseUrl: string): Promise<FactoryAuthState>
   return {
     authEnabled: true,
     authenticated: Boolean(data.authenticated),
+    ...(typeof data.telemetryEnabled === 'boolean' ? { telemetryEnabled: data.telemetryEnabled } : {}),
     user: data.user ?? undefined,
     provider: data.provider,
     signUpDisabled: data.signUpDisabled,

--- a/mastracode/factory-ui/src/ui/domains/telemetry/FactoryWebTelemetry.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/telemetry/FactoryWebTelemetry.msw.test.tsx
@@ -1,0 +1,177 @@
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { StrictMode } from 'react';
+import { MemoryRouter, useNavigate } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { server } from '../../../../e2e/ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../../e2e/ui/render';
+import { queryKeys } from '../../../api/keys';
+import type { FactoryAuthState } from '../auth/services/auth';
+import { FactoryWebTelemetry } from './FactoryWebTelemetry';
+
+let captured: unknown[];
+const enabledAuth: FactoryAuthState = {
+  authEnabled: true,
+  authenticated: true,
+  telemetryEnabled: true,
+  user: { userId: 'user_123', organizationId: 'org_123', email: 'private@example.com' },
+  provider: 'mastra-studio',
+};
+
+function Navigation() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button onClick={() => navigate('/factories/private-factory/review?secret=private#hidden')}>Review</button>
+      <button onClick={() => navigate('/factories/private-factory/work')}>Work</button>
+      <input aria-label="Message" />
+    </>
+  );
+}
+
+function renderTelemetry(path = '/factories/private-factory/work?secret=private#hidden') {
+  return renderWithProviders(
+    <StrictMode>
+      <MemoryRouter initialEntries={[path]}>
+        <FactoryWebTelemetry />
+        <Navigation />
+      </MemoryRouter>
+    </StrictMode>,
+  );
+}
+
+async function settle() {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 350));
+  });
+}
+
+beforeEach(() => {
+  captured = [];
+  server.use(
+    http.get(`${TEST_BASE_URL}/auth/me`, () => HttpResponse.json(enabledAuth)),
+    http.post(`${TEST_BASE_URL}/web/telemetry/activity`, async ({ request }) => {
+      expect(request.credentials).toBe('include');
+      captured.push(await request.json());
+      return new HttpResponse(null, { status: 204 });
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Factory usage capture', () => {
+  it('records one visible view under StrictMode without IDs, URLs, queries, or profile data', async () => {
+    renderTelemetry();
+    await waitFor(() => expect(captured).toEqual([{ activity: 'page_view', page: 'work' }]));
+    await settle();
+    expect(captured).toHaveLength(1);
+    fireEvent.click(screen.getByText('Review'));
+    await waitFor(() =>
+      expect(captured).toEqual([
+        { activity: 'page_view', page: 'work' },
+        { activity: 'page_view', page: 'review' },
+      ]),
+    );
+    fireEvent.click(screen.getByText('Work'));
+    await waitFor(() => expect(captured).toHaveLength(3));
+  });
+
+  it('throttles pointer and keyboard interaction without reading input contents', async () => {
+    renderTelemetry();
+    await waitFor(() => expect(captured).toHaveLength(1));
+    fireEvent.pointerDown(screen.getByLabelText('Message'));
+    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'private prompt' } });
+    fireEvent.keyDown(screen.getByLabelText('Message'), { key: 'a' });
+    fireEvent.pointerDown(screen.getByLabelText('Message'));
+    await waitFor(() =>
+      expect(captured).toEqual([
+        { activity: 'page_view', page: 'work' },
+        { activity: 'interaction', page: 'work' },
+      ]),
+    );
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now + 60_001);
+    fireEvent.keyDown(screen.getByLabelText('Message'), { key: 'b' });
+    await waitFor(() => expect(captured).toHaveLength(3));
+    expect(captured[2]).toEqual({ activity: 'interaction', page: 'work' });
+  });
+
+  it('ignores hidden tabs and emits a pending view when the tab becomes visible', async () => {
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    const { client } = renderTelemetry();
+    await waitForMutationsIdle(client);
+    await settle();
+    fireEvent.keyDown(document, { key: 'a' });
+    expect(captured).toEqual([]);
+    visibility.mockReturnValue('visible');
+    fireEvent(document, new Event('visibilitychange'));
+    await waitFor(() => expect(captured).toEqual([{ activity: 'page_view', page: 'work' }]));
+    fireEvent(document, new Event('visibilitychange'));
+    await settle();
+    expect(captured).toHaveLength(1);
+  });
+
+  it.each([
+    { ...enabledAuth, telemetryEnabled: false },
+    { ...enabledAuth, telemetryEnabled: undefined },
+    { ...enabledAuth, authenticated: false },
+  ])('does not send requests unless the authenticated server explicitly enables them (%j)', async auth => {
+    server.use(http.get(`${TEST_BASE_URL}/auth/me`, () => HttpResponse.json(auth)));
+    const { client } = renderTelemetry();
+    await waitForMutationsIdle(client);
+    fireEvent.keyDown(document, { key: 'a' });
+    await settle();
+    expect(captured).toEqual([]);
+  });
+
+  it('does not carry the previous account throttle or keep capturing after logout', async () => {
+    const { client } = renderTelemetry();
+    await waitFor(() => expect(captured).toHaveLength(1));
+    fireEvent.keyDown(document, { key: 'a' });
+    await waitFor(() => expect(captured).toHaveLength(2));
+    const other: FactoryAuthState = { ...enabledAuth, user: { userId: 'user_other' } };
+    server.use(http.get(`${TEST_BASE_URL}/auth/me`, () => HttpResponse.json(other)));
+    await act(async () => {
+      await client.invalidateQueries({ queryKey: queryKeys.factoryAuth() });
+    });
+    await waitFor(() => expect(captured).toHaveLength(3));
+    fireEvent.keyDown(document, { key: 'b' });
+    await waitFor(() => expect(captured).toHaveLength(4));
+    server.use(http.get(`${TEST_BASE_URL}/auth/me`, () => HttpResponse.json({ authenticated: false })));
+    await act(async () => {
+      await client.invalidateQueries({ queryKey: queryKeys.factoryAuth() });
+    });
+    fireEvent.keyDown(document, { key: 'c' });
+    await settle();
+    expect(captured).toHaveLength(4);
+  });
+
+  it('does not retry failed analytics requests or prevent navigation', async () => {
+    const attempts = vi.fn();
+    server.use(
+      http.post(`${TEST_BASE_URL}/web/telemetry/activity`, () => {
+        attempts();
+        return HttpResponse.error();
+      }),
+    );
+    renderTelemetry();
+    await waitFor(() => expect(attempts).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByText('Review'));
+    await waitFor(() => expect(attempts).toHaveBeenCalledTimes(2));
+    await settle();
+    expect(attempts).toHaveBeenCalledTimes(2);
+    expect(screen.getByLabelText('Message')).toBeInTheDocument();
+  });
+
+  it('ignores unknown and redirect-only routes', async () => {
+    const { client } = renderTelemetry('/factories/private-factory/settings');
+    await waitForMutationsIdle(client);
+    await settle();
+    fireEvent.keyDown(document, { key: 'a' });
+    expect(captured).toEqual([]);
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/telemetry/FactoryWebTelemetry.tsx
+++ b/mastracode/factory-ui/src/ui/domains/telemetry/FactoryWebTelemetry.tsx
@@ -1,0 +1,62 @@
+import type { FactoryWebActivity } from '@mastra/factory/telemetry-types';
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router';
+
+import { useApiConfig } from '../../../api/config';
+import { useFactoryAuth } from '../../../hooks/useFactoryAuth';
+import { telemetryPage } from './telemetry-page';
+
+/** No persistence, anonymous tracking, input contents, or background heartbeat. */
+export function FactoryWebTelemetry() {
+  const { baseUrl } = useApiConfig();
+  const { data: auth } = useFactoryAuth();
+  const { pathname, key } = useLocation();
+  const lastView = useRef<string | undefined>(undefined);
+  const lastInteraction = useRef<{ userId: string; at: number } | undefined>(undefined);
+  const page = telemetryPage(pathname);
+  const userId = auth?.user?.userId;
+  const enabled = auth?.authenticated && auth.telemetryEnabled === true;
+
+  useEffect(() => {
+    if (!enabled || !userId || !page) return;
+    const visit = JSON.stringify([baseUrl, userId, key, pathname]);
+    const currentPage = page;
+    const currentUserId = userId;
+    function capture(activity: FactoryWebActivity['activity']) {
+      void fetch(`${baseUrl}/web/telemetry/activity`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ activity, page: currentPage } satisfies FactoryWebActivity),
+      }).catch(() => {
+        /* Analytics must not interrupt the UI. */
+      });
+    }
+    function pageView() {
+      if (document.visibilityState !== 'visible' || lastView.current === visit) return;
+      lastView.current = visit;
+      capture('page_view');
+    }
+    function interaction() {
+      if (document.visibilityState !== 'visible') return;
+      const now = Date.now();
+      if (lastInteraction.current?.userId === currentUserId && now - lastInteraction.current.at < 60_000) return;
+      lastInteraction.current = { userId: currentUserId, at: now };
+      pageView();
+      capture('interaction');
+    }
+    // Coalesce redirect chains and StrictMode effect replay before recording a view.
+    const timer = window.setTimeout(pageView, 250);
+    document.addEventListener('visibilitychange', pageView);
+    document.addEventListener('pointerdown', interaction, { passive: true });
+    document.addEventListener('keydown', interaction);
+    return () => {
+      window.clearTimeout(timer);
+      document.removeEventListener('visibilitychange', pageView);
+      document.removeEventListener('pointerdown', interaction);
+      document.removeEventListener('keydown', interaction);
+    };
+  }, [enabled, userId, page, baseUrl, key, pathname]);
+
+  return undefined;
+}

--- a/mastracode/factory-ui/src/ui/domains/telemetry/telemetry-page.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/telemetry/telemetry-page.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { telemetryPage } from './telemetry-page';
+
+describe('telemetry page categories', () => {
+  it.each([
+    ['/onboarding', 'onboarding'],
+    ['/factories/id/work', 'work'],
+    ['/factories/id/settings/preferences', 'settings'],
+    ['/factories/id/settings/connections/slack', 'slack_connection'],
+    ['/factories/id/workspaces/private-session', 'workspace'],
+    ['/factories/id/workspaces/private-session/threads/private-thread', 'thread'],
+    ['/factories/id/user/threads/private-thread', 'thread'],
+    ['/factories/id/new', 'new_session'],
+    ['/factories/id/new-factory', 'new_factory'],
+  ])('normalizes %s to %s', (path, page) => {
+    expect(telemetryPage(path)).toBe(page);
+  });
+  it.each([
+    '/',
+    '/signin',
+    '/auth/callback',
+    '/factories/id',
+    '/factories/id/metrics',
+    '/factories/id/settings',
+    '/factories/id/private-page',
+  ])('ignores %s', path => {
+    expect(telemetryPage(path)).toBeUndefined();
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/telemetry/telemetry-page.ts
+++ b/mastracode/factory-ui/src/ui/domains/telemetry/telemetry-page.ts
@@ -1,0 +1,22 @@
+import { FACTORY_WEB_PAGES } from '@mastra/factory/telemetry-types';
+import type { FactoryWebActivity } from '@mastra/factory/telemetry-types';
+
+/** Only known screen categories cross the network, never route parameters. */
+export function telemetryPage(pathname: string): FactoryWebActivity['page'] | undefined {
+  if (pathname === '/onboarding') return 'onboarding';
+  const match = /^\/factories\/[^/]+\/(.+?)\/?$/.exec(pathname);
+  if (!match) return undefined;
+  const screen = match[1];
+  if (screen === 'settings/connections/slack') return 'slack_connection';
+  if (/^settings\/[^/]+$/.test(screen)) return 'settings';
+  if (/^workspaces\/[^/]+\/threads\/[^/]+$/.test(screen) || /^user\/threads\/[^/]+$/.test(screen)) return 'thread';
+  if (/^workspaces\/[^/]+$/.test(screen)) return 'workspace';
+  if (screen === 'new') return 'new_session';
+  if (screen === 'new-factory') return 'new_factory';
+  // These are redirects or categories represented by the patterns above.
+  if (
+    ['onboarding', 'settings', 'workspace', 'thread', 'slack_connection', 'new_session', 'new_factory'].includes(screen)
+  )
+    return undefined;
+  return FACTORY_WEB_PAGES.find(page => page === screen);
+}

--- a/mastracode/factory/README.md
+++ b/mastracode/factory/README.md
@@ -29,6 +29,32 @@ A host application calls `MastraFactory.prepare()`, constructs its `Mastra` inst
 
 `prepare()` initializes the Factory-owned resources needed before Mastra is constructed. `finalize()` connects those resources to the completed host, including Factory routes, integrations, storage-backed behavior, and agent-controller features. Consumers should keep frontend concerns in `factory-ui` and host-specific environment or deployment wiring in `web` rather than adding them to this package.
 
+### Product telemetry
+
+Factory records `factory_web_activity` in Mastra's existing PostHog project for users signed in through the default `mastra-studio` auth provider. The browser sends only a known page category and an activity type to the authenticated `/web/telemetry/activity` endpoint. The server adds the verified account and deployment context.
+
+| Property                              | Meaning                                                                          |
+| ------------------------------------- | -------------------------------------------------------------------------------- |
+| `activity`                            | `page_view` for a visible screen, or `interaction` for pointer/keyboard activity |
+| `page`                                | A bounded category such as `work`, `review`, or `settings`; never a URL          |
+| `platform_user_id`, `platform_org_id` | Opaque IDs from the authenticated platform account                               |
+| `platform_project_id`                 | `MASTRA_PROJECT_ID`, when configured                                             |
+| `platform_hosted`                     | Whether a nonempty `MASTRA_DEPLOYMENT_ID` is present                             |
+| `deployment_id`, `platform_region`    | `MASTRA_DEPLOYMENT_ID` and `MASTRA_PLATFORM_REGION`, when configured             |
+| `schema_version`                      | `1`                                                                              |
+
+The person ID is `factory:platform:<user ID>`, consistent across local and hosted servers. This does not merge existing CLI or platform analytics profiles. A local server can have a platform project ID and use platform services while `platform_hosted` remains `false`. Non-platform hosting includes both local and other self-hosted servers; this event does not distinguish them.
+
+Count unique people per day for visitors, and filter to `activity = interaction` for engaged users. Group by `platform_project_id` for project adoption. Interaction events are limited to once per minute per mounted browser app, and the server caps captures at 60 per minute per account/organization per process. Hidden tabs do not capture activity, and there is no background heartbeat. These are best-effort usage signals, not a record of successful product actions.
+
+To disable collection, set this on the Factory Server:
+
+```bash
+MASTRA_TELEMETRY_DISABLED=true
+```
+
+`1`, `true`, and `yes` are accepted, ignoring case and surrounding whitespace. Older servers without the explicit capability do not receive browser telemetry requests. Custom auth providers are outside this initial measurement scope until they have a stable identity namespace. No names, emails, tokens, prompts, input values, raw URLs, session replay, or anonymous browser identity are collected by this event. Account IDs are identifiable account data, not anonymous data.
+
 ### Board lifecycle rules
 
 Installed board definitions exclusively own phase entry and exit handlers. Work and Review are installed automatically with Mastra's preferred defaults; no rule configuration is needed. Custom boards declare source-specific `onEnter` and `onExit` handlers through `defineBoard()`:

--- a/mastracode/factory/package.json
+++ b/mastracode/factory/package.json
@@ -69,6 +69,7 @@
     "chat": "^4.34.0",
     "@octokit/rest": "^22.0.1",
     "hono": "^4.12.8",
+    "posthog-node": "^5.46.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/mastracode/factory/src/auth.test.ts
+++ b/mastracode/factory/src/auth.test.ts
@@ -597,6 +597,7 @@ describe('mountFactoryAuth /auth routes (enabled)', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
       authenticated: true,
+      telemetryEnabled: false,
       // No-org accounts are bootstrapped into a personal org during /auth/me.
       user: {
         userId: 'user_me',
@@ -622,6 +623,7 @@ describe('mountFactoryAuth /auth routes (enabled)', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
       authenticated: true,
+      telemetryEnabled: false,
       user: { email: 'user@example.com', name: 'User', organizationId: 'org_a', userId: 'user_1' },
       provider: 'workos',
     });

--- a/mastracode/factory/src/auth.ts
+++ b/mastracode/factory/src/auth.ts
@@ -15,6 +15,7 @@ import { HTTPException } from 'hono/http-exception';
 
 import type { RouteAuth } from './routes/route.js';
 import { actorFromAuthUser } from './storage/domains/comments/actor.js';
+import { isFactoryTelemetryEnabled } from './telemetry.js';
 import { timedAboveThreshold } from './timing.js';
 
 const ORGANIZATION_ID_HEADER = 'X-Mastra-Organization-Id';
@@ -460,6 +461,7 @@ async function handleAuthMe(provider: IMastraAuthProvider, c: Context): Promise<
   await ensureUserOrg(provider, user);
   return c.json({
     authenticated: true,
+    telemetryEnabled: isFactoryTelemetryEnabled(provider.name),
     user: {
       userId: getFactoryAuthUserId(user),
       email: user.email,

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -58,6 +58,7 @@ import { createCustomProvidersPrimer, registerCustomProvidersSource } from './ro
 import { ProjectRoutes } from './routes/projects.js';
 import { assembleFactoryApiRoutes, buildIntegrationContext } from './routes/surface.js';
 import type { FactoryApiRoutesDeps } from './routes/surface.js';
+import { TelemetryRoutes } from './routes/telemetry.js';
 import {
   createTenantCredentialPrimer,
   primeTenantCredentials,
@@ -908,6 +909,7 @@ export class MastraFactory {
           // Hono app the deployer generates. `requiresAuth: false`; the gate
           // skips `/auth/*`.
           ...(auth ? buildAuthRoutes(auth, { publicUrl: publicOrigin }) : []),
+          ...new TelemetryRoutes({ auth: routeAuth, providerName: auth?.name, publicOrigin, allowedOrigins }).routes(),
           // Custom `/web/*` routes (fs / config / integrations / factory / audit).
           ...assembleFactoryApiRoutes({
             controllerId: CONTROLLER_ID,

--- a/mastracode/factory/src/routes/telemetry.test.ts
+++ b/mastracode/factory/src/routes/telemetry.test.ts
@@ -1,0 +1,208 @@
+import type { ApiRoute, IMastraAuthProvider } from '@mastra/core/server';
+import { Hono } from 'hono';
+import type { PostHog } from 'posthog-node';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildAuthRoutes } from '../auth.js';
+import type { FactoryAuthUser } from '../auth.js';
+import { TelemetryRoutes } from './telemetry.js';
+import { fakeRouteAuth, mountApiRoutes } from './test-utils.js';
+import type { TestAuthUser } from './test-utils.js';
+
+const { capture } = vi.hoisted(() => ({ capture: vi.fn<PostHog['capture']>() }));
+vi.mock('posthog-node', () => ({
+  PostHog: class {
+    capture = capture;
+  },
+}));
+
+const user = { workosId: 'user_123', organizationId: 'org_123' };
+const body = { activity: 'page_view', page: 'work' };
+
+function buildApp(options: { user?: TestAuthUser; enabled?: boolean; providerName?: string } = {}) {
+  const app = new Hono<{ Variables: { factoryAuthUser: TestAuthUser } }>();
+  app.use('*', async (c, next) => {
+    if (options.user) c.set('factoryAuthUser', options.user);
+    await next();
+  });
+  const routes = new TelemetryRoutes({
+    auth: fakeRouteAuth({ enabled: options.enabled }),
+    providerName: options.providerName ?? 'mastra-studio',
+    publicOrigin: 'http://localhost:4111',
+    allowedOrigins: ['http://localhost:5173'],
+  }).routes();
+  // The generic route-test helper mounts handlers; mount middleware as well so
+  // oversized requests exercise the same body limit as the production adapter.
+  for (const route of routes) {
+    if (route.middleware) app.use(route.path, ...[route.middleware].flat());
+  }
+  mountApiRoutes(app, routes);
+  return app;
+}
+
+function request(payload: unknown = body, headers: Record<string, string> = {}) {
+  return { method: 'POST', headers: { 'Content-Type': 'application/json', ...headers }, body: JSON.stringify(payload) };
+}
+
+beforeEach(() => {
+  capture.mockReset();
+  for (const name of [
+    'MASTRA_TELEMETRY_DISABLED',
+    'MASTRA_PROJECT_ID',
+    'MASTRA_DEPLOYMENT_ID',
+    'MASTRA_PLATFORM_REGION',
+  ]) {
+    vi.stubEnv(name, '');
+  }
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+});
+
+describe('Factory web activity', () => {
+  it('attributes hosted usage to the authenticated account and server metadata', async () => {
+    vi.stubEnv('MASTRA_PROJECT_ID', ' project_123 ');
+    vi.stubEnv('MASTRA_DEPLOYMENT_ID', ' deployment_123 ');
+    vi.stubEnv('MASTRA_PLATFORM_REGION', ' us-east ');
+    const response = await buildApp({ user }).request('/web/telemetry/activity', request());
+    expect(response.status).toBe(204);
+    expect(capture).toHaveBeenCalledExactlyOnceWith({
+      distinctId: 'factory:platform:user_123',
+      event: 'factory_web_activity',
+      properties: {
+        schema_version: 1,
+        activity: 'page_view',
+        page: 'work',
+        platform_user_id: 'user_123',
+        platform_org_id: 'org_123',
+        platform_hosted: true,
+        platform_project_id: 'project_123',
+        deployment_id: 'deployment_123',
+        platform_region: 'us-east',
+      },
+    });
+  });
+
+  it('does not mistake a platform-backed local server for platform hosting', async () => {
+    vi.stubEnv('MASTRA_PROJECT_ID', 'project_123');
+    vi.stubEnv('MASTRA_PLATFORM_REGION', 'us-east');
+    vi.stubEnv('MASTRA_DEPLOYMENT_ID', '  ');
+    await buildApp({ user }).request('/web/telemetry/activity', request());
+    expect(capture.mock.calls[0]?.[0].properties).toMatchObject({
+      platform_hosted: false,
+      platform_project_id: 'project_123',
+    });
+    expect(capture.mock.calls[0]?.[0].properties?.deployment_id).toBeUndefined();
+  });
+
+  it('keeps the same person across projects, organizations, and hosting locations', async () => {
+    await buildApp({ user }).request('/web/telemetry/activity', request());
+    vi.stubEnv('MASTRA_PROJECT_ID', 'other-project');
+    vi.stubEnv('MASTRA_DEPLOYMENT_ID', 'other-deployment');
+    await buildApp({ user: { ...user, organizationId: 'other-org' } }).request('/web/telemetry/activity', request());
+    await buildApp({ user: { ...user, workosId: 'other-user' } }).request('/web/telemetry/activity', request());
+    expect(capture.mock.calls.map(([event]) => event.distinctId)).toEqual([
+      'factory:platform:user_123',
+      'factory:platform:user_123',
+      'factory:platform:other-user',
+    ]);
+  });
+
+  it.each([{}, { user, enabled: false }])('rejects unauthenticated or no-auth usage (%j)', async options => {
+    expect((await buildApp(options).request('/web/telemetry/activity', request())).status).toBe(401);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it.each(['1', 'true', ' YES '])('honors the telemetry opt-out (%s)', async value => {
+    vi.stubEnv('MASTRA_TELEMETRY_DISABLED', value);
+    expect((await buildApp({ user }).request('/web/telemetry/activity', request())).status).toBe(204);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('does not merge custom-provider accounts with platform accounts', async () => {
+    await buildApp({ user, providerName: 'workos' }).request('/web/telemetry/activity', request());
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { ...body, userId: 'someone-else' },
+    { ...body, platform_project_id: 'forged' },
+    { ...body, orgId: 'forged' },
+    { ...body, factoryId: 'forged' },
+    { ...body, page: '/work?token=private' },
+    { ...body, activity: 'login' },
+  ])('rejects unknown properties and unbounded values (%j)', async payload => {
+    expect((await buildApp({ user }).request('/web/telemetry/activity', request(payload))).status).toBe(400);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversized, malformed, non-JSON, and foreign-origin requests', async () => {
+    const app = buildApp({ user });
+    expect((await app.request('/web/telemetry/activity', request({ ...body, extra: 'x'.repeat(600) }))).status).toBe(
+      413,
+    );
+    expect((await app.request('/web/telemetry/activity', { ...request(), body: '{' })).status).toBe(400);
+    expect((await app.request('/web/telemetry/activity', request(body, { 'Content-Type': 'text/plain' }))).status).toBe(
+      415,
+    );
+    expect(
+      (await app.request('/web/telemetry/activity', request(body, { Origin: 'https://other.example' }))).status,
+    ).toBe(403);
+    expect(capture).not.toHaveBeenCalled();
+    expect(
+      (await app.request('/web/telemetry/activity', request(body, { Origin: 'http://localhost:5173' }))).status,
+    ).toBe(204);
+    expect(capture).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds per-account captures and recovers after the rate window', async () => {
+    vi.useFakeTimers();
+    const app = buildApp({ user });
+    for (let i = 0; i < 65; i++) await app.request('/web/telemetry/activity', request());
+    expect(capture).toHaveBeenCalledTimes(60);
+    vi.advanceTimersByTime(60_000);
+    await app.request('/web/telemetry/activity', request());
+    expect(capture).toHaveBeenCalledTimes(61);
+  });
+
+  it('does not fail the endpoint when the analytics client fails', async () => {
+    capture.mockImplementationOnce(() => {
+      throw new Error('unavailable');
+    });
+    expect((await buildApp({ user }).request('/web/telemetry/activity', request())).status).toBe(204);
+  });
+});
+
+describe('authenticated telemetry capability', () => {
+  function authApp(providerName: string, authenticated = true) {
+    const provider: IMastraAuthProvider<FactoryAuthUser> = {
+      name: providerName,
+      authenticateToken: async () => (authenticated ? { id: 'user_123', organizationId: 'org_123' } : null),
+      authorizeUser: () => true,
+    };
+    const app = new Hono();
+    const routes: ApiRoute[] = buildAuthRoutes(provider);
+    mountApiRoutes(app, routes);
+    return app;
+  }
+
+  it('advertises capture only for signed-in platform accounts with telemetry enabled', async () => {
+    const app = authApp('mastra-studio');
+    expect(await (await app.request('/auth/me')).json()).toMatchObject({ authenticated: true, telemetryEnabled: true });
+    vi.stubEnv('MASTRA_TELEMETRY_DISABLED', 'true');
+    expect(await (await app.request('/auth/me')).json()).toMatchObject({
+      authenticated: true,
+      telemetryEnabled: false,
+    });
+  });
+
+  it('does not enable capture for custom providers or signed-out visitors', async () => {
+    expect(await (await authApp('workos').request('/auth/me')).json()).toMatchObject({ telemetryEnabled: false });
+    expect(await (await authApp('mastra-studio', false).request('/auth/me')).json()).toEqual({
+      authenticated: false,
+      user: null,
+      provider: 'mastra-studio',
+    });
+  });
+});

--- a/mastracode/factory/src/routes/telemetry.ts
+++ b/mastracode/factory/src/routes/telemetry.ts
@@ -1,0 +1,78 @@
+import { registerApiRoute } from '@mastra/core/server';
+import type { Context } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+import { z } from 'zod';
+
+import { FACTORY_WEB_PAGES } from '../telemetry-types.js';
+import { captureFactoryWebActivity, isFactoryTelemetryEnabled } from '../telemetry.js';
+import { Route } from './route.js';
+import type { RouteDependencies } from './route.js';
+
+const activitySchema = z
+  .object({
+    activity: z.enum(['page_view', 'interaction']),
+    page: z.enum(FACTORY_WEB_PAGES),
+  })
+  .strict();
+
+// Core bundles Hono declarations, so the same runtime Context has distinct
+// nominal request types across the package boundary (as in other route modules).
+function localContext(context: unknown): Context {
+  return context as Context;
+}
+
+interface TelemetryRoutesDeps extends RouteDependencies {
+  providerName?: string;
+  publicOrigin: string;
+  allowedOrigins: string[];
+}
+
+export class TelemetryRoutes extends Route<TelemetryRoutesDeps> {
+  private readonly budgets = new Map<string, { until: number; count: number }>();
+
+  routes() {
+    const limitBody = bodyLimit({ maxSize: 512 });
+    const origins = new Set([this.deps.publicOrigin, ...this.deps.allowedOrigins]);
+    return [
+      registerApiRoute('/web/telemetry/activity', {
+        method: 'POST',
+        middleware: (context, next) => limitBody(localContext(context), next),
+        handler: async context => {
+          const c = localContext(context);
+          if (!this.deps.auth.enabled()) return c.body(null, 401);
+          await this.deps.auth.ensureUser(c);
+          const actor = this.deps.auth.tenant(c);
+          if (!actor?.userId) return c.body(null, 401);
+          const origin = c.req.header('Origin');
+          if (origin && !origins.has(origin)) return c.body(null, 403);
+          if (c.req.header('Content-Type')?.split(';')[0]?.trim().toLowerCase() !== 'application/json') {
+            return c.body(null, 415);
+          }
+          const parsed = activitySchema.safeParse(await c.req.json().catch(() => undefined));
+          if (!parsed.success) return c.body(null, 400);
+          if (!isFactoryTelemetryEnabled(this.deps.providerName)) return c.body(null, 204);
+
+          // Bound capture rate and memory per process; this is not a distributed
+          // quota or a promise of exactly-once delivery.
+          const key = JSON.stringify([actor.orgId, actor.userId]);
+          const now = Date.now();
+          const previous = this.budgets.get(key);
+          if (previous && previous.until > now) {
+            if (previous.count >= 60) return c.body(null, 204);
+            previous.count += 1;
+          } else {
+            if (this.budgets.size >= 10_000) {
+              for (const [id, budget] of this.budgets) {
+                if (budget.until <= now) this.budgets.delete(id);
+              }
+              if (this.budgets.size >= 10_000) return c.body(null, 204);
+            }
+            this.budgets.set(key, { until: now + 60_000, count: 1 });
+          }
+          captureFactoryWebActivity(parsed.data, actor);
+          return c.body(null, 204);
+        },
+      }),
+    ];
+  }
+}

--- a/mastracode/factory/src/telemetry-types.ts
+++ b/mastracode/factory/src/telemetry-types.ts
@@ -1,0 +1,24 @@
+/** Browser-safe vocabulary: never send URLs, route parameters, or input contents. */
+export const FACTORY_WEB_PAGES = [
+  'onboarding',
+  'work',
+  'review',
+  'overview',
+  'attention',
+  'activity',
+  'rules',
+  'audit',
+  'knowledge',
+  'settings',
+  'slack_connection',
+  'workspace',
+  'thread',
+  'supervisor',
+  'new_session',
+  'new_factory',
+] as const;
+
+export interface FactoryWebActivity {
+  activity: 'page_view' | 'interaction';
+  page: (typeof FACTORY_WEB_PAGES)[number];
+}

--- a/mastracode/factory/src/telemetry.ts
+++ b/mastracode/factory/src/telemetry.ts
@@ -1,0 +1,52 @@
+import { PostHog } from 'posthog-node';
+
+import type { FactoryWebActivity } from './telemetry-types.js';
+
+let client: PostHog | undefined;
+
+/** Start with the default platform auth provider; custom identity authorities are separate work. */
+export function isFactoryTelemetryEnabled(providerName: string | undefined): boolean {
+  return (
+    providerName === 'mastra-studio' &&
+    !['1', 'true', 'yes'].includes(process.env.MASTRA_TELEMETRY_DISABLED?.trim().toLowerCase() ?? '')
+  );
+}
+
+function env(name: string): string | undefined {
+  return process.env[name]?.trim() || undefined;
+}
+
+/** Identity is resolved by the server. This never aliases existing CLI or platform profiles. */
+export function captureFactoryWebActivity(
+  activity: FactoryWebActivity,
+  actor: { userId: string; orgId?: string },
+): void {
+  if (!isFactoryTelemetryEnabled('mastra-studio')) return;
+  try {
+    const deploymentId = env('MASTRA_DEPLOYMENT_ID');
+    client ??= new PostHog('phc_SBLpZVAB6jmHOct9CABq3PF0Yn5FU3G2FgT4xUr2XrT', {
+      host: 'https://us.posthog.com',
+      flushAt: 1,
+      flushInterval: 0,
+      maxQueueSize: 100,
+      disableGeoip: true,
+    });
+    client.capture({
+      distinctId: `factory:platform:${actor.userId}`,
+      event: 'factory_web_activity',
+      properties: {
+        schema_version: 1,
+        activity: activity.activity,
+        page: activity.page,
+        platform_user_id: actor.userId,
+        platform_org_id: actor.orgId,
+        platform_hosted: Boolean(deploymentId),
+        platform_project_id: env('MASTRA_PROJECT_ID'),
+        deployment_id: deploymentId,
+        platform_region: env('MASTRA_PLATFORM_REGION'),
+      },
+    });
+  } catch {
+    // Analytics is best effort and must never interrupt Factory usage.
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2394,6 +2394,9 @@ importers:
       hono:
         specifier: 4.12.34
         version: 4.12.34
+      posthog-node:
+        specifier: ^5.46.1
+        version: 5.48.0(rxjs@7.8.2)
       zod:
         specifier: ^4.3.6
         version: 4.4.3


### PR DESCRIPTION
Factory currently has no authenticated web usage events, and a platform project ID alone cannot distinguish local servers from platform-hosted servers. This adds one `factory_web_activity` event for visible page views and throttled pointer/keyboard interactions. The authenticated server attaches account and organization IDs, `MASTRA_PROJECT_ID`, `MASTRA_DEPLOYMENT_ID`, and `MASTRA_PLATFORM_REGION`. Only a nonempty deployment ID marks the server as platform-hosted.

Collection respects `MASTRA_TELEMETRY_DISABLED`, skips hidden tabs, validates a small allowlisted payload, and keeps analytics failures separate from product actions. It sends no names, emails, prompts, input values, or raw URLs. This first version covers the default Mastra platform auth provider; custom auth identity and local-versus-other-self-hosted segmentation remain follow-up work.

Existing CLI/server events, person identities, and usage cursors remain unchanged, keeping #22067 independent. The new event uses a Factory-specific person namespace and explicit platform project attribution. Event documentation and release notes are included.

Validated both package typechecks, the production Factory UI/dependency build, 160 server tests, and 404 browser unit tests. The full browser MSW suite passed 854 tests and failed five: three reproduce on the unchanged base, and the remaining two pass on focused reruns on both branches. All new telemetry tests pass. Analytics was intercepted during testing; production ingestion has not been exercised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR helps the Factory team understand which pages people use and how they interact with them. It collects limited, non-sensitive activity data only for authenticated platform users and supports opt-out.

## What changed

- Added `factory_web_activity` telemetry for supported page views and throttled pointer or keyboard interactions.
- Added authenticated `POST /web/telemetry/activity` handling with:
  - Payload, origin, content-type, and request-size validation.
  - Per-user and organization rate limits.
  - Visibility checks and telemetry opt-in checks.
  - Failure isolation so analytics errors do not affect product actions.
- Added account, organization, project, deployment, and region metadata for platform-hosted servers.
- Added `MASTRA_TELEMETRY_DISABLED=true` support.
- Added browser-safe page and activity types with route normalization.
- Added Factory UI telemetry initialization and `/auth/me` capability reporting.
- Added documentation, release notes, server tests, browser tests, and telemetry route tests.

Existing CLI/server events, person identities, and usage cursors remain unchanged. Custom auth providers and local or self-hosted segmentation are not included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->