### PR TITLE
docs(connect): Mastra Platform integrations and @mastra/connect reference

### DIFF
--- a/docs/src/content/en/docs/mastra-platform/integrations.mdx
+++ b/docs/src/content/en/docs/mastra-platform/integrations.mdx
@@ -1,0 +1,121 @@
+---
+title: 'Integrations | Mastra platform'
+description: 'Connect third-party providers once in Mastra platform, then use those connections as agent toolsets with @mastra/connect. No provider credentials in your app.'
+packages:
+  - '@mastra/connect'
+---
+
+# Integrations
+
+Mastra platform integrations connect your project to third-party providers. You complete a provider's authorization flow once and the platform stores the connection. Your application then consumes supported provider toolsets through the `@mastra/connect` package.
+
+Your app never handles provider credentials. Every tool call is routed through the platform connection proxy, which injects credentials and refreshes tokens on your behalf.
+
+## Supported providers
+
+Provider toolsets are generated and released independently from the `@mastra/connect` runtime. `connect()` automatically loads the generated providers included in the installed package version, so adding a provider doesn't change the API.
+
+## Connect a provider
+
+Connect the provider from your project in the Mastra platform dashboard. OAuth providers open the provider's consent screen, while API-key providers accept the key directly. The resulting **connection** becomes available to your project.
+
+Multiple connections per provider are allowed. [`connect()`](/reference/connect/overview) resolves which connection to use at runtime, as described below.
+
+## Install
+
+```bash npm2yarn
+npm install @mastra/connect
+```
+
+## Use connections as agent toolsets
+
+### Discover connections at runtime
+
+[`connect()`](/reference/connect/overview) returns a live toolset resolver over your project's connections. Pass it straight to an agent's `tools` and Mastra calls it on every generate/stream. The resolver serves a cached view of the project's connections, revalidating in the background every 30 seconds by default (configurable with `ttlMs`):
+
+```typescript title="src/agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { connect } from '@mastra/connect'
+
+const agent = new Agent({
+  name: 'ops',
+  instructions: 'You manage our workspaces.',
+  model: 'openai/gpt-5-mini',
+  tools: connect(),
+})
+```
+
+`connect()` reads `MASTRA_PROJECT_ID` to know which project to list connections for. When a provider has exactly one active connection, it's used automatically. When a provider has several connections, pass the one you want through the `integrations` option, or set the provider's `MASTRA_<PROVIDER>_CONNECTION_ID` env var.
+
+When someone connects a new integration to the project in the platform dashboard, its tools become available to the running server within the TTL, with no restart or redeploy. Tools for a disconnected integration are dropped the same way.
+
+The resolver stays safe on a long-running server. If the platform is unreachable during a background refresh, it keeps serving the last good toolsets and warns. A provider that needs re-authentication or has ambiguous connections is skipped with a warning instead of failing the whole resolution. The same applies to an allowlisted provider that isn't connected yet. To force an immediate refresh right after connecting a provider, call `refresh()` or `invalidate()` on the resolver returned by `connect()`.
+
+To resolve toolsets on demand instead, call the resolver directly. The result is a plain record suitable for the `toolsets` option at generate time:
+
+```typescript title="src/generate.ts"
+import { connect } from '@mastra/connect'
+
+const tools = connect()
+
+const toolsets = await tools()
+
+const response = await agent.generate('Summarize my open issues.', { toolsets })
+```
+
+## Limit agent access
+
+The `integrations` option acts as an allowlist and can restrict a provider to specific tool keys. Unknown provider IDs and tool names throw immediately so configuration errors surface at startup.
+
+```typescript
+const tools = connect({
+  integrations: {
+    'provider-id': { allowTools: ['provider_action'] },
+  },
+})
+```
+
+Set `disabled: true` to exclude a provider. You can also set `connectionId` when the project has multiple active connections for the same provider.
+
+## Environment variables
+
+`@mastra/connect` reads these environment variables. Every one can also be passed explicitly through options, which always win.
+
+| Variable | Purpose |
+| - | - |
+| `MASTRA_PLATFORM_ACCESS_TOKEN` | Platform access token used to authenticate every request |
+| `MASTRA_PLATFORM_SECRET_KEY` | Fallback token when `MASTRA_PLATFORM_ACCESS_TOKEN` is unset |
+| `MASTRA_ORG_ID` | Organization id; sent as the `x-organization-id` header when set |
+| `MASTRA_PROJECT_ID` | Project id used by `connect()` to list connections |
+| `MASTRA_PLATFORM_REGION` | `us` or `eu`; selects the regional integrations endpoint |
+| `MASTRA_INTEGRATIONS_API_URL` | Explicit integrations service base URL; overrides region resolution |
+| `MASTRA_<PROVIDER>_CONNECTION_ID` | Connection ID fallback for a generated provider toolset |
+
+The default integrations endpoint is `https://integrations.mastra.ai`. Setting `MASTRA_PLATFORM_REGION` to `us` or `eu` selects `https://integrations.us.mastra.ai` or `https://integrations.eu.mastra.ai`.
+
+## Custom interactions with `credential()`
+
+For use cases the curated toolsets don't cover, such as driving a provider SDK or an MCP server, [`credential(connectionId)`](/reference/connect/credential) fetches the raw credential for a connection:
+
+```typescript
+import { credential } from '@mastra/connect'
+
+const cred = await credential('c_yourconnectionid')
+
+if (cred.type === 'oauth2') {
+  startMcpSession(cred.accessToken)
+} else {
+  startMcpSession(cred.apiKey)
+}
+```
+
+Handle returned credentials carefully. They grant direct access to the provider account and bypass the proxy's guardrails.
+
+## Access control
+
+In this release, access limiting is name-based: `allowTools` per toolset and the `integrations` allowlist on `connect()`. Wiring the platform's role-based access control into toolset resolution is planned as a follow-up.
+
+## Reference
+
+- [`connect()`](/reference/connect/overview)
+- [`credential()`](/reference/connect/credential)

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -755,6 +755,11 @@ const sidebars = {
     },
     {
       type: 'doc',
+      id: 'mastra-platform/integrations',
+      label: 'Integrations',
+    },
+    {
+      type: 'doc',
       id: 'mastra-platform/configuration',
       label: 'Configuration',
     },

--- a/docs/src/content/en/reference/connect/credential.mdx
+++ b/docs/src/content/en/reference/connect/credential.mdx
@@ -1,0 +1,69 @@
+---
+title: "Reference: credential() | Connect"
+description: "API reference for credential() in @mastra/connect: fetch the raw oauth2 or api_key credential for a platform connection."
+packages:
+  - "@mastra/connect"
+---
+
+# credential()
+
+Fetches the raw credential for a platform connection, for custom interactions the curated toolsets don't cover, such as driving a provider SDK or an MCP server.
+
+```typescript
+import { credential } from '@mastra/connect'
+
+const cred = await credential('c_yourconnectionid')
+
+if (cred.type === 'oauth2') {
+  startMcpSession(cred.accessToken)
+} else {
+  startMcpSession(cred.apiKey)
+}
+```
+
+Returns: `Promise<ConnectionCredential>`, a discriminated union:
+
+```typescript
+type ConnectionCredential =
+  | { type: 'oauth2'; accessToken: string; expiresAt: string | null }
+  | { type: 'api_key'; apiKey: string }
+```
+
+Most applications should prefer the [provider toolsets](/docs/mastra-platform/integrations#supported-providers) or [`connect()`](/reference/connect/overview), which keep credentials entirely on the platform.
+
+## Parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'connectionId',
+    type: 'string',
+    description: 'Id of the connection to fetch credentials for.',
+  },
+  {
+    name: 'options',
+    type: '{ client?: ConnectClientOptions }',
+    description:
+      'Optional platform client overrides (accessToken, orgId, baseUrl, fetch). See ConnectClientOptions in connect().',
+    isOptional: true,
+  },
+]}
+/>
+
+## Credential handling
+
+Returned credentials grant direct access to the provider account and bypass the proxy's guardrails. Don't log them or embed them in agent output. OAuth2 access tokens expire, so check `expiresAt` and re-fetch when needed.
+
+Connections that use credential types this function doesn't support (for example basic auth) throw `unsupported_credential_type`.
+
+## Errors
+
+Throws `MastraConnectError` with a `code` property:
+
+| Code | When |
+| - | - |
+| `missing_access_token` | No platform token configured |
+| `connection_not_found` | The connection doesn't exist or isn't accessible |
+| `unsupported_credential_type` | The connection's credential type can't be returned |
+| `unauthorized` | The platform rejected the token (401/403) |
+| `platform_error` | Any other platform request failure |

