### PR TITLE
fix(pg): last-N memory reads use the thread/createdAt index

### DIFF
--- a/.changeset/pg-list-messages-index-limit.md
+++ b/.changeset/pg-list-messages-index-limit.md
@@ -1,0 +1,6 @@
+---
+'@mastra/pg': patch
+'@mastra/core': patch
+---
+
+Last-N memory reads on PostgresStore use the thread/createdAt index instead of scanning every message in the thread. The agent MessageHistory processor skips the unused total count. Studio and other callers that still need `total` get it from a skinny `COUNT(*)` in the same round-trip.

--- a/.changeset/pg-list-messages-index-limit.md
+++ b/.changeset/pg-list-messages-index-limit.md
@@ -3,4 +3,4 @@
 '@mastra/core': patch
 ---
 
-Last-N memory reads on PostgresStore use the thread/createdAt index instead of scanning every message in the thread. The agent MessageHistory processor skips the unused total count. Studio and other callers that still need `total` get it from a skinny `COUNT(*)` in the same round-trip.
+Improved recent-message reads on Postgres so they can stop after the requested page instead of scanning the whole thread. Agent history skips the unused total; callers that still need a total get it in the same round-trip.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4579,6 +4579,9 @@ export class Agent<
       threadConfig: memoryConfig,
       // The new user messages aren't in the list yet cause we add memory messages first to try to make sure ordering is correct (memory comes before new user messages)
       vectorSearchString: threadConfig.semanticRecall && vectorMessageSearch ? vectorMessageSearch : undefined,
+      // This path only returns `messages`. Counting the thread is unused work
+      // that, on PostgresStore, forces a full-thread scan on every turn.
+      includeTotal: false,
     });
   }
 

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -213,6 +213,7 @@ describe('MessageHistory', () => {
       }
 
       expect(listMessages).toHaveBeenCalledTimes(1);
+      expect(listMessages).toHaveBeenCalledWith(expect.objectContaining({ includeTotal: false }));
     });
 
     it('should merge historical messages with new messages', async () => {

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -133,6 +133,7 @@ export class MessageHistory implements Processor {
           page: 0,
           perPage: this.lastMessages,
           orderBy: { field: 'createdAt', direction: 'DESC' },
+          includeTotal: false,
         });
         return result.messages;
       };

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -113,6 +113,14 @@ type StorageListMessagesOptions = {
     metadata?: StorageMetadataFilter;
   };
   orderBy?: StorageOrderBy<'createdAt'>;
+  /**
+   * When false, skip counting every matching row. `total` is then the size of
+   * the returned page (`offset + messages.length`), not the thread. `hasMore`
+   * is still accurate (the store peeks one extra row). Defaults to true.
+   * MessageHistory on the agent path passes false because it only consumes
+   * `messages`.
+   */
+  includeTotal?: boolean;
 };
 
 /**

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -591,6 +591,7 @@ export class Memory extends MastraMemory {
       vectorSearchString,
       includeSystemReminders,
       filter,
+      includeTotal,
     } = args;
     const config = this.getMergedThreadConfig(threadConfig || {});
     const semanticRecallEnabled = Boolean(config.semanticRecall);
@@ -736,6 +737,7 @@ export class Memory extends MastraMemory {
         page,
         orderBy: effectiveOrderBy,
         filter,
+        includeTotal,
         ...(filteredVectorResults?.length
           ? {
               include: filteredVectorResults.map(r => ({

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1849,6 +1849,7 @@ ${workingMemory}`;
           resourceId,
           orderBy: { field: 'createdAt', direction: 'DESC' },
           perPage: typeof lastMessages === 'number' ? lastMessages : undefined,
+          includeTotal: false,
         });
         messages = result.messages.reverse(); // DESC → chronological order
       }
@@ -2437,6 +2438,7 @@ Notes:
         resourceId,
         perPage: SUMMARIZE_THREAD_DEFAULTS.pageSize,
         page,
+        includeTotal: false,
       });
       if (batch.length === 0) break;
 

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -1030,14 +1030,19 @@ export class MemoryPG extends MemoryStorage {
   }
 
   /**
-   * Reads one page of messages together with the total row count.
+   * Reads one page of messages, optionally with the total row count, in one
+   * round-trip.
    *
-   * `COUNT(*) OVER ()` reports the count over the whole WHERE result on the same
-   * statement as the page, so the page costs one database round-trip instead of
-   * two. The page and the count also come from one snapshot, so the count always
-   * describes the returned rows. A separate `COUNT(*)` runs only when the page is
-   * empty and the caller asked for a page after the last row, because a window
-   * function has no row to carry the count on.
+   * `COUNT(*) OVER ()` on the full SELECT list made Postgres heap-fetch
+   * `content` for every matching row before applying LIMIT, so the default
+   * `(thread_id, createdAt)` index could not stop after N rows. A nested LIMIT
+   * plus a skinny `COUNT(*)` keeps one statement and one pool connection while
+   * letting the index serve the page. Callers that only consume `messages`
+   * pass `includeTotal: false` and skip the count.
+   *
+   * A separate `COUNT(*)` runs only when the page is empty and the caller
+   * asked for a page after the last row, because an empty inner SELECT has no
+   * row to carry the count on.
    */
   async #fetchMessagePage({
     selectStatement,
