### PR TITLE
docs: update Factory template README

### DIFF
--- a/.changeset/fiery-numbers-repeat.md
+++ b/.changeset/fiery-numbers-repeat.md
@@ -1,5 +1,0 @@
----
-'create-factory': patch
----
-
-Updated the Factory template README with Mastra platform defaults, issue intake setup, and self-hosting guidance.

--- a/.changeset/fiery-numbers-repeat.md
+++ b/.changeset/fiery-numbers-repeat.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+Updated the Factory template README with Mastra platform defaults, issue intake setup, and self-hosting guidance.

--- a/mastracode/mastra-factory/template/README.md
+++ b/mastracode/mastra-factory/template/README.md
@@ -2,15 +2,13 @@
 
 Mastra Factory is an open source environment for building software with coding agents. Connect your repository to turn issues into plans, implementations, and reviewed pull requests.
 
-Created with [`npm create factory@latest`](https://www.npmjs.com/package/create-factory). This project contains the Factory Server and its configuration. Keep it separate from the repository you want agents to change.
+Created with [`npm create factory`](https://www.npmjs.com/package/create-factory). This project contains the Factory Server and its configuration. Keep it separate from the repository you want agents to change.
 
-[Read the documentation](https://factory.mastra.ai/) or [watch the Mastra Factory overview](https://youtu.be/iMA-Xkhj7fU).
+Read the [documentation](https://factory.mastra.ai/) or [watch the Mastra Factory overview](https://youtu.be/iMA-Xkhj7fU).
 
 ## Start the Factory Server
 
-The standard installer installs dependencies and provisions a Mastra platform project, credentials, and PostgreSQL database. It writes the configuration to `.env`. New projects use Mastra platform for authentication, storage, and sandboxes by default.
-
-Before connecting a model provider, check for `FACTORY_CREDENTIAL_ENCRYPTION_KEY` in `.env`. If it's missing, generate a key once for this project:
+New projects use Mastra platform for authentication, storage, and sandboxes by default. Before connecting a model provider, check for `FACTORY_CREDENTIAL_ENCRYPTION_KEY` in `.env`. If it's missing, generate a key once for this project:
 
 ```bash
 openssl rand -base64 32
@@ -24,17 +22,15 @@ From the Factory project directory, start the server:
 npm run dev
 ```
 
-Open the local URL printed by the server, then sign in through Mastra platform. One server serves both the Factory UI and API.
+Open the local URL printed by the server, then sign in through Mastra platform. One server serves both the Factory UI and API. After login you'll see an onboarding wizard, select the repository agents should change. Use **Manage GitHub connection** to grant the GitHub App access if the repository is missing. Optionally add Linear. Connect a model provider using an API key or a supported subscription, then choose the Factory model.
 
-After cloning an existing Factory repository, run `npm ci` and configure its environment before starting it. If you skipped platform setup during installation, follow [Get started](https://factory.mastra.ai/) to complete configuration.
+If you skipped platform setup during installation, follow [Get started](https://factory.mastra.ai/) to complete configuration.
 
 ## Run your first issue
 
-1. Create a Factory in the UI and select the repository agents should change. Use **Manage GitHub connection** to grant the GitHub App access if the repository is missing.
-2. Connect a model provider using an API key or a supported subscription, then choose the Factory model.
-3. Open **Settings → Work Intake → GitHub issues**. Enable **Sync GitHub issues** and select your repository. Each teammate chooses their own issue sources.
-4. Create a small GitHub issue, such as adding contribution guidance to the repository's README.
-5. Find the issue in **Work → Intake**, select **Investigate**, and open its session to follow the agent's work.
+1. Open **Settings → Work Intake → GitHub issues**. Enable **Sync GitHub issues** and select your repository. Each teammate chooses their own issue sources.
+1. Create a small GitHub issue, such as adding contribution guidance to the repository's README.
+1. Find the issue in **Work → Intake**, select **Investigate**, and open its session to follow the agent's work.
 
 Continue with the [issue-to-pull-request walkthrough](https://factory.mastra.ai/#create-your-first-pull-request) to review a plan and take the change through implementation and pull request review.
 

--- a/mastracode/mastra-factory/template/README.md
+++ b/mastracode/mastra-factory/template/README.md
@@ -1,112 +1,108 @@
 # Mastra Factory
 
-An open source, agent-powered software delivery environment built on [Mastra](https://mastra.ai). Connect GitHub and Linear, pull issues into an intake board, hand them to coding agents, and ship pull requests — from a web app you own and can deploy anywhere.
+Mastra Factory is an open source environment for building software with coding agents. Connect your repository to turn issues into plans, implementations, and reviewed pull requests.
 
-Created with [`npm create factory`](https://www.npmjs.com/package/create-factory).
+Created with [`npm create factory@latest`](https://www.npmjs.com/package/create-factory). This project contains the Factory Server and its configuration. Keep it separate from the repository you want agents to change.
 
-## Quick start
+[Read the documentation](https://factory.mastra.ai/) or [watch the Mastra Factory overview](https://youtu.be/iMA-Xkhj7fU).
+
+## Start the Factory Server
+
+The standard installer installs dependencies and provisions a Mastra platform project, credentials, and PostgreSQL database. It writes the configuration to `.env`. New projects use Mastra platform for authentication, storage, and sandboxes by default.
+
+Before connecting a model provider, check for `FACTORY_CREDENTIAL_ENCRYPTION_KEY` in `.env`. If it's missing, generate a key once for this project:
 
 ```bash
-npm install
+openssl rand -base64 32
+```
 
-# optional: local Postgres (+pgvector) & Redis via Docker
-npm run db:up
+Save the output as `FACTORY_CREDENTIAL_ENCRYPTION_KEY` in `.env`. Preserve the key across restarts and deployments, and keep a protected backup. See [credential encryption](https://factory.mastra.ai/reference/configuration#stored-credential-encryption) for details.
 
+From the Factory project directory, start the server:
+
+```bash
 npm run dev
 ```
 
-- **Factory UI** → http://localhost:4111
-- **API** → http://localhost:4111/api
+Open the local URL printed by the server, then sign in through Mastra platform. One server serves both the Factory UI and API.
 
-One server serves both the UI and the API.
+After cloning an existing Factory repository, run `npm ci` and configure its environment before starting it. If you skipped platform setup during installation, follow [Get started](https://factory.mastra.ai/) to complete configuration.
 
-With zero configuration the app runs in local, auth-less mode (agents + local storage, no integrations). Open the Factory UI to finish setup — model provider keys are added there (Settings › Models). Deployment-level features enable themselves as you add environment variables — see below.
+## Run your first issue
 
-### Ports
+1. Create a Factory in the UI and select the repository agents should change. Use **Manage GitHub connection** to grant the GitHub App access if the repository is missing.
+2. Connect a model provider using an API key or a supported subscription, then choose the Factory model.
+3. Open **Settings → Work Intake → GitHub issues**. Enable **Sync GitHub issues** and select your repository. Each teammate chooses their own issue sources.
+4. Create a small GitHub issue, such as adding contribution guidance to the repository's README.
+5. Find the issue in **Work → Intake**, select **Investigate**, and open its session to follow the agent's work.
 
-The server port is overridable with `PORT`. OAuth callback URLs (WorkOS/GitHub/Linear) are registered against the configured origin, so if you change the port, also set `MASTRACODE_PUBLIC_URL=http://localhost:<port>` in `.env` (then update the callback URLs on your OAuth apps).
+Continue with the [issue-to-pull-request walkthrough](https://factory.mastra.ai/#create-your-first-pull-request) to review a plan and take the change through implementation and pull request review.
 
-## Configuration
+## Configure your Factory
 
-Day-to-day configuration (model providers, integrations) happens in the web UI. Deployment-level settings live in `.env` (validated against `.env.schema` by [varlock](https://varlock.dev)). Every value is optional; each feature activates when its variables are set. Restart `npm run dev` after changing `.env`.
+Choose authentication, storage, and sandboxes independently. Model providers and issue sources are configured through the Factory UI. Server settings live in `.env`; restart the server after changing them.
 
-| Feature                  | Requires                                                                                                                                            |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Agents / model providers | add keys in the UI (Settings › Models), or `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`                                                                   |
-| Sign-in (WorkOS)         | `WORKOS_API_KEY`, `WORKOS_CLIENT_ID`, `FACTORY_CREDENTIAL_ENCRYPTION_KEY`                                                                           |
-| GitHub projects & intake | WorkOS + `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`, `GITHUB_APP_SLUG` + `APP_DATABASE_URL`      |
-| Linear intake            | WorkOS + `LINEAR_CLIENT_ID`, `LINEAR_CLIENT_SECRET` + `APP_DATABASE_URL` + a state secret (`GITHUB_APP_WEBHOOK_SECRET` or `WORKOS_COOKIE_PASSWORD`) |
-| Slack channels           | `SLACK_APP_SIGNING_SECRET`, `SLACK_APP_BOT_TOKEN`, `SLACK_APP_CLIENT_ID`, `SLACK_APP_CLIENT_SECRET` + WorkOS + a state secret (see above)           |
-| Distributed event bus    | `REDIS_URL` (only needed for multi-process deployments)                                                                                             |
-| Cloud sandboxes          | `MASTRA_PLATFORM_ACCESS_TOKEN` or `MASTRA_PLATFORM_SECRET_KEY`, plus `MASTRA_PROJECT_ID` and `MASTRA_ENVIRONMENT_ID`                                |
+| Configuration                                              | What you can change                                                           |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [Models](https://factory.mastra.ai/configure/models)       | Provider access, personal or organization credentials, and the default model. |
+| [GitHub](https://factory.mastra.ai/configure/github)       | Repository access and personal issue intake.                                  |
+| [Linear](https://factory.mastra.ai/configure/linear)       | Workspace connection, project selection, and routing issues to a Factory.     |
+| [Slack](https://factory.mastra.ai/configure/slack)         | App setup, account linking, and starting sessions from Slack.                 |
+| [Auth](https://factory.mastra.ai/configure/auth)           | Mastra platform sign-in or another provider with Server and Studio support.   |
+| [Storage](https://factory.mastra.ai/configure/storage)     | The database connection or Factory storage adapter.                           |
+| [Sandboxes](https://factory.mastra.ai/configure/sandboxes) | Mastra platform, local execution, or another Mastra sandbox provider.         |
 
-Set `FACTORY_SANDBOX_PROVIDER=local` in `.env` to run sandbox commands on the machine running Factory, even when cloud credentials are configured. This leaves Platform auth and database settings unchanged. The separate `SANDBOX_PROVIDER` variable selects the PlatformSandbox cloud backend (`e2b` or `railway`).
+The generated server uses `DATABASE_URL` for PostgreSQL with pgvector. To use the included local PostgreSQL service, run `npm run db:up` and set `DATABASE_URL` to its connection string in `.env`. The generated `docker-compose.yml` contains the connection settings.
 
-### Database
+Mastra platform sandboxes use `MASTRA_PLATFORM_ACCESS_TOKEN` or `MASTRA_PLATFORM_SECRET_KEY`, together with `MASTRA_PROJECT_ID` and `MASTRA_ENVIRONMENT_ID`. To run commands on the Factory Server's machine, set this override in `.env`:
 
-Integrations and shared agent state need Postgres **with the pgvector extension**. Two easy options:
+```dotenv
+FACTORY_SANDBOX_PROVIDER=local
+```
 
-- **Local Docker** (recommended to start): `npm run db:up` starts Postgres on `localhost:54329` matching `APP_DATABASE_URL=postgres://user:pass@localhost:54329/mastracode_web` (plus Redis on `localhost:63799`).
-- **Hosted Postgres**: any provider works if pgvector is available (Neon, Supabase, Railway, RDS, ...) — enable the extension and set `APP_DATABASE_URL`.
+Install Git and your repository's build tools on that machine. Authentication and storage can continue to use Mastra platform. The separate `SANDBOX_PROVIDER` setting selects the backend used by Mastra platform sandboxes.
 
-Without `APP_DATABASE_URL`, agent state falls back to a local libSQL file and integrations stay off.
+## Deploy
 
-### Sign-in (WorkOS)
+### Mastra platform
 
-Integrations are per-organization, so they require sign-in, powered by [WorkOS](https://workos.com) (free tier is fine):
+Deploy the Factory Server to your Mastra platform project:
 
-1. Create a WorkOS project → copy the **API key** and **Client ID** into `.env`.
-2. In WorkOS → Redirects, add `http://localhost:4111/auth/callback`.
-3. Set `WORKOS_COOKIE_PASSWORD` to a random 32+ character string.
-4. Generate a deployment-stable credential encryption key with `openssl rand -base64 32` and set it as `FACTORY_CREDENTIAL_ENCRYPTION_KEY`.
+```bash
+npm run deploy
+```
 
-Keep the encryption key outside the database and stable across replicas and deploys. Losing it makes stored model-provider keys, custom-provider API keys, GitHub PATs, and integration OAuth tokens unreadable. To rotate it, set a new `FACTORY_CREDENTIAL_ENCRYPTION_KEY` and `FACTORY_CREDENTIAL_ENCRYPTION_KEY_ID`, then provide the old key in `FACTORY_CREDENTIAL_ENCRYPTION_PREVIOUS_KEYS` as a JSON object such as `{"v1":"<old-base64-key>"}`. Factory rewrites legacy plaintext and old-key ciphertext with the primary key during startup and reads.
+The CLI reports the deployed Factory URL. See [Deployment](https://factory.mastra.ai/deployment) for environment configuration and deployment options.
 
-### GitHub
+### Self-host
 
-The Factory connects to GitHub through a GitHub App you own. Create an app at https://github.com/settings/apps/new (or under your org) and set the `GITHUB_APP_*` variables in `.env`.
+Run Factory as a persistent Node.js service on a virtual machine or in a container. Configure persistent storage and set `MASTRACODE_PUBLIC_URL` to the public HTTPS origin. Supply your provider credentials through the deployment environment, then build and start the server:
 
-The app needs **Contents, Issues, Pull requests** (Read & write) and **Metadata** (Read-only) permissions. Set its callback URL to `<your app origin>/auth/github/callback`.
+```bash
+npm run build
+npm run start
+```
 
-Webhooks (optional — powers auto-triage and PR notifications, requires a public host; GitHub rejects localhost webhook URLs): in the App settings, set the webhook URL to `https://<public-host>/web/github/webhook` with the `GITHUB_APP_WEBHOOK_SECRET` from `.env` as the secret, activate it, and subscribe to the **issues, issue_comment, pull_request, pull_request_review, pull_request_review_comment** events. Local development works without webhooks; issues are fetched on demand.
-
-### Linear (optional)
-
-Create a Linear OAuth app (Linear → Settings → API → OAuth applications → New) with callback URL `<your app origin>/auth/linear/callback`, then set `LINEAR_CLIENT_ID` / `LINEAR_CLIENT_SECRET` in `.env`.
-
-### Slack (optional)
-
-Talk to the Factory from Slack threads. Create a Slack app at [api.slack.com/apps](https://api.slack.com/apps) with:
-
-- **Event Subscriptions** request URL: `<your app origin>/api/agent-controllers/mastra-code/channels/slack/webhook` (subscribe to bot events for messages and mentions)
-- **OpenID Connect** redirect URL: `<your app origin>/connect/slack/oidc/callback` (used to link Slack users to their Factory accounts)
-
-Install it to your workspace, then copy the credentials into `.env`: `SLACK_APP_SIGNING_SECRET` and the client ID/secret from **Basic Information**, and `SLACK_APP_BOT_TOKEN` from **OAuth & Permissions**.
-
-Slack only delivers events to public HTTPS origins, so local development needs a tunnel (e.g. `cloudflared tunnel --url http://127.0.0.1:4111`); set `MASTRACODE_CHANNELS_PUBLIC_URL` to the tunnel origin.
+Keep the generated project's CLI dependencies installed for these commands. You can use Mastra platform services while hosting the Factory Server elsewhere. See [self-hosting](https://factory.mastra.ai/deployment#self-host) for runtime requirements and setup steps.
 
 ## Scripts
 
-| Script                      | What it does                                                                        |
-| --------------------------- | ----------------------------------------------------------------------------------- |
-| `npm run dev`               | Factory server (:4111) serving the UI and the API                                   |
-| `npm run db:up` / `db:down` | Start/stop local Postgres + Redis (Docker)                                          |
-| `npm run build`             | Bundle the server and copy the CLI-bundled Factory UI to `.mastra/output`           |
-| `npm run start`             | Run the production build                                                            |
-| `npm run deploy`            | Build and deploy to [Mastra Cloud](https://mastra.ai/docs/mastra-platform/overview) |
-| `npm run check`             | Typecheck the Factory server                                                        |
+| Script                              | What it does                                                    |
+| ----------------------------------- | --------------------------------------------------------------- |
+| `npm run dev`                       | Start the local Factory Server with its UI and API.             |
+| `npm run check`                     | Typecheck the Factory Server.                                   |
+| `npm run build`                     | Build the server and Factory UI in `.mastra/output`.            |
+| `npm run start`                     | Run the production build.                                       |
+| `npm run deploy`                    | Build and deploy to Mastra platform.                            |
+| `npm run db:up` / `npm run db:down` | Start or stop the optional local PostgreSQL and Redis services. |
 
-`mastra build` and `mastra deploy` detect the Factory entry automatically and copy the versioned Factory UI bundled with the Mastra CLI while bundling the server. The SPA is written to `.mastra/output/factory/` and a `mastra-project.json` manifest is emitted alongside it.
+## Troubleshooting
 
-## Requirements
+- **Runtime:** Use a Node.js version that matches `engines.node` in this project's `package.json`.
+- **Port changes:** Set `PORT` and update `MASTRACODE_PUBLIC_URL` to match. Update callback URLs for any auth or integration apps you manage.
+- **Missing issues:** Check repository access and your **Work Intake** selections. See [intake troubleshooting](https://factory.mastra.ai/troubleshooting#intake-is-empty).
 
-- Node.js ≥ 22.19
-- Docker (optional, for the local database)
-- Postgres 15+ with pgvector (for integrations)
-
-## Versions
-
-The Mastra packages are pinned to `latest`, so `npm install` pulls the current published set. Upgrade them together by re-running `npm install` (or by rescaffolding).
+See [Troubleshooting](https://factory.mastra.ai/troubleshooting) for sign-in, provider access, and sandbox errors, or [Environment variables](https://factory.mastra.ai/reference/configuration) for server settings.
 
 ## License
 


### PR DESCRIPTION
The Factory template README still described manual WorkOS setup and a local database as the default. This update explains Mastra platform defaults, credential encryption, and the first GitHub issue workflow. It links to the configuration guides and covers self-hosting alongside platform deployment.

Companion to https://github.com/mastra-ai/softwarefactory-docs/pull/3. The new documentation links should be published before this template update ships.

Validated with Oxfmt, Remark, and link and anchor checks against the reviewed Factory docs build. Commands and defaults were checked against the current scaffold. Includes the required create-factory patch changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This update makes the Factory README match the current Mastra setup. It explains how to use the platform, protect credentials, create GitHub issues, and deploy the project.

## Changes

- Updated the README for platform-backed defaults.
- Removed local-first setup instructions and manual WorkOS configuration.
- Added credential encryption guidance.
- Documented the first GitHub issue workflow.
- Added Factory configuration guide links.
- Documented self-hosting and platform deployment.
- Added the required `create-factory` changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->