### PR TITLE
feat(factory): supervisor updates and signals worker sessions

### DIFF
--- a/.changeset/social-rocks-tease.md
+++ b/.changeset/social-rocks-tease.md
@@ -1,0 +1,13 @@
+---
+'@mastra/factory': patch
+---
+
+Added approval-free Factory supervisor session updates for model, mode, memory settings and thread title. Updates report whether each field applies now, at the next run start, at the next thread switch, or was skipped. Worker signaling is also approval-free and audited.
+
+In authenticated supervisor chat, `factory_update_session` accepts:
+
+```json
+{ "target": { "all": true }, "changes": { "memory": "resync" } }
+```
+
+This reapplies stored Factory memory settings to idle active workers; busy workers are reported as skipped.

--- a/mastracode/factory/README.md
+++ b/mastracode/factory/README.md
@@ -29,6 +29,16 @@ A host application calls `MastraFactory.prepare()`, constructs its `Mastra` inst
 
 `prepare()` initializes the Factory-owned resources needed before Mastra is constructed. `finalize()` connects those resources to the completed host, including Factory routes, integrations, storage-backed behavior, and agent-controller features. Consumers should keep frontend concerns in `factory-ui` and host-specific environment or deployment wiring in `web` rather than adding them to this package.
 
+### Supervisor session tools
+
+Authenticated supervisor chat can use `factory_update_session` without an approval prompt. Pass a `target` of `{ sessionId }`, `{ workItemId, role }`, or `{ all: true }`, and `changes` containing `model`, `mode`, `memory`, or `title`. Only active worker bindings in the current Factory are targeted. Results and human-attributed audit events are per binding.
+
+Model IDs may be any non-empty string; they are not validated against a provider catalog. On a current, idle thread, model and mode changes apply `now`. A busy thread persists the model for `next-run-start` and skips mode and memory changes. Non-current threads persist model and mode for `next-thread-switch`; their titles are skipped. Titles can be updated on the current thread even while it runs.
+
+Memory is session-wide. Use `memory: 'resync'` to restore the Factory's stored settings and defaults, or pass explicit observer/reflector model IDs and observation/reflection thresholds. The tool reports written, unchanged, and skipped knobs, including partial-failure warnings. It cannot change yolo, permissions, or notification settings.
+
+`factory_signal_session` also needs no approval prompt. The supervisor can change a worker's model, inspect the result, then send it a message. Starting work and other governed repairs still require their existing approvals.
+
 ### Product telemetry
 
 Factory records `factory_web_activity` in Mastra's existing PostHog project for users signed in through the default `mastra-studio` auth provider. The browser sends only a known page category and an activity type to the authenticated `/web/telemetry/activity` endpoint. The server adds the verified account and deployment context.

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -549,6 +549,47 @@ describe('MastraFactory.prepare', () => {
     expect(paths).toContain('/auth/me');
   });
 
