### PR TITLE
fix(core): make experiment score persistence replay-safe

### DIFF
--- a/.changeset/gold-cobras-carry.md
+++ b/.changeset/gold-cobras-carry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved experiment persistence so runner-owned experiments retain scorer selections and repeated item executions replace existing score records instead of creating duplicates.

--- a/packages/core/src/datasets/__tests__/dataset.test.ts
+++ b/packages/core/src/datasets/__tests__/dataset.test.ts
@@ -328,12 +328,13 @@ describe('Dataset', () => {
   });
 
   // 23. startExperimentAsync
-  it('startExperimentAsync returns pending status immediately', async () => {
+  it('startExperimentAsync returns pending status with scorer IDs persisted immediately', async () => {
     await ds.addItem({ input: { prompt: 'Hello' } });
+    const scorer = createMockScorer('async-scorer', 'Async scorer');
 
     const { experimentId, status } = await ds.startExperimentAsync({
       task: async () => 'ok',
-      scorers: [],
+      scorers: [scorer],
     });
 
     expect(status).toBe('pending');
@@ -342,6 +343,7 @@ describe('Dataset', () => {
     // Verify run record exists
     const run = await experimentsStorage.getExperimentById({ id: experimentId });
     expect(run).not.toBeNull();
+    expect(run?.scorerIds).toEqual(['async-scorer']);
 
     // Wait for fire-and-forget to complete
     await new Promise(r => setTimeout(r, 500));

--- a/packages/core/src/datasets/dataset.ts
+++ b/packages/core/src/datasets/dataset.ts
@@ -28,7 +28,7 @@ import type {
   UpdateExperimentResultInput,
 } from '../storage/types.js';
 import { runExperiment, resolveTarget, executeExperimentItem } from './experiment/index.js';
-import { experimentScoreId } from './experiment/scorer.js';
+import { experimentScoreId, normalizeExperimentScorers } from './experiment/scorer.js';
 import type { ExperimentConfig, StartExperimentConfig, ExperimentSummary } from './experiment/types.js';
 import { deleteExperimentTraces } from './experiment-traces.js';
 
@@ -411,6 +411,7 @@ export class Dataset {
     }
 
     const experimentId = crypto.randomUUID();
+    const { persistedScorerIds } = normalizeExperimentScorers(config.scorers);
 
     if (experimentsStore) {
       await experimentsStore.createExperiment({
@@ -419,6 +420,7 @@ export class Dataset {
         datasetVersion: targetVersion,
         targetType: config.targetType ?? 'agent',
         targetId: config.targetId ?? 'inline',
+        scorerIds: persistedScorerIds,
         totalItems: items.length,
         name: config.name,
         description: config.description,

--- a/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
+++ b/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
@@ -14,6 +14,7 @@ import { ScoresInMemory } from '../../../storage/domains/scores/inmemory';
 import { createStep, createWorkflow } from '../../../workflows';
 import type { ExperimentEvent } from '../index';
 import { EXPERIMENT_ITEM_SCORER_NOT_FOUND, runExperiment } from '../index';
+import { experimentScoreId, experimentStepScoreId } from '../scorer';
 import { scriptedModel } from './scenarios/scenario-helpers';
 
 // Mock agent that returns predictable output
@@ -473,6 +474,22 @@ describe('runExperiment', () => {
   });
 
   describe('scorer source precedence', () => {
+    it('persists categorized scorer IDs uniquely in first-seen order', async () => {
+      const first = createMockScorer('first', 'First');
+      const second = createMockScorer('second', 'Second');
+      const third = createMockScorer('third', 'Third');
+
+      const result = await runExperiment(mastra, {
+        data: [{ input: { prompt: 'test' } }],
+        task: async () => 'output',
+        scorers: { agent: [first, second], trajectory: [first, third] },
+      });
+
+      const experiment = await experimentsStorage.getExperimentById({ id: result.experimentId });
+      expect(experiment?.scorerIds).toEqual(['first', 'second', 'third']);
+      expect(result.results[0].scores.map(score => score.scorerId)).toEqual(['first', 'second', 'first', 'third']);
+    });
+
     it('uses run-level scorers instead of item and dataset scorer IDs', async () => {
       const runScorer = createMockScorer('run', 'Run');
       const lowerScorer = createMockScorer('lower', 'Lower');
@@ -494,6 +511,17 @@ describe('runExperiment', () => {
       expect(runScorer.run).toHaveBeenCalledTimes(2);
       expect(lowerScorer.run).not.toHaveBeenCalled();
       expect(mastra.getScorerById).not.toHaveBeenCalled();
+
+      const experiment = await experimentsStorage.getExperimentById({ id: result.experimentId });
+      expect(experiment?.scorerIds).toEqual(['run']);
+      const { scores } = await scoresStorage.listScoresByRunId({
+        runId: result.experimentId,
+        pagination: { page: 0, perPage: 10 },
+      });
+      const baseScoreId = experimentScoreId(result.experimentId, result.results[0].itemId, 0, 'run');
+      expect(scores.map(score => score.id).sort()).toEqual(
+        [`${baseScoreId}:occurrence:0`, `${baseScoreId}:occurrence:1`].sort(),
+      );
     });
 
     it('treats an explicit run-level empty array as an override', async () => {
@@ -515,6 +543,8 @@ describe('runExperiment', () => {
       expect(result.results[0].scores).toEqual([]);
       expect(lowerScorer.run).not.toHaveBeenCalled();
       expect(mastra.getScorerById).not.toHaveBeenCalled();
+      const experiment = await experimentsStorage.getExperimentById({ id: result.experimentId });
+      expect(experiment?.scorerIds).toEqual([]);
     });
 
     it('treats an empty categorized run-level config as an override', async () => {
@@ -579,6 +609,8 @@ describe('runExperiment', () => {
       expect(itemScorer.run).toHaveBeenCalledTimes(1);
       expect(datasetScorer.run).toHaveBeenCalledTimes(1);
       expect(sharedScorer.run).toHaveBeenCalledTimes(2);
+      const experiment = await experimentsStorage.getExperimentById({ id: result.experimentId });
+      expect(experiment?.scorerIds).toBeNull();
     });
 
     it('does not resolve dataset scorer IDs when every item has an override', async () => {
@@ -747,6 +779,15 @@ describe('runExperiment', () => {
       expect(db.experiments.size).toBe(1);
       expect(db.experimentResults.size).toBe(2);
       expect(db.scores.size).toBe(2);
+      const experiment = await experimentsStorage.getExperimentById({ id: result.experimentId });
+      expect(experiment?.scorerIds).toEqual(['default-scorer']);
+      const { scores } = await scoresStorage.listScoresByRunId({
+        runId: result.experimentId,
+        pagination: { page: 0, perPage: 10 },
+      });
+      expect(scores.map(score => score.id).sort()).toEqual(
+        result.results.map(item => experimentScoreId(result.experimentId, item.itemId, 0, 'default-scorer')).sort(),
+      );
     });
 
     it('suppresses experiment writes independently while still persisting scores', async () => {
@@ -1002,12 +1043,19 @@ describe('runExperiment', () => {
         outputSchema,
         execute: async ({ inputData }) => ({ text: `echo:${inputData.prompt}` }),
       });
+      const repeatStep = createStep({
+        id: 'repeat',
+        inputSchema: outputSchema,
+        outputSchema,
+        execute: async ({ inputData }) => ({ text: `repeat:${inputData.text}` }),
+      });
       const workflow = createWorkflow({
         id: 'categorized-wf',
         inputSchema,
         outputSchema,
       })
         .then(echoStep)
+        .then(repeatStep)
         .commit();
       (mastra.getWorkflowById as ReturnType<typeof vi.fn>).mockReturnValue(workflow);
       (mastra.getWorkflow as ReturnType<typeof vi.fn>).mockReturnValue(workflow);
@@ -1029,15 +1077,33 @@ describe('runExperiment', () => {
         targetId: 'categorized-wf',
         scorers: {
           workflow: [workflowScorer],
-          steps: { echo: [stepScorer] },
+          steps: { echo: [stepScorer], repeat: [stepScorer] },
         },
       });
 
-      expect(result.results[0].scores.map(score => score.scorerId)).toEqual(['workflow-run', 'workflow-step']);
-      expect(result.results[0].scores[1]?.stepId).toBe('echo');
+      expect(result.results[0].scores.map(score => score.scorerId)).toEqual([
+        'workflow-run',
+        'workflow-step',
+        'workflow-step',
+      ]);
+      expect(result.results[0].scores.slice(1).map(score => score.stepId)).toEqual(['echo', 'repeat']);
       expect(workflowScorer.run).toHaveBeenCalledTimes(1);
-      expect(stepScorer.run).toHaveBeenCalledTimes(1);
+      expect(stepScorer.run).toHaveBeenCalledTimes(2);
       expect(lowerScorer.run).not.toHaveBeenCalled();
+
+      const experiment = await experimentsStorage.getExperimentById({ id: result.experimentId });
+      expect(experiment?.scorerIds).toEqual(['workflow-run']);
+      const { scores } = await scoresStorage.listScoresByRunId({
+        runId: result.experimentId,
+        pagination: { page: 0, perPage: 10 },
+      });
+      expect(scores.map(score => score.id).sort()).toEqual(
+        [
+          experimentScoreId(result.experimentId, result.results[0].itemId, 0, 'workflow-run'),
+          experimentStepScoreId(result.experimentId, result.results[0].itemId, 0, 'echo', 'workflow-step'),
+          experimentStepScoreId(result.experimentId, result.results[0].itemId, 0, 'repeat', 'workflow-step'),
+        ].sort(),
+      );
     });
   });
 

--- a/packages/core/src/datasets/experiment/index.ts
+++ b/packages/core/src/datasets/experiment/index.ts
@@ -10,6 +10,8 @@ import { resolveTarget } from './resolve-target';
 import {
   createItemScorerResolver,
   EXPERIMENT_ITEM_SCORER_NOT_FOUND,
+  experimentScoreKey,
+  normalizeExperimentScorers,
   resolveScorers,
   resolveStepScorers,
   runScorersForItem,
@@ -370,33 +372,12 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
       );
   }
 
-  // Preserve whether the caller supplied run-level scorers before normalizing.
-  // Empty arrays and empty categorized configs intentionally override lower-precedence sources.
-  const hasRunLevelScorers = scorerInput !== undefined;
-  let stepsConfigInput: Record<string, (MastraScorer<any, any, any, any> | string)[]> | undefined;
-  let flatScorerInput: (MastraScorer<any, any, any, any> | string)[] | undefined;
-  if (scorerInput !== undefined) {
-    if (Array.isArray(scorerInput)) {
-      flatScorerInput = scorerInput;
-    } else {
-      flatScorerInput = [];
-      if ('agent' in scorerInput && scorerInput.agent) flatScorerInput.push(...scorerInput.agent);
-      if ('workflow' in scorerInput && scorerInput.workflow) flatScorerInput.push(...scorerInput.workflow);
-      if ('trajectory' in scorerInput && scorerInput.trajectory) flatScorerInput.push(...scorerInput.trajectory);
-      if ('steps' in scorerInput && scorerInput.steps) stepsConfigInput = scorerInput.steps;
-    }
-  }
-
-  if (flatScorerInput?.length) {
-    const seen = new Set<string>();
-    flatScorerInput = flatScorerInput.filter(entry => {
-      if (typeof entry !== 'string') return true;
-      if (seen.has(entry)) return false;
-      seen.add(entry);
-      return true;
-    });
-  }
-
+  const {
+    hasRunLevelScorers,
+    flatScorers: flatScorerInput,
+    stepScorers: stepsConfigInput,
+    persistedScorerIds,
+  } = normalizeExperimentScorers(scorerInput);
   const runLevelScorers = hasRunLevelScorers ? resolveScorers(mastra, flatScorerInput) : [];
   const runLevelStepScorers = hasRunLevelScorers ? resolveStepScorers(mastra, stepsConfigInput) : {};
   const resolveItemScorers = createItemScorerResolver(mastra);
@@ -423,6 +404,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
         datasetVersion,
         targetType: targetType ?? 'agent',
         targetId: targetId ?? 'inline',
+        scorerIds: persistedScorerIds,
         totalItems: items.length,
         agentVersion,
         organizationId: datasetRecord?.organizationId ?? null,
@@ -639,6 +621,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
               execResult.traceId ?? undefined,
               workflowData,
               persistScores,
+              experimentScoreKey(experimentId, item.id, 0),
             );
 
             const stepScores = await runStepScorersForItem(
@@ -652,6 +635,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
               item.id,
               execResult.traceId ?? undefined,
               persistScores,
+              experimentScoreKey(experimentId, item.id, 0),
             );
 
             itemScores = [...flatScores, ...stepScores];

--- a/packages/core/src/datasets/experiment/scorer.ts
+++ b/packages/core/src/datasets/experiment/scorer.ts
@@ -14,7 +14,54 @@ import type { CorrelationContext } from '../../observability';
 import type { MastraCompositeStore } from '../../storage/base';
 import type { TargetType } from '../../storage/types';
 import type { StepResult } from '../../workflows';
-import type { ScorerResult } from './types';
+import type { ExperimentConfig, ScorerResult } from './types';
+
+export interface NormalizedExperimentScorers {
+  hasRunLevelScorers: boolean;
+  flatScorers?: (MastraScorer<any, any, any, any> | string)[];
+  stepScorers?: Record<string, (MastraScorer<any, any, any, any> | string)[]>;
+  persistedScorerIds: string[] | null;
+}
+
+/** Normalize flat and categorized scorer configuration for execution and persistence. */
+export function normalizeExperimentScorers(scorers: ExperimentConfig['scorers']): NormalizedExperimentScorers {
+  if (scorers === undefined) {
+    return {
+      hasRunLevelScorers: false,
+      persistedScorerIds: null,
+    };
+  }
+
+  let flatScorers: (MastraScorer<any, any, any, any> | string)[];
+  let stepScorers: Record<string, (MastraScorer<any, any, any, any> | string)[]> | undefined;
+
+  if (Array.isArray(scorers)) {
+    flatScorers = scorers;
+  } else {
+    flatScorers = [];
+    if ('agent' in scorers && scorers.agent) flatScorers.push(...scorers.agent);
+    if ('workflow' in scorers && scorers.workflow) flatScorers.push(...scorers.workflow);
+    if ('trajectory' in scorers && scorers.trajectory) flatScorers.push(...scorers.trajectory);
+    if ('steps' in scorers && scorers.steps) stepScorers = scorers.steps;
+  }
+
+  const seenStringIds = new Set<string>();
+  const normalizedFlatScorers = flatScorers.filter(entry => {
+    if (typeof entry !== 'string') return true;
+    if (seenStringIds.has(entry)) return false;
+    seenStringIds.add(entry);
+    return true;
+  });
+
+  return {
+    hasRunLevelScorers: true,
+    flatScorers: normalizedFlatScorers,
+    stepScorers,
+    persistedScorerIds: [
+      ...new Set(normalizedFlatScorers.map(entry => (typeof entry === 'string' ? entry : entry.id))),
+    ],
+  };
+}
 
 function toScorerTargetEntityType(targetType?: TargetType): EntityType | undefined {
   switch (targetType) {
@@ -146,6 +193,55 @@ export interface WorkflowScorerData {
 }
 
 /**
+ * Deterministic score id for experiment score rows. Retried executions of the
+ * same (experiment, item, attempt, scorer) produce the same id, so the scores
+ * store upserts (latest wins) instead of accumulating duplicate rows.
+ */
+function scoreIdFromKey(scoreKey: string, scorerId: string): string {
+  return `${scoreKey}:${scorerId}`;
+}
+
+function stepScoreIdFromKey(scoreKey: string, stepId: string, scorerId: string): string {
+  return `${scoreKey}:step:${stepId}:${scorerId}`;
+}
+
+export function experimentScoreId(experimentId: string, itemId: string, attempt: number, scorerId: string): string {
+  return scoreIdFromKey(experimentScoreKey(experimentId, itemId, attempt), scorerId);
+}
+
+/** Prefix shared by all scores of one (experiment, item, attempt) execution. */
+export function experimentScoreKey(experimentId: string, itemId: string, attempt: number): string {
+  return `expscore:${experimentId}:${itemId}:${attempt}`;
+}
+
+/** Deterministic score id for a scorer applied to one workflow step. */
+export function experimentStepScoreId(
+  experimentId: string,
+  itemId: string,
+  attempt: number,
+  stepId: string,
+  scorerId: string,
+): string {
+  return stepScoreIdFromKey(experimentScoreKey(experimentId, itemId, attempt), stepId, scorerId);
+}
+
+function stableScoreIdsForScorers(
+  scorers: MastraScorer<any, any, any, any>[],
+  getBaseId: (scorerId: string) => string,
+): string[] {
+  const totals = new Map<string, number>();
+  for (const scorer of scorers) totals.set(scorer.id, (totals.get(scorer.id) ?? 0) + 1);
+
+  const occurrences = new Map<string, number>();
+  return scorers.map(scorer => {
+    const occurrence = occurrences.get(scorer.id) ?? 0;
+    occurrences.set(scorer.id, occurrence + 1);
+    const baseId = getBaseId(scorer.id);
+    return totals.get(scorer.id) === 1 ? baseId : `${baseId}:occurrence:${occurrence}`;
+  });
+}
+
+/**
  * Run all scorers for a single item result.
  * Errors are isolated per scorer - one failing scorer doesn't affect others.
  * Trajectory scorers (scorer.type === 'trajectory') receive a pre-extracted
@@ -156,20 +252,6 @@ export interface WorkflowScorerData {
  * source for trajectory extraction, so nulling it to stop writes would silently
  * downgrade trajectory scorers to the raw-message fallback.
  */
-/**
- * Deterministic score id for experiment score rows. Retried executions of the
- * same (experiment, item, attempt, scorer) produce the same id, so the scores
- * store upserts (latest wins) instead of accumulating duplicate rows.
- */
-export function experimentScoreId(experimentId: string, itemId: string, attempt: number, scorerId: string): string {
-  return `${experimentScoreKey(experimentId, itemId, attempt)}:${scorerId}`;
-}
-
-/** Prefix shared by all scores of one (experiment, item, attempt) execution. */
-export function experimentScoreKey(experimentId: string, itemId: string, attempt: number): string {
-  return `expscore:${experimentId}:${itemId}:${attempt}`;
-}
-
 export async function runScorersForItem(
   scorers: MastraScorer<any, any, any, any>[],
   item: {
@@ -212,8 +294,11 @@ export async function runScorersForItem(
     experimentId: runId,
   };
 
+  const stableScoreIds = stableScoreKey
+    ? stableScoreIdsForScorers(scorers, scorerId => scoreIdFromKey(stableScoreKey, scorerId))
+    : undefined;
   const settled = await Promise.allSettled(
-    scorers.map(async scorer => {
+    scorers.map(async (scorer, scorerIndex) => {
       const { result, promptMetadata } = await runScorerSafe(
         scorer,
         item,
@@ -233,7 +318,7 @@ export async function runScorersForItem(
         try {
           // Legacy score-store emission. This path is being deprecated.
           await validateAndSaveScore(storage, {
-            ...(stableScoreKey ? { id: `${stableScoreKey}:${scorer.id}` } : {}),
+            ...(stableScoreIds ? { id: stableScoreIds[scorerIndex] } : {}),
             scorerId: scorer.id,
             score: result.score,
             reason: result.reason ?? undefined,
@@ -484,6 +569,7 @@ export async function runStepScorersForItem(
   itemId: string,
   traceId?: string,
   persistScores: boolean = true,
+  stableScoreKey?: string,
 ): Promise<ScorerResult[]> {
   const stepIds = Object.keys(stepScorers);
   if (stepIds.length === 0) return [];
@@ -524,8 +610,11 @@ export async function runStepScorersForItem(
       experimentId: runId,
     };
 
+    const stableScoreIds = stableScoreKey
+      ? stableScoreIdsForScorers(scorers, scorerId => stepScoreIdFromKey(stableScoreKey, stepId, scorerId))
+      : undefined;
     const settled = await Promise.allSettled(
-      scorers.map(async scorer => {
+      scorers.map(async (scorer, scorerIndex) => {
         try {
           const scoreResult: unknown = await scorer.run({
             input: stepInput,
@@ -559,13 +648,14 @@ export async function runStepScorersForItem(
           if (persistScores && storage && score !== null) {
             try {
               await validateAndSaveScore(storage, {
+                ...(stableScoreIds ? { id: stableScoreIds[scorerIndex] } : {}),
                 scorerId: scorer.id,
                 score,
                 reason: reason ?? undefined,
                 input: stepInput,
                 output: stepOutput,
                 additionalContext: { ...item.metadata, stepId },
-                entityType: 'WORKFLOW_STEP',
+                entityType: 'STEP',
                 entityId: itemId,
                 source: 'TEST',
                 runId,

--- a/packages/core/src/evals/types.ts
+++ b/packages/core/src/evals/types.ts
@@ -234,9 +234,8 @@ export const saveScorePayloadSchema = scoreRowDataSchema
     /**
      * Optional caller-supplied stable id. When provided, storage adapters
      * upsert by this id (latest write wins) instead of inserting a new row
-     * with a random id. Used by caller-driven experiments so retried
-     * submissions converge on one score row per (experiment, item, attempt,
-     * scorer).
+     * with a random id. Used by experiments so repeated executions converge
+     * on one score row per logical scorer occurrence.
      */
     id: z.string().optional(),
   });


### PR DESCRIPTION
Runner-owned experiments now persist their normalized run-level scorer IDs for both synchronous and asynchronous starts. Flat and workflow-step scores also receive deterministic IDs, including stable occurrence suffixes for duplicate scorer objects, so repeated logical writes replace prior rows without changing scorer execution behavior.

The change stays within `@mastra/core` and does not expose retry or mark existing experiments as replayable.

Test plan: focused dataset experiment tests (170 tests), core typecheck, `pnpm build:core`, and the full core suite (15,057 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The same experiment result now updates the existing record instead of creating duplicates when it runs again. The system also remembers which scorers belong to each experiment, including workflow-step scorers.

## Changes

- Normalize scorer configuration before synchronous and asynchronous experiment persistence.
- Persist normalized run-level scorer IDs.
- Use deterministic score IDs for flat and workflow-step scores.
- Add occurrence suffixes for duplicate scorer objects.
- Preserve scorer execution behavior while making repeated writes replace existing rows.
- Use `STEP` for legacy workflow-step score persistence.
- Add focused tests for scorer persistence, deduplication, stable IDs, overrides, and workflow steps.
- Add a patch changeset for `@mastra/core`.

## Validation

- Focused dataset experiment tests
- Core typechecking
- `pnpm build:core`
- Full core test suite

<!-- end of auto-generated comment: release notes by coderabbit.ai -->