### PR TITLE
fix(pg): skip unused totals on agent last-N reads

### DIFF
--- a/.changeset/pg-skip-unused-message-total.md
+++ b/.changeset/pg-skip-unused-message-total.md
@@ -1,0 +1,7 @@
+---
+'@mastra/pg': patch
+'@mastra/core': patch
+'@mastra/memory': patch
+---
+
+Improved recent-message reads so callers that only need the page can skip counting the whole thread. Agent history does this by default. Postgres peeks one extra row to keep pagination accurate.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4579,6 +4579,7 @@ export class Agent<
       threadConfig: memoryConfig,
       // The new user messages aren't in the list yet cause we add memory messages first to try to make sure ordering is correct (memory comes before new user messages)
       vectorSearchString: threadConfig.semanticRecall && vectorMessageSearch ? vectorMessageSearch : undefined,
+      includeTotal: false,
     });
   }
 

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -213,6 +213,7 @@ describe('MessageHistory', () => {
       }
 
       expect(listMessages).toHaveBeenCalledTimes(1);
+      expect(listMessages).toHaveBeenCalledWith(expect.objectContaining({ includeTotal: false }));
     });
 
     it('should merge historical messages with new messages', async () => {

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -133,6 +133,7 @@ export class MessageHistory implements Processor {
           page: 0,
           perPage: this.lastMessages,
           orderBy: { field: 'createdAt', direction: 'DESC' },
+          includeTotal: false,
         });
         return result.messages;
       };

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -113,6 +113,14 @@ type StorageListMessagesOptions = {
     metadata?: StorageMetadataFilter;
   };
   orderBy?: StorageOrderBy<'createdAt'>;
+  /**
+   * When false, skip counting every matching row. `total` is then the size of
+   * the returned page (`offset + messages.length`), not the thread. `hasMore`
+   * is still accurate (Postgres peeks one extra row). Defaults to true.
+   * MessageHistory on the agent path passes false because it only consumes
+   * `messages`.
+   */
+  includeTotal?: boolean;
 };
 
 /**

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -591,6 +591,7 @@ export class Memory extends MastraMemory {
       vectorSearchString,
       includeSystemReminders,
       filter,
+      includeTotal,
     } = args;
     const config = this.getMergedThreadConfig(threadConfig || {});
     const semanticRecallEnabled = Boolean(config.semanticRecall);
@@ -736,6 +737,7 @@ export class Memory extends MastraMemory {
         page,
         orderBy: effectiveOrderBy,
         filter,
+        includeTotal,
         ...(filteredVectorResults?.length
           ? {
               include: filteredVectorResults.map(r => ({
@@ -1847,6 +1849,7 @@ ${workingMemory}`;
           resourceId,
           orderBy: { field: 'createdAt', direction: 'DESC' },
           perPage: typeof lastMessages === 'number' ? lastMessages : undefined,
+          includeTotal: false,
         });
         messages = result.messages.reverse(); // DESC → chronological order
       }
@@ -2435,6 +2438,7 @@ Notes:
         resourceId,
         perPage: SUMMARIZE_THREAD_DEFAULTS.pageSize,
         page,
+        includeTotal: false,
       });
       if (batch.length === 0) break;
 

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -1030,15 +1030,16 @@ export class MemoryPG extends MemoryStorage {
   }
 
   /**
-   * Reads one page of messages together with the total row count.
+   * Reads one page of messages, optionally with the total row count, in one
+   * round-trip.
    *
-   * Every page query carries a skinny scalar `(SELECT COUNT(*) ...)` subquery that
-   * reports the total over the whole WHERE result on the same statement as the page,
-   * so the page costs one database round-trip instead of two. The page and the count
-   * also come from one snapshot, so the count always describes the returned rows. A
-   * separate `COUNT(*)` runs only as a fallback when the page is empty and the caller
-   * asked for a page after the last row, because there is then no row to carry the
-   * count on.
+   * When the caller needs `total`, the page query carries a skinny scalar
+   * `(SELECT COUNT(*) ...)` subquery on the same statement as the page. When
+   * the caller only consumes `messages` (`includeTotal: false`), the count is
+   * skipped and `hasMore` comes from peeking one extra row. A separate
+   * `COUNT(*)` still runs as a fallback when totals are requested and the page
+   * is empty past the last row, because there is then no row to carry the count
+   * on.
    */
   async #fetchMessagePage({
     selectStatement,
@@ -1049,6 +1050,7 @@ export class MemoryPG extends MemoryStorage {
     perPageInput,
     perPage,
     offset,
+    includeTotal = true,
   }: {
     selectStatement: string;
     tableName: string;
@@ -1058,10 +1060,33 @@ export class MemoryPG extends MemoryStorage {
     perPageInput: number | false | undefined;
     perPage: number;
     offset: number;
-  }): Promise<{ total: number; messages: MessageRowFromDB[] }> {
+    includeTotal?: boolean;
+  }): Promise<{ total: number; messages: MessageRowFromDB[]; hasMore?: boolean }> {
+    if (!includeTotal) {
+      if (perPageInput === false) {
+        const allRows =
+          (await this.#db.readClient.manyOrNone<MessageRowFromDB>(
+            `${selectStatement} FROM ${tableName} ${whereClause} ${orderByStatement}`,
+            queryParams,
+          )) || [];
+        return { total: allRows.length, messages: allRows, hasMore: false };
+      }
+      const peekParams = [...queryParams, perPage + 1, offset];
+      const peeked =
+        (await this.#db.readClient.manyOrNone<MessageRowFromDB>(
+          `${selectStatement} FROM ${tableName} ${whereClause} ${orderByStatement} LIMIT $${queryParams.length + 1} OFFSET $${queryParams.length + 2}`,
+          peekParams,
+        )) || [];
+      const hasMore = peeked.length > perPage;
+      const pageRows = hasMore ? peeked.slice(0, perPage) : peeked;
+      return { total: offset + pageRows.length, messages: pageRows, hasMore };
+    }
+
     // `perPageInput === false` means "every row", so no LIMIT is applied.
+    const limitPlaceholder = `$${queryParams.length + 1}`;
+    const offsetPlaceholder = `$${queryParams.length + 2}`;
     const limitClause =
-      perPageInput === false ? '' : ` LIMIT $${queryParams.length + 1} OFFSET $${queryParams.length + 2}`;
+      perPageInput === false ? '' : ` LIMIT ${limitPlaceholder} OFFSET ${offsetPlaceholder}`;
     const dataParams = perPageInput === false ? queryParams : [...queryParams, perPage, offset];
     // Use a skinny scalar COUNT(*) subquery rather than COUNT(*) OVER (). The window ran over
     // the full SELECT list, forcing Postgres to materialize/heap-fetch `content` for every
@@ -1075,17 +1100,23 @@ export class MemoryPG extends MemoryStorage {
       )) || [];
 
     if (rows.length > 0) {
-      return { total: Number(rows[0]!.__total), messages: rows };
+      const total = Number(rows[0]!.__total);
+      return {
+        total,
+        messages: rows,
+        hasMore: perPageInput === false ? false : offset + perPage < total,
+      };
     }
     if (offset === 0) {
-      return { total: 0, messages: [] };
+      return { total: 0, messages: [], hasMore: false };
     }
     const countResult = await this.#db.readClient.one(`SELECT COUNT(*) FROM ${tableName} ${whereClause}`, queryParams);
