### PR TITLE
feat(playground): show review status on trace feedback threads

### DIFF
--- a/packages/playground/src/domains/feedback/hooks/use-feedback.ts
+++ b/packages/playground/src/domains/feedback/hooks/use-feedback.ts
@@ -50,6 +50,12 @@ export function useUpdateFeedbackReviewStatus() {
   return useMutation({
     mutationFn: ({ feedbackId, reviewStatus }: { feedbackId: string; reviewStatus: FeedbackReviewStatus }) =>
       client.updateFeedbackReviewStatus({ feedbackId, reviewStatus }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feedback'] }),
+    // Trace/span threads render the same records, so refresh them alongside the inbox list.
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['feedback'] }),
+        queryClient.invalidateQueries({ queryKey: ['trace-feedback'] }),
+        queryClient.invalidateQueries({ queryKey: ['span-feedback'] }),
+      ]),
   });
 }

--- a/packages/playground/src/domains/traces/components/__tests__/feedback-tabs.msw.test.tsx
+++ b/packages/playground/src/domains/traces/components/__tests__/feedback-tabs.msw.test.tsx
@@ -8,6 +8,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   authoredFeedbackResponse,
+  feedbackRecord,
+  listFeedbackResponse,
+  reviewedFeedbackResponse,
   SPAN_ID,
   spanFeedbackResponse,
   TRACE_ID,
