### PR TITLE
feat: show experiment-scoped token usage, cost and average latency on the experiment page

### DIFF
--- a/.changeset/experiment-page-metrics.md
+++ b/.changeset/experiment-page-metrics.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Added Tokens and Latency cells to the Studio experiment page. The meta bar now shows the total tokens used and estimated cost of the run, plus the average agent run duration across items, scoped to that experiment only. While an experiment is running the numbers update live. These cells only appear when the configured observability storage supports metrics.

--- a/packages/playground/src/domains/experiments/__tests__/experiment-item-route.msw.test.tsx
+++ b/packages/playground/src/domains/experiments/__tests__/experiment-item-route.msw.test.tsx
@@ -1,3 +1,4 @@
+import type { GetMetricAggregateArgs, GetMetricAggregateResponse } from '@mastra/client-js';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
@@ -23,6 +24,7 @@ import {
   noWorkflows,
   resultsResponse,
 } from './fixtures/experiment-item-route';
+import { renamedPostgresWithMetrics } from '@/domains/configuration/hooks/__tests__/fixtures/observability-storage-capabilities';
 import ExperimentPage from '@/pages/experiments/experiment';
 import ExperimentItemPage from '@/pages/experiments/experiment/item';
 import ReviewQueuePage from '@/pages/experiments/review-queue';
@@ -73,8 +75,23 @@ const renderExperimentRoute = (initialPath = `/experiments/${EXPERIMENT_ID}`) =>
   return { router, queryClient };
 };
 