-    return { total: parseInt(countResult.count, 10), messages: [] };
+    const total = parseInt(countResult.count, 10);
+    return { total, messages: [], hasMore: offset < total };
   }
 
   public async listMessages(args: StorageListMessagesInput): Promise<StorageListMessagesOutput> {
-    const { threadId, resourceId, include, filter, perPage: perPageInput, page = 0, orderBy } = args;
+    const { threadId, resourceId, include, filter, perPage: perPageInput, page = 0, orderBy, includeTotal } = args;
 
     const threadIds = (Array.isArray(threadId) ? threadId : [threadId]).filter(
       (id): id is string => typeof id === 'string',
@@ -1192,6 +1223,7 @@ export class MemoryPG extends MemoryStorage {
 
       let total: number;
       let messages: MessageRowFromDB[];
+      let pageHasMore: boolean | undefined;
       if (metadataFilter) {
         const rows = await this.#db.readClient.manyOrNone(
           `${selectStatement} FROM ${tableName} ${whereClause} ${orderByStatement}`,
@@ -1202,8 +1234,9 @@ export class MemoryPG extends MemoryStorage {
         );
         total = filteredRows.length;
         messages = perPageInput === false ? filteredRows : filteredRows.slice(offset, offset + perPage);
+        pageHasMore = perPageInput !== false && offset + messages.length < total;
       } else {
-        ({ total, messages } = await this.#fetchMessagePage({
+        ({ total, messages, hasMore: pageHasMore } = await this.#fetchMessagePage({
           selectStatement,
           tableName,
           whereClause,
@@ -1212,6 +1245,7 @@ export class MemoryPG extends MemoryStorage {
           perPageInput,
           perPage,
           offset,
+          includeTotal,
         }));
       }
       const primaryPageCount = messages.length;
@@ -1250,9 +1284,12 @@ export class MemoryPG extends MemoryStorage {
         finalMessages.filter(m => m.threadId && threadIdSet.has(m.threadId)).map(m => m.id),
       );
       const allThreadMessagesReturned = returnedThreadMessageIds.size >= total;
-      const hasMore = metadataFilter
-        ? perPageInput !== false && offset + primaryPageCount < total
-        : perPageInput !== false && !allThreadMessagesReturned && offset + perPage < total;
+      const hasMore =
+        includeTotal === false && pageHasMore !== undefined
+          ? pageHasMore
+          : metadataFilter
+            ? perPageInput !== false && offset + primaryPageCount < total
+            : perPageInput !== false && !allThreadMessagesReturned && offset + perPage < total;
 
       return {
         messages: finalMessages,
@@ -1287,7 +1324,7 @@ export class MemoryPG extends MemoryStorage {
   public async listMessagesByResourceId(
     args: StorageListMessagesByResourceIdInput,
   ): Promise<StorageListMessagesOutput> {
-    const { resourceId, include, filter, perPage: perPageInput, page = 0, orderBy } = args;
+    const { resourceId, include, filter, perPage: perPageInput, page = 0, orderBy, includeTotal } = args;
 
     // Validate that resourceId is provided
     const hasResourceId = resourceId !== undefined && resourceId !== null && resourceId.trim() !== '';
@@ -1405,6 +1442,7 @@ export class MemoryPG extends MemoryStorage {
 
       let total: number;
       let messages: MessageRowFromDB[];
+      let pageHasMore: boolean | undefined;
       if (metadataFilter) {
         const rows = await this.#db.readClient.manyOrNone(
           `${selectStatement} FROM ${tableName} ${whereClause} ${orderByStatement}`,
@@ -1415,8 +1453,9 @@ export class MemoryPG extends MemoryStorage {
         );
         total = filteredRows.length;
         messages = perPageInput === false ? filteredRows : filteredRows.slice(offset, offset + perPage);
+        pageHasMore = perPageInput !== false && offset + messages.length < total;
       } else {
-        ({ total, messages } = await this.#fetchMessagePage({
+        ({ total, messages, hasMore: pageHasMore } = await this.#fetchMessagePage({
           selectStatement,
           tableName,
           whereClause,
@@ -1425,6 +1464,7 @@ export class MemoryPG extends MemoryStorage {
           perPageInput,
           perPage,
           offset,
+          includeTotal,
         }));
       }
 
@@ -1457,7 +1497,10 @@ export class MemoryPG extends MemoryStorage {
       const list = new MessageList().add(messagesWithParsedContent, 'memory');
       const finalMessages = this._sortMessages(list.get.all.db(), field, direction);
 
-      const hasMore = perPageInput !== false && offset + perPage < total;
+      const hasMore =
+        includeTotal === false && pageHasMore !== undefined
+          ? pageHasMore
+          : perPageInput !== false && offset + perPage < total;
 
       return {
         messages: finalMessages,

--- a/stores/pg/src/storage/domains/memory/list-messages-round-trips.test.ts
+++ b/stores/pg/src/storage/domains/memory/list-messages-round-trips.test.ts
@@ -38,15 +38,18 @@ class MessageQueryClient extends RecordingDbClientBase {
   override async manyOrNone<T = any>(query: string, values?: QueryValues): Promise<T[]> {
     this.queries.push({ query, values });
     await this.#gate;
-    if (query.includes('AS "__total"')) {
-      return this.pageRows.map(row => ({ ...row, __total: String(this.windowTotal) })) as T[];
-    }
     if (query.includes('thread_id, "createdAt" FROM')) {
       return this.includeRows.map(row => ({
         id: row.id,
         thread_id: row.threadId,
         createdAt: row.createdAt,
       })) as T[];
+    }
+    if (query.includes('AS "__total"')) {
+      return this.pageRows.map(row => ({ ...row, __total: String(this.windowTotal) })) as T[];
+    }
+    if (query.includes('thread_id IN') || query.includes('"resourceId" =')) {
+      return this.pageRows as T[];
     }
     return this.includeRows as T[];
   }
@@ -207,5 +210,39 @@ describe('MemoryPG message paging round-trips', () => {
     expect(pageQuery!.query).not.toContain('ORDER BY COALESCE');
     expect(pageQuery!.query).toContain('ORDER BY "createdAt"');
     expect(pageQuery!.query).toContain('(SELECT COUNT(*) FROM');
+  });
+
+  it('skips the count when includeTotal is false', async () => {
+    const client = new MessageQueryClient();
+    client.pageRows = pageRows;
+    const memory = new MemoryPG({ client });
+
+    const result = await memory.listMessages({ threadId: 'thread-1', perPage: 10, page: 0, includeTotal: false });
+
+    expect(client.queries).toHaveLength(1);
+    const [pageQuery] = client.queries;
+    expect(pageQuery!.query).not.toContain('COUNT(*)');
+    expect(pageQuery!.query).not.toContain('__total');
+    expect(pageQuery!.query).toContain('LIMIT $2 OFFSET $3');
+    expect(pageQuery!.query).toContain('ORDER BY "createdAt"');
+    expect(pageQuery!.values).toEqual(['thread-1', 11, 0]);
+    expect(result.messages).toHaveLength(2);
+    expect(result.total).toBe(2);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('sets hasMore from a peeked extra row when includeTotal is false', async () => {
+    const client = new MessageQueryClient();
+    client.pageRows = [
+      createRow('message-1', '2025-01-01T00:00:00.000Z'),
+      createRow('message-2', '2025-01-01T00:00:01.000Z'),
+    ];
+    const memory = new MemoryPG({ client });
+
+    const result = await memory.listMessages({ threadId: 'thread-1', perPage: 1, page: 0, includeTotal: false });
+
+    expect(client.queries[0]!.values).toEqual(['thread-1', 2, 0]);
+    expect(result.messages).toHaveLength(1);
+    expect(result.hasMore).toBe(true);
   });
 });


### PR DESCRIPTION
## Description

Follow-up invited on #23370. After #23369, last-N pages are index-servable, but Postgres still runs the skinny `COUNT(*)` subquery on every Memory-backed agent turn. `MessageHistory` only reads `messages`.

`includeTotal` (default `true`) lets those callers skip the count. Postgres peeks `LIMIT n+1` for `hasMore`. Studio pagination is unchanged.

## Related issue(s)

Fixes #23376

Invited in https://github.com/mastra-ai/mastra/pull/23370#issuecomment-5592732897

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

Default `listMessages` still asserts the skinny count subquery from #23369. New tests cover skip-count and the extra-row `hasMore` peek.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Verification

SQL-shape tests in `list-messages-round-trips.test.ts`: default path still has `(SELECT COUNT(*) FROM` and no window; `includeTotal: false` has no `COUNT(*)`, peeks `LIMIT n+1`, and sets `hasMore` from the extra row.

I could not run `pnpm --filter @mastra/pg test` in this worktree (no local install of the monorepo). The round-trip tests are fake-client SQL-shape tests and do not need Docker.

## Notes

Other adapters ignore the flag and keep counting. Date-range `COALESCE` filters are untouched. `total` when `includeTotal` is false is `offset + page length`, except the metadata-filter path, which already has every matching row in memory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Recent-message reads no longer count every message when they only need the latest messages. PostgreSQL reads one extra message to detect whether more messages exist, while existing callers keep the current total-count behavior.

## Changes

- Added optional `includeTotal` support to message listing options.
- Kept `includeTotal: true` as the default.
- Updated agent history, context, and summarization reads to use `includeTotal: false`.
- Updated PostgreSQL message listing to:
  - Skip the `COUNT(*)` query when totals are not requested.
  - Fetch one extra row to calculate `hasMore`.
  - Return the page boundary as `total`.
- Preserved counting behavior in other adapters.
- Preserved date-range `COALESCE` filters.
- Added regression tests for default counting, skipped counts, extra-row pagination, and `hasMore` detection.
- Added a changeset for `@mastra/pg`, `@mastra/core`, and `@mastra/memory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->