### PR TITLE
feat(factory): supervisor files work items on a person's behalf

### DIFF
--- a/.changeset/clean-months-shop.md
+++ b/.changeset/clean-months-shop.md
@@ -1,0 +1,13 @@
+---
+'@mastra/factory': patch
+---
+
+Added approval-free, audited `factory_create_work_item` for authenticated supervisor chat. Cards enter intake with the requesting person as creator and their brief as the first comment, including their display name and avatar when available.
+
+Ask the supervisor to file work, for example: "File a card titled Fix login, with the brief: Preserve the return URL when login succeeds." The supervisor can call:
+
+```json
+{ "title": "Fix login", "brief": "Preserve the return URL when login succeeds." }
+```
+
+The governed creation helper and its input/outcome types are available from `@mastra/factory/work-item-create`. `createFactoryWorkItem` shares the HTTP route's board-entry and preparation cleanup behavior; callers own their audit events.

--- a/mastracode/factory/README.md
+++ b/mastracode/factory/README.md
@@ -29,6 +29,14 @@ A host application calls `MastraFactory.prepare()`, constructs its `Mastra` inst
 
 `prepare()` initializes the Factory-owned resources needed before Mastra is constructed. `finalize()` connects those resources to the completed host, including Factory routes, integrations, storage-backed behavior, and agent-controller features. Consumers should keep frontend concerns in `factory-ui` and host-specific environment or deployment wiring in `web` rather than adding them to this package.
 
+### Supervisor tools
+
+In an authenticated supervisor chat, `factory_create_work_item({ title, brief })` files a card on the person's behalf without an approval prompt. The person is recorded as its creator, and the brief is the first feed comment with the person's display name and avatar when available. Each creation is audited. The supervisor checks for existing work before filing a duplicate.
+
+The card enters the Work board's initial phase through its lifecycle rules. With the default board, manual cards stay in intake until a person starts them. Asking the supervisor to start one uses the approval-gated `factory_transition_work_item` tool to move it to planning.
+
+The public `@mastra/factory/work-item-create` subpath exports `createFactoryWorkItem` and its input/outcome types for integrations that need the same governed creation flow as the HTTP route. Callers supply the board and initial phase, storage, transition service, and actor. An optional `beforeEntry` hook prepares the card before lifecycle entry. Preparation failure, rejected entry, or an unavailable transition service deletes the new card and its feed state. Source-key reuse does not re-enter the lifecycle. The helper does not audit; callers own their audit event.
+
 ### Board lifecycle rules
 
 Installed board definitions exclusively own phase entry and exit handlers. Work and Review are installed automatically with Mastra's preferred defaults; no rule configuration is needed. Custom boards declare source-specific `onEnter` and `onExit` handlers through `defineBoard()`:

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -1,6 +1,6 @@
 import type * as authStudioModule from '@mastra/auth-studio';
 import { AgentControllerChannels } from '@mastra/core/channels';
-import { RequestContext } from '@mastra/core/request-context';
+import { MASTRA_MESSAGE_AUTHOR_KEY, RequestContext } from '@mastra/core/request-context';
 import type { AuthInitContext, IMastraAuthProvider } from '@mastra/core/server';
 import type { MastraWorker } from '@mastra/core/worker';
 
@@ -21,6 +21,7 @@ import type * as terminalCleanupModule from './rules/terminal-cleanup.js';
 import type * as transitionServiceModule from './rules/transition-service.js';
 import { DEFAULT_FACTORY_CONFIG_VERSION } from './rules/validation.js';
 import { createFactorySecretEncryption } from './secret-encryption.js';
+import type { WorkItemCommentsStorage } from './storage/domains/comments/base.js';
 import type { MemorySettingsStorage } from './storage/domains/memory-settings/base.js';
 import type { FactoryProjectsStorage } from './storage/domains/projects/base.js';
 import type { SourceControlStorage } from './storage/domains/source-control/base.js';
