### PR TITLE
fix(playground): invalidate deleted experiment caches

### DIFF
--- a/packages/playground/src/domains/datasets/hooks/__tests__/fixtures/dataset-mutations.ts
+++ b/packages/playground/src/domains/datasets/hooks/__tests__/fixtures/dataset-mutations.ts
@@ -3,3 +3,7 @@ import type { RouteResponse } from '@mastra/client-js';
 export const successfulPurgeDatasetItemResponse = {
   success: true,
 } satisfies RouteResponse<'DELETE /datasets/:datasetId/items/:itemId/purge'>;
+
+export const successfulDeleteExperimentResponse = {
+  success: true,
+} satisfies RouteResponse<'DELETE /experiments/:experimentId'>;

--- a/packages/playground/src/domains/datasets/hooks/__tests__/use-dataset-mutations-delete-experiment.test.tsx
+++ b/packages/playground/src/domains/datasets/hooks/__tests__/use-dataset-mutations-delete-experiment.test.tsx
@@ -1,0 +1,59 @@
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { PropsWithChildren } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { useDatasetMutations } from '../use-dataset-mutations';
+import { successfulDeleteExperimentResponse } from './fixtures/dataset-mutations';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+const createTestHarness = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+
+  return { queryClient, wrapper };
+};
+
+describe('useDatasetMutations delete experiment', () => {
+  describe('when an experiment deletion succeeds', () => {
+    it('invalidates every cache that can reference the deleted experiment', async () => {
+      server.use(
+        http.delete(`${BASE_URL}/api/experiments/experiment-1`, () =>
+          HttpResponse.json(successfulDeleteExperimentResponse),
+        ),
+      );
+      const { queryClient, wrapper } = createTestHarness();
+      const affectedQueryKeys = [
+        ['experiments'],
+        ['dataset-experiments'],
+        ['dataset-experiment'],
+        ['dataset-experiment-results'],
+        ['review-items'],
+        ['completed-items'],
+        ['experiment-review-summary'],
+        ['inbox-dataset-review-items'],
+        ['inbox-dataset-review-count'],
+      ] as const;
+      for (const queryKey of affectedQueryKeys) {
+        queryClient.setQueryData(queryKey, { cached: true });
+      }
+
+      const { result } = renderHook(() => useDatasetMutations(), { wrapper });
+      await result.current.deleteExperiment.mutateAsync('experiment-1');
+
+      await waitFor(() => {
+        for (const queryKey of affectedQueryKeys) {
+          expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+        }
+      });
+    });
+  });
+});

--- a/packages/playground/src/domains/datasets/hooks/use-dataset-mutations.ts
+++ b/packages/playground/src/domains/datasets/hooks/use-dataset-mutations.ts
@@ -143,7 +143,13 @@ export const useDatasetMutations = () => {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['experiments'] });
       void queryClient.invalidateQueries({ queryKey: ['dataset-experiments'] });
+      void queryClient.invalidateQueries({ queryKey: ['dataset-experiment'] });
+      void queryClient.invalidateQueries({ queryKey: ['dataset-experiment-results'] });
+      void queryClient.invalidateQueries({ queryKey: ['review-items'] });
+      void queryClient.invalidateQueries({ queryKey: ['completed-items'] });
       void queryClient.invalidateQueries({ queryKey: ['experiment-review-summary'] });
+      void queryClient.invalidateQueries({ queryKey: ['inbox-dataset-review-items'] });
+      void queryClient.invalidateQueries({ queryKey: ['inbox-dataset-review-count'] });
     },
   });
 


### PR DESCRIPTION
Deleting an experiment now invalidates every Playground query cache that can still reference it. Previously, the mutation refreshed only the experiment lists and review summary, so experiment details, results, review queues, completed items, and inbox counts could remain stale.

Before:
```ts
invalidateQueries({ queryKey: ['dataset-experiments'] })
```

After:
```ts
invalidateQueries({ queryKey: ['dataset-experiment'] })
invalidateQueries({ queryKey: ['dataset-experiment-results'] })
invalidateQueries({ queryKey: ['review-items'] })
invalidateQueries({ queryKey: ['completed-items'] })
invalidateQueries({ queryKey: ['inbox-dataset-review-items'] })
invalidateQueries({ queryKey: ['inbox-dataset-review-count'] })
```

The new MSW-backed hook test exercises the real client and React Query mutation path and verifies that all affected caches are invalidated after a successful deletion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an experiment is deleted, the app now refreshes every related screen so users do not see old data. Tests confirm that the refresh works.

## Changes

- Invalidate experiment details, results, review items, completed items, inbox review items, and inbox review counts after deletion.
- Add an MSW-backed test for the deletion mutation and cache invalidation flow.
- Add a typed successful deletion response fixture for `DELETE /experiments/:experimentId`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->