+let metricRequests: GetMetricAggregateArgs[] = [];
+
+const metricAggregateByAggregation: Record<string, GetMetricAggregateResponse> = {
+  sum: { value: 12400, estimatedCost: 0.0123, costUnit: 'USD' },
+  avg: { value: 1850 },
+  count: { value: 42 },
+};
+
 beforeEach(() => {
+  metricRequests = [];
   server.use(
+    http.get(`${TEST_BASE_URL}/api/system/packages`, () => HttpResponse.json(renamedPostgresWithMetrics)),
+    http.post(`${TEST_BASE_URL}/api/observability/metrics/aggregate`, async ({ request }) => {
+      const body = (await request.json()) as GetMetricAggregateArgs;
+      metricRequests.push(body);
+      return HttpResponse.json(metricAggregateByAggregation[body.aggregation] ?? { value: null });
+    }),
     http.get(`${TEST_BASE_URL}/api/agents`, () => HttpResponse.json(noAgents)),
     http.get(`${TEST_BASE_URL}/api/processors`, () => HttpResponse.json(noProcessors)),
     http.get(`${TEST_BASE_URL}/api/workflows`, () => HttpResponse.json(noWorkflows)),
@@ -114,6 +131,22 @@ describe('experiment item sub-route', () => {
 
       await screen.findByText('item-2');
       expect(screen.queryByRole('tab')).toBeNull();
+    });
+  });
+
+  describe('given the experiment route on a metrics-capable store', () => {
+    it('when the page loads, then it requests metric aggregates filtered by the route experimentId and renders Tokens/Latency in the meta bar', async () => {
+      renderExperimentRoute();
+
+      expect(await screen.findByText('Tokens')).toBeDefined();
+      expect(await screen.findByText('12.4K')).toBeDefined();
+      expect(screen.getByText('Latency (avg)')).toBeDefined();
+      expect(await screen.findByText('1.9s')).toBeDefined();
+
+      expect(metricRequests.length).toBeGreaterThanOrEqual(3);
+      for (const body of metricRequests) {
+        expect(body.filters).toEqual({ experimentId: EXPERIMENT_ID });
+      }
     });
   });
 

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-meta-bar.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-meta-bar.test.tsx
@@ -2,7 +2,8 @@ import type { DatasetExperiment, DatasetRecord, GetScorerResponse } from '@mastr
 import { cleanup, screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { ExperimentMetaBar } from '../experiment-meta-bar';
+import type { ExperimentMetrics } from '../../hooks/use-experiment-metrics';
+import { ExperimentMetaBar, type ExperimentMetaBarProps } from '../experiment-meta-bar';
 import { experiments } from './fixtures/experiments';
 import { TestLinkProvider } from '@/test/link-provider';
 import { server } from '@/test/msw-server';
@@ -45,12 +46,28 @@ const runningExperiment: DatasetExperiment = {
   completedAt: null,
 };
 
-const renderBar = (experiment: DatasetExperiment) =>
+const renderBar = (experiment: DatasetExperiment, metrics?: ExperimentMetaBarProps['metrics']) =>
   renderWithProviders(
     <TestLinkProvider>
-      <ExperimentMetaBar experiment={experiment} />
+      <ExperimentMetaBar experiment={experiment} metrics={metrics} />
     </TestLinkProvider>,
   );
+
+const fullMetrics: ExperimentMetrics = {
+  totalTokens: 12400,
+  estimatedCost: 0.0123,
+  costUnit: 'USD',
+  avgAgentDurationMs: 1850,
+  agentRuns: 42,
+};
+
+const nullMetrics: ExperimentMetrics = {
+  totalTokens: null,
+  estimatedCost: null,
+  costUnit: null,
+  avgAgentDurationMs: null,
+  agentRuns: null,
+};
 
 describe('ExperimentMetaBar', () => {
   afterEach(cleanup);
@@ -116,10 +133,12 @@ describe('ExperimentMetaBar', () => {
       await waitForMutationsIdle(queryClient);
     });
 
-    it('shows the start time with a relative suffix', async () => {
+    it('shows the start time on one line, with the relative time as a tooltip', async () => {
       const { queryClient } = renderBar(completedExperiment);
 
-      expect(await screen.findByText(/· .+ ago/)).toBeDefined();
+      const started = await screen.findByTitle(/ago$/);
+      expect(started.textContent).toMatch(/^[A-Z][a-z]{2} \d{1,2}, \d{1,2}:\d{2} [AP]M$/);
+      expect(screen.queryByText(/· .+ ago/)).toBeNull();
 
       await waitForMutationsIdle(queryClient);
     });
@@ -155,6 +174,76 @@ describe('ExperimentMetaBar', () => {
       expect(await screen.findByText('· so far')).toBeDefined();
 
       await waitForMutationsIdle(queryClient);
+    });
+  });
+
+  describe('metrics cells', () => {
+    describe('given metrics are enabled', () => {
+      it('when totals are present, then it shows a Tokens cell with a compact count and cost', async () => {
+        const { queryClient } = renderBar(completedExperiment, {
+          data: fullMetrics,
+          isLoading: false,
+          isEnabled: true,
+        });
+
+        expect(await screen.findByText('Tokens')).toBeDefined();
+        expect(screen.getByText('12.4K')).toBeDefined();
+        expect(screen.getByText('· $0.01')).toBeDefined();
+
+        await waitForMutationsIdle(queryClient);
+      });
+
+      it('when avg duration is present, then it shows a "Latency (avg)" cell with the formatted duration', async () => {
+        const { queryClient } = renderBar(completedExperiment, {
+          data: fullMetrics,
+          isLoading: false,
+          isEnabled: true,
+        });
+
+        expect(await screen.findByText('Latency (avg)')).toBeDefined();
+        expect(screen.getByText('1.9s')).toBeDefined();
+        expect(screen.queryByText(/avg over/)).toBeNull();
+
+        await waitForMutationsIdle(queryClient);
+      });
+
+      it('when values are null, then Tokens and Latency show "—"', async () => {
+        const { queryClient } = renderBar(completedExperiment, {
+          data: nullMetrics,
+          isLoading: false,
+          isEnabled: true,
+        });
+
+        expect(await screen.findByText('Tokens')).toBeDefined();
+        expect(screen.getByText('Latency (avg)')).toBeDefined();
+        // Avg score also renders "—" until scores load, so at least the two metric cells are dashes.
+        expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+
+        await waitForMutationsIdle(queryClient);
+      });
+
+      it('when the experiment is running, then Tokens shows the "· so far" suffix', async () => {
+        const { queryClient } = renderBar(runningExperiment, { data: fullMetrics, isLoading: false, isEnabled: true });
+
+        expect(await screen.findByText('12.4K')).toBeDefined();
+        // Avg score shows one "· so far" as well; Tokens adds a second.
+        await screen.findAllByText('· so far');
+        expect(screen.getAllByText('· so far')).toHaveLength(2);
+
+        await waitForMutationsIdle(queryClient);
+      });
+    });
+
+    describe('given metrics are disabled', () => {
+      it('when rendered, then Tokens and Latency cells are absent', async () => {
+        const { queryClient } = renderBar(completedExperiment, { data: undefined, isLoading: false, isEnabled: false });
+
+        expect(await screen.findByText('Duration')).toBeDefined();
+        expect(screen.queryByText('Tokens')).toBeNull();
+        expect(screen.queryByText('Latency (avg)')).toBeNull();
+
+        await waitForMutationsIdle(queryClient);
+      });
     });
   });
 });

--- a/packages/playground/src/domains/experiments/components/experiment-meta-bar.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-meta-bar.tsx
@@ -1,11 +1,18 @@
 import type { DatasetExperiment } from '@mastra/client-js';
+import { formatCompact, formatCost } from '@mastra/playground-ui/domains/metrics/components/metrics-utils';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { format, formatDistanceToNow } from 'date-fns';
 import { type ReactNode, useMemo } from 'react';
+import type { ExperimentMetrics } from '../hooks/use-experiment-metrics';
 import { useScoresByExperimentId } from '@/domains/datasets/hooks/use-dataset-experiments';
 
 export interface ExperimentMetaBarProps {
   experiment: DatasetExperiment;
+  metrics?: {
+    data?: ExperimentMetrics;
+    isLoading: boolean;
+    isEnabled: boolean;
+  };
   className?: string;
 }
 
@@ -31,11 +38,13 @@ function formatDuration(ms: number): string {
 
 /**
  * Horizontal metadata strip for the experiment page — Avg score / Items /
- * Started / Duration cells separated by vertical borders. The dataset lives in
- * the page title, so it is not repeated here.
+ * Started / Duration cells separated by vertical borders, plus Tokens / Latency
+ * when the observability store supports metrics. The dataset lives in the page
+ * title, so it is not repeated here.
  */
-export function ExperimentMetaBar({ experiment, className }: ExperimentMetaBarProps) {
+export function ExperimentMetaBar({ experiment, metrics, className }: ExperimentMetaBarProps) {
   const { data: scoresByItemId } = useScoresByExperimentId(experiment.id, experiment.status);
+  const isActive = experiment.status === 'running' || experiment.status === 'pending';
 
   // Averages every score fetched so far, so a running experiment reflects only
   // the items scored up to now.
@@ -65,15 +74,13 @@ export function ExperimentMetaBar({ experiment, className }: ExperimentMetaBarPr
         ) : (
           <>
             <span>{overallAverage.toFixed(3)}</span>
-            {(experiment.status === 'running' || experiment.status === 'pending') && (
-              <span className="text-neutral3">· so far</span>
-            )}
+            {isActive && <span className="text-neutral3">· so far</span>}
           </>
         )}
       </MetaCell>
 
       <MetaCell label="Items">
-        {experiment.status === 'running' || experiment.status === 'pending' ? (
+        {isActive ? (
           <span className="text-neutral3">
             {(experiment.succeededCount ?? 0) + (experiment.failedCount ?? 0)}/{experiment.totalItems} items processed
           </span>
@@ -91,10 +98,9 @@ export function ExperimentMetaBar({ experiment, className }: ExperimentMetaBarPr
 
       <MetaCell label="Started">
         {startedDate ? (
-          <>
-            <span>{format(startedDate, 'MMM d, h:mm a')}</span>
-            <span className="text-neutral3">· {formatDistanceToNow(startedDate, { addSuffix: true })}</span>
-          </>
+          <span title={formatDistanceToNow(startedDate, { addSuffix: true })}>
+            {format(startedDate, 'MMM d, h:mm a')}
+          </span>
         ) : (
           <span>—</span>
         )}
@@ -103,6 +109,34 @@ export function ExperimentMetaBar({ experiment, className }: ExperimentMetaBarPr
       <MetaCell label="Duration">
         <span>{durationValue}</span>
       </MetaCell>
+
+      {metrics?.isEnabled && (
+        <>
+          <MetaCell label="Tokens">
+            {metrics.data?.totalTokens == null ? (
+              <span className="text-neutral3">—</span>
+            ) : (
+              <>
+                <span>{formatCompact(metrics.data.totalTokens)}</span>
+                {metrics.data.estimatedCost != null && (
+                  <span className="text-neutral3">
+                    · {formatCost(metrics.data.estimatedCost, metrics.data.costUnit)}
+                  </span>
+                )}
+                {isActive && <span className="text-neutral3">· so far</span>}
+              </>
+            )}
+          </MetaCell>
+
+          <MetaCell label="Latency (avg)">
+            {metrics.data?.avgAgentDurationMs == null ? (
+              <span className="text-neutral3">—</span>
+            ) : (
+              <span>{formatDuration(Math.round(metrics.data.avgAgentDurationMs))}</span>
+            )}
+          </MetaCell>
+        </>
+      )}
     </div>
   );
 }

--- a/packages/playground/src/domains/experiments/components/experiment-top-area.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-top-area.tsx
@@ -9,11 +9,14 @@ import { ExperimentMetaBar } from '@/domains/experiments/components/experiment-m
 import { ExperimentStatusIcon } from '@/domains/experiments/components/experiment-stats';
 import { RenameExperimentButton } from '@/domains/experiments/components/rename-experiment-button';
 import { RerunExperimentButton } from '@/domains/experiments/components/rerun-experiment-button';
+import type { useExperimentMetrics } from '@/domains/experiments/hooks/use-experiment-metrics';
 import { experimentReviewQueueLink } from '@/lib/app-routing';
 import { useLinkComponent } from '@/lib/framework';
 
 export interface ExperimentTopAreaProps {
   experiment: DatasetExperiment;
+  /** Experiment-scoped metrics resolved by the page; omitted where metrics are not surfaced. */
+  metrics?: ReturnType<typeof useExperimentMetrics>;
   /** When provided, renders a delete action in the header. */
   onDeleteClick?: () => void;
 }
@@ -23,7 +26,7 @@ export interface ExperimentTopAreaProps {
  * on the left, stats on the right. Wrapped in PageLayout primitives so it slots into
  * any consumer's PageLayout shell.
  */
-export function ExperimentTopArea({ experiment, onDeleteClick }: ExperimentTopAreaProps) {
+export function ExperimentTopArea({ experiment, metrics, onDeleteClick }: ExperimentTopAreaProps) {
   const { Link: LinkComponent, paths } = useLinkComponent();
 
   const versionLinkHref =
@@ -78,7 +81,7 @@ export function ExperimentTopArea({ experiment, onDeleteClick }: ExperimentTopAr
       </PageLayout.Row>
 
       {/* Full-bleed: cancel the PageLayout root's horizontal p-6 so the bar's borders span edge to edge. */}
-      <ExperimentMetaBar experiment={experiment} className="-mx-6 w-auto" />
+      <ExperimentMetaBar experiment={experiment} metrics={metrics} className="-mx-6 w-auto" />
     </PageLayout.TopArea>
   );
 }

--- a/packages/playground/src/domains/experiments/hooks/__tests__/use-experiment-metrics.msw.test.tsx
+++ b/packages/playground/src/domains/experiments/hooks/__tests__/use-experiment-metrics.msw.test.tsx
@@ -1,0 +1,185 @@
+import type { GetMetricAggregateArgs, GetMetricAggregateResponse } from '@mastra/client-js';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useExperimentMetrics } from '../use-experiment-metrics';
+import {
+  renamedPostgresWithMetrics,
+  storageWithoutMetrics,
+} from '@/domains/configuration/hooks/__tests__/fixtures/observability-storage-capabilities';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+const EXPERIMENT_ID = 'exp-123';
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+};
+
+const tokensAggregate: GetMetricAggregateResponse = { value: 12400, estimatedCost: 0.0123, costUnit: 'USD' };
+const avgDurationAggregate: GetMetricAggregateResponse = { value: 1850 };
+const countAggregate: GetMetricAggregateResponse = { value: 42 };
+const nullAggregate: GetMetricAggregateResponse = { value: null, estimatedCost: null, costUnit: null };
+
+let requests: GetMetricAggregateArgs[] = [];
+
+const useAggregateHandler = (respond: (body: GetMetricAggregateArgs) => GetMetricAggregateResponse) => {
+  server.use(
+    http.post(`${BASE_URL}/api/observability/metrics/aggregate`, async ({ request }) => {
+      const body = (await request.json()) as GetMetricAggregateArgs;
+      requests.push(body);
+      return HttpResponse.json(respond(body));
+    }),
+  );
+};
+
+const respondByAggregation = (body: GetMetricAggregateArgs): GetMetricAggregateResponse => {
+  if (body.aggregation === 'sum') return tokensAggregate;
+  if (body.aggregation === 'avg') return avgDurationAggregate;
+  return countAggregate;
+};
+
+beforeEach(() => {
+  requests = [];
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('useExperimentMetrics', () => {
+  describe('given a metrics-capable observability store', () => {
+    beforeEach(() => {
+      server.use(http.get(`${BASE_URL}/api/system/packages`, () => HttpResponse.json(renamedPostgresWithMetrics)));
+    });
+
+    it('when called with an experimentId, then it requests aggregates filtered by that experimentId and no time window', async () => {
+      useAggregateHandler(respondByAggregation);
+
+      const { result } = renderHook(
+        () => useExperimentMetrics({ experimentId: EXPERIMENT_ID, experimentStatus: 'completed' }),
+        { wrapper: makeWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.data).toBeDefined());
+
+      expect(requests).toHaveLength(3);
+      for (const body of requests) {
+        expect(body.filters).toEqual({ experimentId: EXPERIMENT_ID });
+        expect(body).not.toHaveProperty('comparePeriod');
+      }
+      expect(requests.map(r => r.aggregation).sort()).toEqual(['avg', 'count', 'sum']);
+    });
+
+    it('when aggregates resolve, then it exposes totalTokens, estimatedCost, costUnit, avgAgentDurationMs and agentRuns', async () => {
+      useAggregateHandler(respondByAggregation);
+
+      const { result } = renderHook(
+        () => useExperimentMetrics({ experimentId: EXPERIMENT_ID, experimentStatus: 'completed' }),
+        { wrapper: makeWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.data).toBeDefined());
+
+      expect(result.current.isEnabled).toBe(true);
+      expect(result.current.data).toEqual({
+        totalTokens: 12400,
+        estimatedCost: 0.0123,
+        costUnit: 'USD',
+        avgAgentDurationMs: 1850,
+        agentRuns: 42,
+      });
+    });
+
+    it('when the store returns null values, then metrics fields are null (not 0)', async () => {
+      useAggregateHandler(() => nullAggregate);
+
+      const { result } = renderHook(
+        () => useExperimentMetrics({ experimentId: EXPERIMENT_ID, experimentStatus: 'completed' }),
+        { wrapper: makeWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.data).toBeDefined());
+
+      expect(result.current.data).toEqual({
+        totalTokens: null,
+        estimatedCost: null,
+        costUnit: null,
+        avgAgentDurationMs: null,
+        agentRuns: null,
+      });
+    });
+
+    it('when experimentStatus is running, then it refetches on an interval', async () => {
+      useAggregateHandler(respondByAggregation);
+
+      const { result } = renderHook(
+        () => useExperimentMetrics({ experimentId: EXPERIMENT_ID, experimentStatus: 'running' }),
+        { wrapper: makeWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.data).toBeDefined());
+      expect(requests).toHaveLength(3);
+
+      await waitFor(() => expect(requests.length).toBeGreaterThan(3), { timeout: 4000 });
+    });
+
+    it('when experimentStatus is completed, then it does not refetch', async () => {
+      useAggregateHandler(respondByAggregation);
+
+      const { result } = renderHook(
+        () => useExperimentMetrics({ experimentId: EXPERIMENT_ID, experimentStatus: 'completed' }),
+        { wrapper: makeWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.data).toBeDefined());
+      expect(requests).toHaveLength(3);
+
+      await act(() => new Promise(resolve => setTimeout(resolve, 2500)));
+      expect(requests).toHaveLength(3);
+    });
+
+    it('when experimentId is undefined, then no request is made and isEnabled is false', async () => {
+      useAggregateHandler(respondByAggregation);
+
+      const { result } = renderHook(
+        () => useExperimentMetrics({ experimentId: undefined, experimentStatus: 'completed' }),
+        { wrapper: makeWrapper() },
+      );
+
+      await act(() => new Promise(resolve => setTimeout(resolve, 50)));
+
+      expect(result.current.isEnabled).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(requests).toHaveLength(0);
+    });
+  });
+
+  describe('given an observability store that does not support metrics', () => {
+    it('when called, then it makes no aggregate request and isEnabled is false', async () => {
+      server.use(http.get(`${BASE_URL}/api/system/packages`, () => HttpResponse.json(storageWithoutMetrics)));
+      useAggregateHandler(respondByAggregation);
+
+      const { result } = renderHook(
+        () => useExperimentMetrics({ experimentId: EXPERIMENT_ID, experimentStatus: 'completed' }),
+        { wrapper: makeWrapper() },
+      );
+
+      await act(() => new Promise(resolve => setTimeout(resolve, 100)));
+
+      expect(result.current.isEnabled).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(requests).toHaveLength(0);
+    });
+  });
+});

--- a/packages/playground/src/domains/experiments/hooks/use-experiment-metrics.ts
+++ b/packages/playground/src/domains/experiments/hooks/use-experiment-metrics.ts
@@ -32,7 +32,9 @@ export const useExperimentMetrics = ({ experimentId, experimentStatus }: UseExpe
     enabled: isEnabled,
     refetchInterval: isActive ? 2000 : false,
     queryFn: async (): Promise<ExperimentMetrics> => {
-      const filters = { experimentId: experimentId! };
+      // `enabled` already guards this; the check exists to narrow the type.
+      if (!experimentId) throw new Error('experimentId is required');
+      const filters = { experimentId };
 
       const [tokens, avgDuration, runs] = await Promise.all([
         client.getMetricAggregate({

--- a/packages/playground/src/domains/experiments/hooks/use-experiment-metrics.ts
+++ b/packages/playground/src/domains/experiments/hooks/use-experiment-metrics.ts
@@ -1,0 +1,58 @@
+import type { DatasetExperiment } from '@mastra/client-js';
+import { useMastraClient } from '@mastra/react';
+import { useQuery } from '@tanstack/react-query';
+import { useObservabilityStorageCapabilities } from '@/domains/configuration/hooks/use-observability-storage-capabilities';
+
+export interface ExperimentMetrics {
+  totalTokens: number | null;
+  estimatedCost: number | null;
+  costUnit: string | null;
+  avgAgentDurationMs: number | null;
+  agentRuns: number | null;
+}
+
+interface UseExperimentMetricsArgs {
+  experimentId: string | undefined;
+  experimentStatus: DatasetExperiment['status'] | undefined;
+}
+
+/**
+ * Experiment-scoped metrics (tokens, cost, avg agent latency).
+ * Filters only by experimentId — no time window, since the experiment already bounds the row set.
+ * Polls every 2 seconds while the experiment is running or pending.
+ */
+export const useExperimentMetrics = ({ experimentId, experimentStatus }: UseExperimentMetricsArgs) => {
+  const client = useMastraClient();
+  const { supportsMetrics } = useObservabilityStorageCapabilities();
+  const isEnabled = Boolean(experimentId) && supportsMetrics;
+  const isActive = experimentStatus === 'running' || experimentStatus === 'pending';
+
+  const query = useQuery({
+    queryKey: ['experiment-metrics', experimentId],
+    enabled: isEnabled,
+    refetchInterval: isActive ? 2000 : false,
+    queryFn: async (): Promise<ExperimentMetrics> => {
+      const filters = { experimentId: experimentId! };
+
+      const [tokens, avgDuration, runs] = await Promise.all([
+        client.getMetricAggregate({
+          name: ['mastra_model_total_input_tokens', 'mastra_model_total_output_tokens'],
+          aggregation: 'sum',
+          filters,
+        }),
+        client.getMetricAggregate({ name: ['mastra_agent_duration_ms'], aggregation: 'avg', filters }),
+        client.getMetricAggregate({ name: ['mastra_agent_duration_ms'], aggregation: 'count', filters }),
+      ]);
+
+      return {
+        totalTokens: tokens.value ?? null,
+        estimatedCost: tokens.estimatedCost ?? null,
+        costUnit: tokens.costUnit ?? null,
+        avgAgentDurationMs: avgDuration.value ?? null,
+        agentRuns: runs.value ?? null,
+      };
+    },
+  });
+
+  return { data: query.data, isLoading: query.isLoading, isEnabled };
+};

--- a/packages/playground/src/pages/experiments/experiment/index.tsx
+++ b/packages/playground/src/pages/experiments/experiment/index.tsx
@@ -75,30 +75,23 @@ function ExperimentPage() {
     );
   }
 
-  // Not found: either an explicit 404 from the dataset/experiment fetch, or the
-  // experimentId isn't present in the full experiments listing (so we can't
-  // resolve a datasetId for it).
-  if (
-    (experimentError && is404NotFoundError(experimentError)) ||
-    (!experimentsListLoading && !datasetId) ||
-    (!experimentLoading && !experimentError && !experiment)
-  ) {
-    return (
-      <ExperimentPageShell>
-        <EmptyState
-          iconSlot={<PlayCircle />}
-          titleSlot="Experiment not found"
-          descriptionSlot={`No experiment with id "${experimentId}".`}
-          actionSlot={
-            <Button as={Link} to="/experiments">
-              <ArrowLeft />
-              Back to Experiments
-            </Button>
-          }
-        />
-      </ExperimentPageShell>
-    );
-  }
+  const notFound = (
+    <ExperimentPageShell>
+      <EmptyState
+        iconSlot={<PlayCircle />}
+        titleSlot="Experiment not found"
+        descriptionSlot={`No experiment with id "${experimentId}".`}
+        actionSlot={
+          <Button as={Link} to="/experiments">
+            <ArrowLeft />
+            Back to Experiments
+          </Button>
+        }
+      />
+    </ExperimentPageShell>
+  );
+
+  if (experimentError && is404NotFoundError(experimentError)) return notFound;
 
   if (experimentError) {
     return (
@@ -115,11 +108,15 @@ function ExperimentPage() {
     );
   }
 
+  // Not found: the experimentId isn't present in the full experiments listing
+  // (so we can't resolve a datasetId for it), or the fetch resolved empty.
+  if (!datasetId || !experiment) return notFound;
+
   return (
     <ExperimentItemPanelProvider
       experimentId={experimentId}
       datasetId={datasetId}
-      experimentStatus={experiment!.status}
+      experimentStatus={experiment.status}
       results={results ?? []}
       isLoadingResults={resultsLoading}
       hasNextPage={hasNextPage}
@@ -127,7 +124,7 @@ function ExperimentPage() {
       <div className="h-full">
         <PageLayout height="full">
           <ExperimentTopArea
-            experiment={experiment!}
+            experiment={experiment}
             metrics={experimentMetrics}
             onDeleteClick={() => setDeleteDialogOpen(true)}
           />
@@ -136,7 +133,7 @@ function ExperimentPage() {
             <ExperimentResultsSection
               experimentId={experimentId}
               datasetId={datasetId}
-              experimentStatus={experiment!.status}
+              experimentStatus={experiment.status}
               results={results ?? []}
               isLoading={resultsLoading}
               setEndOfListElement={setEndOfListElement}
@@ -153,7 +150,7 @@ function ExperimentPage() {
           open={deleteDialogOpen}
           onOpenChange={setDeleteDialogOpen}
           experimentId={experimentId}
-          experimentName={experiment!.name ?? undefined}
+          experimentName={experiment.name ?? undefined}
           onSuccess={() => navigate('/experiments')}
         />
       </div>

--- a/packages/playground/src/pages/experiments/experiment/index.tsx
+++ b/packages/playground/src/pages/experiments/experiment/index.tsx
@@ -15,6 +15,7 @@ import { DeleteExperimentDialog } from '@/domains/experiments/components/delete-
 import { ExperimentResultsSection } from '@/domains/experiments/components/experiment-results-section';
 import { ExperimentTopArea } from '@/domains/experiments/components/experiment-top-area';
 import { ExperimentItemPanelProvider } from '@/domains/experiments/context/experiment-item-panel-context';
+import { useExperimentMetrics } from '@/domains/experiments/hooks/use-experiment-metrics';
 
 function ExperimentPageShell({ children }: { children?: ReactNode }) {
   return (
@@ -52,6 +53,8 @@ function ExperimentPage() {
     experimentId: experimentId ?? '',
     experimentStatus: experiment?.status,
   });
+
+  const experimentMetrics = useExperimentMetrics({ experimentId, experimentStatus: experiment?.status });
 
   if (!experimentId) return null;
   if (experimentsListLoading || experimentLoading) return null; // Avoid layout shift on initial load
@@ -123,7 +126,11 @@ function ExperimentPage() {
     >
       <div className="h-full">
         <PageLayout height="full">
-          <ExperimentTopArea experiment={experiment!} onDeleteClick={() => setDeleteDialogOpen(true)} />
+          <ExperimentTopArea
+            experiment={experiment!}
+            metrics={experimentMetrics}
+            onDeleteClick={() => setDeleteDialogOpen(true)}
+          />
 
           <PageLayout.MainArea className="overflow-visible">
             <ExperimentResultsSection


### PR DESCRIPTION

<img width="3840" height="2160" alt="CleanShot 2026-09-09 at 10 36 47@2x" src="https://github.com/user-attachments/assets/5570427d-d5f4-4471-a91c-57b18055ef18" />


## Summary
The experiment page meta bar now shows what a run actually cost and how fast the target ran, scoped to that experiment only.

- Adds `useExperimentMetrics` (playground) querying `POST /observability/metrics/aggregate` with `filters: { experimentId }` — no time window and no compare period, unlike the dashboard KPI hooks, so old runs still resolve and there is no meaningless "vs previous period"
- Resolved once at the experiment page level and passed through `ExperimentTopArea` → `ExperimentMetaBar`
- New cells: **Tokens** (compact count + estimated cost, "· so far" while running) and **Latency (avg)**
- Polls every 2s while the experiment is running/pending; cells are hidden on observability stores without metrics support (e.g. in-memory)
- Started cell renders on a single line; the relative time moved to a tooltip

## Test plan
- [x] `pnpm --filter @internal/playground vitest run src/domains/experiments` — 193/193 (hook MSW specs asserting the `experimentId`-only filter contract and polling, meta-bar cell specs, page-level route spec)
- [x] `tsc --noEmit` clean
- [ ] Open `/experiments/:id` on a DuckDB/ClickHouse-backed project → 6 cells, Tokens/Latency tick up during a run
- [ ] Same page on an in-memory observability store → original 4 cells


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The experiment page now shows token usage, estimated cost, and average latency. These values update while the experiment runs and appear only when the storage supports metrics.

## Changes

- Added `useExperimentMetrics` to fetch experiment-scoped metrics from `POST /observability/metrics/aggregate`.
- Poll metrics every two seconds while an experiment is pending or running.
- Pass metrics from the experiment page through `ExperimentTopArea` to `ExperimentMetaBar`.
- Display compact token usage, estimated cost, and average target latency.
- Show `· so far` for active experiments.
- Hide metric cells when the observability store does not support metrics.
- Show the started time on one line and move relative time to its tooltip.
- Reordered experiment page guards and removed non-null assertions.
- Added MSW coverage for metric requests, polling, disabled states, null values, and rendered metrics.
- Added a `mastra` changeset entry.

## Testing

- 193 experiment-related tests pass.
- TypeScript checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->