### PR TITLE
fix(playground): show metrics in Studio for Mastra platform deployments

### DIFF
--- a/.changeset/hosted-metrics-gate.md
+++ b/.changeset/hosted-metrics-gate.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed Studio's Metrics page showing "Metrics are not available with your current storage" for projects deployed on the Mastra platform. When Studio runs on the platform, observability reads are served by the hosted observability service, so metrics now work regardless of the project's configured storage. This also restores token and cost usage columns on the Traces page for platform deployments.

--- a/packages/playground/src/domains/configuration/hooks/__tests__/use-observability-storage-capabilities.msw.test.tsx
+++ b/packages/playground/src/domains/configuration/hooks/__tests__/use-observability-storage-capabilities.msw.test.tsx
@@ -28,7 +28,10 @@ const useSystemPackagesFixture = (fixture: typeof renamedPostgresWithMetrics) =>
   server.use(http.get(`${BASE_URL}/api/system/packages`, () => HttpResponse.json(fixture)));
 };
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  delete (window as Partial<Window>).MASTRA_CLOUD_API_ENDPOINT;
+});
 
 describe('useObservabilityStorageCapabilities', () => {
   describe('when the server advertises metrics support for a renamed storage class', () => {
@@ -58,6 +61,31 @@ describe('useObservabilityStorageCapabilities', () => {
       const { result } = renderHook(() => useObservabilityStorageCapabilities(), { wrapper: makeWrapper() });
 
       await waitFor(() => expect(result.current.supportsMetrics).toBe(false));
+    });
+  });
+
+  describe('when running on the Mastra platform', () => {
+    // Observability reads are proxied by the edge router to the hosted
+    // ClickHouse query service, so metrics are supported regardless of the
+    // project's own storage.
+    it('reports metrics as available even when storage does not support them', () => {
+      window.MASTRA_CLOUD_API_ENDPOINT = 'https://api.mastra.cloud';
+      useSystemPackagesFixture(storageWithoutMetrics);
+
+      const { result } = renderHook(() => useObservabilityStorageCapabilities(), { wrapper: makeWrapper() });
+
+      expect(result.current.supportsMetrics).toBe(true);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('does not surface the in-memory warning', async () => {
+      window.MASTRA_CLOUD_API_ENDPOINT = 'https://api.mastra.cloud';
+      useSystemPackagesFixture({ ...storageWithoutMetrics, observabilityStorageType: 'ObservabilityInMemory' });
+
+      const { result } = renderHook(() => useObservabilityStorageCapabilities(), { wrapper: makeWrapper() });
+
+      await waitFor(() => expect(result.current.isInMemory).toBe(false));
+      expect(result.current.supportsMetrics).toBe(true);
     });
   });
 });

--- a/packages/playground/src/domains/configuration/hooks/use-observability-storage-capabilities.ts
+++ b/packages/playground/src/domains/configuration/hooks/use-observability-storage-capabilities.ts
@@ -1,4 +1,5 @@
 import { useMastraPackages } from './use-mastra-packages';
+import { useMastraPlatform } from '@/lib/mastra-platform/hooks/use-mastra-platform';
 
 const LEGACY_ANALYTICS_OBSERVABILITY_TYPES = new Set([
   'ObservabilityStorageClickhouseVNext',
@@ -9,16 +10,20 @@ const LEGACY_ANALYTICS_OBSERVABILITY_TYPES = new Set([
 ]);
 
 export const useObservabilityStorageCapabilities = () => {
+  // On the Mastra platform, observability reads (/api/observability/*) are
+  // proxied by the edge router to the hosted ClickHouse-backed query service,
+  // so the project's own storage capabilities are irrelevant.
+  const { isMastraPlatform } = useMastraPlatform();
   const { data, isLoading } = useMastraPackages();
   const observabilityType = data?.observabilityStorageType;
   const advertisedCapabilities = data?.observabilityStorageCapabilities;
-  const supportsMetrics =
+  const storageSupportsMetrics =
     advertisedCapabilities?.metrics ??
     (observabilityType ? LEGACY_ANALYTICS_OBSERVABILITY_TYPES.has(observabilityType) : false);
 
   return {
-    supportsMetrics,
-    isInMemory: observabilityType === 'ObservabilityInMemory',
-    isLoading,
+    supportsMetrics: isMastraPlatform || storageSupportsMetrics,
+    isInMemory: !isMastraPlatform && observabilityType === 'ObservabilityInMemory',
+    isLoading: !isMastraPlatform && isLoading,
   };
 };


### PR DESCRIPTION
## Summary

Projects deployed on the Mastra platform (e.g. `*.studio.mastra.cloud`) showed **"Metrics are not available with your current storage"** on Studio's Metrics page, even though the platform fully supports metrics: exporters are injected at deploy time, telemetry flows into the hosted ClickHouse pipeline, and the edge router already proxies `POST /api/observability/metrics/*` reads to the hosted query service (mobs-query).

The block was purely client-side: `useObservabilityStorageCapabilities()` gated the Metrics page on the **project's own** observability storage type. On the platform that storage never serves observability reads, so the gate was a false negative. (Traces worked because that page fetches unconditionally.)

## Change

- When Studio detects it is running on the Mastra platform (via the edge-router-injected `MASTRA_CLOUD_API_ENDPOINT`), metrics are treated as supported and the in-memory storage warning is suppressed. Off-platform behavior is unchanged (server-advertised capabilities, then legacy class-name fallback).
- This also restores token/cost usage columns on the Traces page for platform deployments, which are gated by the same hook.

## Test plan

- New MSW tests: metrics available on platform even when storage reports unsupported; in-memory warning suppressed on platform. Existing gate tests unchanged and passing (5/5).
- `tsc --noEmit` clean in `packages/playground`.
- Suggested staging verification: load a platform Studio deployment's Metrics page and confirm `POST /api/observability/metrics/breakdown` returns 200 from the proxied query service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Studio now shows metrics for Mastra platform deployments. It also hides an in-memory storage warning that does not apply to the platform.

## Changes

- Detect Mastra platform deployments through `MASTRA_CLOUD_API_ENDPOINT`.
- Treat metrics as supported on the platform, regardless of observability storage type.
- Preserve existing off-platform capability detection and legacy fallback behavior.
- Restore token and cost columns on the Traces page for platform deployments.
- Add MSW coverage for platform metrics and warning suppression.
- Reset `window.MASTRA_CLOUD_API_ENDPOINT` between tests.
- Add a patch changeset for `mastra`.

## Validation

- Existing gate tests pass.
- `tsc --noEmit` passes in `packages/playground`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->