### PR TITLE
docs: fix Parallel Extract quickstart links

### DIFF
--- a/docs/src/content/en/integrations/tools/parallel.mdx
+++ b/docs/src/content/en/integrations/tools/parallel.mdx
@@ -7,7 +7,7 @@ packages:
 
 # Parallel
 
-The `@mastra/parallel` package exposes [Parallel Search](https://docs.parallel.ai/search/search-quickstart) and [Extract](https://docs.parallel.ai/search/extract-quickstart) as Mastra-compatible tools. Each factory returns a tool created with [`createTool()`](/reference/tools/create-tool) and a typed Zod input and output schema.
+The `@mastra/parallel` package exposes [Parallel Search](https://docs.parallel.ai/search/search-quickstart) and [Extract](https://docs.parallel.ai/extract/extract-quickstart) as Mastra-compatible tools. Each factory returns a tool created with [`createTool()`](/reference/tools/create-tool) and a typed Zod input and output schema.
 
 ## Installation
 
@@ -419,5 +419,5 @@ export const researchAgent = new Agent({
 ## Related
 
 - [Parallel Search documentation](https://docs.parallel.ai/search/search-quickstart)
-- [Parallel Extract documentation](https://docs.parallel.ai/search/extract-quickstart)
+- [Parallel Extract documentation](https://docs.parallel.ai/extract/extract-quickstart)
 - [`createTool()` reference](/reference/tools/create-tool)


### PR DESCRIPTION
## Description

Both Extract documentation links on the Parallel integration page lead to a 404. This updates the introductory link and the Related link from `/search/extract-quickstart` to `/extract/extract-quickstart`.

Verified the old destination returns HTTP 404 and the replacement returns HTTP 200. The served production page renders both corrected links. Focused MDX formatting, Remark, Vale, and `git diff --check` pass. `pnpm run build` and `pnpm run validate` also pass. The Vercel docs preview needs authorization from a Mastra team member.

## Related issue(s)

Fixes #23382

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