@@ -1048,6 +1053,7 @@ export class MemoryPG extends MemoryStorage {
     perPageInput,
     perPage,
     offset,
+    includeTotal = true,
   }: {
     selectStatement: string;
     tableName: string;
@@ -1057,29 +1063,55 @@ export class MemoryPG extends MemoryStorage {
     perPageInput: number | false | undefined;
     perPage: number;
     offset: number;
-  }): Promise<{ total: number; messages: MessageRowFromDB[] }> {
-    // `perPageInput === false` means "every row", so no LIMIT is applied.
-    const limitClause =
-      perPageInput === false ? '' : ` LIMIT $${queryParams.length + 1} OFFSET $${queryParams.length + 2}`;
-    const dataParams = perPageInput === false ? queryParams : [...queryParams, perPage, offset];
+    includeTotal?: boolean;
+  }): Promise<{ total: number; messages: MessageRowFromDB[]; hasMore?: boolean }> {
+    // `perPageInput === false` means "every row", so no LIMIT is applied and
+    // the returned length is the total.
+    if (perPageInput === false) {
+      const allRows =
+        (await this.#db.readClient.manyOrNone<MessageRowFromDB>(
+          `${selectStatement} FROM ${tableName} ${whereClause} ${orderByStatement}`,
+          queryParams,
+        )) || [];
+      return { total: allRows.length, messages: allRows, hasMore: false };
+    }
+
+    const limitPlaceholder = `$${queryParams.length + 1}`;
+    const offsetPlaceholder = `$${queryParams.length + 2}`;
+    const dataParams = [...queryParams, perPage, offset];
+    const pageSelect = `${selectStatement} FROM ${tableName} ${whereClause} ${orderByStatement} LIMIT ${limitPlaceholder} OFFSET ${offsetPlaceholder}`;
+
+    if (!includeTotal) {
+      // Peek one extra row so hasMore is real without counting the thread.
+      const peekParams = [...queryParams, perPage + 1, offset];
+      const peeked = (await this.#db.readClient.manyOrNone<MessageRowFromDB>(pageSelect, peekParams)) || [];
+      const hasMore = peeked.length > perPage;
+      const pageRows = hasMore ? peeked.slice(0, perPage) : peeked;
+      return { total: offset + pageRows.length, messages: pageRows, hasMore };
+    }
+
+    // Reuse the WHERE placeholders ($1..$n) in the count subquery. LIMIT/OFFSET
+    // occupy $n+1 and $n+2 and are not referenced by the count.
     const rows =
       (await this.#db.readClient.manyOrNone<MessageRowFromDB & { __total?: string | number }>(
-        `${selectStatement}, COUNT(*) OVER () AS "__total" FROM ${tableName} ${whereClause} ${orderByStatement}${limitClause}`,
+        `SELECT page.*, count_row.__total FROM (${pageSelect}) page CROSS JOIN (SELECT COUNT(*)::int AS "__total" FROM ${tableName} ${whereClause}) count_row`,
         dataParams,
       )) || [];
 
     if (rows.length > 0) {
-      return { total: Number(rows[0]!.__total), messages: rows };
+      const total = Number(rows[0]!.__total);
+      return { total, messages: rows, hasMore: offset + perPage < total };
     }
     if (offset === 0) {
-      return { total: 0, messages: [] };
+      return { total: 0, messages: [], hasMore: false };
     }
     const countResult = await this.#db.readClient.one(`SELECT COUNT(*) FROM ${tableName} ${whereClause}`, queryParams);