@@ -89,5 +92,69 @@ describe('feedback tabs composer', () => {
     expect((await screen.findByText('Marvin Frachet')).getAttribute('data-slot')).toBe('comment-item-author');
     expect((screen.getByAltText('Marvin Frachet') as HTMLImageElement).src).toBe('https://example.com/marvin.png');
     expect(screen.getByText('Looks off to me')).toBeTruthy();
+  });
+});
+
+describe('feedback tabs review status', () => {
+  const REVIEW_STATUS_URL = `${FEEDBACK_URL}/:feedbackId/review-status`;
+
+  /** GET serves `needsReview` until the PATCH lands, then `reviewed` — mirroring the server. */
+  const reviewFlow = (needsReview: unknown, reviewed: unknown) => {
+    const onList = vi.fn();
+    const onPatch = vi.fn<(feedbackId: string, body: Record<string, unknown>) => void>();
+    let isReviewed = false;
+    server.use(
+      http.get(FEEDBACK_URL, () => {
+        onList();
+        return HttpResponse.json(isReviewed ? reviewed : needsReview);
+      }),
+      http.patch(REVIEW_STATUS_URL, async ({ params, request }) => {
+        onPatch(params.feedbackId as string, (await request.json()) as Record<string, unknown>);
+        isReviewed = true;
+        return HttpResponse.json({ success: true });
+      }),
+    );
+    return { onList, onPatch };
+  };
+
+  it('shows the review status of trace feedback', async () => {
+    server.use(http.get(FEEDBACK_URL, () => HttpResponse.json(authoredFeedbackResponse)));
+    const { unmount } = render(<TraceFeedbackTab traceId={TRACE_ID} />, { wrapper });
+    expect(await screen.findByText('Needs review')).toBeTruthy();
+    unmount();
+
+    server.use(http.get(FEEDBACK_URL, () => HttpResponse.json(reviewedFeedbackResponse)));
+    render(<TraceFeedbackTab traceId={TRACE_ID} />, { wrapper });
+    expect(await screen.findByText('Reviewed')).toBeTruthy();
+  });
+
+  it('marks trace feedback reviewed and refetches the thread', async () => {
+    const { onList, onPatch } = reviewFlow(authoredFeedbackResponse, reviewedFeedbackResponse);
+
+    render(<TraceFeedbackTab traceId={TRACE_ID} />, { wrapper });
+    await screen.findByText('Needs review');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark reviewed' }));
+
+    await waitFor(() => expect(onPatch).toHaveBeenCalledWith('authored', { reviewStatus: 'reviewed' }));
+    expect(await screen.findByText('Reviewed')).toBeTruthy();
+    expect(onList).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole('button', { name: 'Mark reviewed' })).toBeNull();
+  });
+
+  it('marks span feedback reviewed and refetches the thread', async () => {
+    const reviewedSpanResponse = listFeedbackResponse([
+      feedbackRecord({ feedbackId: 'span-a-feedback', spanId: SPAN_ID, reviewStatus: 'reviewed' }),
+    ]);
+    const { onList, onPatch } = reviewFlow(spanFeedbackResponse, reviewedSpanResponse);
+
+    render(<SpanFeedbackTab traceId={TRACE_ID} spanId={SPAN_ID} />, { wrapper });
+    await screen.findByText('Needs review');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark reviewed' }));
+
+    await waitFor(() => expect(onPatch).toHaveBeenCalledWith('span-a-feedback', { reviewStatus: 'reviewed' }));
+    expect(await screen.findByText('Reviewed')).toBeTruthy();
+    expect(onList).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/playground/src/domains/traces/components/__tests__/feedback-thread.test.tsx
+++ b/packages/playground/src/domains/traces/components/__tests__/feedback-thread.test.tsx
@@ -14,11 +14,13 @@ const type = (value: string) => fireEvent.change(getInput(), { target: { value }
 const feedbackData = {
   feedback: [
     {
+      feedbackId: 'fb-1',
       traceId: 'trace-1',
       feedbackType: 'comment',
       feedbackSource: 'user',
       value: 'this span looks wrong',
       timestamp: new Date('2026-08-26T09:00:00Z'),
+      reviewStatus: 'needs-review',
     },
   ],
   pagination: { page: 0, perPage: 10, total: 1, hasMore: false },
@@ -27,6 +29,9 @@ const feedbackData = {
 const withAuthor = (author: { id: string; name?: string; email?: string; avatarUrl?: string }) =>
   ({ ...feedbackData, feedback: [{ ...feedbackData.feedback[0], author }] }) as unknown as ListFeedbackResponse;
 
+const withReviewStatus = (reviewStatus: 'needs-review' | 'reviewed') =>
+  ({ ...feedbackData, feedback: [{ ...feedbackData.feedback[0], reviewStatus }] }) as unknown as ListFeedbackResponse;
+
 describe('FeedbackThread', () => {
   it('renders existing feedback as comments', () => {
     render(<FeedbackThread feedbackData={feedbackData} onSubmit={vi.fn()} />);
@@ -34,8 +39,8 @@ describe('FeedbackThread', () => {
     expect(screen.getByText('this span looks wrong')).toBeTruthy();
     expect(screen.queryByText('user')).toBeNull();
     expect(document.querySelector('[data-slot="comment-item-author"]')).toBeNull();
-    // The gutter stays so bodies align, but it is empty.
-    expect(document.querySelector('[data-slot="comment-item-avatar"]')?.childElementCount).toBe(0);
+    // No author means no avatar gutter, otherwise the row is indented by an empty 24px column.
+    expect(document.querySelector('[data-slot="comment-item-avatar"]')).toBeNull();
   });
 
   it('renders the author avatar and name when the feedback has an author', () => {
@@ -122,6 +127,58 @@ describe('FeedbackThread', () => {
 
     rerender(<FeedbackThread onSubmit={vi.fn()} isSubmitting />);
     expect(getSubmit().disabled).toBe(true);
+  });
+
+  describe('review status', () => {
+    it('shows a "Needs review" badge on unreviewed feedback', () => {
+      render(<FeedbackThread feedbackData={withReviewStatus('needs-review')} onSubmit={vi.fn()} />);
+
+      expect(screen.getByText('Needs review').closest('[data-slot="feedback-review-status"]')).toBeTruthy();
+    });
+
+    it('shows a "Reviewed" badge on reviewed feedback and no action', () => {
+      render(
+        <FeedbackThread feedbackData={withReviewStatus('reviewed')} onMarkReviewed={vi.fn()} onSubmit={vi.fn()} />,
+      );
+
+      expect(screen.getByText('Reviewed')).toBeTruthy();
+      expect(screen.queryByRole('button', { name: 'Mark reviewed' })).toBeNull();
+    });
+
+    it('offers "Mark reviewed" on unreviewed feedback and calls onMarkReviewed with the feedbackId', () => {
+      const onMarkReviewed = vi.fn();
+      render(
+        <FeedbackThread
+          feedbackData={withReviewStatus('needs-review')}
+          onMarkReviewed={onMarkReviewed}
+          onSubmit={vi.fn()}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Mark reviewed' }));
+
+      expect(onMarkReviewed).toHaveBeenCalledWith('fb-1');
+    });
+
+    it('does not offer "Mark reviewed" when no handler is given', () => {
+      render(<FeedbackThread feedbackData={withReviewStatus('needs-review')} onSubmit={vi.fn()} />);
+
+      expect(screen.getByText('Needs review')).toBeTruthy();
+      expect(screen.queryByRole('button', { name: 'Mark reviewed' })).toBeNull();
+    });
+
+    it('disables "Mark reviewed" for the feedback currently being updated', () => {
+      render(
+        <FeedbackThread
+          feedbackData={withReviewStatus('needs-review')}
+          onMarkReviewed={vi.fn()}
+          pendingFeedbackId="fb-1"
+          onSubmit={vi.fn()}
+        />,
+      );
+
+      expect((screen.getByRole('button', { name: 'Mark reviewed' }) as HTMLButtonElement).disabled).toBe(true);
+    });
   });
 
   it('pages through feedback when there is more than one page', () => {

--- a/packages/playground/src/domains/traces/components/feedback-thread.tsx
+++ b/packages/playground/src/domains/traces/components/feedback-thread.tsx
@@ -1,5 +1,6 @@
 import type { FeedbackItem, ListFeedbackResponse } from '@mastra/client-js';
 import { Avatar } from '@mastra/playground-ui/components/Avatar';
+import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import {
   Comment,
@@ -34,7 +35,24 @@ type FeedbackThreadProps = {
    * `embed` renders a compact card suitable for inline use.
    */
   variant?: CommentVariant;
+  /** When provided, unreviewed rows get a "Mark reviewed" action. */
+  onMarkReviewed?: (feedbackId: string) => void;
+  /** feedbackId whose review-status update is in flight (disables its action). */
+  pendingFeedbackId?: string;
 };
+
+// The server defaults `reviewStatus` to `needs-review`, so a missing value means the same.
+function ReviewStatusBadge({ status }: { status: FeedbackItem['reviewStatus'] }) {
+  return status === 'reviewed' ? (
+    <Badge data-slot="feedback-review-status" variant="green" size="xs" indicator="dot">
+      Reviewed
+    </Badge>
+  ) : (
+    <Badge data-slot="feedback-review-status" variant="yellow" size="xs" indicator="dot">
+      Needs review
+    </Badge>
+  );
+}
 
 function formatBody(fb: FeedbackItem): string {
   const text = fb.comment || (typeof fb.value === 'string' ? fb.value : '');
@@ -43,7 +61,12 @@ function formatBody(fb: FeedbackItem): string {
   return String(fb.value ?? '');
 }
 
-function FeedbackItems({ variant, items }: { variant: CommentVariant; items: FeedbackItem[] }) {
+type FeedbackItemsProps = Pick<FeedbackThreadProps, 'onMarkReviewed' | 'pendingFeedbackId'> & {
+  variant: CommentVariant;
+  items: FeedbackItem[];
+};
+
+function FeedbackItems({ variant, items, onMarkReviewed, pendingFeedbackId }: FeedbackItemsProps) {
   const rows = items.map((fb, index) => {
     const ts = new Date(fb.timestamp);
     const author = feedbackAuthorLabel(fb);
@@ -52,18 +75,34 @@ function FeedbackItems({ variant, items }: { variant: CommentVariant; items: Fee
     const timestamp = (
       <CommentItemTimestamp dateTime={ts.toISOString()}>{format(ts, 'MMM d, h:mm:ss aaa')}</CommentItemTimestamp>
     );
+    const feedbackId = fb.feedbackId;
+    const status = <ReviewStatusBadge status={fb.reviewStatus} />;
+    const markReviewed = onMarkReviewed && feedbackId && fb.reviewStatus !== 'reviewed' && (
+      <Button
+        variant="ghost"
+        size="sm"
+        className="ml-auto"
+        disabled={pendingFeedbackId === feedbackId}
+        onClick={() => onMarkReviewed(feedbackId)}
+      >
+        Mark reviewed
+      </Button>
+    );
     const body = <CommentItemBody>{formatBody(fb)}</CommentItemBody>;
-    const key = `${fb.traceId}-${index}`;
+    const key = feedbackId ?? `${fb.traceId}-${index}`;
 
     // The thread variant lays the row out as avatar gutter + content column.
+    // Without an author there is nothing to align under, so skip the gutter entirely.
     if (variant === 'thread') {
       return (
         <CommentItem key={key}>
-          <CommentItemAvatar>{avatar}</CommentItemAvatar>
+          {avatar && <CommentItemAvatar>{avatar}</CommentItemAvatar>}
           <CommentItemContent>
             <CommentItemHeader>
               {name}
               {timestamp}
+              {status}
+              {markReviewed}
             </CommentItemHeader>
             {body}
           </CommentItemContent>
@@ -78,6 +117,8 @@ function FeedbackItems({ variant, items }: { variant: CommentVariant; items: Fee
           {avatar}
           {name}
           {timestamp}
+          {status}
+          {markReviewed}
         </CommentItemHeader>
         {body}
       </CommentItem>
@@ -99,6 +140,8 @@ export function FeedbackThread({
   onSubmit,
   isSubmitting = false,
   variant = 'thread',
+  onMarkReviewed,
+  pendingFeedbackId,
 }: FeedbackThreadProps) {
   const [text, setText] = useState('');
   const sendBlocked = text.trim().length === 0 || isSubmitting;
@@ -119,7 +162,12 @@ export function FeedbackThread({
             No feedback yet
           </Txt>
         ) : (
-          <FeedbackItems variant={variant} items={feedbackItems} />
+          <FeedbackItems
+            variant={variant}
+            items={feedbackItems}
+            onMarkReviewed={onMarkReviewed}
+            pendingFeedbackId={pendingFeedbackId}
+          />
         )}
       </div>
 

--- a/packages/playground/src/domains/traces/components/span-feedback-tab.tsx
+++ b/packages/playground/src/domains/traces/components/span-feedback-tab.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useCreateFeedback } from '../hooks/use-create-feedback';
 import { useSpanFeedback } from '../hooks/use-span-feedback';
 import { FeedbackThread } from './feedback-thread';
+import { useUpdateFeedbackReviewStatus } from '@/domains/feedback/hooks/use-feedback';
 
 type SpanFeedbackTabProps = {
   traceId: string;
@@ -17,6 +18,7 @@ export function SpanFeedbackTab({ traceId, spanId }: SpanFeedbackTabProps) {
   const [page, setPage] = useState(0);
   const { data, isLoading } = useSpanFeedback({ traceId, spanId, page });
   const { mutateAsync, isPending } = useCreateFeedback({ traceId, spanId });
+  const updateReviewStatus = useUpdateFeedbackReviewStatus();
 
   return (
     <FeedbackThread
@@ -25,6 +27,8 @@ export function SpanFeedbackTab({ traceId, spanId }: SpanFeedbackTabProps) {
       onPageChange={setPage}
       onSubmit={text => mutateAsync({ text })}
       isSubmitting={isPending}
+      onMarkReviewed={feedbackId => updateReviewStatus.mutate({ feedbackId, reviewStatus: 'reviewed' })}
+      pendingFeedbackId={updateReviewStatus.isPending ? updateReviewStatus.variables.feedbackId : undefined}
     />
   );
 }

--- a/packages/playground/src/domains/traces/components/trace-feedback-tab.tsx
+++ b/packages/playground/src/domains/traces/components/trace-feedback-tab.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useCreateFeedback } from '../hooks/use-create-feedback';
 import { useTraceFeedback } from '../hooks/use-trace-feedback';
 import { FeedbackThread } from './feedback-thread';
+import { useUpdateFeedbackReviewStatus } from '@/domains/feedback/hooks/use-feedback';
 
 type TraceFeedbackTabProps = {
   traceId: string;
@@ -19,6 +20,7 @@ export function TraceFeedbackTab({ traceId, variant }: TraceFeedbackTabProps) {
   const [page, setPage] = useState(0);
   const { data, isLoading } = useTraceFeedback({ traceId, page });
   const { mutateAsync, isPending } = useCreateFeedback({ traceId });
+  const updateReviewStatus = useUpdateFeedbackReviewStatus();
 
   return (
     <FeedbackThread
@@ -28,6 +30,8 @@ export function TraceFeedbackTab({ traceId, variant }: TraceFeedbackTabProps) {
       onSubmit={text => mutateAsync({ text })}
       isSubmitting={isPending}
       variant={variant}
+      onMarkReviewed={feedbackId => updateReviewStatus.mutate({ feedbackId, reviewStatus: 'reviewed' })}
+      pendingFeedbackId={updateReviewStatus.isPending ? updateReviewStatus.variables.feedbackId : undefined}
     />
   );
 }

--- a/packages/playground/src/domains/traces/hooks/__tests__/fixtures/trace-feedback.ts
+++ b/packages/playground/src/domains/traces/hooks/__tests__/fixtures/trace-feedback.ts
@@ -12,6 +12,7 @@ const baseFeedback = {
   timestamp: new Date('2026-08-26T10:00:00.000Z'),
   feedbackType: 'thumbs',
   value: 1,
+  reviewStatus: 'needs-review',
 } satisfies Partial<Feedback>;
 
 export function feedbackRecord(overrides: Partial<Feedback> & { feedbackId: string }): Feedback {
@@ -44,6 +45,11 @@ export const authoredFeedbackResponse = listFeedbackResponse([
     value: 'Looks off to me',
     author: { id: 'user-1', name: 'Marvin Frachet', avatarUrl: 'https://example.com/marvin.png' },
   }),
+]);
+
+/** Trace-level record that has already been reviewed. */
+export const reviewedFeedbackResponse = listFeedbackResponse([
+  feedbackRecord({ feedbackId: 'reviewed', feedbackType: 'comment', value: 'All good', reviewStatus: 'reviewed' }),
 ]);
 
 export const otherSpanFeedbackResponse = listFeedbackResponse([


### PR DESCRIPTION
## Summary

Feedback records carry a `reviewStatus` (`needs-review` / `reviewed`), but when opening a trace in Studio nothing indicated whether a given feedback still needed action. This PR surfaces it directly in the trace and span feedback threads:

- Each feedback row now shows a **Needs review** (yellow) or **Reviewed** (green) badge, matching the dataset experiment review cell.
- Unreviewed rows get an inline **Mark reviewed** action, so the feedback can be resolved without going to the Inbox.
- Marking a feedback reviewed now invalidates the trace/span feedback queries as well as the Inbox list, so the badge flips immediately instead of waiting for the next poll.
- The thread layout no longer renders an empty avatar gutter for feedback without an author.

No changeset: `@internal/playground` is private and bundled into `mastra`.

## Test plan

- [x] `feedback-thread.test.tsx` — badge rendering for both statuses, action presence/absence, callback payload, disabled-while-pending state, no gutter without author
- [x] `feedback-tabs.msw.test.tsx` — trace and span tabs issue `PATCH /observability/feedback/:id/review-status` with `{ reviewStatus: 'reviewed' }` and refetch the thread
- [x] `inbox-page.msw.test.tsx` regression suite
- [x] `pnpm --filter ./packages/playground typecheck`
- [ ] Manual: open a trace with feedback in Studio, confirm badge, click **Mark reviewed**, confirm it flips to Reviewed and disappears from Inbox → Feedback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Studio feedback now shows whether someone reviewed each comment. Users can mark comments as reviewed, and the interface updates immediately.

## Changes

- Added **Needs review** and **Reviewed** badges to feedback rows.
- Added a **Mark reviewed** action for unreviewed feedback.
- Disabled the action while an update is pending.
- Refetched trace, span, and Inbox feedback after review-status updates.
- Removed the empty avatar space for feedback without an author.
- Added tests for badges, actions, callbacks, pending states, refetching, and unauthored feedback layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->