### PR TITLE
fix(studio): refresh working memory after observational memory updates

### DIFF
--- a/.changeset/tidy-memory-refresh.md
+++ b/.changeset/tidy-memory-refresh.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Refresh Studio working memory after observational-memory completion and background buffering, and prevent an older refresh response from overwriting newer working memory.

--- a/packages/playground/src/domains/agents/hooks/use-agent-working-memory.ts
+++ b/packages/playground/src/domains/agents/hooks/use-agent-working-memory.ts
@@ -1,5 +1,5 @@
 import { useMastraClient } from '@mastra/react';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { usePlaygroundStore } from '@/store/playground-store';
 
 function parseJsonString(jsonString: string): any {
@@ -19,8 +19,10 @@ export function useAgentWorkingMemory(agentId: string, threadId: string, resourc
   const [isLoading, setIsLoading] = useState(true);
   const [isUpdating, setIsUpdating] = useState(false);
   const { requestContext } = usePlaygroundStore();
+  const latestRequest = useRef(0);
 
   const refetch = useCallback(async () => {
+    const requestId = ++latestRequest.current;
     setIsLoading(true);
     try {
       if (!agentId || !threadId) {
@@ -29,6 +31,7 @@ export function useAgentWorkingMemory(agentId: string, threadId: string, resourc
         return;
       }
       const res = await client.getWorkingMemory({ agentId, threadId, resourceId, requestContext });
+      if (requestId !== latestRequest.current) return;
       const { workingMemory, source, workingMemoryTemplate, threadExists } = res as {
         workingMemory: string | null;
         source: 'thread' | 'resource';
@@ -53,12 +56,13 @@ export function useAgentWorkingMemory(agentId: string, threadId: string, resourc
         setWorkingMemoryData(workingMemory || workingMemoryTemplate?.content || '');
       }
     } catch (error) {
+      if (requestId !== latestRequest.current) return;
       setWorkingMemoryData(null);
       console.error('Error fetching working memory', error);
     } finally {
-      setIsLoading(false);
+      if (requestId === latestRequest.current) setIsLoading(false);
     }
-  }, [agentId, threadId, resourceId]);
+  }, [agentId, threadId, resourceId, client, requestContext]);
 
   useEffect(() => {
     void refetch();

--- a/packages/playground/src/lib/ai-ui/chat/__tests__/chat-provider.test.tsx
+++ b/packages/playground/src/lib/ai-ui/chat/__tests__/chat-provider.test.tsx
@@ -12,11 +12,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useChatMessages, useChatRunning, useChatSend } from '../chat-context';
 import { ChatProvider } from '../chat-provider';
-import { WorkingMemoryProvider } from '@/domains/agents/context/agent-working-memory-context';
+import { workingMemoryFixture } from './fixtures/working-memory';
+import { WorkingMemoryProvider, useWorkingMemory } from '@/domains/agents/context/agent-working-memory-context';
 import { PlaygroundModelProvider, usePlaygroundModel } from '@/domains/agents/context/playground-model-context';
+import { useMemoryConfig } from '@/domains/memory/hooks';
 import { server } from '@/test/msw-server';
 
 const BASE_URL = 'http://localhost:4111';
+
+const createDeferred = () => {
+  let resolve = () => {};
+  const promise = new Promise<void>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
 
 type CapturedBody = Record<string, unknown>;
 
@@ -747,4 +757,248 @@ describe('ChatProvider', () => {
     expect(messageRequests.length).toBeGreaterThan(1);
     expect(messageRequests.every(url => url.includes('/threads/thread-1/messages'))).toBe(true);
   });
+
+  // Adapted from Jaya Krishna's regression cases in #22270, with independent completion gates.
+  it.each(['observation-end', 'buffer-status'])(
+    'refreshes working memory after %s without the other completion path',
+    async boundary => {
+      const emitBoundary = createDeferred();
+      const finish = createDeferred();
+      let persisted = false;
+      let initialWorkingMemoryReads = 0;
+      const workingMemoryRequest = vi.fn(() =>
+        HttpResponse.json(workingMemoryFixture(persisted ? 'fresh working memory' : 'stale working memory')),
+      );
+      const bufferRequest = vi.fn(() => {
+        persisted = true;
+        return HttpResponse.json({ record: null });
+      });
+      const Probe = () => {
+        const { workingMemoryData } = useWorkingMemory();
+        const { data } = useMemoryConfig('agent-1');
+        return (
+          <>
+            <div data-testid="wm-value">{workingMemoryData}</div>
+            <div data-testid="wm-config">{String(data?.config?.observationalMemory)}</div>
+          </>
+        );
+      };
+      server.use(...baseHandlers([]));
+      server.use(
+        http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json({ config: { observationalMemory: true } })),
+        http.get(`${BASE_URL}/api/memory/threads/thread-1/working-memory`, workingMemoryRequest),
+        http.post(`${BASE_URL}/api/memory/observational-memory/buffer-status`, bufferRequest),
+        http.post(
+          `${BASE_URL}/api/agents/agent-1/stream`,
+          () =>
+            new HttpResponse(
+              new ReadableStream<Uint8Array>({
+                async start(controller) {
+                  const encoder = new TextEncoder();
+                  await emitBoundary.promise;
+                  if (boundary === 'observation-end') {
+                    controller.enqueue(
+                      encoder.encode(
+                        `data: ${JSON.stringify({ type: 'data-om-observation-start', data: { operationType: 'observation' } })}\n\n`,
+                      ),
+                    );
+                    persisted = true;
+                    controller.enqueue(
+                      encoder.encode(
+                        `data: ${JSON.stringify({ type: 'data-om-observation-end', data: { operationType: 'observation' } })}\n\n`,
+                      ),
+                    );
+                    await finish.promise;
+                  }
+                  controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: 'finish', payload: {} })}\n\n`));
+                  controller.close();
+                },
+              }),
+              { headers: { 'content-type': 'text/event-stream' } },
+            ),
+        ),
+      );
+      render(
+        <Wrapper>
+          <ChatProvider agentId="agent-1" threadId="thread-1" initialMessages={[]}>
+            <Probe />
+            <SendOnMount text="update working memory" />
+          </ChatProvider>
+        </Wrapper>,
+      );
+      try {
+        await screen.findByText('stale working memory');
+        await waitFor(() => expect(screen.getByTestId('wm-config').textContent).toBe('true'));
+        initialWorkingMemoryReads = workingMemoryRequest.mock.calls.length;
+        emitBoundary.resolve();
+        await screen.findByText('fresh working memory');
+        expect(workingMemoryRequest).toHaveBeenCalledTimes(initialWorkingMemoryReads + 1);
+        expect(bufferRequest).toHaveBeenCalledTimes(boundary === 'buffer-status' ? 1 : 0);
+      } finally {
+        emitBoundary.resolve();
+        finish.resolve();
+        await waitFor(() => expect(bufferRequest).toHaveBeenCalledTimes(1));
+      }
+    },
+  );
+
+  it('waits for the signals run to finish before refreshing buffered working memory', async () => {
+    delete window.MASTRA_AGENT_SIGNALS;
+    const accepted = createDeferred();
+    const finish = createDeferred();
+    const persisted = createDeferred();
+    const close = createDeferred();
+    let runFinished = false;
+    let workingMemory = 'stale working memory';
+    const bufferRequest = vi.fn(async () => {
+      if (runFinished) await persisted.promise;
+      return HttpResponse.json({ record: null });
+    });
+    const Probe = () => {
+      const send = useChatSend();
+      const { workingMemoryData } = useWorkingMemory();
+      const { data } = useMemoryConfig('agent-1');
+      return (
+        <>
+          <div>{workingMemoryData}</div>
+          <button
+            disabled={!data?.config?.observationalMemory}
+            onClick={async () => {
+              await send({ message: 'update working memory' });
+              accepted.resolve();
+            }}
+          >
+            Send signals message
+          </button>
+        </>
+      );
+    };
+    server.use(...baseHandlers([]));
+    server.use(
+      http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json({ config: { observationalMemory: true } })),
+      http.get(`${BASE_URL}/api/memory/threads/thread-1/working-memory`, () =>
+        HttpResponse.json(workingMemoryFixture(workingMemory)),
+      ),
+      http.post(`${BASE_URL}/api/memory/observational-memory/buffer-status`, bufferRequest),
+      http.post(`${BASE_URL}/api/agents/agent-1/send-message`, () => HttpResponse.json({ accepted: true })),
+      http.post(
+        `${BASE_URL}/api/agents/agent-1/threads/subscribe`,
+        () =>
+          new HttpResponse(
+            new ReadableStream<Uint8Array>({
+              async start(controller) {
+                await finish.promise;
+                runFinished = true;
+                controller.enqueue(
+                  new TextEncoder().encode(`data: ${JSON.stringify({ type: 'finish', payload: {} })}\n\n`),
+                );
+                await close.promise;
+                controller.close();
+              },
+            }),
+            { headers: { 'content-type': 'text/event-stream' } },
+          ),
+      ),
+    );
+    render(
+      <Wrapper>
+        <ChatProvider agentId="agent-1" threadId="thread-1" initialMessages={[]}>
+          <Probe />
+        </ChatProvider>
+      </Wrapper>,
+    );
+    try {
+      await screen.findByText('stale working memory');
+      const send = screen.getByRole('button', { name: 'Send signals message' });
+      await waitFor(() => expect(send.hasAttribute('disabled')).toBe(false));
+      fireEvent.click(send);
+      await act(async () => {
+        await accepted.promise;
+      });
+      expect(bufferRequest).not.toHaveBeenCalled();
+      finish.resolve();
+      await waitFor(() => expect(bufferRequest).toHaveBeenCalledTimes(1));
+      expect(screen.queryByText('fresh working memory')).toBeNull();
+      workingMemory = 'fresh working memory';
+      persisted.resolve();
+      await screen.findByText('fresh working memory');
+      expect(bufferRequest).toHaveBeenCalledTimes(1);
+    } finally {
+      finish.resolve();
+      persisted.resolve();
+      close.resolve();
+    }
+  });
+
+  it.each(['success', 'error', 'before-newer', 'newer-error'])(
+    'keeps ownership with the newest working-memory refresh: %s',
+    async outcome => {
+      const releaseOlder = createDeferred();
+      const releaseNewer = createDeferred();
+      const newerStarted = createDeferred();
+      const olderStarted = createDeferred();
+      const olderCompleted = createDeferred();
+      const newerCompleted = createDeferred();
+      let requests = 0;
+      const Probe = () => {
+        const { workingMemoryData, isLoading, refetch: refreshWorkingMemory } = useWorkingMemory();
+        return (
+          <>
+            <div data-testid="wm-current">{workingMemoryData}</div>
+            <div data-testid="wm-loading">{String(isLoading)}</div>
+            <button onClick={() => void refreshWorkingMemory().then(olderCompleted.resolve)}>older refresh</button>
+            <button onClick={() => void refreshWorkingMemory().then(newerCompleted.resolve)}>newer refresh</button>
+          </>
+        );
+      };
+      server.use(...baseHandlers([]));
+      server.use(
+        http.get(`${BASE_URL}/api/memory/threads/thread-1/working-memory`, async () => {
+          requests++;
+          if (requests === 1) return HttpResponse.json(workingMemoryFixture('initial working memory'));
+          if (requests === 2) {
+            olderStarted.resolve();
+            await releaseOlder.promise;
+            if (outcome === 'error') return new HttpResponse(undefined, { status: 400 });
+            return HttpResponse.json(workingMemoryFixture('older working memory'));
+          }
+          newerStarted.resolve();
+          if (outcome === 'before-newer') await releaseNewer.promise;
+          if (outcome === 'newer-error') return new HttpResponse(undefined, { status: 400 });
+          return HttpResponse.json(workingMemoryFixture('newer working memory'));
+        }),
+      );
+      render(
+        <Wrapper>
+          <Probe />
+        </Wrapper>,
+      );
+      await screen.findByText('initial working memory');
+      fireEvent.click(screen.getByText('older refresh'));
+      await olderStarted.promise;
+      fireEvent.click(screen.getByText('newer refresh'));
+      await newerStarted.promise;
+      if (outcome === 'before-newer') {
+        await act(async () => {
+          releaseOlder.resolve();
+          await olderCompleted.promise;
+        });
+        expect(screen.getByTestId('wm-loading').textContent).toBe('true');
+        expect(screen.queryByText('older working memory')).toBeNull();
+        releaseNewer.resolve();
+      }
+      await act(async () => {
+        await newerCompleted.promise;
+      });
+      const expectedValue = outcome === 'newer-error' ? '' : 'newer working memory';
+      expect(screen.getByTestId('wm-current').textContent).toBe(expectedValue);
+      await waitFor(() => expect(screen.getByTestId('wm-loading').textContent).toBe('false'));
+      await act(async () => {
+        releaseOlder.resolve();
+        await olderCompleted.promise;
+      });
+      expect(screen.getByTestId('wm-current').textContent).toBe(expectedValue);
+      expect(screen.queryByText('older working memory')).toBeNull();
+    },
+  );
 });

--- a/packages/playground/src/lib/ai-ui/chat/__tests__/fixtures/working-memory.ts
+++ b/packages/playground/src/lib/ai-ui/chat/__tests__/fixtures/working-memory.ts
@@ -1,0 +1,10 @@
+import type { RouteResponse } from '@mastra/client-js';
+
+export const workingMemoryFixture = (
+  workingMemory: string,
+): RouteResponse<'GET /memory/threads/:threadId/working-memory'> => ({
+  workingMemory,
+  source: 'resource',
+  workingMemoryTemplate: null,
+  threadExists: true,
+});

--- a/packages/playground/src/lib/ai-ui/chat/use-chat-send-handler.ts
+++ b/packages/playground/src/lib/ai-ui/chat/use-chat-send-handler.ts
@@ -201,10 +201,11 @@ export const useChatSendHandler = ({
           // Refetch the panel again once buffering completes, so any records that
           // only landed after awaitBufferStatus resolved are reflected immediately.
           refreshTimelinePanel(currentThreadId);
+          void refreshWorkingMemory?.();
         })
         .catch(() => {});
     },
-    [agentId, baseClient, queryClient, refreshTimelinePanel, setMessages],
+    [agentId, baseClient, queryClient, refreshTimelinePanel, refreshWorkingMemory, setMessages],
   );
 
   const handleHandledChunk = useCallback(
@@ -225,11 +226,21 @@ export const useChatSendHandler = ({
       ) {
         refreshObservationalMemory(handled.data?.operationType);
       }
+      if (handled?.type === 'data-om-observation-end') {
+        void refreshWorkingMemory?.();
+      }
       if (handled?.type === 'data-om-activation') {
         handleActivation(handled.data);
       }
     },
-    [handleActivation, handleObservationStart, handleProgressUpdate, refreshObservationalMemory, setStreamErrors],
+    [
+      handleActivation,
+      handleObservationStart,
+      handleProgressUpdate,
+      refreshObservationalMemory,
+      refreshWorkingMemory,
+      setStreamErrors,
+    ],
   );
 
   const send = useCallback(
@@ -295,6 +306,8 @@ export const useChatSendHandler = ({
                   setStreamErrors(prev => [...prev, buildMaxStepsStreamErrorMessage(chunk, deps.maxSteps)]);
                 }
                 await refreshThreadList?.();
+                refreshTimelinePanel(deps.threadId);
+                completeObservationalMemoryBuffering(deps.threadId);
               }
               if (didUpdateWorkingMemory(chunk)) {
                 void refreshWorkingMemory?.();
@@ -304,8 +317,6 @@ export const useChatSendHandler = ({
             signal: controller.signal,
           });
 
-          refreshTimelinePanel(deps.threadId);
-          completeObservationalMemoryBuffering(deps.threadId);
           return;
         }
 


### PR DESCRIPTION
Studio can keep showing old working memory after observational memory updates it. This refreshes the sidebar on observation completion and after the buffer-status request returns. The completion check now runs when the stream finishes, rather than when the send-message request is accepted. Older refresh responses can no longer replace a newer result.

Builds on @JayaKrishnaNamburu's work in #22270, including the observation and buffering refresh points and the deferred-event test approach. The changes stay in Studio; memory extraction and storage are unchanged.

Tested in Studio in Chromium against a local kitchen-sink backend running released @mastra/core and @mastra/memory with LibSQL, deterministic model fixtures, and idle buffering enabled. Before the timing change, the sidebar stayed stale even though a separate backend read returned the new value. Afterward, it updated without a reload. This used Markdown working memory, not the reporter's exact JSON-schema configuration. The buffer-status check remains best-effort; this does not add handling for streams that terminate without a finish event.

The new signals test fails before the timing change and passes after it. All 20 focused tests pass, and the Studio suite passes with 2,361 tests and 2 skipped. Typecheck passes. Oxlint and ESLint each pass with 34 warnings and no errors; ESLint excludes generated build and mutation-test directories. The regression tests also cover the independent observation and buffering refreshes and out-of-order responses.

Closes #22226


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Studio now updates the Working Memory panel automatically when observational memory changes it. It also prevents older refresh results from replacing newer data.

## Changes

- Refresh working memory after observation completion.
- Refresh working memory after background buffering completes.
- Run buffering checks when the stream finishes.
- Ignore stale out-of-order refresh responses and errors.
- Add regression tests for observation, buffering, deferred events, and overlapping requests.
- Add a patch changeset for `mastra`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->