### PR TITLE
fix(editor): bypass cache for version zero requests

### DIFF
--- a/.changeset/calm-editors-cache.md
+++ b/.changeset/calm-editors-cache.md
@@ -1,0 +1,5 @@
+---
+'@mastra/editor': patch
+---
+
+Fixed version-specific editor reads so numeric version requests always bypass the default cache. Fixes #23396.

--- a/packages/editor/src/namespaces/base.test.ts
+++ b/packages/editor/src/namespaces/base.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CrudEditorNamespace } from './base';
+import type { GetByIdOptions, StorageAdapter } from './base';
+
+type Entity = { id: string; versionNumber: number };
+type Input = { id: string };
+
+function createNamespace() {
+  const latest: Entity = { id: 'cached', versionNumber: 3 };
+  const getByIdResolved = vi.fn(async (id: string, options?: GetByIdOptions): Promise<Entity | null> => {
+    if (options?.versionNumber === 0) return null;
+    if (options?.versionNumber !== undefined) return { id, versionNumber: options.versionNumber };
+    return latest;
+  });
+  const adapter: StorageAdapter<Input, Input, void, Entity[], Entity[], Entity> = {
+    create: vi.fn(async () => undefined),
+    getByIdResolved,
+    update: vi.fn(async () => undefined),
+    delete: vi.fn(async () => undefined),
+    list: vi.fn(async () => []),
+    listResolved: vi.fn(async () => []),
+  };
+
+  class TestNamespace extends CrudEditorNamespace<Input, Input, void, Entity[], Entity[], Entity> {
+    protected async getStorageAdapter() {
+      return adapter;
+    }
+  }
+
+  return {
+    namespace: new TestNamespace({ __mastra: {} } as never),
+    getByIdResolved,
+  };
+}
+
+describe('CrudEditorNamespace', () => {
+  it('bypasses the default cache whenever versionNumber is provided', async () => {
+    const { namespace, getByIdResolved } = createNamespace();
+
+    await namespace.create({ id: 'cached' });
+    getByIdResolved.mockClear();
+
+    await expect(namespace.getById('cached', { versionNumber: 0 })).resolves.toBeNull();
+    expect(getByIdResolved).toHaveBeenCalledWith('cached', { versionNumber: 0 });
+
+    await expect(namespace.getById('cached', { versionNumber: 2 })).resolves.toEqual({
+      id: 'cached',
+      versionNumber: 2,
+    });
+    expect(getByIdResolved).toHaveBeenCalledWith('cached', { versionNumber: 2 });
+  });
+});

--- a/packages/editor/src/namespaces/base.ts
+++ b/packages/editor/src/namespaces/base.ts
@@ -120,7 +120,8 @@ export abstract class CrudEditorNamespace<
     }
 
     // Only use the cache for default version requests (no specific version or status override)
-    const isVersionRequest = options?.versionId || options?.versionNumber || options?.status;
+    const isVersionRequest =
+      options?.versionId !== undefined || options?.versionNumber !== undefined || options?.status !== undefined;
     if (!isVersionRequest) {
       const cached = this._cache.get(id);
       if (cached) {


### PR DESCRIPTION
## Description

Treat any provided `versionNumber` as a version-specific Editor read, including zero. This prevents an invalid version-zero request from returning an unrelated entity from the warm default cache.

Adds focused regression coverage for zero and positive numeric version requests through the shared `CrudEditorNamespace` cache path, plus a patch changeset for `@mastra/editor`.

Validation: `pnpm --filter @mastra/editor exec vitest run src/namespaces/base.test.ts` (1 test passed) and focused `oxfmt --check` passed. Package typecheck was attempted but the fresh worktree does not contain built `@mastra/core`/workspace dependency outputs, so it cannot resolve those imports.

## Related issue(s)

Fixes #23396

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR
