### PR TITLE
feat(cli): add mastra env suggestions/diagnosis command

### DIFF
--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -921,6 +921,12 @@ async function runUnifiedDeploy(dir: string | undefined, opts: DeployOptions) {
     p.outro(`Deploy succeeded in ${elapsed(performance.now() - tTotal)}!`);
   } else if (finalStatus.status === 'failed') {
     p.log.error(`Deploy failed: ${finalStatus.error}`);
+    // Progressive discovery: point the user (or their agent) at the diagnosis
+    // command so they can pull suggestions without hunting for the flag.
+    // The failed-deploy webhook has already inserted a PENDING diagnosis row,
+    // so `mastra env diagnosis <id>` returns "in progress" immediately rather
+    // than 404-ing while the agent runs.
+    p.log.info(`Run \`mastra env diagnosis ${deployResult.id}\` for suggestions.`);
     process.exit(1);
   } else {
     p.log.warning(`Deploy ended with status: ${finalStatus.status}`);

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -15,6 +15,7 @@ import { mkdir, rm, stat, access, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import * as p from '@clack/prompts';
+import { coreFeatures } from '@mastra/core/features';
 import { analyzeEntryProjectType } from '@mastra/deployer/build';
 import { ZipArchive } from 'archiver';
 import pc from 'picocolors';
@@ -921,12 +922,14 @@ async function runUnifiedDeploy(dir: string | undefined, opts: DeployOptions) {
     p.outro(`Deploy succeeded in ${elapsed(performance.now() - tTotal)}!`);
   } else if (finalStatus.status === 'failed') {
     p.log.error(`Deploy failed: ${finalStatus.error}`);
-    // Progressive discovery: point the user (or their agent) at the diagnosis
-    // command so they can pull suggestions without hunting for the flag.
-    // The failed-deploy webhook has already inserted a PENDING diagnosis row,
-    // so `mastra env diagnosis <id>` returns "in progress" immediately rather
-    // than 404-ing while the agent runs.
-    p.log.info(`Run \`mastra env diagnosis ${deployResult.id}\` for suggestions.`);
+    // Progressive discovery: only hint at `mastra env diagnosis` when the
+    // command is actually registered (same feature gate as index.ts). The
+    // failed-deploy webhook has already inserted a PENDING diagnosis row,
+    // so the command returns "in progress" immediately rather than 404-ing
+    // while the agent runs.
+    if (coreFeatures.has('deploy-diagnosis')) {
+      p.log.info(`Run \`mastra env diagnosis ${deployResult.id}\` for suggestions.`);
+    }
     process.exit(1);
   } else {
     p.log.warning(`Deploy ended with status: ${finalStatus.status}`);

--- a/packages/cli/src/commands/dev/DevBundler.test.ts
+++ b/packages/cli/src/commands/dev/DevBundler.test.ts
@@ -20,6 +20,7 @@ vi.mock('commander', () => {
     action: any;
     argument: any;
     command: any;
+    alias: any;
     description: any;
     option: any;
     requiredOption: any;
@@ -33,6 +34,7 @@ vi.mock('commander', () => {
       this.action = vi.fn().mockReturnThis();
       this.argument = vi.fn().mockReturnThis();
       this.command = vi.fn().mockReturnThis();
+      this.alias = vi.fn().mockReturnThis();
       this.description = vi.fn().mockReturnThis();
       this.option = vi.fn().mockReturnThis();
       this.requiredOption = vi.fn().mockReturnThis();

--- a/packages/cli/src/commands/env/deploy-suggestions.test.ts
+++ b/packages/cli/src/commands/env/deploy-suggestions.test.ts
@@ -140,6 +140,38 @@ describe('envSuggestionsAction', () => {
     expect(mockStartEnvironmentDeployDiagnosis).toHaveBeenCalledWith('t', 'o', 'proj-1', 'env-1', 'dep-1');
   });
 
+  it('reports the diagnosis error and exits when diagnosis status is FAILED', async () => {
+    mockFetchEnvironments.mockResolvedValue([{ id: 'env-1', name: 'production', slug: 'production' }]);
+    mockFetchEnvironmentDeploys.mockResolvedValue([{ id: 'dep-1', environmentId: 'env-1', createdAt: '2025-06-01' }]);
+    mockFetchEnvironmentDeployDiagnosis.mockResolvedValue({
+      state: 'ready',
+      diagnosis: {
+        id: 'diag-1',
+        deployId: 'dep-1',
+        status: 'FAILED',
+        summary: null,
+        recommendations: [],
+        error: 'agent timed out',
+        createdAt: '2025-06-01T00:00:00Z',
+        completedAt: '2025-06-01T00:00:05Z',
+      },
+    });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    const { envSuggestionsAction } = await import('./deploy-suggestions.js');
+    await expect(envSuggestionsAction('dep-1', { environment: 'production' })).rejects.toThrow('exit:1');
+
+    const errorMsg = String(mockLogError.mock.calls[0]?.[0] ?? '');
+    expect(errorMsg).toContain('agent timed out');
+    const stepMsg = String(mockLogStep.mock.calls[0]?.[0] ?? '');
+    expect(stepMsg).toContain('projects.mastra.ai');
+    expect(stepMsg).toContain('dep-1');
+
+    mockExit.mockRestore();
+  });
+
   it('exits with error when the environment cannot be found', async () => {
     mockFetchEnvironments.mockResolvedValue([{ id: 'env-1', name: 'production', slug: 'production' }]);
     const mockExit = vi.spyOn(process, 'exit').mockImplementation(((code?: string | number | null) => {

--- a/packages/cli/src/commands/env/deploy-suggestions.test.ts
+++ b/packages/cli/src/commands/env/deploy-suggestions.test.ts
@@ -1,0 +1,155 @@
+import process from 'node:process';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetToken = vi.fn();
+const mockResolveCurrentOrg = vi.fn();
+const mockResolveProject = vi.fn();
+const mockFetchEnvironments = vi.fn();
+const mockFetchEnvironmentDeploys = vi.fn();
+const mockFetchEnvironmentDeployDiagnosis = vi.fn();
+const mockStartEnvironmentDeployDiagnosis = vi.fn();
+const mockIntro = vi.fn();
+const mockOutro = vi.fn();
+const mockLogError = vi.fn();
+const mockLogInfo = vi.fn();
+const mockLogStep = vi.fn();
+const mockLogMessage = vi.fn();
+const mockLogWarn = vi.fn();
+
+vi.mock('../auth/credentials.js', () => ({
+  getToken: (...args: unknown[]) => mockGetToken(...args),
+}));
+
+vi.mock('../auth/orgs.js', () => ({
+  resolveCurrentOrg: (...args: unknown[]) => mockResolveCurrentOrg(...args),
+}));
+
+vi.mock('../auth/client.js', () => ({
+  MASTRA_PLATFORM_API_URL: 'https://platform.mastra.ai',
+}));
+
+vi.mock('./resolve-project.js', () => ({
+  resolveProject: (...args: unknown[]) => mockResolveProject(...args),
+}));
+
+vi.mock('./platform-api.js', () => ({
+  fetchEnvironments: (...args: unknown[]) => mockFetchEnvironments(...args),
+  fetchEnvironmentDeploys: (...args: unknown[]) => mockFetchEnvironmentDeploys(...args),
+  fetchEnvironmentDeployDiagnosis: (...args: unknown[]) => mockFetchEnvironmentDeployDiagnosis(...args),
+  startEnvironmentDeployDiagnosis: (...args: unknown[]) => mockStartEnvironmentDeployDiagnosis(...args),
+}));
+
+vi.mock('../deploy-suggestions.js', async () => {
+  const actual = await vi.importActual<typeof import('../deploy-suggestions.js')>('../deploy-suggestions.js');
+  return {
+    ...actual,
+    pollForDiagnosis: async (fetchOnce: () => Promise<unknown>) => fetchOnce(),
+  };
+});
+
+vi.mock('@clack/prompts', () => ({
+  intro: (...args: unknown[]) => mockIntro(...args),
+  outro: (...args: unknown[]) => mockOutro(...args),
+  spinner: () => ({ start: vi.fn(), stop: vi.fn() }),
+  log: {
+    error: (...args: unknown[]) => mockLogError(...args),
+    info: (...args: unknown[]) => mockLogInfo(...args),
+    step: (...args: unknown[]) => mockLogStep(...args),
+    message: (...args: unknown[]) => mockLogMessage(...args),
+    warn: (...args: unknown[]) => mockLogWarn(...args),
+  },
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.resetAllMocks();
+  mockGetToken.mockResolvedValue('t');
+  mockResolveCurrentOrg.mockResolvedValue({ orgId: 'o' });
+  mockResolveProject.mockResolvedValue({ id: 'proj-1', name: 'App' });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('envSuggestionsAction', () => {
+  it('reports when deploy is already healthy', async () => {
+    mockFetchEnvironments.mockResolvedValue([{ id: 'env-1', name: 'production', slug: 'production' }]);
+    mockFetchEnvironmentDeploys.mockResolvedValue([{ id: 'dep-1', environmentId: 'env-1', createdAt: '2025-06-01' }]);
+    mockFetchEnvironmentDeployDiagnosis.mockResolvedValue({ state: 'healthy' });
+
+    const { envSuggestionsAction } = await import('./deploy-suggestions.js');
+    await envSuggestionsAction('dep-1', { environment: 'production' });
+
+    expect(mockOutro).toHaveBeenCalledWith('Deploy is running successfully. No suggestions required.');
+  });
+
+  it('prints suggestions when diagnosis is ready', async () => {
+    mockFetchEnvironments.mockResolvedValue([{ id: 'env-1', name: 'production', slug: 'production' }]);
+    mockFetchEnvironmentDeploys.mockResolvedValue([{ id: 'dep-1', environmentId: 'env-1', createdAt: '2025-06-01' }]);
+    mockFetchEnvironmentDeployDiagnosis.mockResolvedValue({
+      state: 'ready',
+      diagnosis: {
+        id: 'diag-1',
+        deployId: 'dep-1',
+        status: 'COMPLETE',
+        summary: 'Missing API key.',
+        recommendations: [
+          {
+            title: 'Set API_KEY',
+            description: 'The deployment could not find API_KEY.',
+            action: 'Set API_KEY and redeploy.',
+            docsUrl: 'https://mastra.ai/docs/env',
+          },
+        ],
+        error: null,
+        createdAt: '2025-06-01T00:00:00Z',
+        completedAt: '2025-06-01T00:00:05Z',
+      },
+    });
+
+    const { envSuggestionsAction } = await import('./deploy-suggestions.js');
+    await envSuggestionsAction('dep-1', { environment: 'production' });
+
+    const messages = mockLogMessage.mock.calls.map(c => String(c[0])).join('\n');
+    expect(messages).toContain('Deploy Suggestions');
+    expect(messages).toContain('Set API_KEY');
+  });
+
+  it('starts a diagnosis when none exists yet', async () => {
+    mockFetchEnvironments.mockResolvedValue([{ id: 'env-1', name: 'production', slug: 'production' }]);
+    mockFetchEnvironmentDeploys.mockResolvedValue([{ id: 'dep-1', environmentId: 'env-1', createdAt: '2025-06-01' }]);
+    mockFetchEnvironmentDeployDiagnosis.mockResolvedValueOnce({ state: 'missing' }).mockResolvedValueOnce({
+      state: 'ready',
+      diagnosis: {
+        id: 'diag-1',
+        deployId: 'dep-1',
+        status: 'COMPLETE',
+        summary: 'x',
+        recommendations: [],
+        error: null,
+        createdAt: '2025-06-01T00:00:00Z',
+        completedAt: '2025-06-01T00:00:05Z',
+      },
+    });
+
+    const { envSuggestionsAction } = await import('./deploy-suggestions.js');
+    await envSuggestionsAction('dep-1', { environment: 'production' });
+
+    expect(mockStartEnvironmentDeployDiagnosis).toHaveBeenCalledWith('t', 'o', 'proj-1', 'env-1', 'dep-1');
+  });
+
+  it('exits with error when the environment cannot be found', async () => {
+    mockFetchEnvironments.mockResolvedValue([{ id: 'env-1', name: 'production', slug: 'production' }]);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    const { envSuggestionsAction } = await import('./deploy-suggestions.js');
+    await expect(envSuggestionsAction('dep-1', { environment: 'staging' })).rejects.toThrow('exit:1');
+    expect(mockLogError).toHaveBeenCalled();
+
+    mockExit.mockRestore();
+  });
+});

--- a/packages/cli/src/commands/env/deploy-suggestions.ts
+++ b/packages/cli/src/commands/env/deploy-suggestions.ts
@@ -1,0 +1,161 @@
+import * as p from '@clack/prompts';
+
+import { getToken } from '../auth/credentials.js';
+import { resolveCurrentOrg } from '../auth/orgs.js';
+import { pollForDiagnosis, printDeploySuggestions } from '../deploy-suggestions.js';
+import type { Environment, EnvironmentDeploy } from './platform-api.js';
+import {
+  fetchEnvironmentDeployDiagnosis,
+  fetchEnvironmentDeploys,
+  fetchEnvironments,
+  startEnvironmentDeployDiagnosis,
+} from './platform-api.js';
+import { resolveProject } from './resolve-project.js';
+
+interface SuggestionsOptions {
+  project?: string;
+  environment?: string;
+}
+
+interface ResolvedTarget {
+  projectId: string;
+  projectName: string;
+  envId: string;
+  envSlug: string;
+  deployId: string;
+}
+
+function findEnvironment(environments: Environment[], envArg: string): Environment | undefined {
+  return environments.find((e) => e.id === envArg || e.name === envArg || e.slug === envArg);
+}
+
+function pickLatestDeployForEnv(deploys: EnvironmentDeploy[], envId: string): EnvironmentDeploy | undefined {
+  const forEnv = deploys.filter((d) => d.environmentId === envId);
+  const sorted = [...forEnv].sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''));
+  return sorted[0];
+}
+
+async function resolveTarget(
+  token: string,
+  orgId: string,
+  options: SuggestionsOptions,
+  deployId?: string,
+): Promise<ResolvedTarget> {
+  const project = await resolveProject(token, orgId, options.project);
+
+  // When a deploy id is supplied, we still need its environment for the URL.
+  // Fetch all deploys once and look it up.
+  if (deployId) {
+    const deploys = await fetchEnvironmentDeploys(token, orgId, project.id);
+    const deploy = deploys.find((d) => d.id === deployId);
+    if (!deploy) {
+      throw new Error(`Deploy not found in project ${project.name}: ${deployId}`);
+    }
+    return {
+      projectId: project.id,
+      projectName: project.name,
+      envId: deploy.environmentId,
+      envSlug: deploy.environmentSlug,
+      deployId,
+    };
+  }
+
+  // No deploy id: resolve environment (flag or lone environment on project),
+  // then pick its latest deploy.
+  const environments = await fetchEnvironments(token, orgId, project.id);
+  if (environments.length === 0) {
+    throw new Error(
+      `No environments found for project ${project.name}. Deploy first with \`mastra deploy\`, then rerun \`mastra env suggestions\`.`,
+    );
+  }
+
+  let environment: Environment | undefined;
+  if (options.environment) {
+    environment = findEnvironment(environments, options.environment);
+    if (!environment) {
+      throw new Error(`Environment not found: ${options.environment}`);
+    }
+  } else if (environments.length === 1) {
+    environment = environments[0]!;
+  } else {
+    const slugs = environments.map((e) => e.slug).join(', ');
+    throw new Error(
+      `Project ${project.name} has multiple environments (${slugs}). Pass --environment <name|slug|id> or a deploy id.`,
+    );
+  }
+
+  const deploys = await fetchEnvironmentDeploys(token, orgId, project.id);
+  const latest = pickLatestDeployForEnv(deploys, environment.id);
+  if (!latest) {
+    throw new Error(
+      `No deploys found for environment ${environment.slug} in project ${project.name}. The suggestions command helps debug failed deployments; run it after a deployment fails with \`mastra env suggestions <deploy-id>\` or \`mastra env suggestions --environment ${environment.slug}\`.`,
+    );
+  }
+
+  p.log.info(`Using latest deploy for ${environment.slug}: ${latest.id}`);
+
+  return {
+    projectId: project.id,
+    projectName: project.name,
+    envId: environment.id,
+    envSlug: environment.slug,
+    deployId: latest.id,
+  };
+}
+
+function buildLogsUrl(orgId: string, projectId: string, envId: string, deployId: string): string {
+  return `https://projects.mastra.ai/orgs/${orgId}/projects/${projectId}/environments/${envId}/deploys/${deployId}`;
+}
+
+export async function envSuggestionsAction(deployId: string | undefined, opts: SuggestionsOptions = {}) {
+  p.intro('mastra env suggestions');
+  try {
+    const token = await getToken();
+    const { orgId } = await resolveCurrentOrg(token);
+
+    const target = await resolveTarget(token, orgId, opts, deployId);
+
+    const initial = await fetchEnvironmentDeployDiagnosis(token, orgId, target.projectId, target.envId, target.deployId);
+    if (initial.state === 'healthy') {
+      p.outro('Deploy is running successfully. No suggestions required.');
+      return;
+    }
+
+    if (initial.state === 'missing') {
+      // No diagnosis row yet — kick one off. The API is idempotent; when the
+      // platform's own failure hook has already inserted a PENDING row this
+      // is a no-op.
+      await startEnvironmentDeployDiagnosis(token, orgId, target.projectId, target.envId, target.deployId);
+      p.log.info('Diagnosis in progress...');
+    } else if (initial.diagnosis.status === 'PENDING') {
+      p.log.info('Diagnosis in progress...');
+    }
+
+    let firstPoll = initial.state === 'ready';
+    const result = await pollForDiagnosis(async () => {
+      if (firstPoll) {
+        firstPoll = false;
+        return initial;
+      }
+      return fetchEnvironmentDeployDiagnosis(token, orgId, target.projectId, target.envId, target.deployId);
+    });
+
+    if (result.state !== 'ready') {
+      p.outro('Deploy is running successfully. No suggestions required.');
+      return;
+    }
+
+    const logsUrl = buildLogsUrl(orgId, target.projectId, target.envId, target.deployId);
+
+    if (result.diagnosis.status === 'FAILED') {
+      p.log.error(`Diagnosis failed: ${result.diagnosis.error ?? 'unknown error'}`);
+      p.log.step(`Deploy logs: ${logsUrl}`);
+      process.exit(1);
+    }
+
+    printDeploySuggestions(target.deployId, result.diagnosis, { logsUrl });
+  } catch (err) {
+    p.log.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/commands/env/deploy-suggestions.ts
+++ b/packages/cli/src/commands/env/deploy-suggestions.ts
@@ -1,5 +1,6 @@
 import * as p from '@clack/prompts';
 
+import { MASTRA_PLATFORM_API_URL } from '../auth/client.js';
 import { getToken } from '../auth/credentials.js';
 import { resolveCurrentOrg } from '../auth/orgs.js';
 import { pollForDiagnosis, printDeploySuggestions } from '../deploy-suggestions.js';
@@ -104,7 +105,12 @@ async function resolveTarget(
 }
 
 function buildLogsUrl(orgId: string, projectId: string, envId: string, deployId: string): string {
-  return `https://projects.mastra.ai/orgs/${orgId}/projects/${projectId}/environments/${envId}/deploys/${deployId}`;
+  // Mirror derivePublicUrls() in deploy/index.ts: pick the staging dashboard
+  // host when the platform API is staging so users don't get sent to a prod
+  // link that doesn't contain their deploy.
+  const isStaging = MASTRA_PLATFORM_API_URL.includes('staging');
+  const host = isStaging ? 'https://projects.staging.mastra.ai' : 'https://projects.mastra.ai';
+  return `${host}/orgs/${orgId}/projects/${projectId}/environments/${envId}/deploys/${deployId}`;
 }
 
 export async function envSuggestionsAction(deployId: string | undefined, opts: SuggestionsOptions = {}) {

--- a/packages/cli/src/commands/env/deploy-suggestions.ts
+++ b/packages/cli/src/commands/env/deploy-suggestions.ts
@@ -27,11 +27,11 @@ interface ResolvedTarget {
 }
 
 function findEnvironment(environments: Environment[], envArg: string): Environment | undefined {
-  return environments.find((e) => e.id === envArg || e.name === envArg || e.slug === envArg);
+  return environments.find(e => e.id === envArg || e.name === envArg || e.slug === envArg);
 }
 
 function pickLatestDeployForEnv(deploys: EnvironmentDeploy[], envId: string): EnvironmentDeploy | undefined {
-  const forEnv = deploys.filter((d) => d.environmentId === envId);
+  const forEnv = deploys.filter(d => d.environmentId === envId);
   const sorted = [...forEnv].sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''));
   return sorted[0];
 }
@@ -48,7 +48,7 @@ async function resolveTarget(
   // Fetch all deploys once and look it up.
   if (deployId) {
     const deploys = await fetchEnvironmentDeploys(token, orgId, project.id);
-    const deploy = deploys.find((d) => d.id === deployId);
+    const deploy = deploys.find(d => d.id === deployId);
     if (!deploy) {
       throw new Error(`Deploy not found in project ${project.name}: ${deployId}`);
     }
@@ -79,7 +79,7 @@ async function resolveTarget(
   } else if (environments.length === 1) {
     environment = environments[0]!;
   } else {
-    const slugs = environments.map((e) => e.slug).join(', ');
+    const slugs = environments.map(e => e.slug).join(', ');
     throw new Error(
       `Project ${project.name} has multiple environments (${slugs}). Pass --environment <name|slug|id> or a deploy id.`,
     );
@@ -121,7 +121,13 @@ export async function envSuggestionsAction(deployId: string | undefined, opts: S
 
     const target = await resolveTarget(token, orgId, opts, deployId);
 
-    const initial = await fetchEnvironmentDeployDiagnosis(token, orgId, target.projectId, target.envId, target.deployId);
+    const initial = await fetchEnvironmentDeployDiagnosis(
+      token,
+      orgId,
+      target.projectId,
+      target.envId,
+      target.deployId,
+    );
     if (initial.state === 'healthy') {
       p.outro('Deploy is running successfully. No suggestions required.');
       return;

--- a/packages/cli/src/commands/env/deploy-suggestions.ts
+++ b/packages/cli/src/commands/env/deploy-suggestions.ts
@@ -4,6 +4,7 @@ import { MASTRA_PLATFORM_API_URL } from '../auth/client.js';
 import { getToken } from '../auth/credentials.js';
 import { resolveCurrentOrg } from '../auth/orgs.js';
 import { pollForDiagnosis, printDeploySuggestions } from '../deploy-suggestions.js';
+import { serverSuggestionsAction } from '../server/deploy-suggestions.js';
 import type { Environment, EnvironmentDeploy } from './platform-api.js';
 import {
   fetchEnvironmentDeployDiagnosis,
@@ -114,6 +115,15 @@ function buildLogsUrl(orgId: string, projectId: string, envId: string, deployId:
 }
 
 export async function envSuggestionsAction(deployId: string | undefined, opts: SuggestionsOptions = {}) {
+  // Bare deploy id with no project context: delegate to the flat
+  // server-diagnosis endpoint, which server-side dual-looks-up across the
+  // server and environment deploy tables and doesn't need project/env in the
+  // URL. Keeps `mastra env diagnosis <id>` working without a linked project.
+  if (deployId && !opts.project && !opts.environment && !process.env.MASTRA_PROJECT_ID) {
+    await serverSuggestionsAction(deployId, { org: undefined });
+    return;
+  }
+
   p.intro('mastra env suggestions');
   try {
     const token = await getToken();

--- a/packages/cli/src/commands/env/platform-api.ts
+++ b/packages/cli/src/commands/env/platform-api.ts
@@ -1,4 +1,5 @@
 import { extractApiErrorDetail, throwApiError } from '../auth/client.js';
+import type { DeployDiagnosis, DeployDiagnosisLookup } from '../deploy-suggestions.js';
 
 export interface Project {
   id: string;
@@ -178,6 +179,73 @@ export async function deleteEnvironment(token: string, orgId: string, projectId:
     const err = await resp.json().catch(() => ({}));
     throwApiError('Failed to delete environment', resp.status, extractApiErrorDetail(err));
   }
+}
+
+/**
+ * Look up an existing diagnosis for a failed environment deploy.
+ *
+ * - 204: deploy has not failed; nothing to diagnose ({ state: 'healthy' })
+ * - 200 with `{ diagnosis: null }`: no diagnosis row yet ({ state: 'missing' })
+ * - 200 with `{ diagnosis: … }`: diagnosis exists ({ state: 'ready', diagnosis })
+ *
+ * The diagnosis may still be PENDING — callers should poll via
+ * `pollForDiagnosis`.
+ */
+export async function fetchEnvironmentDeployDiagnosis(
+  token: string,
+  orgId: string,
+  projectId: string,
+  envId: string,
+  deployId: string,
+): Promise<DeployDiagnosisLookup> {
+  const resp = await fetch(
+    `${getApiUrl()}/v1/projects/${projectId}/environments/${envId}/deploys/${deployId}/diagnosis`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'x-organization-id': orgId,
+      },
+    },
+  );
+
+  if (resp.status === 204) return { state: 'healthy' };
+
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({}));
+    throwApiError('Failed to fetch deploy diagnosis', resp.status, extractApiErrorDetail(err));
+  }
+
+  const data = (await resp.json()) as { diagnosis: DeployDiagnosis | null };
+  if (!data.diagnosis) return { state: 'missing' };
+  return { state: 'ready', diagnosis: data.diagnosis };
+}
+
+/**
+ * Kick off a diagnosis run for a failed environment deploy. Idempotent:
+ * the API returns 304 if a non-failed diagnosis already exists.
+ */
+export async function startEnvironmentDeployDiagnosis(
+  token: string,
+  orgId: string,
+  projectId: string,
+  envId: string,
+  deployId: string,
+): Promise<void> {
+  const resp = await fetch(
+    `${getApiUrl()}/v1/projects/${projectId}/environments/${envId}/deploys/${deployId}/diagnosis`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'x-organization-id': orgId,
+      },
+    },
+  );
+
+  if (resp.status === 304 || resp.ok) return;
+
+  const err = await resp.json().catch(() => ({}));
+  throwApiError('Failed to start deploy diagnosis', resp.status, extractApiErrorDetail(err));
 }
 
 function getApiUrl(): string {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,6 +25,7 @@ import { whoamiAction } from './commands/auth/whoami';
 import { configureCreateCommand } from './commands/create/create';
 import { registerEnvDbCommands } from './commands/db/index.js';
 import { unifiedDeployAction } from './commands/deploy/index.js';
+import { envSuggestionsAction } from './commands/env/deploy-suggestions.js';
 import { registerEnvCommands } from './commands/env/index.js';
 import { buildExperimentWorker } from './commands/experiment/build';
 import { COMPONENTS, LLMProvider } from './commands/init/utils';
@@ -310,6 +311,7 @@ deployCommand
 if (coreFeatures.has('deploy-diagnosis')) {
   deployCommand
     .command('suggestions [deploy-id]')
+    .alias('diagnosis')
     .description('Show deploy suggestions for a failed deploy')
     .action(wrapAction(suggestionsAction));
 }
@@ -368,6 +370,16 @@ const envCommand = registerEnvCommands(program);
 // Databases: mastra env db ...
 registerEnvDbCommands(envCommand);
 
+if (coreFeatures.has('deploy-diagnosis')) {
+  envCommand
+    .command('suggestions [deploy-id]')
+    .alias('diagnosis')
+    .description('Show deploy suggestions for a failed environment deploy')
+    .option('--project <project>', 'Project name, slug, or ID (default: linked project)')
+    .option('--environment <name>', 'Environment name, slug, or ID (default: only env, or required when >1)')
+    .action(wrapAction(envSuggestionsAction));
+}
+
 // ---- Server commands ----
 
 const serverCommand = program.command('server').description('Manage Mastra Server deployments');
@@ -388,6 +400,7 @@ const serverDeployCommand = serverCommand
 if (coreFeatures.has('deploy-diagnosis')) {
   serverDeployCommand
     .command('suggestions [deploy-id]')
+    .alias('diagnosis')
     .description('Show deploy suggestions for a failed deploy')
     .option('--org <id>', 'Organization ID')
     .action(wrapAction(serverSuggestionsAction));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -251,7 +251,7 @@ program
 
 // ---- Unified deploy command (new entry point) ----
 
-program
+const unifiedDeployCommand = program
   .command('deploy [dir]')
   .description('Deploy your Mastra application to an environment')
   .option('--env <name>', 'Target environment (default: production)', 'production')
@@ -265,6 +265,18 @@ program
   .option('--region <region>', 'Region for new environments (e.g., us, eu)')
   .option('--debug', 'Enable debug logs', false)
   .action(wrapAction(unifiedDeployAction));
+
+// `mastra deploy diagnosis <id>` handles bare deploy ids by reusing the
+// server-diagnosis endpoint, which server-side dual-looks-up across server
+// and environment deploy tables. No project/env context required.
+if (coreFeatures.has('deploy-diagnosis')) {
+  unifiedDeployCommand
+    .command('suggestions [deploy-id]')
+    .alias('diagnosis')
+    .description('Show deploy suggestions for a failed deploy')
+    .option('--org <id>', 'Organization ID')
+    .action(wrapAction(serverSuggestionsAction));
+}
 
 // ---- Studio commands ----
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -251,7 +251,7 @@ program
 
 // ---- Unified deploy command (new entry point) ----
 
-const unifiedDeployCommand = program
+program
   .command('deploy [dir]')
   .description('Deploy your Mastra application to an environment')
   .option('--env <name>', 'Target environment (default: production)', 'production')
@@ -265,18 +265,6 @@ const unifiedDeployCommand = program
   .option('--region <region>', 'Region for new environments (e.g., us, eu)')
   .option('--debug', 'Enable debug logs', false)
   .action(wrapAction(unifiedDeployAction));
-
-// `mastra deploy diagnosis <id>` handles bare deploy ids by reusing the
-// server-diagnosis endpoint, which server-side dual-looks-up across server
-// and environment deploy tables. No project/env context required.
-if (coreFeatures.has('deploy-diagnosis')) {
-  unifiedDeployCommand
-    .command('suggestions [deploy-id]')
-    .alias('diagnosis')
-    .description('Show deploy suggestions for a failed deploy')
-    .option('--org <id>', 'Organization ID')
-    .action(wrapAction(serverSuggestionsAction));
-}
 
 // ---- Studio commands ----
 


### PR DESCRIPTION
## Summary

Adds a first-class diagnosis command for unified-runtime env deploys, and wires progressive discovery into the failed-deploy CLI output so users (and agents) don't have to hunt for it.

## What's new

- **`mastra env suggestions [deploy-id]`** — new command, with `diagnosis` as an alias.
  - `--project <name|slug|id>` — falls back to the linked project.
  - `--environment <name|slug|id>` — auto-selected when the project has a single env.
  - With no `[deploy-id]`, picks the latest deploy for the resolved environment.
  - With a `[deploy-id]`, looks up its environment for you.
  - Uses the same `pollForDiagnosis` + `printDeploySuggestions` helpers as the legacy server/studio commands, so output and polling behavior are consistent.
- **`diagnosis` alias on legacy commands** for parity:
  - `mastra server deploy diagnosis` (alias of `... suggestions`)
  - `mastra studio deploy diagnosis` (alias of `... suggestions`)
- **Progressive discovery on `mastra deploy` (unified env path)** — on failure the CLI now prints:
  ```
  Run `mastra env diagnosis <deploy-id>` for suggestions.
  ```
  right after the `Deploy failed: ...` error line.

## Why CLI-side (not platform log)

The platform's failed-deploy webhook already inserts a `PENDING` diagnosis row immediately when a deploy fails, so following the hint always returns "in progress" — never a 404 — while the diagnosis agent runs.

The hint lives in the CLI, not in the archived deploy log, because:

- The CLI version that just ran the failing deploy is guaranteed to be the version that supports the hint it prints. Older CLIs streaming logs would otherwise see a command they don't recognize.
- If the command is ever renamed or re-flagged, we don't want stale command syntax stuck in GCS log archives.
- Studio / web log viewers should surface their own "See suggestions" affordance instead of leaning on CLI-shaped text.

## Test plan

- `pnpm --filter ./packages/cli typecheck` — clean.
- `pnpm build:cli` — clean.
- `pnpm --filter ./packages/cli test` — 1120/1120 pass, including new env deploy-suggestions test coverage and the updated `DevBundler.test.ts` commander mock (added `.alias`).
- Manual: `mastra env diagnosis <id>` resolves project + env, hits `GET /v1/projects/:pid/environments/:eid/deploys/:did/diagnosis`, starts a diagnosis via `POST` when none exists, and polls to completion using the shared state machine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a command that checks a deployment for environment problems and suggests possible fixes. It also adds aliases and error hints to make diagnosis easier.

## Changes

- Added feature-gated `mastra env suggestions [deploy-id]`.
- Added `diagnosis` as an alias.
- Added project and environment options.
- Resolves projects, environments, and deploys from flags, linked configuration, or deploy metadata.
- Selects the latest deploy when no deploy ID is provided.
- Added APIs to fetch and start deploy diagnosis.
- Reuses existing diagnosis polling and output helpers.
- Added `diagnosis` aliases to legacy server and studio suggestion commands.
- Failed unified `mastra deploy` executions show a diagnosis hint when `deploy-diagnosis` is enabled.
- Updated CLI mocks for command aliases.
- Added unit tests for healthy deployments, ready diagnoses, diagnosis creation, polling, failed diagnoses, and missing environments.
- Added CLI typecheck, build, automated test coverage, and manual verification for diagnosis lookup, creation, and polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->