+  it('registers session updates only for authenticated scoped supervisor turns', async () => {
+    const storage = fakeStorage();
+    const config = await prepareFactory({ storage });
+    const projects = storage.getDomain<FactoryProjectsStorage>('projects');
+    vi.spyOn(projects, 'get').mockResolvedValue({
+      id: 'project',
+      orgId: 'org-1',
+      createdBy: 'user-1',
+      name: 'Project',
+      description: null,
+      defaultModelId: null,
+      slackWorkItemsEnabled: false,
+      autoRunEnabled: false,
+      autoApprovePlans: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const extraTools = config.extraTools as (args: {
+      requestContext: RequestContext;
+    }) => Promise<Record<string, unknown>>;
+    const requestContext = new RequestContext();
+    requestContext.set('user', { workosId: 'user-1', organizationId: 'org-1' });
+    requestContext.set('controller', {
+      resourceId: 'factory-supervisor:project',
+      threadId: 'thread',
+      scope: '/worktree',
+      getState: () => ({}),
+    });
+    expect(await extraTools({ requestContext })).toHaveProperty('factory_update_session');
+    requestContext.set('user', { organizationId: 'org-1' });
+    expect(await extraTools({ requestContext })).not.toHaveProperty('factory_update_session');
+    requestContext.set('user', { workosId: 'user-1', organizationId: 'org-1' });
+    requestContext.set('controller', {
+      resourceId: 'worker',
+      threadId: 'thread',
+      scope: '/worktree',
+      getState: () => ({}),
+    });
+    expect(await extraTools({ requestContext })).not.toHaveProperty('factory_update_session');
+  });
+
   it('registers the Factory transition tool only for exact active bindings', async () => {
     const storage = fakeStorage();
     const config = await prepareFactory({ storage });

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -863,8 +863,8 @@ export class MastraFactory {
                                   ),
                               }
                             : {}),
-                          signalSession: async ({ sessionId, message }) => {
-                            const session = await prepared.base.controller.getSessionByResource(sessionId);
+                          signalSession: async ({ resourceId, message }) => {
+                            const session = await prepared.base.controller.getSessionByResource(resourceId);
                             if (!session) throw new Error('The worker session is not currently available.');
                             await session.sendMessage({
                               content: message,

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -107,6 +107,7 @@ import type { WorkItemRow } from './storage/domains/work-items/base.js';
 import { FactorySupervisorHealthWorker } from './supervisor/health-worker.js';
 import { SUPERVISOR_INSTRUCTIONS } from './supervisor/instructions.js';
 import { createFactorySupervisorReadTools } from './supervisor/read-tools.js';
+import { createFactorySupervisorSessionTools } from './supervisor/session-tools.js';
 import { hydrateSupervisorSession, parseSupervisorResourceId, resolveSupervisorScope } from './supervisor/session.js';
 import { createFactorySupervisorWriteTools } from './supervisor/write-tools.js';
 import { timedPhase } from './timing.js';
@@ -828,6 +829,18 @@ export class MastraFactory {
                       }),
                     );
                     if (userId) {
+                      mergeTools(
+                        'factory-supervisor-sessions',
+                        createFactorySupervisorSessionTools({
+                          scope: supervisorScope,
+                          userId,
+                          workItems: workItemsStorage,
+                          audit: auditStorage,
+                          controller: prepared.base.controller,
+                          memorySettings: memorySettingsStorage,
+                          projects: factoryProjectsStorage,
+                        }),
+                      );
                       mergeTools(
                         'factory-supervisor-write',
                         createFactorySupervisorWriteTools({

--- a/mastracode/factory/src/supervisor/instructions.ts
+++ b/mastracode/factory/src/supervisor/instructions.ts
@@ -53,9 +53,22 @@ You have no repository and no sandbox. Everything you know comes from the
 
 ## Repairs
 
-Write tools require confirmation and are recorded against the person who
-asked. Use the repair suggested by the health finding: retry or dismiss a
+Repair tools require confirmation, except session updates and worker signals.
+All mutations are recorded against the person who asked. Use the repair suggested by the health finding: retry or dismiss a
 decision, accept a held card, approve or dismiss a proposal, revoke an
 orphaned seat, signal a worker, or reconcile stale acceptance labels. Never
 claim a repair happened unless a tool result says it did.
+
+## Session updates
+
+Use \`factory_update_session\` to change a worker's model, mode, memory settings,
+or thread title. Target a session, a work item and role, or all active sessions.
+Use memory \`resync\` to apply stored Factory settings to existing sessions.
+Updates and \`factory_signal_session\` need no approval prompt: when asked to
+change a model and nudge the worker, update first, inspect the result, then signal.
+Report each applied or skipped field honestly: \`now\`, \`next-run-start\`, or
+\`next-thread-switch\`. Busy sessions skip mode and memory changes. Non-current
+threads skip title changes. Memory applies to the whole session. Do not claim
+skipped changes succeeded, and surface partial-application warnings. These tools
+cannot change yolo, permissions, or notification settings.
 `;

--- a/mastracode/factory/src/supervisor/session-instructions.test.ts
+++ b/mastracode/factory/src/supervisor/session-instructions.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { SUPERVISOR_INSTRUCTIONS } from './instructions.js';
+
+describe('supervisor session instructions', () => {
+  it('distinguishes approval-free session operations and deferred or skipped changes', () => {
+    expect(SUPERVISOR_INSTRUCTIONS).toContain('need no approval prompt');
+    expect(SUPERVISOR_INSTRUCTIONS).toContain('update first, inspect the result, then signal');
+    expect(SUPERVISOR_INSTRUCTIONS).toContain('next-run-start');
+    expect(SUPERVISOR_INSTRUCTIONS).toContain('next-thread-switch');
+    expect(SUPERVISOR_INSTRUCTIONS).toContain('Busy sessions skip mode and memory changes');
+  });
+});

--- a/mastracode/factory/src/supervisor/session-tools.test.ts
+++ b/mastracode/factory/src/supervisor/session-tools.test.ts
@@ -102,6 +102,23 @@ async function setup({ current = true, busy = false } = {}) {
 }
 
 describe('factory_update_session', () => {
+  it('persists the model for the current configured mode when a non-current thread has a retired mode', async () => {
+    const c = await setup({ current: false });
+    c.metadata.currentModeId = 'retired-mode';
+    const output = await c.call({ target: { sessionId: 'session' }, changes: { model: 'custom/model' } });
+    expect(c.metadata.modeModelId_work).toBe('custom/model');
+    expect(c.metadata['modeModelId_retired-mode']).toBeUndefined();
+    expect(c.session.thread.setSettingOn).toHaveBeenCalledExactlyOnceWith({
+      threadId: 'bound',
+      key: 'modeModelId_work',
+      value: 'custom/model',
+    });
+    expect(c.session.model.switch).not.toHaveBeenCalled();
+    expect(c.session.mode.switch).not.toHaveBeenCalled();
+    expect(output.results[0].applied.model).toBe('next-thread-switch');
+    expect((await c.audits())[0].metadata.applied).toEqual({ model: 'next-thread-switch' });
+  });
+
   it.each([
     { current: true, busy: false, timing: 'now' },
     { current: true, busy: true, timing: 'next-run-start' },

--- a/mastracode/factory/src/supervisor/session-tools.test.ts
+++ b/mastracode/factory/src/supervisor/session-tools.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import type { MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
+import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
+import { createFactoryStorageForTests } from '../storage/test-utils.js';
+import { createFactorySupervisorSessionTools } from './session-tools.js';
+
+const scope = { orgId: 'org-1', factoryProjectId: '11111111-2222-4333-8444-555555555555' };
+async function setup({ current = true, busy = false } = {}) {
+  const seed = await createFactoryStorageForTests();
+  const item = (
+    await seed.workItems.upsert({ ...scope, userId: 'person', input: { title: 'Card', stages: ['execute'] } })
+  ).item;
+  const { binding } = await seed.workItems.prepareRunStart({
+    ...scope,
+    userId: 'person',
+    workItem: { id: item.id, input: { title: item.title, stages: item.stages } },
+    role: 'work',
+    session: { sessionId: 'session', threadId: 'bound', branch: 'test' },
+    resourceId: 'resource',
+    kickoffKey: 'kickoff',
+    kickoffMessage: null,
+  });
+  let mode = 'work';
+  let model = 'old-model';
+  const state: Record<string, unknown> = {};
+  const metadata: Record<string, unknown> = { currentModeId: 'work' };
+  const omRole = () => {
+    let modelId = 'old-om';
+    return {
+      modelId: () => modelId,
+      switchModel: vi.fn(async (input: { modelId: string }) => {
+        modelId = input.modelId;
+      }),
+    };
+  };
+  const session = {
+    thread: {
+      getId: () => (current ? 'bound' : 'other'),
+      getById: vi.fn(async () => ({ metadata })),
+      setSettingOn: vi.fn(async ({ key, value }: { threadId: string; key: string; value: unknown }) => {
+        metadata[key] = value;
+      }),
+      rename: vi.fn(async (_input: { title: string }) => {}),
+    },
+    run: { isRunning: () => busy },
+    mode: {
+      get: () => mode,
+      switch: vi.fn(async ({ modeId }: { modeId: string }) => {
+        mode = modeId;
+      }),
+    },
+    model: {
+      get: () => model,
+      switch: vi.fn(async ({ modelId }: { modelId: string; scope: 'thread' }) => {
+        model = modelId;
+      }),
+    },
+    om: { observer: omRole(), reflector: omRole() },
+    state: {
+      get: () => state,
+      set: vi.fn(async (values: Record<string, unknown>) => {
+        Object.assign(state, values);
+      }),
+    },
+  };
+  const controller = {
+    getSessionByResource: vi.fn(async () => session),
+    listModes: () => [{ id: 'work' }, { id: 'plan' }],
+  };
+  const memorySettings = { get: vi.fn<MemorySettingsStorage['get']>(async () => null) };
+  const projects = {
+    getById: vi.fn<FactoryProjectsStorage['getById']>(async () => ({
+      id: scope.factoryProjectId,
+      orgId: scope.orgId,
+      createdBy: 'person',
+      name: 'Factory',
+      description: null,
+      defaultModelId: null,
+      slackWorkItemsEnabled: false,
+      autoRunEnabled: false,
+      autoApprovePlans: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })),
+  };
+  const tool = createFactorySupervisorSessionTools({
+    ...seed,
+    scope,
+    userId: 'person',
+    controller,
+    memorySettings,
+    projects,
+  }).factory_update_session;
+  const call = async (input: unknown) => {
+    const parsed = (tool.inputSchema as z.ZodType).parse(input);
+    return (tool.execute as (input: unknown, context: unknown) => Promise<any>)(parsed, {});
+  };
+  const audits = async () => (await seed.audit.list({ ...scope, limit: 100 })).events;
+  return { ...seed, item, binding, session, controller, memorySettings, projects, tool, call, metadata, audits };
+}
+
+describe('factory_update_session', () => {
+  it.each([
+    { current: true, busy: false, timing: 'now' },
+    { current: true, busy: true, timing: 'next-run-start' },
+    { current: false, busy: false, timing: 'next-thread-switch' },
+  ])('applies the current=$current busy=$busy matrix', async ({ current, busy, timing }) => {
+    const c = await setup({ current, busy });
+    expect(c.tool.requireApproval).toBe(false);
+    const output = await c.call({
+      target: { sessionId: 'session' },
+      changes: { mode: 'plan', model: 'custom/model', title: 'Retitled', memory: { observationThreshold: 123 } },
+    });
+    const result = output.results[0];
+    expect(result.applied.model).toBe(timing);
+    expect(c.controller.getSessionByResource).toHaveBeenCalledWith('resource');
+    expect(c.metadata[`modeModelId_${busy ? 'work' : 'plan'}`]).toBe('custom/model');
+    if (!current || busy) {
+      expect(c.session.model.switch).not.toHaveBeenCalled();
+      expect(c.session.mode.switch).not.toHaveBeenCalled();
+    } else {
+      expect(c.session.model.switch).toHaveBeenCalledWith({ modelId: 'custom/model', scope: 'thread' });
+      expect(result.applied.mode).toBe('now');
+    }
+    if (busy) {
+      expect(result.skipped.mode).toBe('session-busy');
+      expect(result.skipped.memory).toBe('session-busy');
+      expect(c.session.state.set).not.toHaveBeenCalled();
+    }
+    if (!current) {
+      expect(result.applied.mode).toBe('next-thread-switch');
+      expect(result.skipped.title).toBe('thread-not-current');
+      expect(c.session.thread.rename).not.toHaveBeenCalled();
+    } else expect(result.applied.title).toBe('now');
+    expect(output.summary).toEqual({ targets: 1, touched: 1, untouched: 0 });
+    expect(await c.audits()).toMatchObject([
+      {
+        actorId: 'person',
+        actorType: 'human',
+        action: 'factory.supervisor.session_updated',
+        metadata: { cause: 'supervisor', applied: result.applied, warnings: result.warnings },
+      },
+    ]);
+  });
+
+  it('rejects forbidden fields and empty changes or memory', async () => {
+    const c = await setup();
+    for (const changes of [
+      {},
+      { memory: {} },
+      { yolo: true },
+      { model: 'x', notifications: true },
+      { memory: { permissions: 'all' } },
+      { model: ' ' },
+      { memory: { observationThreshold: -1 } },
+    ]) {
+      await expect(c.call({ target: { all: true }, changes })).rejects.toThrow();
+    }
+    await expect(c.call({ target: { all: true, sessionId: 'session' }, changes: { title: 'x' } })).rejects.toThrow();
+  });
+
+  it('targets work item and role, and rejects foreign or revoked sessions', async () => {
+    const c = await setup();
+    await c.call({ target: { workItemId: c.item.id, role: 'work' }, changes: { title: 'x' } });
+    await expect(c.call({ target: { sessionId: 'foreign' }, changes: { title: 'x' } })).rejects.toThrow(
+      'Not an active worker session',
+    );
+    vi.spyOn(c.workItems, 'listRunBindings').mockResolvedValue([{ ...c.binding, status: 'revoked' }]);
+    await expect(c.call({ target: { sessionId: 'session' }, changes: { title: 'x' } })).rejects.toThrow(
+      'Not an active worker session',
+    );
+    expect((await c.call({ target: { all: true }, changes: { title: 'x' } })).summary.targets).toBe(0);
+  });
+
+  it('reports deleted work items and non-live sessions without audit or writes', async () => {
+    const c = await setup();
+    const getItem = vi.spyOn(c.workItems, 'getForProject').mockResolvedValueOnce(null);
+    expect((await c.call({ target: { all: true }, changes: { model: 'new' } })).results[0].skipReason).toBe(
+      'work-item-gone',
+    );
+    expect(c.controller.getSessionByResource).not.toHaveBeenCalled();
+    getItem.mockRestore();
+    c.controller.getSessionByResource.mockResolvedValueOnce(undefined!);
+    expect((await c.call({ target: { all: true }, changes: { model: 'new' } })).results[0].skipReason).toBe(
+      'session-not-live',
+    );
+    expect(await c.audits()).toEqual([]);
+  });
+
+  it('skips unknown mode but writes model against the existing mode', async () => {
+    const c = await setup();
+    const { results } = await c.call({ target: { all: true }, changes: { mode: 'unknown', model: 'new' } });
+    expect(results[0].skipped.mode).toBe('unknown-mode');
+    expect(c.metadata.modeModelId_work).toBe('new');
+  });
+
+  it.each([false, true])('reports a failed live model switch honestly when mutation=%s', async mutated => {
+    const c = await setup();
+    const original = c.session.model.switch.getMockImplementation()!;
+    c.session.model.switch.mockImplementationOnce(async args => {
+      if (mutated) await original(args);
+      throw new Error('persistence failed');
+    });
+    const { results } = await c.call({ target: { all: true }, changes: { model: 'new' } });
+    expect(results[0].applied.model).toBe(mutated ? 'now' : 'next-run-start');
+    expect(results[0].warnings[0]).toContain('persistence failed');
+    expect((await c.audits())[0].metadata).toMatchObject({ warnings: results[0].warnings });
+  });
+
+  it('reports mode mutation before a throw, then applies model to that mode', async () => {
+    const c = await setup();
+    const original = c.session.mode.switch.getMockImplementation()!;
+    c.session.mode.switch.mockImplementationOnce(async args => {
+      await original(args);
+      throw new Error('persist failed');
+    });
+    const { results } = await c.call({ target: { all: true }, changes: { mode: 'plan', model: 'new' } });
+    expect(results[0].applied).toEqual({ mode: 'now', model: 'now' });
+    expect(results[0].warnings[0]).toContain('persistence or incoming-model reconciliation failed');
+    expect(c.metadata.modeModelId_plan).toBe('new');
+  });
+
+  it('resyncs defaults per knob and reports already-matching state unchanged', async () => {
+    const c = await setup();
+    const first = await c.call({ target: { all: true }, changes: { memory: 'resync' } });
+    expect(first.results[0].applied.memory).toEqual({
+      observerModelId: 'written',
+      reflectorModelId: 'written',
+      observationThreshold: 'written',
+      reflectionThreshold: 'written',
+      observeAttachments: 'unchanged',
+    });
+    expect(c.session.state.get()).toMatchObject({ observationThreshold: 30000, reflectionThreshold: 40000 });
+    expect(c.memorySettings.get).toHaveBeenCalledWith({
+      orgId: scope.orgId,
+      userId: `factory-project:${scope.factoryProjectId}`,
+    });
+    const second = await c.call({ target: { all: true }, changes: { memory: 'resync' } });
+    expect(Object.values(second.results[0].applied.memory)).toEqual(Array(5).fill('unchanged'));
+    expect(c.session.om.observer.switchModel).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues model updates when resync fails and reuses the failure for a shared session', async () => {
+    const c = await setup();
+    vi.spyOn(c.workItems, 'listRunBindings').mockResolvedValue([
+      c.binding,
+      { ...c.binding, id: 'second', threadId: 'second', role: 'review' },
+    ]);
+    c.memorySettings.get.mockRejectedValueOnce(new Error('storage unavailable'));
+    const { results } = await c.call({ target: { all: true }, changes: { model: 'new', memory: 'resync' } });
+    expect(results.map((r: any) => r.skipped.memory)).toEqual(['storage unavailable', 'storage unavailable']);
+    expect(results.map((r: any) => r.applied.model)).toEqual(['now', 'next-thread-switch']);
+    expect(c.memorySettings.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not switch after the session becomes busy during persistence', async () => {
+    const c = await setup();
+    c.session.thread.setSettingOn.mockImplementationOnce(async () => {
+      c.session.run.isRunning = () => true;
+    });
+    const { results } = await c.call({ target: { all: true }, changes: { model: 'new' } });
+    expect(results[0].applied.model).toBe('next-run-start');
+    expect(c.session.model.switch).not.toHaveBeenCalled();
+  });
+
+  it('reports partial memory application per knob and deduplicates shared resource updates', async () => {
+    const c = await setup();
+    vi.spyOn(c.workItems, 'listRunBindings').mockResolvedValue([
+      c.binding,
+      { ...c.binding, id: 'second', threadId: 'second', role: 'review' },
+    ]);
+    c.session.om.reflector.switchModel.mockRejectedValueOnce(new Error('reflector failed'));
+    const { results, summary } = await c.call({
+      target: { sessionId: 'session' },
+      changes: { memory: { observerModelId: 'new', reflectorModelId: 'new', observationThreshold: 123 } },
+    });
+    expect(summary).toEqual({ targets: 2, touched: 2, untouched: 0 });
+    expect(results[0].applied.memory).toEqual({ observerModelId: 'written', observationThreshold: 'written' });
+    expect(results[0].skipped.memory).toEqual({ reflectorModelId: 'reflector failed' });
+    expect(results[1].applied.memory).toEqual(results[0].applied.memory);
+    expect(c.session.om.observer.switchModel).toHaveBeenCalledTimes(1);
+    expect(c.session.om.reflector.switchModel).toHaveBeenCalledTimes(1);
+    expect(await c.audits()).toHaveLength(2);
+  });
+});

--- a/mastracode/factory/src/supervisor/session-tools.test.ts
+++ b/mastracode/factory/src/supervisor/session-tools.test.ts
@@ -38,7 +38,7 @@ async function setup({ current = true, busy = false } = {}) {
   const session = {
     thread: {
       getId: () => (current ? 'bound' : 'other'),
-      getById: vi.fn(async () => ({ metadata })),
+      getById: vi.fn(async () => ({ resourceId: 'resource', metadata })),
       setSettingOn: vi.fn(async ({ key, value }: { threadId: string; key: string; value: unknown }) => {
         metadata[key] = value;
       }),
@@ -220,6 +220,45 @@ describe('factory_update_session', () => {
     expect(results[0].applied).toEqual({ mode: 'now', model: 'now' });
     expect(results[0].warnings[0]).toContain('persistence or incoming-model reconciliation failed');
     expect(c.metadata.modeModelId_plan).toBe('new');
+  });
+
+  it('skips a binding revoked during session lookup', async () => {
+    const c = await setup();
+    vi.spyOn(c.workItems, 'listRunBindings')
+      .mockResolvedValueOnce([c.binding])
+      .mockResolvedValue([{ ...c.binding, status: 'revoked' }]);
+    const { results } = await c.call({
+      target: { all: true },
+      changes: { model: 'new', memory: { observationThreshold: 10 } },
+    });
+    expect(results[0].skipped.model).toBe('Worker binding is no longer active.');
+    expect(c.session.thread.setSettingOn).not.toHaveBeenCalled();
+    expect(c.session.state.set).not.toHaveBeenCalled();
+    expect(await c.audits()).toEqual([]);
+  });
+
+  it('refuses foreign-resource thread metadata', async () => {
+    const c = await setup({ current: false });
+    c.session.thread.getById.mockResolvedValue({ resourceId: 'foreign', metadata: {} });
+    const { results } = await c.call({ target: { all: true }, changes: { mode: 'plan', model: 'new' } });
+    expect(results[0].skipped.model).toContain('another resource');
+    expect(c.session.thread.setSettingOn).not.toHaveBeenCalled();
+    expect(await c.audits()).toEqual([]);
+  });
+
+  it.each(['lookup', 'audit'])('continues the batch after a per-binding %s failure', async failure => {
+    const c = await setup();
+    vi.spyOn(c.workItems, 'listRunBindings').mockResolvedValue([
+      c.binding,
+      { ...c.binding, id: 'second', threadId: 'second', role: 'review' },
+    ]);
+    if (failure === 'lookup') vi.spyOn(c.workItems, 'getForProject').mockRejectedValueOnce(new Error('lookup failed'));
+    else vi.spyOn(c.audit, 'record').mockRejectedValueOnce(new Error('audit failed'));
+    const { results } = await c.call({ target: { all: true }, changes: { model: 'new' } });
+    expect(results).toHaveLength(2);
+    expect(results[1].applied.model).toBe('next-thread-switch');
+    expect(results[0].warnings.join(' ')).toContain(`${failure} failed`);
+    if (failure === 'audit') expect(results[0].applied.model).toBe('now');
   });
 
   it('resyncs defaults per knob and reports already-matching state unchanged', async () => {

--- a/mastracode/factory/src/supervisor/session-tools.ts
+++ b/mastracode/factory/src/supervisor/session-tools.ts
@@ -16,7 +16,7 @@ import type { SupervisorScope } from './read-tools.js';
 interface ConfigurableSession extends OMConfigurableSession {
   thread: {
     getId(): string | null;
-    getById(args: { threadId: string }): Promise<{ metadata?: Record<string, unknown> } | null>;
+    getById(args: { threadId: string }): Promise<{ resourceId: string; metadata?: Record<string, unknown> } | null>;
     setSettingOn(args: { threadId: string; key: string; value: unknown }): Promise<void>;
     rename(args: { title: string }): Promise<void>;
   };
@@ -167,139 +167,168 @@ export function createFactorySupervisorSessionTools(deps: Dependencies): Integra
             warnings: [],
           };
           results.push(result);
-          if (!(await deps.workItems.getForProject(orgId, factoryProjectId, workItemId))) {
-            result.skipReason = 'work-item-gone';
-            continue;
-          }
-          const session = await deps.controller.getSessionByResource(resourceId);
-          if (!session) {
-            result.skipReason = 'session-not-live';
-            continue;
-          }
-          const current = () => session.thread.getId() === threadId;
-          if (changes.mode) {
-            if (!deps.controller.listModes().some(mode => mode.id === changes.mode))
-              result.skipped.mode = 'unknown-mode';
-            else if (current() && session.run.isRunning()) result.skipped.mode = 'session-busy';
-            else
-              try {
-                if (current()) {
-                  await session.mode.switch({ modeId: changes.mode });
-                  result.applied.mode = 'now';
-                } else {
-                  await session.thread.setSettingOn({ threadId, key: 'currentModeId', value: changes.mode });
-                  result.applied.mode = 'next-thread-switch';
-                }
-              } catch (error) {
-                if (current() && session.mode.get() === changes.mode) {
-                  result.applied.mode = 'now';
-                  result.warnings.push(
-                    `Mode switched in memory; persistence or incoming-model reconciliation failed: ${message(error)}`,
-                  );
-                } else result.skipped.mode = message(error);
-              }
-          }
-          if (changes.model) {
-            try {
-              const storedMode = current()
-                ? undefined
-                : (await session.thread.getById({ threadId }))?.metadata?.currentModeId;
-              const effectiveMode = result.applied.mode
-                ? changes.mode!
-                : typeof storedMode === 'string'
-                  ? storedMode
-                  : session.mode.get();
-              await session.thread.setSettingOn({
-                threadId,
-                key: `modeModelId_${effectiveMode}`,
-                value: changes.model,
-              });
-              result.applied.model = current() ? 'next-run-start' : 'next-thread-switch';
-              if (current() && !session.run.isRunning() && session.mode.get() === effectiveMode) {
+          try {
+            if (!(await deps.workItems.getForProject(orgId, factoryProjectId, workItemId))) {
+              result.skipReason = 'work-item-gone';
+              continue;
+            }
+            const session = await deps.controller.getSessionByResource(resourceId);
+            if (!session) {
+              result.skipReason = 'session-not-live';
+              continue;
+            }
+            const current = () => session.thread.getId() === threadId;
+            const boundThread = await session.thread.getById({ threadId });
+            if (!boundThread || boundThread.resourceId !== resourceId)
+              throw new Error('Bound thread is missing or belongs to another resource.');
+            const stillActive = (await deps.workItems.listRunBindings(orgId, factoryProjectId)).some(
+              row =>
+                row.id === binding.id &&
+                row.status === 'active' &&
+                row.resourceId === resourceId &&
+                row.threadId === threadId,
+            );
+            if (!stillActive) throw new Error('Worker binding is no longer active.');
+            if (changes.mode) {
+              if (!deps.controller.listModes().some(mode => mode.id === changes.mode))
+                result.skipped.mode = 'unknown-mode';
+              else if (current() && session.run.isRunning()) result.skipped.mode = 'session-busy';
+              else
                 try {
-                  await session.model.switch({ modelId: changes.model, scope: 'thread' });
-                  result.applied.model = 'now';
+                  if (current()) {
+                    await session.mode.switch({ modeId: changes.mode });
+                    result.applied.mode = 'now';
+                  } else {
+                    await session.thread.setSettingOn({ threadId, key: 'currentModeId', value: changes.mode });
+                    result.applied.mode = 'next-thread-switch';
+                  }
                 } catch (error) {
-                  if (session.model.get() === changes.model) result.applied.model = 'now';
-                  result.warnings.push(`Model persisted; live switch failed: ${message(error)}`);
+                  if (current() && session.mode.get() === changes.mode) {
+                    result.applied.mode = 'now';
+                    result.warnings.push(
+                      `Mode switched in memory; persistence or incoming-model reconciliation failed: ${message(error)}`,
+                    );
+                  } else result.skipped.mode = message(error);
                 }
-              }
-            } catch (error) {
-              result.skipped.model = message(error);
             }
-          }
-          if (changes.memory) {
-            let outcome = memoryOutcomes.get(resourceId);
-            if (outcome !== undefined)
-              result.warnings.push('Memory reused the first binding outcome for this shared session.');
-            else {
+            if (changes.model) {
               try {
-                if (session.run.isRunning()) outcome = 'session-busy';
-                else {
-                  let values: MemoryValues;
-                  if (changes.memory === 'resync') {
-                    const stored = await deps.memorySettings.get({
-                      orgId,
-                      userId: factoryMemorySettingsUserId(factoryProjectId),
-                    });
-                    const project = await deps.projects.getById({ id: factoryProjectId });
-                    if (!project) throw new Error('Factory project no longer exists.');
-                    const provider = project.defaultModelId?.split('/')[0];
-                    const fallback =
-                      (provider
-                        ? resolveProviderOMDefault(provider, project.defaultModelId ?? undefined).modelId
-                        : undefined) ?? DEFAULT_OM_MODEL_ID;
-                    values = {
-                      observerModelId: stored?.observerModelId ?? fallback,
-                      reflectorModelId: stored?.reflectorModelId ?? fallback,
-                      observationThreshold: stored?.observationThreshold ?? DEFAULT_OBSERVATION_THRESHOLD,
-                      reflectionThreshold: stored?.reflectionThreshold ?? DEFAULT_REFLECTION_THRESHOLD,
-                      observeAttachments: stored?.observeAttachments ?? 'auto',
-                    };
-                  } else values = changes.memory;
-                  outcome = await updateMemory(session, values);
+                const storedMode = current()
+                  ? undefined
+                  : (await session.thread.getById({ threadId }))?.metadata?.currentModeId;
+                const effectiveMode = result.applied.mode
+                  ? changes.mode!
+                  : typeof storedMode === 'string'
+                    ? storedMode
+                    : session.mode.get();
+                await session.thread.setSettingOn({
+                  threadId,
+                  key: `modeModelId_${effectiveMode}`,
+                  value: changes.model,
+                });
+                result.applied.model = current() ? 'next-run-start' : 'next-thread-switch';
+                if (current() && !session.run.isRunning() && session.mode.get() === effectiveMode) {
+                  try {
+                    await session.model.switch({ modelId: changes.model, scope: 'thread' });
+                    result.applied.model = 'now';
+                  } catch (error) {
+                    if (session.model.get() === changes.model) result.applied.model = 'now';
+                    result.warnings.push(`Model persisted; live switch failed: ${message(error)}`);
+                  }
                 }
               } catch (error) {
-                outcome = message(error);
+                result.skipped.model = message(error);
               }
-              memoryOutcomes.set(resourceId, outcome);
             }
-            if (typeof outcome === 'string') result.skipped.memory = outcome;
-            else {
-              if (Object.keys(outcome.applied).length) result.applied.memory = outcome.applied;
-              if (Object.keys(outcome.skipped).length) result.skipped.memory = outcome.skipped;
-              result.warnings.push(...outcome.warnings);
+            if (changes.memory) {
+              let outcome = memoryOutcomes.get(resourceId);
+              if (outcome !== undefined)
+                result.warnings.push('Memory reused the first binding outcome for this shared session.');
+              else {
+                try {
+                  if (session.run.isRunning()) outcome = 'session-busy';
+                  else {
+                    let values: MemoryValues;
+                    if (changes.memory === 'resync') {
+                      const stored = await deps.memorySettings.get({
+                        orgId,
+                        userId: factoryMemorySettingsUserId(factoryProjectId),
+                      });
+                      const project = await deps.projects.getById({ id: factoryProjectId });
+                      if (!project) throw new Error('Factory project no longer exists.');
+                      const provider = project.defaultModelId?.split('/')[0];
+                      const fallback =
+                        (provider
+                          ? resolveProviderOMDefault(provider, project.defaultModelId ?? undefined).modelId
+                          : undefined) ?? DEFAULT_OM_MODEL_ID;
+                      values = {
+                        observerModelId: stored?.observerModelId ?? fallback,
+                        reflectorModelId: stored?.reflectorModelId ?? fallback,
+                        observationThreshold: stored?.observationThreshold ?? DEFAULT_OBSERVATION_THRESHOLD,
+                        reflectionThreshold: stored?.reflectionThreshold ?? DEFAULT_REFLECTION_THRESHOLD,
+                        observeAttachments: stored?.observeAttachments ?? 'auto',
+                      };
+                    } else values = changes.memory;
+                    outcome = await updateMemory(session, values);
+                  }
+                } catch (error) {
+                  outcome = message(error);
+                }
+                memoryOutcomes.set(resourceId, outcome);
+              }
+              if (typeof outcome === 'string') result.skipped.memory = outcome;
+              else {
+                if (Object.keys(outcome.applied).length) result.applied.memory = outcome.applied;
+                if (Object.keys(outcome.skipped).length) result.skipped.memory = outcome.skipped;
+                result.warnings.push(...outcome.warnings);
+              }
+            }
+            if (changes.title) {
+              if (!current()) result.skipped.title = 'thread-not-current';
+              else
+                try {
+                  await session.thread.rename({ title: changes.title });
+                  result.applied.title = 'now';
+                } catch (error) {
+                  result.skipped.title = message(error);
+                }
+            }
+          } catch (error) {
+            for (const field of ['model', 'mode', 'memory', 'title'] as const) {
+              if (
+                changes[field] !== undefined &&
+                result.applied[field] === undefined &&
+                result.skipped[field] === undefined
+              )
+                result.skipped[field] = message(error);
             }
           }
-          if (changes.title) {
-            if (!current()) result.skipped.title = 'thread-not-current';
-            else
-              try {
-                await session.thread.rename({ title: changes.title });
-                result.applied.title = 'now';
-              } catch (error) {
-                result.skipped.title = message(error);
-              }
+          for (const [field, reason] of Object.entries(result.skipped)) {
+            result.warnings.push(`${field} skipped: ${typeof reason === 'string' ? reason : JSON.stringify(reason)}`);
           }
           if (Object.keys(result.applied).length) {
             result.status = 'updated';
-            await deps.audit.record({
-              orgId,
-              factoryProjectId,
-              actorId: deps.userId,
-              actorType: 'human',
-              action: 'factory.supervisor.session_updated',
-              targets: [{ type: 'factory_session', id: sessionId }],
-              metadata: {
-                cause: 'supervisor',
-                workItemId,
-                role,
-                threadId,
-                applied: result.applied,
-                warnings: result.warnings,
-              },
-              occurredAt: deps.now?.() ?? new Date(),
-            });
+            try {
+              await deps.audit.record({
+                orgId,
+                factoryProjectId,
+                actorId: deps.userId,
+                actorType: 'human',
+                action: 'factory.supervisor.session_updated',
+                targets: [{ type: 'factory_session', id: sessionId }],
+                metadata: {
+                  cause: 'supervisor',
+                  workItemId,
+                  role,
+                  threadId,
+                  applied: result.applied,
+                  warnings: result.warnings,
+                },
+                occurredAt: deps.now?.() ?? new Date(),
+              });
+            } catch (error) {
+              result.warnings.push(`Changes applied but audit recording failed: ${message(error)}`);
+            }
           }
         }
         const touched = results.filter(result => result.status === 'updated').length;

--- a/mastracode/factory/src/supervisor/session-tools.ts
+++ b/mastracode/factory/src/supervisor/session-tools.ts
@@ -218,7 +218,7 @@ export function createFactorySupervisorSessionTools(deps: Dependencies): Integra
                   : (await session.thread.getById({ threadId }))?.metadata?.currentModeId;
                 const effectiveMode = result.applied.mode
                   ? changes.mode!
-                  : typeof storedMode === 'string'
+                  : typeof storedMode === 'string' && deps.controller.listModes().some(mode => mode.id === storedMode)
                     ? storedMode
                     : session.mode.get();
                 await session.thread.setSettingOn({

--- a/mastracode/factory/src/supervisor/session-tools.ts
+++ b/mastracode/factory/src/supervisor/session-tools.ts
@@ -1,0 +1,310 @@
+import { DEFAULT_OM_MODEL_ID } from '@mastra/code-sdk/constants';
+import { resolveProviderOMDefault } from '@mastra/code-sdk/onboarding/packs';
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import type { IntegrationTools } from '../integrations/base.js';
+import { DEFAULT_OBSERVATION_THRESHOLD, DEFAULT_REFLECTION_THRESHOLD } from '../session/memory-settings-hydration.js';
+import type { OMConfigurableSession } from '../session/memory-settings-hydration.js';
+import type { AuditStorage } from '../storage/domains/audit/base.js';
+import { factoryMemorySettingsUserId } from '../storage/domains/memory-settings/base.js';
+import type { MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
+import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
+import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import type { SupervisorScope } from './read-tools.js';
+
+interface ConfigurableSession extends OMConfigurableSession {
+  thread: {
+    getId(): string | null;
+    getById(args: { threadId: string }): Promise<{ metadata?: Record<string, unknown> } | null>;
+    setSettingOn(args: { threadId: string; key: string; value: unknown }): Promise<void>;
+    rename(args: { title: string }): Promise<void>;
+  };
+  run: { isRunning(): boolean };
+  mode: { get(): string; switch(args: { modeId: string }): Promise<void> };
+  model: { get(): string; switch(args: { modelId: string; scope: 'thread' }): Promise<void> };
+}
+
+interface Dependencies {
+  scope: SupervisorScope;
+  userId: string;
+  workItems: Pick<WorkItemsStorage, 'listRunBindings' | 'getForProject'>;
+  audit: AuditStorage;
+  controller: {
+    getSessionByResource(resourceId: string): Promise<ConfigurableSession | undefined>;
+    listModes(): { id: string }[];
+  };
+  memorySettings: Pick<MemorySettingsStorage, 'get'>;
+  projects: Pick<FactoryProjectsStorage, 'getById'>;
+  now?: () => Date;
+}
+
+const modelId = z.string().trim().min(1);
+const memorySchema = z
+  .object({
+    observerModelId: modelId.optional(),
+    reflectorModelId: modelId.optional(),
+    observationThreshold: z.number().int().positive().optional(),
+    reflectionThreshold: z.number().int().positive().optional(),
+  })
+  .strict()
+  .refine(value => Object.values(value).some(v => v !== undefined), 'Provide at least one memory setting.');
+const inputSchema = z
+  .object({
+    target: z.union([
+      z.object({ sessionId: z.string().min(1) }).strict(),
+      z.object({ workItemId: z.string().min(1), role: z.string().min(1) }).strict(),
+      z.object({ all: z.literal(true) }).strict(),
+    ]),
+    changes: z
+      .object({
+        model: modelId.optional(),
+        mode: modelId.optional(),
+        memory: z.union([z.literal('resync'), memorySchema]).optional(),
+        title: z.string().trim().min(1).max(200).optional(),
+      })
+      .strict()
+      .refine(value => Object.values(value).some(v => v !== undefined), 'Provide at least one change.'),
+  })
+  .strict();
+
+type MemoryValues = z.infer<typeof memorySchema> & { observeAttachments?: 'auto' | boolean };
+type MemoryKnob = keyof MemoryValues;
+type MemoryOutcome = {
+  applied: Partial<Record<MemoryKnob, 'written' | 'unchanged'>>;
+  skipped: Partial<Record<MemoryKnob, string>>;
+  warnings: string[];
+};
+type Result = {
+  sessionId: string;
+  resourceId: string;
+  workItemId: string;
+  role: string;
+  threadId: string;
+  status: 'updated' | 'skipped';
+  skipReason?: 'work-item-gone' | 'session-not-live';
+  applied: {
+    model?: 'now' | 'next-run-start' | 'next-thread-switch';
+    mode?: 'now' | 'next-thread-switch';
+    title?: 'now';
+    memory?: MemoryOutcome['applied'];
+  };
+  skipped: { model?: string; mode?: string; title?: string; memory?: string | MemoryOutcome['skipped'] };
+  warnings: string[];
+};
+const message = (error: unknown) => (error instanceof Error ? error.message : String(error));
+
+async function updateMemory(session: ConfigurableSession, values: MemoryValues): Promise<MemoryOutcome> {
+  const outcome: MemoryOutcome = { applied: {}, skipped: {}, warnings: [] };
+  for (const knob of Object.keys(values) as MemoryKnob[]) {
+    const value = values[knob];
+    if (value === undefined) continue;
+    const role = knob === 'observerModelId' ? 'observer' : knob === 'reflectorModelId' ? 'reflector' : undefined;
+    const read = () =>
+      role
+        ? session.om[role].modelId()
+        : (session.state.get()?.[knob] ?? (knob === 'observeAttachments' ? 'auto' : undefined));
+    if (read() === value) {
+      outcome.applied[knob] = 'unchanged';
+      continue;
+    }
+    if (session.run.isRunning()) {
+      outcome.skipped[knob] = 'session-busy';
+      continue;
+    }
+    try {
+      if (role && typeof value === 'string') await session.om[role].switchModel({ modelId: value });
+      else if (knob === 'observationThreshold' && typeof value === 'number')
+        await session.state.set({ observationThreshold: value });
+      else if (knob === 'reflectionThreshold' && typeof value === 'number')
+        await session.state.set({ reflectionThreshold: value });
+      else if (knob === 'observeAttachments' && (value === 'auto' || typeof value === 'boolean'))
+        await session.state.set({ observeAttachments: value });
+      outcome.applied[knob] = 'written';
+    } catch (error) {
+      if (read() === value) outcome.applied[knob] = 'written';
+      else outcome.skipped[knob] = message(error);
+      outcome.warnings.push(`${knob}: ${message(error)}`);
+    }
+  }
+  return outcome;
+}
+
+export function createFactorySupervisorSessionTools(deps: Dependencies): IntegrationTools {
+  return {
+    factory_update_session: createTool({
+      id: 'factory_update_session',
+      description:
+        'Update active Factory worker sessions without approval. Choose one session, a work item and role, or all active bindings. Model changes apply now when current and idle, next run start when busy, or next thread switch for other threads. Busy sessions skip mode and memory changes; non-current threads skip title changes. Memory is session-wide; resync restores stored Factory settings and defaults. Returns per-binding applied/skipped fields and warnings. Cannot change permissions, yolo or notifications.',
+      requireApproval: false,
+      inputSchema,
+      execute: async ({ target, changes }) => {
+        const { orgId, factoryProjectId } = deps.scope;
+        const bindings = (await deps.workItems.listRunBindings(orgId, factoryProjectId))
+          .filter(binding => binding.status === 'active')
+          .filter(
+            binding =>
+              'all' in target ||
+              ('sessionId' in target
+                ? binding.sessionId === target.sessionId
+                : binding.workItemId === target.workItemId && binding.role === target.role),
+          );
+        if (!('all' in target) && (bindings.length === 0 || ('workItemId' in target && bindings.length !== 1)))
+          throw new Error('Not an active worker session of this factory.');
+        const results: Result[] = [];
+        const memoryOutcomes = new Map<string, MemoryOutcome | string>();
+        for (const binding of bindings) {
+          const { sessionId, resourceId, workItemId, role, threadId } = binding;
+          const result: Result = {
+            sessionId,
+            resourceId,
+            workItemId,
+            role,
+            threadId,
+            status: 'skipped',
+            applied: {},
+            skipped: {},
+            warnings: [],
+          };
+          results.push(result);
+          if (!(await deps.workItems.getForProject(orgId, factoryProjectId, workItemId))) {
+            result.skipReason = 'work-item-gone';
+            continue;
+          }
+          const session = await deps.controller.getSessionByResource(resourceId);
+          if (!session) {
+            result.skipReason = 'session-not-live';
+            continue;
+          }
+          const current = () => session.thread.getId() === threadId;
+          if (changes.mode) {
+            if (!deps.controller.listModes().some(mode => mode.id === changes.mode))
+              result.skipped.mode = 'unknown-mode';
+            else if (current() && session.run.isRunning()) result.skipped.mode = 'session-busy';
+            else
+              try {
+                if (current()) {
+                  await session.mode.switch({ modeId: changes.mode });
+                  result.applied.mode = 'now';
+                } else {
+                  await session.thread.setSettingOn({ threadId, key: 'currentModeId', value: changes.mode });
+                  result.applied.mode = 'next-thread-switch';
+                }
+              } catch (error) {
+                if (current() && session.mode.get() === changes.mode) {
+                  result.applied.mode = 'now';
+                  result.warnings.push(
+                    `Mode switched in memory; persistence or incoming-model reconciliation failed: ${message(error)}`,
+                  );
+                } else result.skipped.mode = message(error);
+              }
+          }
+          if (changes.model) {
+            try {
+              const storedMode = current()
+                ? undefined
+                : (await session.thread.getById({ threadId }))?.metadata?.currentModeId;
+              const effectiveMode = result.applied.mode
+                ? changes.mode!
+                : typeof storedMode === 'string'
+                  ? storedMode
+                  : session.mode.get();
+              await session.thread.setSettingOn({
+                threadId,
+                key: `modeModelId_${effectiveMode}`,
+                value: changes.model,
+              });
+              result.applied.model = current() ? 'next-run-start' : 'next-thread-switch';
+              if (current() && !session.run.isRunning() && session.mode.get() === effectiveMode) {
+                try {
+                  await session.model.switch({ modelId: changes.model, scope: 'thread' });
+                  result.applied.model = 'now';
+                } catch (error) {
+                  if (session.model.get() === changes.model) result.applied.model = 'now';
+                  result.warnings.push(`Model persisted; live switch failed: ${message(error)}`);
+                }
+              }
+            } catch (error) {
+              result.skipped.model = message(error);
+            }
+          }
+          if (changes.memory) {
+            let outcome = memoryOutcomes.get(resourceId);
+            if (outcome !== undefined)
+              result.warnings.push('Memory reused the first binding outcome for this shared session.');
+            else {
+              try {
+                if (session.run.isRunning()) outcome = 'session-busy';
+                else {
+                  let values: MemoryValues;
+                  if (changes.memory === 'resync') {
+                    const stored = await deps.memorySettings.get({
+                      orgId,
+                      userId: factoryMemorySettingsUserId(factoryProjectId),
+                    });
+                    const project = await deps.projects.getById({ id: factoryProjectId });
+                    if (!project) throw new Error('Factory project no longer exists.');
+                    const provider = project.defaultModelId?.split('/')[0];
+                    const fallback =
+                      (provider
+                        ? resolveProviderOMDefault(provider, project.defaultModelId ?? undefined).modelId
+                        : undefined) ?? DEFAULT_OM_MODEL_ID;
+                    values = {
+                      observerModelId: stored?.observerModelId ?? fallback,
+                      reflectorModelId: stored?.reflectorModelId ?? fallback,
+                      observationThreshold: stored?.observationThreshold ?? DEFAULT_OBSERVATION_THRESHOLD,
+                      reflectionThreshold: stored?.reflectionThreshold ?? DEFAULT_REFLECTION_THRESHOLD,
+                      observeAttachments: stored?.observeAttachments ?? 'auto',
+                    };
+                  } else values = changes.memory;
+                  outcome = await updateMemory(session, values);
+                }
+              } catch (error) {
+                outcome = message(error);
+              }
+              memoryOutcomes.set(resourceId, outcome);
+            }
+            if (typeof outcome === 'string') result.skipped.memory = outcome;
+            else {
+              if (Object.keys(outcome.applied).length) result.applied.memory = outcome.applied;
+              if (Object.keys(outcome.skipped).length) result.skipped.memory = outcome.skipped;
+              result.warnings.push(...outcome.warnings);
+            }
+          }
+          if (changes.title) {
+            if (!current()) result.skipped.title = 'thread-not-current';
+            else
+              try {
+                await session.thread.rename({ title: changes.title });
+                result.applied.title = 'now';
+              } catch (error) {
+                result.skipped.title = message(error);
+              }
+          }
+          if (Object.keys(result.applied).length) {
+            result.status = 'updated';
+            await deps.audit.record({
+              orgId,
+              factoryProjectId,
+              actorId: deps.userId,
+              actorType: 'human',
+              action: 'factory.supervisor.session_updated',
+              targets: [{ type: 'factory_session', id: sessionId }],
+              metadata: {
+                cause: 'supervisor',
+                workItemId,
+                role,
+                threadId,
+                applied: result.applied,
+                warnings: result.warnings,
+              },
+              occurredAt: deps.now?.() ?? new Date(),
+            });
+          }
+        }
+        const touched = results.filter(result => result.status === 'updated').length;
+        return { results, summary: { targets: results.length, touched, untouched: results.length - touched } };
+      },
+    }),
+  };
+}

--- a/mastracode/factory/src/supervisor/write-tools.test.ts
+++ b/mastracode/factory/src/supervisor/write-tools.test.ts
@@ -257,6 +257,34 @@ describe('createFactorySupervisorWriteTools', () => {
     });
   });
 
+  it('signals without approval using active bindings only and audits every active role', async () => {
+    const context = await setup();
+    const item = await createItem(context.workItems, 7, 'execute');
+    const { binding } = await bindRun(context.workItems, item, 7);
+    const list = vi
+      .spyOn(context.workItems, 'listRunBindings')
+      .mockResolvedValue([
+        { ...binding, id: 'revoked', status: 'revoked', role: 'old' },
+        binding,
+        { ...binding, id: 'second', role: 'review', threadId: 'second-thread' },
+      ]);
+    expect(context.tools.factory_signal_session.requireApproval).toBe(false);
+    await expect(
+      execute(context.tools.factory_signal_session, { sessionId: 'session-7', message: 'Continue.' }),
+    ).resolves.toEqual({ sessionId: 'session-7', delivered: true, workItemId: item.id, role: 'work' });
+    expect((await latestAudit(context.audit))?.metadata).toMatchObject({
+      bindings: [
+        { workItemId: item.id, role: 'work' },
+        { workItemId: item.id, role: 'review' },
+      ],
+    });
+    list.mockResolvedValue([{ ...binding, status: 'revoked' }]);
+    await expect(
+      execute(context.tools.factory_signal_session, { sessionId: 'session-7', message: 'Continue.' }),
+    ).rejects.toThrow('does not belong');
+    expect(context.signalSession).toHaveBeenCalledTimes(1);
+  });
+
   it('signals only a session bound to this factory', async () => {
     const context = await setup();
     const item = await createItem(context.workItems, 6, 'execute');

--- a/mastracode/factory/src/supervisor/write-tools.test.ts
+++ b/mastracode/factory/src/supervisor/write-tools.test.ts
@@ -261,13 +261,11 @@ describe('createFactorySupervisorWriteTools', () => {
     const context = await setup();
     const item = await createItem(context.workItems, 7, 'execute');
     const { binding } = await bindRun(context.workItems, item, 7);
-    const list = vi
-      .spyOn(context.workItems, 'listRunBindings')
-      .mockResolvedValue([
-        { ...binding, id: 'revoked', status: 'revoked', role: 'old' },
-        binding,
-        { ...binding, id: 'second', role: 'review', threadId: 'second-thread' },
-      ]);
+    const list = vi.spyOn(context.workItems, 'listRunBindings').mockResolvedValue([
+      { ...binding, id: 'revoked', status: 'revoked', role: 'old' },
+      { ...binding, resourceId: 'distinct-resource' },
+      { ...binding, id: 'second', role: 'review', threadId: 'second-thread', resourceId: 'distinct-resource' },
+    ]);
     expect(context.tools.factory_signal_session.requireApproval).toBe(false);
     await expect(
       execute(context.tools.factory_signal_session, { sessionId: 'session-7', message: 'Continue.' }),
@@ -283,6 +281,12 @@ describe('createFactorySupervisorWriteTools', () => {
       execute(context.tools.factory_signal_session, { sessionId: 'session-7', message: 'Continue.' }),
     ).rejects.toThrow('does not belong');
     expect(context.signalSession).toHaveBeenCalledTimes(1);
+    expect(context.signalSession).toHaveBeenCalledWith({
+      sessionId: 'session-7',
+      resourceId: 'distinct-resource',
+      message: 'Continue.',
+      userId: 'user-supervisor',
+    });
   });
 
   it('signals only a session bound to this factory', async () => {
@@ -295,6 +299,7 @@ describe('createFactorySupervisorWriteTools', () => {
     ).resolves.toMatchObject({ delivered: true, workItemId: item.id });
     expect(context.signalSession).toHaveBeenCalledWith({
       sessionId: 'session-6',
+      resourceId: 'session-6',
       message: 'Please stop after tests.',
       userId: 'user-supervisor',
     });

--- a/mastracode/factory/src/supervisor/write-tools.ts
+++ b/mastracode/factory/src/supervisor/write-tools.ts
@@ -186,13 +186,14 @@ export function createFactorySupervisorWriteTools(deps: SupervisorWriteDependenc
     }),
     factory_signal_session: createTool({
       id: 'factory_signal_session',
-      description: 'Send bounded guidance to a worker session after the person confirms the exact message.',
+      description: 'Send a message to a worker session bound to this factory without an approval prompt.',
       inputSchema: z.object({ sessionId: z.string().min(1), message: z.string().trim().min(1).max(2000) }),
-      requireApproval: true,
+      requireApproval: false,
       execute: async ({ sessionId, message }) => {
         if (!deps.signalSession) throw new Error('Worker session signaling is unavailable.');
         const bindings = await deps.workItems.listRunBindings(deps.scope.orgId, deps.scope.factoryProjectId);
-        const binding = bindings.find(row => row.sessionId === sessionId);
+        const activeBindings = bindings.filter(row => row.sessionId === sessionId && row.status === 'active');
+        const binding = activeBindings[0];
         if (!binding) throw new Error('The session does not belong to this factory.');
         await deps.signalSession({ sessionId, message, userId: deps.userId });
         await audit(
@@ -201,6 +202,7 @@ export function createFactorySupervisorWriteTools(deps: SupervisorWriteDependenc
           {
             workItemId: binding.workItemId,
             role: binding.role,
+            bindings: activeBindings.map(({ workItemId, role }) => ({ workItemId, role })),
           },
         );
         return { sessionId, delivered: true, workItemId: binding.workItemId, role: binding.role };

--- a/mastracode/factory/src/supervisor/write-tools.ts
+++ b/mastracode/factory/src/supervisor/write-tools.ts
@@ -15,7 +15,12 @@ interface SupervisorWriteDependencies {
   audit: AuditStorage;
   transitionService: FactoryTransitionService;
   reconcileAcceptanceLabels?: (input: { orgId: string; factoryProjectId: string; item: WorkItemRow }) => Promise<void>;
-  signalSession?: (input: { sessionId: string; message: string; userId: string }) => Promise<unknown>;
+  signalSession?: (input: {
+    sessionId: string;
+    resourceId: string;
+    message: string;
+    userId: string;
+  }) => Promise<unknown>;
   now?: () => Date;
 }
 
@@ -195,7 +200,7 @@ export function createFactorySupervisorWriteTools(deps: SupervisorWriteDependenc
         const activeBindings = bindings.filter(row => row.sessionId === sessionId && row.status === 'active');
         const binding = activeBindings[0];
         if (!binding) throw new Error('The session does not belong to this factory.');
-        await deps.signalSession({ sessionId, message, userId: deps.userId });
+        await deps.signalSession({ sessionId, resourceId: binding.resourceId, message, userId: deps.userId });
         await audit(
           'factory.agent.signaled',
           { type: 'factory_session', id: sessionId },


### PR DESCRIPTION
A person chatting with a Factory supervisor can now change bound worker sessions and then nudge them without an approval prompt. `factory_update_session` accepts a session ID, a work item plus role, or every active binding in the project. It supports model, mode, thread title, and memory settings, including resync from the factory's stored configuration.

```ts
{
  target: { workItemId: "<work-item-id>", role: "plan" },
  changes: { model: "deepseek/deepseek-chat", title: "Fixture plan" }
}
```

The result reports each field as applied now, at the next run start, at the next thread switch, or skipped. Current idle sessions can switch immediately. Busy sessions persist the model for their next run and skip mode/memory changes. Non-current threads receive persisted model/mode settings without switching the shared live session; their title changes are skipped. Memory settings are session-wide. Partial application is reported rather than treated as rollback.

`factory_signal_session` is also approval-free. It resolves only active bindings, uses their resource address, and includes all matching active bindings in its audit metadata. Its response shape is unchanged. Both tools remain restricted to authenticated, project-scoped supervisor turns. They cannot edit yolo, permissions, or notification settings. Updates audit the requesting person and only the fields actually applied.

Verification: 225 focused tests passed, including shared-thread isolation, busy/idle behavior, retired modes, partial failures, revoked bindings and registration. Typecheck and lint passed. A mounted-controller demo verifies persisted model pickup on thread switch and immediate current-thread updates. A real supervisor-chat run observed an actual reasoner-to-chat model change and signal delivery without approval. The combined proof remains incomplete for its final title snapshot: the worker subsequently renamed its thread before the interrupted capture resumed. That run also predates the final retired-mode fix; it is not claimed as fresh end-to-end proof of this tip.

Known existing limitation: signaling sends before recording its audit. An audit-storage failure after delivery can reject the call after the message was already sent. This PR preserves that existing failure behavior and return contract. Binding revocation checks are best-effort across the storage/live-session boundary.

Try it with an active worker: “Change the plan worker on this card to deepseek/deepseek-chat, retitle it Fixture plan, then tell it to continue.” The supervisor reports immediate, deferred and skipped outcomes separately.