-    return { total: parseInt(countResult.count, 10), messages: [] };
+    const total = parseInt(countResult.count, 10);
+    return { total, messages: [], hasMore: offset < total };
   }
 
   public async listMessages(args: StorageListMessagesInput): Promise<StorageListMessagesOutput> {
-    const { threadId, resourceId, include, filter, perPage: perPageInput, page = 0, orderBy } = args;
+    const { threadId, resourceId, include, filter, perPage: perPageInput, page = 0, orderBy, includeTotal } = args;
 
     const threadIds = (Array.isArray(threadId) ? threadId : [threadId]).filter(
       (id): id is string => typeof id === 'string',
@@ -1116,7 +1148,11 @@ export class MemoryPG extends MemoryStorage {
 
     try {
       const { field, direction } = this.parseOrderBy(orderBy, 'ASC');
-      const orderByStatement = `ORDER BY COALESCE("${field}Z", "${field}") ${direction}`;
+      // Use `createdAt` directly so `(thread_id, createdAt DESC)` covers last-N
+      // LIMIT. COALESCE("createdAtZ", "createdAt") is not the indexed expression;
+      // `_getIncludedMessages` already documents that the two timestamps store
+      // the same instant. Returned timestamps still prefer createdAtZ in parseRow.
+      const orderByStatement = `ORDER BY "${field}" ${direction}`;
 
       const selectStatement = `SELECT id, content, role, type, "createdAt", "createdAtZ", thread_id AS "threadId", "resourceId"`;
       const tableName = getTableName({ indexName: TABLE_MESSAGES, schemaName: getSchemaName(this.#schema) });
@@ -1181,6 +1217,7 @@ export class MemoryPG extends MemoryStorage {
 
       let total: number;
       let messages: MessageRowFromDB[];
+      let pageHasMore: boolean | undefined;
       if (metadataFilter) {
         const rows = await this.#db.readClient.manyOrNone(
           `${selectStatement} FROM ${tableName} ${whereClause} ${orderByStatement}`,
@@ -1191,8 +1228,9 @@ export class MemoryPG extends MemoryStorage {
         );
         total = filteredRows.length;
         messages = perPageInput === false ? filteredRows : filteredRows.slice(offset, offset + perPage);
+        pageHasMore = perPageInput !== false && offset + messages.length < total;
       } else {
-        ({ total, messages } = await this.#fetchMessagePage({
+        ({ total, messages, hasMore: pageHasMore } = await this.#fetchMessagePage({
           selectStatement,
           tableName,
           whereClause,
@@ -1201,6 +1239,7 @@ export class MemoryPG extends MemoryStorage {
           perPageInput,
           perPage,
           offset,
+          includeTotal,
         }));
       }
       const primaryPageCount = messages.length;
@@ -1239,9 +1278,12 @@ export class MemoryPG extends MemoryStorage {
         finalMessages.filter(m => m.threadId && threadIdSet.has(m.threadId)).map(m => m.id),
       );
       const allThreadMessagesReturned = returnedThreadMessageIds.size >= total;
-      const hasMore = metadataFilter
-        ? perPageInput !== false && offset + primaryPageCount < total
-        : perPageInput !== false && !allThreadMessagesReturned && offset + perPage < total;
+      const hasMore =
+        includeTotal === false && pageHasMore !== undefined
+          ? pageHasMore
+          : metadataFilter
+            ? perPageInput !== false && offset + primaryPageCount < total
+            : perPageInput !== false && !allThreadMessagesReturned && offset + perPage < total;
 
       return {
         messages: finalMessages,
@@ -1276,7 +1318,7 @@ export class MemoryPG extends MemoryStorage {
   public async listMessagesByResourceId(
     args: StorageListMessagesByResourceIdInput,
   ): Promise<StorageListMessagesOutput> {
-    const { resourceId, include, filter, perPage: perPageInput, page = 0, orderBy } = args;
+    const { resourceId, include, filter, perPage: perPageInput, page = 0, orderBy, includeTotal } = args;
 
     // Validate that resourceId is provided
     const hasResourceId = resourceId !== undefined && resourceId !== null && resourceId.trim() !== '';
@@ -1314,7 +1356,11 @@ export class MemoryPG extends MemoryStorage {
 
     try {
       const { field, direction } = this.parseOrderBy(orderBy, 'ASC');
-      const orderByStatement = `ORDER BY COALESCE("${field}Z", "${field}") ${direction}`;
+      // Use `createdAt` directly so `(thread_id, createdAt DESC)` covers last-N
+      // LIMIT. COALESCE("createdAtZ", "createdAt") is not the indexed expression;
+      // `_getIncludedMessages` already documents that the two timestamps store
+      // the same instant. Returned timestamps still prefer createdAtZ in parseRow.
+      const orderByStatement = `ORDER BY "${field}" ${direction}`;
 
       const selectStatement = `SELECT id, content, role, type, "createdAt", "createdAtZ", thread_id AS "threadId", "resourceId"`;
       const tableName = getTableName({ indexName: TABLE_MESSAGES, schemaName: getSchemaName(this.#schema) });
@@ -1389,6 +1435,7 @@ export class MemoryPG extends MemoryStorage {
 
       let total: number;
       let messages: MessageRowFromDB[];
+      let pageHasMore: boolean | undefined;
       if (metadataFilter) {
         const rows = await this.#db.readClient.manyOrNone(
           `${selectStatement} FROM ${tableName} ${whereClause} ${orderByStatement}`,
@@ -1399,8 +1446,9 @@ export class MemoryPG extends MemoryStorage {
         );
         total = filteredRows.length;
         messages = perPageInput === false ? filteredRows : filteredRows.slice(offset, offset + perPage);
+        pageHasMore = perPageInput !== false && offset + messages.length < total;
       } else {
-        ({ total, messages } = await this.#fetchMessagePage({
+        ({ total, messages, hasMore: pageHasMore } = await this.#fetchMessagePage({
           selectStatement,
           tableName,
           whereClause,
@@ -1409,6 +1457,7 @@ export class MemoryPG extends MemoryStorage {
           perPageInput,
           perPage,
           offset,
+          includeTotal,
         }));
       }
 
@@ -1441,7 +1490,10 @@ export class MemoryPG extends MemoryStorage {
       const list = new MessageList().add(messagesWithParsedContent, 'memory');
       const finalMessages = this._sortMessages(list.get.all.db(), field, direction);
 
-      const hasMore = perPageInput !== false && offset + perPage < total;
+      const hasMore =
+        includeTotal === false && pageHasMore !== undefined
+          ? pageHasMore
+          : perPageInput !== false && offset + perPage < total;
 
       return {
         messages: finalMessages,

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -1094,7 +1094,7 @@ export class MemoryPG extends MemoryStorage {
     // occupy $n+1 and $n+2 and are not referenced by the count.
     const rows =
       (await this.#db.readClient.manyOrNone<MessageRowFromDB & { __total?: string | number }>(
-        `SELECT page.*, count_row.__total FROM (${pageSelect}) page CROSS JOIN (SELECT COUNT(*)::int AS "__total" FROM ${tableName} ${whereClause}) count_row`,
+        `SELECT page.*, count_row.__total FROM (${pageSelect}) page CROSS JOIN (SELECT COUNT(*) AS "__total" FROM ${tableName} ${whereClause}) count_row`,
         dataParams,
       )) || [];
 

--- a/stores/pg/src/storage/domains/memory/list-messages-round-trips.test.ts
+++ b/stores/pg/src/storage/domains/memory/list-messages-round-trips.test.ts
@@ -4,9 +4,9 @@ import { RecordingDbClientBase } from './test-utils';
 import { MemoryPG } from './index';
 
 /**
- * Fake client that answers the three queries the message paging code can send:
- * the page query with the window count, the fallback `COUNT(*)`, and the two
- * queries of the include (semantic recall) read.
+ * Fake client that answers the queries the message paging code can send:
+ * the page query (with or without a skinny COUNT), the fallback `COUNT(*)`,
+ * and the two queries of the include (semantic recall) read.
  *
  * `block()` holds every `manyOrNone` result until `release()`. A test uses that
  * to look at the queries that are in flight at the same time.
@@ -38,15 +38,18 @@ class MessageQueryClient extends RecordingDbClientBase {
   override async manyOrNone<T = any>(query: string, values?: QueryValues): Promise<T[]> {
     this.queries.push({ query, values });
     await this.#gate;
-    if (query.includes('COUNT(*) OVER ()')) {
-      return this.pageRows.map(row => ({ ...row, __total: String(this.windowTotal) })) as T[];
-    }
     if (query.includes('thread_id, "createdAt" FROM')) {
       return this.includeRows.map(row => ({
         id: row.id,
         thread_id: row.threadId,
         createdAt: row.createdAt,
       })) as T[];
+    }
+    if (query.includes('__total') || query.includes('COUNT(*) OVER ()')) {
+      return this.pageRows.map(row => ({ ...row, __total: String(this.windowTotal) })) as T[];
+    }
+    if (query.includes('thread_id IN') || query.includes('"resourceId" =')) {
+      return this.pageRows as T[];
     }
     return this.includeRows as T[];
   }
@@ -88,12 +91,19 @@ describe('MemoryPG message paging round-trips', () => {
 
     expect(client.queries).toHaveLength(1);
     const [pageQuery] = client.queries;
-    expect(pageQuery!.query).toContain('COUNT(*) OVER () AS "__total"');
+    // One statement still returns the page and the total. The count is a
+    // skinny COUNT(*), not COUNT(*) OVER () on the content-bearing SELECT,
+    // so last-N LIMIT can use (thread_id, createdAt).
+    expect(pageQuery!.query).not.toContain('COUNT(*) OVER ()');
+    expect(pageQuery!.query).toContain('AS "__total"');
+    expect(pageQuery!.query).toContain('COUNT(*)');
     expect(pageQuery!.query).toContain('LIMIT $2 OFFSET $3');
+    expect(pageQuery!.query).toContain('ORDER BY "createdAt"');
+    expect(pageQuery!.query).not.toContain('COALESCE("createdAtZ"');
     expect(pageQuery!.values).toEqual(['thread-1', 10, 0]);
     expect(result.total).toBe(7);
     expect(result.messages).toHaveLength(2);
-    // The window count must not reach the caller as a message field.
+    // The count column must not reach the caller as a message field.
     expect(result.messages[0]).not.toHaveProperty('__total');
   });
 
@@ -107,7 +117,8 @@ describe('MemoryPG message paging round-trips', () => {
 
     expect(client.queries).toHaveLength(1);
     const [pageQuery] = client.queries;
-    expect(pageQuery!.query).toContain('COUNT(*) OVER () AS "__total"');
+    expect(pageQuery!.query).not.toContain('COUNT(*) OVER ()');
+    expect(pageQuery!.query).toContain('AS "__total"');
     expect(pageQuery!.query).toContain('LIMIT $2 OFFSET $3');
     expect(pageQuery!.values).toEqual(['resource-1', 10, 0]);
     expect(result.total).toBe(7);
@@ -125,6 +136,7 @@ describe('MemoryPG message paging round-trips', () => {
     expect(client.queries).toHaveLength(1);
     const [pageQuery] = client.queries;
     expect(pageQuery!.query).not.toContain('LIMIT');
+    expect(pageQuery!.query).not.toContain('COUNT(*)');
     expect(pageQuery!.values).toEqual(['thread-1']);
     expect(result.total).toBe(2);
     expect(result.messages).toHaveLength(2);
@@ -150,7 +162,8 @@ describe('MemoryPG message paging round-trips', () => {
     const result = await memory.listMessages({ threadId: 'thread-1', perPage: 10, page: 2 });
 
     expect(client.queries).toHaveLength(2);
-    expect(client.queries[0]!.query).toContain('COUNT(*) OVER () AS "__total"');
+    expect(client.queries[0]!.query).toContain('AS "__total"');
+    expect(client.queries[0]!.query).not.toContain('COUNT(*) OVER ()');
     expect(client.queries[1]!.query).toContain('SELECT COUNT(*) FROM');
     expect(result.total).toBe(5);
     expect(result.messages).toEqual([]);
@@ -176,8 +189,42 @@ describe('MemoryPG message paging round-trips', () => {
     const result = await pending;
 
     expect(inFlight).toHaveLength(2);
-    expect(inFlight.some(query => query.includes('COUNT(*) OVER () AS "__total"'))).toBe(true);
+    expect(inFlight.some(query => query.includes('AS "__total"') && !query.includes('COUNT(*) OVER ()'))).toBe(true);
     expect(inFlight.some(query => query.includes('thread_id, "createdAt" FROM'))).toBe(true);
     expect(result.messages.map(message => message.id)).toEqual(['message-1', 'message-2', 'message-9']);
+  });
+
+  it('skips the count when includeTotal is false', async () => {
+    const client = new MessageQueryClient();
+    client.pageRows = pageRows;
+    const memory = new MemoryPG({ client });
+
+    const result = await memory.listMessages({ threadId: 'thread-1', perPage: 10, page: 0, includeTotal: false });
+
+    expect(client.queries).toHaveLength(1);
+    const [pageQuery] = client.queries;
+    expect(pageQuery!.query).not.toContain('COUNT(*)');
+    expect(pageQuery!.query).not.toContain('__total');
+    expect(pageQuery!.query).toContain('LIMIT $2 OFFSET $3');
+    expect(pageQuery!.query).toContain('ORDER BY "createdAt"');
+    expect(pageQuery!.values).toEqual(['thread-1', 11, 0]);
+    expect(result.messages).toHaveLength(2);
+    expect(result.total).toBe(2);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('sets hasMore from a peeked extra row when includeTotal is false', async () => {
+    const client = new MessageQueryClient();
+    client.pageRows = [
+      createRow('message-1', '2025-01-01T00:00:00.000Z'),
+      createRow('message-2', '2025-01-01T00:00:01.000Z'),
+    ];
+    const memory = new MemoryPG({ client });
+
+    const result = await memory.listMessages({ threadId: 'thread-1', perPage: 1, page: 0, includeTotal: false });
+
+    expect(client.queries[0]!.values).toEqual(['thread-1', 2, 0]);
+    expect(result.messages).toHaveLength(1);
+    expect(result.hasMore).toBe(true);
   });
 });

--- a/stores/pg/src/storage/domains/memory/list-messages-round-trips.test.ts
+++ b/stores/pg/src/storage/domains/memory/list-messages-round-trips.test.ts
@@ -97,6 +97,7 @@ describe('MemoryPG message paging round-trips', () => {
     expect(pageQuery!.query).not.toContain('COUNT(*) OVER ()');
     expect(pageQuery!.query).toContain('AS "__total"');
     expect(pageQuery!.query).toContain('COUNT(*)');
+    expect(pageQuery!.query).not.toContain('::int');
     expect(pageQuery!.query).toContain('LIMIT $2 OFFSET $3');
     expect(pageQuery!.query).toContain('ORDER BY "createdAt"');
     expect(pageQuery!.query).not.toContain('COALESCE("createdAtZ"');


### PR DESCRIPTION
## Description

PostgresStore last-N message history was scanning the whole thread on every Memory-backed turn.

`#fetchMessagePage` used `COUNT(*) OVER ()` on the full SELECT list (including `content`) and `ORDER BY COALESCE("createdAtZ", "createdAt")`. That combination cannot use `mastra_messages_thread_id_createdat_idx`. The include path in the same file already orders by `createdAt` for that reason.

The page query is now `LIMIT` on `createdAt`. Callers that need `total` still get it from a skinny `COUNT(*)` in the same statement (one round-trip, one connection). `MessageHistory` — the processor that actually loads history on agent turns — passes `includeTotal: false` and peeks one extra row for `hasMore`.

This keeps the one-round-trip goal of #20979 without making Postgres heap-fetch every message to count them.

Same commits as #23362, which was closed while #23359 still had `status: needs triage`. GitHub would not reopen that PR after triage completed (`status: auto-triaged`; route: Plan fix).

## Related issue(s)

Fixes #23359

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

`list-messages-round-trips.test.ts` still asserts one round-trip, LIMIT, and that `__total` does not leak. It no longer asserts `COUNT(*) OVER ()`, because that was the mechanism that forced the full-thread scan. The invariant is one statement returning page+total, not the window function.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Verification

PGlite (PostgreSQL planner, in-process; not RDS) against 20k messages in one thread and the default `(thread_id, createdAt DESC)` index:

- Current query: WindowAgg actual rows=20000, then sort on COALESCE. 243–409 buffers.
- `ORDER BY "createdAt" LIMIT 10` with no window: Index Scan, actual rows=10, 4 buffers.

I could not run `pnpm --filter @mastra/pg test` in this worktree (no local install of the monorepo). The round-trip tests are fake-client SQL-shape tests and do not need Docker.

## Notes

`includeTotal` defaults to true, so Studio pagination is unchanged. Date-range filters still use COALESCE; this PR does not touch `listThreads`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Postgres now reads only the messages it needs instead of scanning the entire thread. It also skips counting messages when the caller does not use the count.

## Changes

- Use the `(thread_id, createdAt)` index for last-N message reads.
- Replace `COUNT(*) OVER ()` with a limited page query and a skinny `COUNT(*)` in one round-trip.
- Order by `"createdAt"` without `COALESCE`.
- Skip total counting for agent history and internal memory reads that do not use totals.
- Fetch one extra row when totals are disabled to calculate `hasMore`.
- Add the `includeTotal` option to message-listing APIs.
- Add SQL-shape and round-trip regression tests.
- Keep LibSQL, MySQL, date-range filters, and Studio pagination behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->