### PR TITLE
fix(factory): use latest releases when syncing templates

### DIFF
--- a/mastracode/mastra-factory/scripts/sync-template.mjs
+++ b/mastracode/mastra-factory/scripts/sync-template.mjs
@@ -18,7 +18,7 @@
  *   node scripts/sync-template.mjs [--out <dir>] [--tag <dist-tag>]
  *
  * `--tag` pins every linked dependency to one dist-tag, for the local E2E
- * registry. Otherwise matching latest/alpha releases are selected.
+ * registry. Otherwise the latest release of each linked dependency is selected.
  */
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
@@ -108,23 +108,9 @@ function resolveTaggedVersion(name, tag) {
   }
 }
 
-function baseVersion(version) {
-  return version.split('-')[0];
-}
-
-function resolveLinkedVersion(name, localVersion) {
-  if (pinTag) return { version: resolveTaggedVersion(name, pinTag), tag: pinTag };
-
-  const localBase = baseVersion(localVersion);
-  if (!localVersion.includes('-alpha.')) {
-    const latestVersion = resolveTaggedVersion(name, 'latest');
-    if (baseVersion(latestVersion) === localBase) return { version: latestVersion, tag: 'latest' };
-  }
-
-  const alphaVersion = resolveTaggedVersion(name, 'alpha');
-  if (baseVersion(alphaVersion) === localBase) return { version: alphaVersion, tag: 'alpha' };
-
-  throw new Error(`sync-template: no published ${name} version matches local release ${localBase}.`);
+function resolveLinkedVersion(name) {
+  const tag = pinTag ?? 'latest';
+  return { version: resolveTaggedVersion(name, tag), tag };
 }
 
 function sourceDependencySpec(manifest, name) {
@@ -137,8 +123,8 @@ function resolveDependency(manifest, name) {
   const spec = sourceDependencySpec(manifest, name);
   if (!spec.startsWith('link:')) return spec;
 
-  const localVersion = linkedPackageVersion(name, linkSpecToRelPath(spec));
-  const { version, tag } = resolveLinkedVersion(name, localVersion);
+  linkedPackageVersion(name, linkSpecToRelPath(spec));
+  const { version, tag } = resolveLinkedVersion(name);
   console.log(`  ✓ ${name}@${version} (${tag})`);
   return version;
 }
@@ -180,10 +166,8 @@ function writePackageJson() {
 
   // Transitive runtime peer that must be declared as a direct dep so npm
   // resolves it without needing pnpm's auto-install-peers behavior.
-  const { version: memoryVersion, tag: memoryTag } = resolveLinkedVersion(
-    '@mastra/memory',
-    linkedPackageVersion('@mastra/memory', 'packages/memory'),
-  );
+  linkedPackageVersion('@mastra/memory', 'packages/memory');
+  const { version: memoryVersion, tag: memoryTag } = resolveLinkedVersion('@mastra/memory');
   manifest.dependencies['@mastra/memory'] = memoryVersion;
   console.log(`  ✓ @mastra/memory@${memoryVersion} (${memoryTag})`);
 

--- a/mastracode/mastra-factory/src/sync-template.test.ts
+++ b/mastracode/mastra-factory/src/sync-template.test.ts
@@ -59,7 +59,7 @@ beforeAll(() => {
     ) as { version: string };
     linkedLocalVersions[name] = linkedManifest.version;
     const baseVersion = linkedManifest.version.split('-')[0]!;
-    registryVersions[name] = { latest: baseVersion, alpha: `${baseVersion}-alpha.0` };
+    registryVersions[name] = { latest: `${Number.parseInt(baseVersion) + 1}.0.0`, alpha: `${baseVersion}-alpha.0` };
   }
 
   const memoryVersion = JSON.parse(
@@ -67,7 +67,10 @@ beforeAll(() => {
   ).version as string;
   linkedLocalVersions['@mastra/memory'] = memoryVersion;
   const memoryBaseVersion = memoryVersion.split('-')[0]!;
-  registryVersions['@mastra/memory'] = { latest: memoryBaseVersion, alpha: `${memoryBaseVersion}-alpha.0` };
+  registryVersions['@mastra/memory'] = {
+    latest: `${Number.parseInt(memoryBaseVersion) + 1}.0.0`,
+    alpha: `${memoryBaseVersion}-alpha.0`,
+  };
 
   fakeBinDir = path.join(workDir, 'bin');
   fs.mkdirSync(fakeBinDir);
@@ -85,6 +88,9 @@ console.log(version);
 `,
     { mode: 0o755 },
   );
+
+  // Skill installation is independent of dependency version selection.
+  fs.writeFileSync(path.join(fakeBinDir, 'npx'), '#!/usr/bin/env node\n', { mode: 0o755 });
 
   sentinel = path.join(webRoot, '.env.test-sentinel');
   fs.writeFileSync(sentinel, 'SECRET=leaked\n');
@@ -108,8 +114,8 @@ describe.skipIf(process.platform === 'win32')('sync-template.mjs', () => {
     expect(fs.existsSync(unsafeOutDir)).toBe(existedBefore);
   });
 
-  it('generates a minimal server scaffold with exact published dependencies', () => {
-    const result = runSync(['--out', outDir]);
+  it.each(['latest', 'alpha'])('generates a minimal server scaffold with exact published dependencies (%s)', tag => {
+    const result = runSync(['--out', outDir, ...(tag === 'latest' ? [] : ['--tag', tag])]);
     expect(result.status).toBe(0);
 
     expect(fs.existsSync(path.join(outDir, 'src/mastra/index.ts'))).toBe(true);
@@ -152,8 +158,10 @@ describe.skipIf(process.platform === 'win32')('sync-template.mjs', () => {
     }
     for (const [name, localVersion] of Object.entries(linkedLocalVersions)) {
       const baseVersion = localVersion.split('-')[0]!;
-      const expectedVersion = localVersion.includes('-alpha.') ? `${baseVersion}-alpha.0` : baseVersion;
-      expect(allDeps[name], `${name} must match its local source release`).toBe(expectedVersion);
+      const expectedVersion = tag === 'latest' ? `${Number.parseInt(baseVersion) + 1}.0.0` : `${baseVersion}-alpha.0`;
+      expect(allDeps[name], `${name} must resolve ${tag} independently of its local source release`).toBe(
+        expectedVersion,
+      );
     }
 
     expect(Object.keys(pkg.dependencies).sort()).toEqual([
@@ -189,7 +197,11 @@ describe.skipIf(process.platform === 'win32')('sync-template.mjs', () => {
     expect(tsconfig.include).toEqual(['src/**/*']);
     expect(tsconfig.exclude).toEqual(['node_modules']);
 
-    expect(fs.readFileSync(path.join(outDir, '.npmrc'), 'utf8')).toBe('legacy-peer-deps=true\n');
+    if (tag === 'latest') {
+      expect(fs.existsSync(path.join(outDir, '.npmrc'))).toBe(false);
+    } else {
+      expect(fs.readFileSync(path.join(outDir, '.npmrc'), 'utf8')).toBe('legacy-peer-deps=true\n');
+    }
     const pnpmWorkspace = fs.readFileSync(path.join(outDir, 'pnpm-workspace.yaml'), 'utf8');
     expect(pnpmWorkspace).toMatch(/^minimumReleaseAgeExclude:\n  - '@mastra\/\*'\n  - mastra$/m);
     expect(pnpmWorkspace).toMatch(/^allowBuilds:/m);


### PR DESCRIPTION
Default Software Factory template synchronization to each linked Mastra package's npm `latest` release instead of selecting a matching local release or falling back to `alpha`. An explicit `--tag` still overrides the default, and existing `link:` path and package-name validation stays in place.

Verified with five focused unit tests, package typechecking and lint. Also ran the real script in a fresh temporary directory without `--tag`: all 11 Mastra dependencies matched npm `latest`, the scaffold and skill copies were generated, and no prerelease-only `.npmrc` was created. The generated project was not installed or built.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The template now uses the newest published version of each linked Mastra package by default. You can still select a specific release type with `--tag`.

## Changes

- Resolve linked dependencies with `--tag`, or `latest` when no tag is provided.
- Keep existing `link:` path and package-name validation.
- Apply the same resolution logic to the memory dependency.
- Add tests for `latest` and `alpha` tags.
- Verify `.npmrc` creation for prerelease installs.
- Validate package types and lint rules.
- Run the sync script in a fresh temporary directory.
- Confirm all 11 Mastra dependencies matched npm `latest`.
- Generate scaffold and skill copies without installing or building the generated project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->