### PR TITLE
fix(voice-openai-realtime): expose public input events

### DIFF
--- a/.changeset/thirty-moments-appear.md
+++ b/.changeset/thirty-moments-appear.md
@@ -1,0 +1,5 @@
+---
+'@mastra/voice-openai-realtime': patch
+---
+
+Fixed public realtime speech boundary events and complete input transcription usage delivery.

--- a/voice/openai-realtime-api/src/index.ts
+++ b/voice/openai-realtime-api/src/index.ts
@@ -673,6 +673,12 @@ export class OpenAIRealtimeVoice extends MastraVoice {
     this.client.on('session.updated', ev => {
       this.emit('session.updated', ev);
     });
+    this.client.on('input_audio_buffer.speech_started', ev => {
+      this.emit('input_audio_buffer.speech_started', ev);
+    });
+    this.client.on('input_audio_buffer.speech_stopped', ev => {
+      this.emit('input_audio_buffer.speech_stopped', ev);
+    });
     this.client.on('response.created', ev => {
       this.emit('response.created', ev);
 
@@ -688,6 +694,7 @@ export class OpenAIRealtimeVoice extends MastraVoice {
       this.emit('writing', { text: ev.delta, response_id: ev.item_id, role: 'user' });
     });
     this.client.on('conversation.item.input_audio_transcription.completed', ev => {
+      this.emit('conversation.item.input_audio_transcription.completed', ev);
       if (!userTranscriptionDeltaItems.has(ev.item_id) && ev.transcript) {
         this.emit('writing', { text: ev.transcript, response_id: ev.item_id, role: 'user' });
       }

--- a/voice/openai-realtime-api/src/public-events.integration.test.ts
+++ b/voice/openai-realtime-api/src/public-events.integration.test.ts
@@ -1,0 +1,84 @@
+import { once } from 'node:events';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WebSocket, WebSocketServer } from 'ws';
+import { OpenAIRealtimeVoice } from './index';
+
+describe('public realtime input events', () => {
+  let server: WebSocketServer | undefined;
+  let voice: OpenAIRealtimeVoice | undefined;
+
+  afterEach(async () => {
+    voice?.disconnect();
+    for (const socket of server?.clients ?? []) socket.terminate();
+    if (server) await new Promise<void>(resolve => server!.close(() => resolve()));
+  });
+
+  const setup = async () => {
+    server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    await once(server, 'listening');
+    server.on('connection', socket => socket.send(JSON.stringify({ type: 'session.created', session: { id: 'test' } })));
+    voice = new OpenAIRealtimeVoice({
+      apiKey: 'local-test-only',
+      url: `ws://127.0.0.1:${(server.address() as AddressInfo).port}`,
+    });
+    return { server, voice };
+  };
+
+  const frames = [
+    { type: 'input_audio_buffer.speech_started', event_id: 'start', item_id: 'input', audio_start_ms: 0 },
+    { type: 'input_audio_buffer.speech_stopped', event_id: 'stop', item_id: 'input', audio_end_ms: 1500 },
+    {
+      type: 'conversation.item.input_audio_transcription.completed', event_id: 'transcript', item_id: 'input',
+      content_index: 0, transcript: 'Hello.', usage: { type: 'duration', seconds: 1.5 },
+    },
+  ];
+
+  it.each(frames)('forwards $type and its full payload once', async frame => {
+    const { server, voice } = await setup();
+    const callback = vi.fn();
+    voice.on(frame.type, callback);
+    const received = new Promise(resolve => voice.on(frame.type, resolve));
+    await voice.connect();
+    const peer = [...server.clients][0]!;
+    peer.send(JSON.stringify(frame));
+    expect(await received).toEqual(frame);
+    expect(callback).toHaveBeenCalledExactlyOnceWith(frame);
+  });
+
+  it('does not duplicate transcription or writing events after reconnect', async () => {
+    const { server, voice } = await setup();
+    const completed = vi.fn();
+    const writing = vi.fn();
+    voice.on(frames[2]!.type, completed);
+    voice.on('writing', writing);
+    for (let connection = 0; connection < 2; connection++) {
+      await voice.connect();
+      const peer = [...server.clients].find(socket => socket.readyState === WebSocket.OPEN)!;
+      const received = new Promise(resolve => voice.on('writing', resolve));
+      peer.send(JSON.stringify(frames[2]));
+      await received;
+      expect(completed).toHaveBeenCalledTimes(connection + 1);
+      expect(writing).toHaveBeenCalledTimes((connection + 1) * 2);
+      expect(writing.mock.calls.slice(connection * 2)).toEqual([
+        [{ text: 'Hello.', response_id: 'input', role: 'user' }],
+        [{ text: '\n', response_id: 'input', role: 'user' }],
+      ]);
+      const closed = once(peer, 'close');
+      voice.disconnect();
+      await closed;
+    }
+  });
+
+  it('removes the public transcription listener without removing writing', async () => {
+    const { server, voice } = await setup();
+    const callback = vi.fn();
+    voice.on(frames[2]!.type, callback);
+    voice.off(frames[2]!.type, callback);
+    const written = new Promise(resolve => voice.on('writing', resolve));
+    await voice.connect();
+    [...server.clients][0]!.send(JSON.stringify(frames[2]));
+    await written;
+    expect(callback).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
OpenAIRealtimeVoice receives speech start/stop and completed transcription frames but drops them before public listeners can observe them. Forward those three frames unchanged so applications can stop playback on interruption and read the provider's transcription usage. Existing writing events keep their current behavior.

For example, `voice.on('conversation.item.input_audio_transcription.completed', event => recordUsage(event.usage))` now receives the complete provider event. The change adds no session state or lifecycle behavior.

All 48 tests in the voice package pass, including five new local WebSocket tests for exact payloads, listener removal, and no duplicate delivery after reconnect. The package builds with its existing build scripts. These tests make no provider calls.

Fixes #23373
