### PR TITLE
fix(editor): validate stored processor config

### DIFF
--- a/.changeset/calm-processors-validate.md
+++ b/.changeset/calm-processors-validate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/editor': patch
+---
+
+Fixed stored processor graphs to validate provider configuration before creating processors. Fixes #23400.

--- a/packages/editor/src/processor-graph-hydrator.ts
+++ b/packages/editor/src/processor-graph-hydrator.ts
@@ -20,6 +20,7 @@ import type { IMastraLogger } from '@mastra/core/logger';
 import type { Mastra } from '@mastra/core';
 
 import { evaluateRuleGroup } from './rule-evaluator';
+import { createProcessorFromStep } from './processor-provider-config';
 
 const PASSTHROUGH_STEP_PREFIX = 'passthrough-';
 
@@ -39,7 +40,7 @@ function resolveStep(step: ProcessorGraphStep, ctx: HydrationContext): Processor
     return undefined;
   }
 
-  const processor = provider.createProcessor(step.config);
+  const processor = createProcessorFromStep(provider, step);
 
   // Wrap with phase filtering if only a subset of phases are enabled
   const allProviderPhases = provider.availablePhases;

--- a/packages/editor/src/processor-provider-config.test.ts
+++ b/packages/editor/src/processor-provider-config.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { createProcessorFromStep } from './processor-provider-config';
+
+function createProvider(configSchema: z.ZodType) {
+  return {
+    configSchema,
+    createProcessor: vi.fn((config: Record<string, unknown>) => ({ id: 'processor', config })),
+  };
+}
+
+describe('createProcessorFromStep', () => {
+  it('passes parsed defaults and transforms to the processor factory', () => {
+    const provider = createProvider(
+      z.object({
+        label: z.string().trim(),
+        retries: z.number().default(2),
+      }),
+    );
+
+    const processor = createProcessorFromStep(provider as never, {
+      id: 'normalizer-step',
+      providerId: 'normalizer',
+      config: { label: ' input ' },
+      enabledPhases: ['processInput'],
+    });
+
+    expect(provider.createProcessor).toHaveBeenCalledWith({ label: 'input', retries: 2 });
+    expect(processor).toEqual({ id: 'processor', config: { label: 'input', retries: 2 } });
+  });
+
+  it('rejects invalid config before calling the processor factory', () => {
+    const provider = createProvider(z.object({ threshold: z.number().min(0).max(1) }));
+
+    expect(() =>
+      createProcessorFromStep(provider as never, {
+        id: 'strict-step',
+        providerId: 'strict-provider',
+        config: { threshold: 'high' },
+        enabledPhases: ['processInput'],
+      }),
+    ).toThrow('Invalid configuration for processor provider "strict-provider" in graph step "strict-step"');
+    expect(provider.createProcessor).not.toHaveBeenCalled();
+  });
+
+  it('does not relabel processor factory errors as config validation failures', () => {
+    const provider = createProvider(z.object({}));
+    const factoryError = new Error('Processor initialization failed');
+    provider.createProcessor.mockImplementation(() => {
+      throw factoryError;
+    });
+
+    expect(() =>
+      createProcessorFromStep(provider as never, {
+        id: 'factory-step',
+        providerId: 'factory-provider',
+        config: {},
+        enabledPhases: ['processInput'],
+      }),
+    ).toThrow(factoryError);
+  });
+});

--- a/packages/editor/src/processor-provider-config.ts
+++ b/packages/editor/src/processor-provider-config.ts
@@ -1,0 +1,17 @@
+import type { ProcessorProvider } from '@mastra/core/processor-provider';
+import type { ProcessorGraphStep } from '@mastra/core/storage';
+
+export function createProcessorFromStep(provider: ProcessorProvider, step: ProcessorGraphStep) {
+  let config: Record<string, unknown>;
+  try {
+    config = provider.configSchema.parse(step.config) as Record<string, unknown>;
+  } catch (error) {
+    const details = error instanceof Error ? `: ${error.message}` : '';
+    throw new Error(
+      `Invalid configuration for processor provider "${step.providerId}" in graph step "${step.id}"${details}`,
+      { cause: error },
+    );
+  }
+
+  return provider.createProcessor(config);
+}


### PR DESCRIPTION
## Description

Stored processor graph steps previously passed raw configuration directly to `createProcessor`, bypassing the provider's declared `configSchema`. This PR validates each stored step before processor creation, passes parsed values (including defaults and transforms) to the factory, and reports invalid data with the provider and graph-step identifiers. Processor factory errors keep their original meaning.

Regression coverage verifies schema transforms/defaults, invalid-config rejection before factory invocation, and preservation of factory errors.

## Related issue(s)

Fixes #23400.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Validation

- `pnpm --filter @mastra/editor exec vitest run src/processor-provider-config.test.ts` (3 tests passed)
- `oxfmt --check` on all changed source and test files
- `git diff --check`

The broader hydrator suite requires built `@mastra/core` package outputs in a fresh worktree. Its dependency build was intentionally not continued after the focused regression suite passed, to keep validation bounded and avoid excessive system load.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The editor now checks saved processor settings before creating a processor. It applies schema defaults and transformations, and reports clear errors for invalid settings.

## Changes

- Added `createProcessorFromStep` to validate graph-step configuration with the provider’s `configSchema`.
- Passed parsed configuration values to `createProcessor`, including defaults and transformations.
- Added provider and graph-step identifiers to validation errors.
- Preserved the original meaning of processor factory errors.
- Updated graph hydration to use the new validation flow.
- Added regression tests for parsing, invalid configuration, and factory errors.
- Added a patch changeset for `@mastra/editor`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->