@@ -547,6 +548,41 @@ describe('MastraFactory.prepare', () => {
     expect(paths).toContain('/auth/callback');
     expect(paths).toContain('/auth/logout');
     expect(paths).toContain('/auth/me');
+  });
+
+  it('registers creation only for authenticated supervisor turns and passes the message author snapshot', async () => {
+    const storage = fakeStorage();
+    const config = await prepareFactory({ storage });
+    const projects = storage.getDomain<FactoryProjectsStorage>('projects');
+    const project = await projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'Test factory' } });
+    const extraTools = config.extraTools as (args: { requestContext: RequestContext }) => Promise<Record<string, any>>;
+    const requestContext = new RequestContext();
+    requestContext.set('controller', {
+      resourceId: `factory-supervisor:${project.id}`,
+      threadId: 'supervisor-thread',
+      getState: () => ({}),
+    });
+    await expect(extraTools({ requestContext })).resolves.not.toHaveProperty('factory_create_work_item');
+    requestContext.set('user', { organizationId: 'org-1' });
+    await expect(extraTools({ requestContext })).resolves.not.toHaveProperty('factory_create_work_item');
+    requestContext.set('user', { workosId: 'user-1', organizationId: 'org-other' });
+    await expect(extraTools({ requestContext })).resolves.not.toHaveProperty('factory_create_work_item');
+    requestContext.set('user', { workosId: 'user-1', organizationId: 'org-1' });
+    requestContext.set(MASTRA_MESSAGE_AUTHOR_KEY, {
+      id: 'user-1',
+      name: 'Caleb Barnes',
+      avatarUrl: 'https://example.com/avatar.png',
+    });
+    const tools = await extraTools({ requestContext });
+    expect(tools.factory_create_work_item.requireApproval).toBe(false);
+    const result = await tools.factory_create_work_item.execute({ title: 'From supervisor', brief: 'A brief' }, {});
+    const comments = storage.getDomain<WorkItemCommentsStorage>('work-item-comments');
+    expect(
+      (await comments.list({ orgId: 'org-1', factoryProjectId: project.id, workItemId: result.workItemId })).comments[0]
+        ?.author,
+    ).toMatchObject({ id: 'user-1', displayName: 'Caleb Barnes', avatarUrl: 'https://example.com/avatar.png' });
+    requestContext.set('controller', { resourceId: 'worker-session', threadId: 'worker-thread', getState: () => ({}) });
+    await expect(extraTools({ requestContext })).resolves.not.toHaveProperty('factory_create_work_item');
   });
 
   it('registers the Factory transition tool only for exact active bindings', async () => {

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -835,7 +835,7 @@ export class MastraFactory {
                           scope: supervisorScope,
                           userId,
                           messageAuthor: requestContext?.get(MASTRA_MESSAGE_AUTHOR_KEY),
-                          email: getFactoryAuthUserFromContext(requestContext)?.email,
+                          authUser: getFactoryAuthUserFromContext(requestContext) ?? {},
                           boards: this.#boards,
                           workItems: workItemsStorage,
                           comments: workItemCommentsStorage,

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -26,6 +26,7 @@ import { AgentControllerChannels } from '@mastra/core/channels';
 import { EventEmitterPubSub } from '@mastra/core/events';
 import type { PubSub } from '@mastra/core/events';
 import type { Mastra } from '@mastra/core/mastra';
+import { MASTRA_MESSAGE_AUTHOR_KEY } from '@mastra/core/request-context';
 import type { RequestContext } from '@mastra/core/request-context';
 import { hasAuthInit, isUserProvider } from '@mastra/core/server';
 import type { IMastraAuthProvider } from '@mastra/core/server';
@@ -103,6 +104,7 @@ import { QueueHealthStorage } from './storage/domains/queue-health/base.js';
 import { SourceControlStorage } from './storage/domains/source-control/base.js';
 import { WorkItemsStorage } from './storage/domains/work-items/base.js';
 import type { WorkItemRow } from './storage/domains/work-items/base.js';
+import { createFactorySupervisorActionTools } from './supervisor/action-tools.js';
 import { FactorySupervisorHealthWorker } from './supervisor/health-worker.js';
 import { SUPERVISOR_INSTRUCTIONS } from './supervisor/instructions.js';
 import { createFactorySupervisorReadTools } from './supervisor/read-tools.js';
@@ -827,6 +829,20 @@ export class MastraFactory {
                       }),
                     );
                     if (userId) {
+                      mergeTools(
+                        'factory-supervisor-actions',
+                        createFactorySupervisorActionTools({
+                          scope: supervisorScope,
+                          userId,
+                          messageAuthor: requestContext?.get(MASTRA_MESSAGE_AUTHOR_KEY),
+                          email: getFactoryAuthUserFromContext(requestContext)?.email,
+                          boards: this.#boards,
+                          workItems: workItemsStorage,
+                          comments: workItemCommentsStorage,
+                          audit: auditStorage,
+                          transitionService,
+                        }),
+                      );
                       mergeTools(
                         'factory-supervisor-write',
                         createFactorySupervisorWriteTools({

--- a/mastracode/factory/src/routes/work-items.ts
+++ b/mastracode/factory/src/routes/work-items.ts
@@ -43,6 +43,7 @@ import {
   WorkItemUpdateConflictError,
 } from '../storage/domains/work-items/base.js';
 import { computeFactoryMetrics, parseMetricsRange } from '../storage/domains/work-items/metrics.js';
+import { createFactoryWorkItem } from '../work-item-create.js';
 import { buildAttentionRoutes, factoryDecisionType } from './attention.js';
 import { FACTORY_ROUTE_CONTRACTS } from './contracts.js';
 import type { RouteDependencies } from './route.js';
@@ -532,36 +533,24 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
 
           await workItems.ensureReady();
           try {
-            const result = await workItems.upsert({
+            const result = await createFactoryWorkItem({
+              workItems,
+              transitionService,
               orgId: resolved.orgId,
-              userId: resolved.userId,
               factoryProjectId: resolved.factoryProjectId,
+              userId: resolved.userId,
+              actor: { type: 'human', id: resolved.userId },
+              ingressType: 'human',
+              board: boardId,
+              stage: board.initialPhase,
               input: { ...input, board: boardId, stages: initialStages },
-              reuseMode: 'non-stage',
             });
-            let item = result.item;
-            if (result.created) {
-              if (!transitionService) {
-                await workItems.delete({ orgId: resolved.orgId, id: item.id });
-                return c.json({ error: 'factory_transitions_unavailable' }, 503);
-              }
-              const entered = await transitionService.transition({
-                orgId: resolved.orgId,
-                factoryProjectId: resolved.factoryProjectId,
-                workItemId: item.id,
-                board: boardId,
-                stage: board.initialPhase,
-                expectedRevision: item.revision,
-                actor: { type: 'human', id: resolved.userId },
-                ingress: { type: 'human', identity: `work-item:${item.id}:initial-entry` },
-                cause: 'work_item_created',
-                initialEntry: true,
-              });
-              if (entered.status === 'rejected') {
-                await workItems.delete({ orgId: resolved.orgId, id: item.id });
-                return c.json({ status: 'rejected', code: entered.code, reason: entered.reason }, 422);
-              }
-              item = (await workItems.getForProject(resolved.orgId, resolved.factoryProjectId, item.id)) ?? item;
+            if (result.status === 'unavailable') return c.json({ error: 'factory_transitions_unavailable' }, 503);
+            if (result.status === 'rejected') {
+              return c.json({ status: 'rejected', code: result.code, reason: result.reason }, 422);
+            }
+            const item = result.item;
+            if (result.status === 'created') {
               await audit.emit({
                 context: loose(c),
                 input: {

--- a/mastracode/factory/src/supervisor/action-tools.test.ts
+++ b/mastracode/factory/src/supervisor/action-tools.test.ts
@@ -15,7 +15,7 @@ async function setup() {
     boards: createBoardRegistry(),
     transitionService,
     messageAuthor: { id: 'user-1', name: 'Caleb Barnes', avatarUrl: 'https://example.com/avatar.png' },
-    email: 'caleb@example.com',
+    authUser: { email: 'caleb@example.com' },
   };
   return { ...seed, deps, transitionService };
 }
@@ -37,7 +37,7 @@ describe('factory_create_work_item', () => {
     const transition = vi.spyOn(transitionService, 'transition');
     const create = vi.spyOn(comments, 'create');
     const result = await execute(target);
-    expect(result).toMatchObject({ requestedBy: 'user-1', stages: ['intake'], briefPosted: true });
+    expect(result).toMatchObject({ requestedBy: 'user-1', stage: 'intake', briefCommentId: expect.any(String) });
     const item = await workItems.getForProject(scope.orgId, scope.factoryProjectId, result.workItemId);
     expect(item).toMatchObject({ createdBy: 'user-1' });
     expect(create.mock.invocationCallOrder[0]).toBeLessThan(transition.mock.invocationCallOrder[0]!);
@@ -53,7 +53,7 @@ describe('factory_create_work_item', () => {
       action: 'factory.work_item.created',
       actorId: 'user-1',
       actorType: 'human',
-      metadata: { cause: 'supervisor', requestedBy: 'user-1', briefPosted: true },
+      metadata: { cause: 'supervisor', requestedBy: 'user-1', briefCommentId: page.comments[0].id },
     });
   });
 
@@ -65,7 +65,22 @@ describe('factory_create_work_item', () => {
     );
   });
 
-  it.each(['comment', 'rejection', 'unavailable'] as const)(
+  it('falls back to the authenticated name and avatar when the message author is absent', async () => {
+    const { deps, comments } = await setup();
+    const result = await execute(
+      tool({
+        ...deps,
+        messageAuthor: undefined,
+        authUser: { name: 'Auth Person', avatarUrl: 'https://example.com/auth.png' },
+      }),
+    );
+    expect((await comments.list({ ...scope, workItemId: result.workItemId })).comments[0]?.author).toMatchObject({
+      displayName: 'Auth Person',
+      avatarUrl: 'https://example.com/auth.png',
+    });
+  });
+
+  it.each(['comment', 'rejection', 'unavailable', 'transition', 'reload', 'missing-row', 'audit'] as const)(
     'leaves no card, comment or audit on %s failure',
     async failure => {
       const { deps, workItems, comments, audit, transitionService } = await setup();
@@ -83,6 +98,11 @@ describe('factory_create_work_item', () => {
           code: 'invalid_stage',
           reason: 'Entry rejected',
         });
+      if (failure === 'transition')
+        vi.spyOn(transitionService, 'transition').mockRejectedValue(new Error('Transition failed'));
+      if (failure === 'reload') vi.spyOn(workItems, 'getForProject').mockRejectedValue(new Error('Reload failed'));
+      if (failure === 'missing-row') vi.spyOn(workItems, 'getForProject').mockResolvedValue(null);
+      if (failure === 'audit') vi.spyOn(audit, 'record').mockRejectedValue(new Error('Audit failed'));
       await expect(
         execute(tool({ ...deps, transitionService: failure === 'unavailable' ? undefined : transitionService })),
       ).rejects.toThrow();

--- a/mastracode/factory/src/supervisor/action-tools.test.ts
+++ b/mastracode/factory/src/supervisor/action-tools.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createBoardRegistry } from '../boards/index.js';
+import { FactoryTransitionService } from '../rules/transition-service.js';
+import { createFactoryStorageForTests } from '../storage/test-utils.js';
+import { createFactorySupervisorActionTools } from './action-tools.js';
+
+const scope = { orgId: 'org-1', factoryProjectId: '11111111-2222-4333-8444-555555555555' };
+async function setup() {
+  const seed = await createFactoryStorageForTests();
+  const transitionService = new FactoryTransitionService({ storage: seed.workItems, configVersion: 'rules-v1' });
+  const deps = {
+    ...seed,
+    scope,
+    userId: 'user-1',
+    boards: createBoardRegistry(),
+    transitionService,
+    messageAuthor: { id: 'user-1', name: 'Caleb Barnes', avatarUrl: 'https://example.com/avatar.png' },
+    email: 'caleb@example.com',
+  };
+  return { ...seed, deps, transitionService };
+}
+function tool(deps: Parameters<typeof createFactorySupervisorActionTools>[0]) {
+  return createFactorySupervisorActionTools(deps).factory_create_work_item;
+}
+function execute(target: unknown) {
+  return (target as { execute: (input: unknown, context: unknown) => Promise<{ workItemId: string }> }).execute(
+    { title: 'Test card', brief: 'The worker brief' },
+    {},
+  );
+}
+
+describe('factory_create_work_item', () => {
+  it('files for the person with their display snapshot before intake, approval-free and audited once', async () => {
+    const { deps, workItems, comments, audit, transitionService } = await setup();
+    const target = tool(deps);
+    expect(target.requireApproval).toBe(false);
+    const transition = vi.spyOn(transitionService, 'transition');
+    const create = vi.spyOn(comments, 'create');
+    const result = await execute(target);
+    expect(result).toMatchObject({ requestedBy: 'user-1', stages: ['intake'], briefPosted: true });
+    const item = await workItems.getForProject(scope.orgId, scope.factoryProjectId, result.workItemId);
+    expect(item).toMatchObject({ createdBy: 'user-1' });
+    expect(create.mock.invocationCallOrder[0]).toBeLessThan(transition.mock.invocationCallOrder[0]!);
+    const page = await comments.list({ ...scope, workItemId: result.workItemId });
+    expect(page.comments).toHaveLength(1);
+    expect(page.comments[0]).toMatchObject({
+      body: 'The worker brief',
+      author: { kind: 'user', id: 'user-1', displayName: 'Caleb Barnes', avatarUrl: 'https://example.com/avatar.png' },
+    });
+    const events = (await audit.list(scope)).events;
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      action: 'factory.work_item.created',
+      actorId: 'user-1',
+      actorType: 'human',
+      metadata: { cause: 'supervisor', requestedBy: 'user-1', briefPosted: true },
+    });
+  });
+
+  it('uses email as the display fallback', async () => {
+    const { deps, comments } = await setup();
+    const result = await execute(tool({ ...deps, messageAuthor: undefined }));
+    expect((await comments.list({ ...scope, workItemId: result.workItemId })).comments[0]?.author.displayName).toBe(
+      'caleb@example.com',
+    );
+  });
+
+  it.each(['comment', 'rejection', 'unavailable'] as const)(
+    'leaves no card, comment or audit on %s failure',
+    async failure => {
+      const { deps, workItems, comments, audit, transitionService } = await setup();
+      let workItemId = '';
+      const create = comments.create.bind(comments);
+      vi.spyOn(comments, 'create').mockImplementation(async input => {
+        workItemId = input.workItemId;
+        const comment = await create(input);
+        if (failure === 'comment') throw new Error('Comment persistence failed');
+        return comment;
+      });
+      if (failure === 'rejection')
+        vi.spyOn(transitionService, 'transition').mockResolvedValue({
+          status: 'rejected',
+          code: 'invalid_stage',
+          reason: 'Entry rejected',
+        });
+      await expect(
+        execute(tool({ ...deps, transitionService: failure === 'unavailable' ? undefined : transitionService })),
+      ).rejects.toThrow();
+      expect(workItemId).not.toBe('');
+      expect(await workItems.list(scope)).toEqual([]);
+      expect((await comments.list({ ...scope, workItemId })).comments).toEqual([]);
+      expect((await audit.list(scope)).events).toEqual([]);
+    },
+  );
+
+  it('accepts only title and brief with bounded lengths', async () => {
+    const { deps } = await setup();
+    const schema = tool(deps).inputSchema;
+    expect(schema?.safeParse({ title: 'test', brief: 'brief', stage: 'execute' }).success).toBe(false);
+    expect(schema?.safeParse({ title: ' ', brief: 'brief' }).success).toBe(false);
+    expect(schema?.safeParse({ title: 'x'.repeat(201), brief: 'brief' }).success).toBe(false);
+    expect(schema?.safeParse({ title: 'test', brief: '' }).success).toBe(false);
+    expect(schema?.safeParse({ title: 'test', brief: 'x'.repeat(4001) }).success).toBe(false);
+  });
+});

--- a/mastracode/factory/src/supervisor/action-tools.ts
+++ b/mastracode/factory/src/supervisor/action-tools.ts
@@ -1,0 +1,89 @@
+import type { MessageAuthor } from '@mastra/core/agent-controller';
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import type { BoardRegistry } from '../boards/index.js';
+import type { IntegrationTools } from '../integrations/base.js';
+import type { FactoryTransitionService } from '../rules/transition-service.js';
+import type { AuditStorage } from '../storage/domains/audit/base.js';
+import { actorFromAuthUser } from '../storage/domains/comments/actor.js';
+import type { WorkItemCommentsStorage } from '../storage/domains/comments/base.js';
+import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import { createFactoryWorkItem } from '../work-item-create.js';
+import type { SupervisorScope } from './read-tools.js';
+
+interface SupervisorActionDependencies {
+  scope: SupervisorScope;
+  userId: string;
+  messageAuthor?: MessageAuthor;
+  email?: string;
+  boards: BoardRegistry;
+  workItems: WorkItemsStorage;
+  comments: WorkItemCommentsStorage;
+  audit: AuditStorage;
+  transitionService?: Pick<FactoryTransitionService, 'transition'>;
+}
+
+export function createFactorySupervisorActionTools(deps: SupervisorActionDependencies): IntegrationTools {
+  return {
+    factory_create_work_item: createTool({
+      id: 'factory_create_work_item',
+      description:
+        'File a work item on behalf of the requesting person, with their brief as its first comment. No approval prompt. Check for an existing card or session covering the request first; point to it instead of filing a duplicate. Filing does not start a worker.',
+      inputSchema: z.object({ title: z.string().trim().min(1).max(200), brief: z.string().min(1).max(4000) }).strict(),
+      requireApproval: false,
+      execute: async ({ title, brief }) => {
+        const board = deps.boards.get('work');
+        if (!board) throw new Error('The work board is not installed.');
+        await deps.workItems.ensureReady();
+        const result = await createFactoryWorkItem({
+          ...deps.scope,
+          userId: deps.userId,
+          actor: { type: 'human', id: deps.userId },
+          ingressType: 'human',
+          board: board.id,
+          stage: board.initialPhase,
+          input: { title, board: board.id, stages: [board.initialPhase] },
+          workItems: deps.workItems,
+          transitionService: deps.transitionService,
+          beforeEntry: async item => {
+            await deps.comments.create({
+              ...deps.scope,
+              workItemId: item.id,
+              author: actorFromAuthUser(deps.userId, {
+                name: deps.messageAuthor?.name,
+                email: deps.email,
+                avatarUrl: deps.messageAuthor?.avatarUrl,
+              }),
+              body: brief,
+            });
+          },
+        });
+        if (result.status === 'unavailable') throw new Error('This factory cannot accept new work items right now.');
+        if (result.status === 'rejected') throw new Error(`Work item was not filed: ${result.reason}`);
+        const item = result.item;
+        await deps.audit.record({
+          ...deps.scope,
+          actorId: deps.userId,
+          actorType: 'human',
+          action: 'factory.work_item.created',
+          targets: [{ type: 'work_item', id: item.id, name: item.title }],
+          metadata: {
+            cause: 'supervisor',
+            title: item.title,
+            stages: item.stages,
+            requestedBy: deps.userId,
+            briefPosted: true,
+          },
+        });
+        return {
+          workItemId: item.id,
+          title: item.title,
+          stages: item.stages,
+          requestedBy: deps.userId,
+          briefPosted: true,
+        };
+      },
+    }),
+  };
+}

--- a/mastracode/factory/src/supervisor/action-tools.ts
+++ b/mastracode/factory/src/supervisor/action-tools.ts
@@ -16,7 +16,7 @@ interface SupervisorActionDependencies {
   scope: SupervisorScope;
   userId: string;
   messageAuthor?: MessageAuthor;
-  email?: string;
+  authUser: { name?: string; email?: string; avatarUrl?: string };
   boards: BoardRegistry;
   workItems: WorkItemsStorage;
   comments: WorkItemCommentsStorage;
@@ -30,59 +30,74 @@ export function createFactorySupervisorActionTools(deps: SupervisorActionDepende
       id: 'factory_create_work_item',
       description:
         'File a work item on behalf of the requesting person, with their brief as its first comment. No approval prompt. Check for an existing card or session covering the request first; point to it instead of filing a duplicate. Filing does not start a worker.',
-      inputSchema: z.object({ title: z.string().trim().min(1).max(200), brief: z.string().min(1).max(4000) }).strict(),
+      inputSchema: z
+        .object({ title: z.string().trim().min(1).max(200), brief: z.string().trim().min(1).max(4000) })
+        .strict(),
       requireApproval: false,
       execute: async ({ title, brief }) => {
         const board = deps.boards.get('work');
         if (!board) throw new Error('The work board is not installed.');
         await deps.workItems.ensureReady();
-        const result = await createFactoryWorkItem({
-          ...deps.scope,
-          userId: deps.userId,
-          actor: { type: 'human', id: deps.userId },
-          ingressType: 'human',
-          board: board.id,
-          stage: board.initialPhase,
-          input: { title, board: board.id, stages: [board.initialPhase] },
-          workItems: deps.workItems,
-          transitionService: deps.transitionService,
-          beforeEntry: async item => {
-            await deps.comments.create({
-              ...deps.scope,
-              workItemId: item.id,
-              author: actorFromAuthUser(deps.userId, {
-                name: deps.messageAuthor?.name,
-                email: deps.email,
-                avatarUrl: deps.messageAuthor?.avatarUrl,
-              }),
-              body: brief,
-            });
-          },
-        });
-        if (result.status === 'unavailable') throw new Error('This factory cannot accept new work items right now.');
-        if (result.status === 'rejected') throw new Error(`Work item was not filed: ${result.reason}`);
-        const item = result.item;
-        await deps.audit.record({
-          ...deps.scope,
-          actorId: deps.userId,
-          actorType: 'human',
-          action: 'factory.work_item.created',
-          targets: [{ type: 'work_item', id: item.id, name: item.title }],
-          metadata: {
-            cause: 'supervisor',
-            title: item.title,
-            stages: item.stages,
+        let workItemId: string | undefined;
+        let briefCommentId: string | undefined;
+        try {
+          const result = await createFactoryWorkItem({
+            ...deps.scope,
+            userId: deps.userId,
+            actor: { type: 'human', id: deps.userId },
+            ingressType: 'human',
+            board: board.id,
+            stage: board.initialPhase,
+            input: { title, board: board.id, stages: [board.initialPhase] },
+            workItems: deps.workItems,
+            transitionService: deps.transitionService,
+            beforeEntry: async item => {
+              workItemId = item.id;
+              const comment = await deps.comments.create({
+                ...deps.scope,
+                workItemId: item.id,
+                author: actorFromAuthUser(deps.userId, {
+                  name: deps.messageAuthor?.name ?? deps.authUser.name,
+                  email: deps.authUser.email,
+                  avatarUrl: deps.messageAuthor?.avatarUrl ?? deps.authUser.avatarUrl,
+                }),
+                body: brief,
+              });
+              briefCommentId = comment.id;
+            },
+          });
+          if (result.status === 'unavailable') throw new Error('This factory cannot accept new work items right now.');
+          if (result.status === 'rejected') throw new Error(`Work item was not filed: ${result.reason}`);
+          const item = await deps.workItems.getForProject(
+            deps.scope.orgId,
+            deps.scope.factoryProjectId,
+            result.item.id,
+          );
+          if (!item) throw new Error('The filed work item is no longer available.');
+          await deps.audit.record({
+            ...deps.scope,
+            actorId: deps.userId,
+            actorType: 'human',
+            action: 'factory.work_item.created',
+            targets: [{ type: 'work_item', id: item.id, name: item.title }],
+            metadata: {
+              cause: 'supervisor',
+              title: item.title,
+              stages: item.stages,
+              requestedBy: deps.userId,
+              briefCommentId,
+            },
+          });
+          return {
+            workItemId: item.id,
+            stage: board.initialPhase,
             requestedBy: deps.userId,
-            briefPosted: true,
-          },
-        });
-        return {
-          workItemId: item.id,
-          title: item.title,
-          stages: item.stages,
-          requestedBy: deps.userId,
-          briefPosted: true,
-        };
+            briefCommentId,
+          };
+        } catch (error) {
+          if (workItemId) await deps.workItems.delete({ orgId: deps.scope.orgId, id: workItemId });
+          throw error;
+        }
       },
     }),
   };

--- a/mastracode/factory/src/supervisor/instructions.test.ts
+++ b/mastracode/factory/src/supervisor/instructions.test.ts
@@ -1,0 +1,8 @@
+import { expect, it } from 'vitest';
+import { SUPERVISOR_INSTRUCTIONS } from './instructions.js';
+
+it('keeps manual filing separate from approval-gated worker startup', () => {
+  expect(SUPERVISOR_INSTRUCTIONS).toContain('do not leave intake on their own');
+  expect(SUPERVISOR_INSTRUCTIONS).toContain('factory_transition_work_item');
+  expect(SUPERVISOR_INSTRUCTIONS).toContain('existing card rather than creating a duplicate');
+});

--- a/mastracode/factory/src/supervisor/instructions.ts
+++ b/mastracode/factory/src/supervisor/instructions.ts
@@ -53,9 +53,22 @@ You have no repository and no sandbox. Everything you know comes from the
 
 ## Repairs
 
-Write tools require confirmation and are recorded against the person who
+Repair tools require confirmation and are recorded against the person who
 asked. Use the repair suggested by the health finding: retry or dismiss a
 decision, accept a held card, approve or dismiss a proposal, revoke an
 orphaned seat, signal a worker, or reconcile stale acceptance labels. Never
 claim a repair happened unless a tool result says it did.
+
+## Filing work
+
+When a person asks you to file work, first check the board and existing sessions
+for the same request. Point to an existing card rather than creating a duplicate.
+Use \`factory_create_work_item\` with a short title and the person's brief. It is
+approval-free and audited against the requesting person. The brief becomes the
+card's first feed comment. Do not implement the brief yourself.
+
+Manual cards do not leave intake on their own. Filing a card does not start its
+worker. When the person asks to start one, use \`factory_transition_work_item\`
+to move it to planning; that tool's approval prompt is the required confirmation.
+Do not claim that a manually filed card will advance automatically.
 `;

--- a/mastracode/factory/src/work-item-create.test.ts
+++ b/mastracode/factory/src/work-item-create.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { FactoryTransitionService } from './rules/transition-service.js';
+import { createFactoryStorageForTests } from './storage/test-utils.js';
+import { createFactoryWorkItem } from './work-item-create.js';
+import type { CreateFactoryWorkItemInput } from './work-item-create.js';
+
+const scope = { orgId: 'org-1', factoryProjectId: '11111111-2222-4333-8444-555555555555' };
+
+async function setup() {
+  const seed = await createFactoryStorageForTests();
+  const transitionService = new FactoryTransitionService({ storage: seed.workItems, configVersion: 'rules-v1' });
+  const input: CreateFactoryWorkItemInput = {
+    ...scope,
+    workItems: seed.workItems,
+    transitionService,
+    userId: 'user-1',
+    actor: { type: 'human', id: 'user-1' },
+    ingressType: 'human',
+    board: 'work',
+    stage: 'intake',
+    input: { title: 'A manual card', board: 'work', stages: ['intake'] },
+  };
+  return { seed, input, transitionService };
+}
+
+describe('createFactoryWorkItem', () => {
+  it('prepares the card before governed entry and returns the reloaded row without auditing', async () => {
+    const { seed, input, transitionService } = await setup();
+    const transition = vi.spyOn(transitionService, 'transition');
+    const reload = vi.spyOn(seed.workItems, 'getForProject');
+    const result = await createFactoryWorkItem({
+      ...input,
+      beforeEntry: async item => {
+        expect(transition).not.toHaveBeenCalled();
+        await seed.comments.create({
+          ...scope,
+          workItemId: item.id,
+          author: { kind: 'user', id: 'user-1' },
+          body: 'Brief',
+        });
+      },
+    });
+    expect(result.status).toBe('created');
+    if (result.status !== 'created') throw new Error('Expected creation');
+    expect(transition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...scope,
+        workItemId: result.item.id,
+        board: 'work',
+        stage: 'intake',
+        initialEntry: true,
+        cause: 'work_item_created',
+        ingress: { type: 'human', identity: `work-item:${result.item.id}:initial-entry` },
+      }),
+    );
+    expect(reload).toHaveBeenCalledWith(scope.orgId, scope.factoryProjectId, result.item.id);
+    expect(result.item).toEqual(
+      await seed.workItems.getForProject(scope.orgId, scope.factoryProjectId, result.item.id),
+    );
+    expect((await seed.audit.list(scope)).events).toEqual([]);
+  });
+
+  it.each(['preparation', 'rejection', 'unavailable'] as const)(
+    'deletes the card and its comment after %s failure',
+    async failure => {
+      const { seed, input, transitionService } = await setup();
+      let workItemId = '';
+      let commentId = '';
+      const transition = vi.spyOn(transitionService, 'transition');
+      if (failure === 'rejection')
+        transition.mockResolvedValue({ status: 'rejected', code: 'invalid_stage', reason: 'Rejected entry' });
+      const result = await createFactoryWorkItem({
+        ...input,
+        transitionService: failure === 'unavailable' ? undefined : transitionService,
+        beforeEntry: async item => {
+          workItemId = item.id;
+          const comment = await seed.comments.create({
+            ...scope,
+            workItemId,
+            author: { kind: 'user', id: 'user-1' },
+            body: 'Brief',
+          });
+          commentId = comment.id;
+          if (failure === 'preparation') throw new Error('Brief preparation failed');
+        },
+      });
+      expect(result.status).toBe(failure === 'unavailable' ? 'unavailable' : 'rejected');
+      expect(workItemId).not.toBe('');
+      expect(commentId).not.toBe('');
+      expect(await seed.workItems.getForProject(scope.orgId, scope.factoryProjectId, workItemId)).toBeNull();
+      expect(await seed.comments.get({ orgId: scope.orgId, commentId })).toBeNull();
+      expect((await seed.audit.list(scope)).events).toEqual([]);
+      if (failure !== 'rejection') expect(transition).not.toHaveBeenCalled();
+    },
+  );
+
+  it('reuses source-key matches without preparing or entering the card again', async () => {
+    const { input, transitionService } = await setup();
+    input.input.externalSource = { integrationId: 'github', type: 'issue', externalId: 'issue-1' };
+    const first = await createFactoryWorkItem(input);
+    expect(first.status).toBe('created');
+    const transition = vi.spyOn(transitionService, 'transition');
+    const beforeEntry = vi.fn();
+    const reused = await createFactoryWorkItem({
+      ...input,
+      input: { ...input.input, title: 'Updated title' },
+      beforeEntry,
+    });
+    expect(reused.status).toBe('reused');
+    if (reused.status !== 'reused' || first.status !== 'created') throw new Error('Expected reuse');
+    expect(reused.item.id).toBe(first.item.id);
+    expect(reused.item.title).toBe('Updated title');
+    expect(reused.previous).toBeDefined();
+    expect(transition).not.toHaveBeenCalled();
+    expect(beforeEntry).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/factory/src/work-item-create.ts
+++ b/mastracode/factory/src/work-item-create.ts
@@ -1,0 +1,100 @@
+/**
+ * The one way a new work item enters a factory: upsert the card, then walk it
+ * through the board's governed initial entry so the entry rules run.
+ * The HTTP route and the supervisor's `factory_create_work_item` both create
+ * through here; a card written any other way skips the lifecycle.
+ */
+
+import type { FactoryTransitionService } from './rules/transition-service.js';
+import type { FactoryRuleActor } from './rules/types.js';
+import type {
+  CreateWorkItemInput,
+  WorkItemPriorState,
+  WorkItemRow,
+  WorkItemsStorage,
+} from './storage/domains/work-items/base.js';
+
+export type CreateFactoryWorkItemOutcome =
+  | { status: 'created'; item: WorkItemRow }
+  /** The source key matched an existing card, which the input updated instead. */
+  | { status: 'reused'; item: WorkItemRow; previous: WorkItemPriorState }
+  /** Intake entry refused the card; it has been deleted again. */
+  | { status: 'rejected'; code: string; reason: string }
+  /** No transition service is mounted, so nothing can enter intake; the card has been deleted again. */
+  | { status: 'unavailable' };
+
+export interface CreateFactoryWorkItemInput {
+  workItems: Pick<WorkItemsStorage, 'upsert' | 'delete' | 'getForProject'>;
+  transitionService: Pick<FactoryTransitionService, 'transition'> | undefined;
+  orgId: string;
+  factoryProjectId: string;
+  /** Stamped as the card's creator (`created_by`, stage history). */
+  userId: string;
+  /** Who the initial-entry transition acts as. */
+  actor: FactoryRuleActor;
+  ingressType: 'human' | 'agent';
+  /** The board the card enters and that board's initial phase (already validated by the caller). */
+  board: string;
+  stage: string;
+  input: CreateWorkItemInput;
+  /**
+   * Runs once the card exists and before it enters intake, for anything the
+   * worker must find on the card the moment the lifecycle starts (a brief on
+   * the feed). If it throws, the card is deleted again and the outcome is
+   * `rejected`: a card never enters the lifecycle without its brief.
+   */
+  beforeEntry?: (item: WorkItemRow) => Promise<unknown>;
+}
+
+export async function createFactoryWorkItem({
+  workItems,
+  transitionService,
+  orgId,
+  factoryProjectId,
+  userId,
+  actor,
+  ingressType,
+  board,
+  stage,
+  input,
+  beforeEntry,
+}: CreateFactoryWorkItemInput): Promise<CreateFactoryWorkItemOutcome> {
+  const result = await workItems.upsert({ orgId, userId, factoryProjectId, input, reuseMode: 'non-stage' });
+  let item = result.item;
+  if (!result.created) return { status: 'reused', item, previous: result.previous };
+
+  if (beforeEntry) {
+    try {
+      await beforeEntry(item);
+    } catch (error) {
+      await workItems.delete({ orgId, id: item.id });
+      return {
+        status: 'rejected',
+        code: 'entry_preparation_failed',
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+  if (!transitionService) {
+    await workItems.delete({ orgId, id: item.id });
+    return { status: 'unavailable' };
+  }
+  const entered = await transitionService.transition({
+    orgId,
+    factoryProjectId,
+    workItemId: item.id,
+    board,
+    stage,
+    expectedRevision: item.revision,
+    actor,
+    ingress: { type: ingressType, identity: `work-item:${item.id}:initial-entry` },
+    cause: 'work_item_created',
+    initialEntry: true,
+  });
+  if (entered.status === 'rejected') {
+    await workItems.delete({ orgId, id: item.id });
+    return { status: 'rejected', code: entered.code, reason: entered.reason };
+  }
+  item = (await workItems.getForProject(orgId, factoryProjectId, item.id)) ?? item;
+  return { status: 'created', item };
+}


### PR DESCRIPTION
## Summary

Adds `factory_create_work_item({ title, brief })` to authenticated Factory supervisor chat. A person can ask the supervisor to file work without leaving the conversation. The card records that person as creator, and its first feed comment holds the brief with their display name and avatar when available.

Filing is approval-free because the person already asked for it. The creation audit records who requested the card and links the brief comment. Starting the worker remains a separate, approval-gated transition. The supervisor is instructed to check for existing work and not promise that manual intake cards advance automatically.

## Implementation

- Shares the HTTP route's governed creation flow through the new public `@mastra/factory/work-item-create` subpath (`createFactoryWorkItem` and its input/outcome types). The helper does not audit; callers own their audit events.
- Preserves HTTP board validation, response mapping, and created-versus-reused auditing.
- Posts the brief before lifecycle entry. The supervisor tool compensates failed preparation, transition, reload, and audit requests by deleting the new card and feed state. Storage cleanup failures remain loud errors.
- Registers the new tool only for a scoped authenticated supervisor turn, never an ordinary worker or unauthenticated turn.

## Try it

In an authenticated Factory supervisor chat:

> File a work item titled Fix login. Brief: Preserve the return URL when login succeeds. File it for the worker; do not implement it yourself.

Expect an intake card attributed to you with the brief as its first comment. Ask to start it to get the separate transition approval prompt.

## Test plan

- [x] 203 tests passed across supervisor, creation helper, HTTP work-item routes and Factory wiring. All 74 existing route tests unchanged.
- [x] Factory TypeScript check, lint, formatting and diff checks.
- [x] Real `mountAgentControllerOnMastra` harness with isolated agent storage and in-memory LibSQLFactoryStorage: resolves the production tool from the mounted agent, verifies creator/first-comment identity, intake, audit, approval flag, and comment-failure cleanup. Final verdict GREEN after the final commit.
- [x] Two adversarial review rounds. Product must-fixes addressed; proof README added. The harness invokes the registered tool directly, not a model-driven chat.

## Review focus

Auth gating and author fallback are in `factory.ts` and `supervisor/action-tools.ts`. Creation ordering and route preservation are in `work-item-create.ts` and `routes/work-items.ts`. Both tools and the public helper are documented in the Factory README. No Factory UI or core APIs changed.