--- a/docs/src/content/en/reference/connect/overview.mdx
+++ b/docs/src/content/en/reference/connect/overview.mdx
@@ -1,0 +1,163 @@
+---
+title: 'Reference: connect() | Connect'
+description: "API reference for connect() in @mastra/connect: a live toolset resolver over a project's platform connections that picks up new connections without a restart."
+packages:
+  - '@mastra/connect'
+---
+
+# connect()
+
+Returns a live toolset resolver over the connections available to a Mastra platform project. Pass it to an agent's dynamic `tools` argument and Mastra calls it on every generate/stream. The resolver serves a cached snapshot of one toolset per connected provider and revalidates from the platform every `ttlMs`, so connections attached after startup are picked up without a restart.
+
+```typescript title="src/agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { connect } from '@mastra/connect'
+
+const agent = new Agent({
+  name: 'ops',
+  model: 'openai/gpt-5-mini',
+  tools: connect(),
+})
+```
+
+Returns: `ConnectTools`, a resolver producing `Record<string, ToolsInput>` keyed by the generated integration IDs shipped in the installed package version. See [The resolver](#the-resolver).
+
+See [Integrations](/docs/mastra-platform/integrations) for the concept overview.
+
+## Parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'options',
+    type: 'ConnectOptions',
+    description: 'Optional discovery and client configuration.',
+    isOptional: true,
+    properties: [
+      {
+        type: 'ConnectOptions',
+        parameters: [
+          {
+            name: 'projectId',
+            type: 'string',
+            description: 'Project to list connections for. Falls back to MASTRA_PROJECT_ID.',
+            isOptional: true,
+          },
+          {
+            name: 'integrations',
+            type: 'Record<string, ConnectIntegrationOptions>',
+            description: 'Provider allowlist and per-provider overrides. See Integrations allowlist below.',
+            isOptional: true,
+          },
+          {
+            name: 'ttlMs',
+            type: 'number',
+            description:
+              'How long a resolved snapshot stays fresh, in milliseconds. Default 30000. 0 revalidates on every resolution.',
+            isOptional: true,
+          },
+          {
+            name: 'client',
+            type: 'ConnectClientOptions',
+            description: 'Platform client overrides. See ConnectClientOptions below.',
+            isOptional: true,
+          },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+### ConnectClientOptions
+
+Every field falls back to an environment variable, so a fully env-configured app can pass nothing.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'accessToken',
+    type: 'string',
+    description: 'Platform access token. Falls back to MASTRA_PLATFORM_ACCESS_TOKEN, then MASTRA_PLATFORM_SECRET_KEY.',
+    isOptional: true,
+  },
+  {
+    name: 'orgId',
+    type: 'string',
+    description: 'Organization id. Falls back to MASTRA_ORG_ID; sent as the x-organization-id header when present.',
+    isOptional: true,
+  },
+  {
+    name: 'baseUrl',
+    type: 'string',
+    description:
+      'Integrations service base URL. Falls back to MASTRA_INTEGRATIONS_API_URL, then the regional default from MASTRA_PLATFORM_REGION (us or eu), then https://integrations.mastra.ai.',
+    isOptional: true,
+  },
+  {
+    name: 'fetch',
+    type: 'typeof globalThis.fetch',
+    description: 'Fetch implementation, for testing or custom transports. Defaults to globalThis.fetch.',
+    isOptional: true,
+  },
+]}
+/>
+
+## The resolver
+
+The returned `ConnectTools` resolver caches its toolset snapshot. Within `ttlMs` of the last fetch, resolutions return the cached snapshot. After that, the cached snapshot is served immediately while a background refresh runs (stale-while-revalidate). Connections attached to the project after startup become available within the TTL, and detached connections are dropped, with no restart or redeploy required.
+
+Call the resolver directly when you need a plain toolsets record, for example for an agent's `toolsets` option at generate time:
+
+```typescript title="src/generate.ts"
+import { connect } from '@mastra/connect'
+
+const tools = connect()
+
+const toolsets = await tools()
+
+const response = await agent.generate('Summarize my open issues.', { toolsets })
+```
+
+The resolver also exposes two methods for manual control:
+
+- `invalidate()` drops the cached snapshot so the next resolution fetches fresh.
+- `refresh()` fetches from the platform immediately, then updates the cache and returns the toolsets.
+
+Failure handling is tuned for long-running servers:
+
+- Configuration errors (missing project id or token, unknown `integrations` keys, invalid `ttlMs`) throw eagerly at `connect()` call time.
+- If a background refresh fails while a snapshot is cached, the resolver keeps serving the cached toolsets and warns. It rejects only when nothing was ever cached.
+
+## Integrations allowlist
+
+When `integrations` is provided, only listed providers are returned. Each value is an options object:
+
+- `connectionId` picks a specific connection.
+- `allowTools` restricts the toolset by tool key.
+- `disabled: true` excludes the provider.
+
+A listed provider with no connection in the project yet is skipped with a one-time warning and is included automatically once a connection is attached. Without `integrations`, every connected provider with a shipped toolset is included.
+
+## Connection resolution
+
+For each provider present in the project's connections:
+
+1. An explicit `connectionId` (option or the provider's `MASTRA_<PROVIDER>_CONNECTION_ID` env var) wins.
+1. Otherwise, a single active connection is used automatically.
+1. Otherwise the provider is ambiguous and is skipped with a `console.warn` listing the candidates.
+
+Connections in `needs_reauth` status are never silently mapped: they're skipped with a warning until reconnected on the platform. Connections whose integration has no toolset in this package are also skipped with a warning. Every per-provider failure during resolution is downgraded to a warning so a single bad integration never fails the whole resolution.
+
+## Errors
+
+Throws `MastraConnectError` with a `code` property:
+
+| Code | When |
+| - | - |
+| `missing_access_token` | No platform token configured |
+| `missing_project_id` | No `projectId` option or `MASTRA_PROJECT_ID` |
+| `invalid_options` | Invalid `ttlMs` |
+| `connection_not_found` | An unknown key in `integrations`, or a directed connection id 404s at tool execution |
+| `unauthorized` | The platform rejected the token (401/403) |
+| `platform_error` | Any other platform request failure |

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -198,6 +198,15 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'Connect',
+      collapsed: true,
+      items: [
+        { type: 'doc', id: 'connect/overview', label: 'connect()' },
+        { type: 'doc', id: 'connect/credential', label: 'credential()' },
+      ],
+    },
+    {
+      type: 'category',
       label: 'Core',
       collapsed: true,
       items: [


### PR DESCRIPTION
Docs for the upcoming `@mastra/connect` package, split out of #23087 so that PR stays code-only.

Adds three pages and their sidebar entries:
- `docs/mastra-platform/integrations` — how platform integrations work with agents
- `reference/connect/overview` — `connect()` API
- `reference/connect/credential` — `credential()` API

Provider-specific docs (per-provider tool tables, etc.) are intentionally not included — we're still deciding how to document generated providers without the docs drifting from the shipped registry.

Shouldn't merge before #23087 does. `pnpm --dir docs validate` passes (643 files, sidebars sorted).
