### PR TITLE
fix(core): send x-opencode-session on OpenCode Go requests

### DIFF
--- a/.changeset/ten-stars-bake.md
+++ b/.changeset/ten-stars-bake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed OpenCode Go requests failing because the required x-opencode-session header was not sent. Mastra now includes a stable session ID on OpenCode and OpenCode Go model requests so routing and prompt caching work.

--- a/packages/core/src/llm/model/gateways/models-dev.test.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.test.ts
@@ -13,6 +13,7 @@ const {
   createGoogleGenerativeAIMock,
   createGroqMock,
   createMistralMock,
+  createOpenAICompatibleMock,
   createOpenAIMock,
   createOpenRouterMock,
   createPerplexityMock,
@@ -31,6 +32,7 @@ const {
   createGoogleGenerativeAIMock: vi.fn(),
   createGroqMock: vi.fn(),
   createMistralMock: vi.fn(),
+  createOpenAICompatibleMock: vi.fn(),
   createOpenAIMock: vi.fn(),
   createOpenRouterMock: vi.fn(),
   createPerplexityMock: vi.fn(),
@@ -47,6 +49,7 @@ vi.mock('@ai-sdk/deepseek-v6', () => ({ createDeepSeek: createDeepSeekMock }));
 vi.mock('@ai-sdk/google-v6', () => ({ createGoogleGenerativeAI: createGoogleGenerativeAIMock }));
 vi.mock('@ai-sdk/groq-v6', () => ({ createGroq: createGroqMock }));
 vi.mock('@ai-sdk/mistral-v6', () => ({ createMistral: createMistralMock }));
+vi.mock('@ai-sdk/openai-compatible-v6', () => ({ createOpenAICompatible: createOpenAICompatibleMock }));
 vi.mock('@ai-sdk/openai-v6', () => ({ createOpenAI: createOpenAIMock }));
 vi.mock('@ai-sdk/perplexity-v6', () => ({ createPerplexity: createPerplexityMock }));
 vi.mock('@ai-sdk/togetherai-v6', () => ({ createTogetherAI: createTogetherAIMock }));
@@ -74,6 +77,7 @@ describe('ModelsDevGateway', () => {
     createGoogleGenerativeAIMock.mockReturnValue({ chat: chatModelMock });
     createGroqMock.mockReturnValue(callableModelMock);
     createMistralMock.mockReturnValue(callableModelMock);
+    createOpenAICompatibleMock.mockReturnValue({ chatModel: chatModelMock });
     createOpenAIMock.mockReturnValue({ responses: openAIResponsesMock });
     createOpenRouterMock.mockReturnValue(callableModelMock);
     createPerplexityMock.mockReturnValue(callableModelMock);
@@ -645,6 +649,63 @@ describe('ModelsDevGateway', () => {
       });
       expect(xAIResponsesMock).toHaveBeenCalledWith('grok-4.3');
       expect(callableModelMock).not.toHaveBeenCalledWith('grok-4.3');
+    });
+
+    it('adds x-opencode-session for OpenCode Go requests', async () => {
+      gateway = new ModelsDevGateway({
+        'opencode-go': {
+          apiKeyEnvVar: 'OPENCODE_API_KEY',
+          name: 'OpenCode Go',
+          models: ['deepseek-v4-flash'],
+          gateway: 'models.dev',
+          url: 'https://opencode.ai/zen/go/v1',
+        },
+      });
+
+      await gateway.resolveLanguageModel({
+        providerId: 'opencode-go',
+        modelId: 'deepseek-v4-flash',
+        apiKey: 'sk-test',
+      });
+
+      expect(createOpenAICompatibleMock).toHaveBeenCalledWith({
+        name: 'opencode-go',
+        apiKey: 'sk-test',
+        baseURL: 'https://opencode.ai/zen/go/v1',
+        headers: {
+          'User-Agent': expect.any(String),
+          'x-opencode-session': expect.any(String),
+        },
+        supportsStructuredOutputs: true,
+      });
+    });
+
+    it('reuses x-thread-id as x-opencode-session for OpenCode Go', async () => {
+      gateway = new ModelsDevGateway({
+        'opencode-go': {
+          apiKeyEnvVar: 'OPENCODE_API_KEY',
+          name: 'OpenCode Go',
+          models: ['deepseek-v4-flash'],
+          gateway: 'models.dev',
+          url: 'https://opencode.ai/zen/go/v1',
+        },
+      });
+
+      await gateway.resolveLanguageModel({
+        providerId: 'opencode-go',
+        modelId: 'deepseek-v4-flash',
+        apiKey: 'sk-test',
+        headers: { 'x-thread-id': 'thread-123' },
+      });
+
+      expect(createOpenAICompatibleMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'x-thread-id': 'thread-123',
+            'x-opencode-session': 'thread-123',
+          }),
+        }),
+      );
     });
   });
 

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -24,6 +24,7 @@ import type {
   TemperatureCapabilities,
 } from './base.js';
 import { EXCLUDED_PROVIDERS, MASTRA_USER_AGENT, PROVIDERS_WITH_INSTALLED_PACKAGES } from './constants.js';
+import { applyOpencodeSessionHeader } from './opencode-session-header.js';
 
 interface ModelsDevModelInfo {
   id: string;
@@ -341,7 +342,10 @@ export class ModelsDevGateway extends MastraModelGateway {
   }): Promise<GatewayLanguageModel> {
     const baseURL = this.buildUrl(`${providerId}/${modelId}`);
 
-    const mastraHeaders = { 'User-Agent': MASTRA_USER_AGENT, ...headers };
+    const mastraHeaders = applyOpencodeSessionHeader(providerId, {
+      'User-Agent': MASTRA_USER_AGENT,
+      ...headers,
+    }) ?? { 'User-Agent': MASTRA_USER_AGENT, ...headers };
 
     // Per-model override: a model may be served over a different request shape
     // than its provider default (e.g. the OpenAI Responses API while the provider

--- a/packages/core/src/llm/model/gateways/opencode-session-header.test.ts
+++ b/packages/core/src/llm/model/gateways/opencode-session-header.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { applyOpencodeSessionHeader } from './opencode-session-header.js';
+
+describe('applyOpencodeSessionHeader', () => {
+  it('does not add a session header for non-opencode providers', () => {
+    const headers = { 'User-Agent': 'mastra/1.0.0', 'x-thread-id': 'thread-1' };
+
+    expect(applyOpencodeSessionHeader('openai', headers)).toEqual(headers);
+  });
+
+  it('leaves missing headers undefined for non-opencode providers', () => {
+    expect(applyOpencodeSessionHeader('openai')).toBeUndefined();
+  });
+
+  it('preserves an explicit x-opencode-session header', () => {
+    const result = applyOpencodeSessionHeader('opencode-go', {
+      'x-opencode-session': 'sess-explicit',
+      'x-thread-id': 'thread-1',
+    });
+
+    expect(result?.['x-opencode-session']).toBe('sess-explicit');
+  });
+
+  it('treats an existing session header as case-insensitive', () => {
+    const result = applyOpencodeSessionHeader('opencode-go', {
+      'X-OpenCode-Session': 'sess-explicit',
+    });
+
+    expect(result?.['X-OpenCode-Session']).toBe('sess-explicit');
+    expect(result?.['x-opencode-session']).toBeUndefined();
+  });
+
+  it('reuses x-thread-id as the OpenCode session id', () => {
+    const result = applyOpencodeSessionHeader('opencode-go', {
+      'x-thread-id': 'thread-123',
+    });
+
+    expect(result?.['x-opencode-session']).toBe('thread-123');
+  });
+
+  it('reuses x-thread-id when the thread header uses a different case', () => {
+    const result = applyOpencodeSessionHeader('opencode-go', {
+      'X-Thread-Id': 'thread-123',
+    });
+
+    expect(result?.['x-opencode-session']).toBe('thread-123');
+  });
+
+  it('generates a session id for OpenCode Go when none is available', () => {
+    const result = applyOpencodeSessionHeader('opencode-go', { 'User-Agent': 'mastra/1.0.0' });
+
+    expect(result?.['x-opencode-session']).toEqual(expect.any(String));
+    expect(result?.['x-opencode-session']?.length).toBeGreaterThan(0);
+    expect(result?.['User-Agent']).toBe('mastra/1.0.0');
+  });
+
+  it('generates a session id for OpenCode Zen when none is available', () => {
+    const result = applyOpencodeSessionHeader('opencode', {});
+
+    expect(result?.['x-opencode-session']).toEqual(expect.any(String));
+    expect(result?.['x-opencode-session']?.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/llm/model/gateways/opencode-session-header.ts
+++ b/packages/core/src/llm/model/gateways/opencode-session-header.ts
@@ -1,0 +1,33 @@
+import { randomUUID } from 'node:crypto';
+
+/**
+ * OpenCode Go requires a stable `x-opencode-session` header so it can route
+ * and cache prompts. See https://opencode.ai/docs/go/#where-can-i-use-it
+ */
+const OPENCODE_SESSION_HEADER = 'x-opencode-session';
+const THREAD_ID_HEADER = 'x-thread-id';
+
+function getHeader(headers: Record<string, string>, name: string): string | undefined {
+  const target = name.toLowerCase();
+  const entry = Object.entries(headers).find(([key]) => key.toLowerCase() === target);
+  return entry?.[1];
+}
+
+export function applyOpencodeSessionHeader(
+  providerId: string,
+  headers?: Record<string, string>,
+): Record<string, string> | undefined {
+  if (!providerId.startsWith('opencode')) {
+    return headers;
+  }
+
+  const resolved = headers ?? {};
+  if (getHeader(resolved, OPENCODE_SESSION_HEADER)) {
+    return resolved;
+  }
+
+  return {
+    ...resolved,
+    [OPENCODE_SESSION_HEADER]: getHeader(resolved, THREAD_ID_HEADER) ?? randomUUID(),
+  };
+}

--- a/packages/core/src/llm/model/router-custom-provider.test.ts
+++ b/packages/core/src/llm/model/router-custom-provider.test.ts
@@ -58,6 +58,32 @@ describe('ModelRouter - Custom Provider Support', () => {
       const mockInstance = vi.mocked(createOpenAICompatible).mock.results[0].value;
       expect(mockInstance.chatModel).toHaveBeenCalledWith('my-model');
     });
+
+    it('adds x-opencode-session when using OpenCode Go with a custom URL', async () => {
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'You are a helpful assistant.',
+        model: {
+          providerId: 'opencode-go',
+          modelId: 'deepseek-v4-flash',
+          url: 'https://opencode.ai/zen/go/v1',
+          apiKey: 'test-key',
+        },
+      });
+
+      await agent.generate('test', { maxSteps: 1 });
+
+      expect(createOpenAICompatible).toHaveBeenCalledWith({
+        name: 'opencode-go',
+        apiKey: 'test-key',
+        baseURL: 'https://opencode.ai/zen/go/v1',
+        headers: {
+          'x-opencode-session': expect.any(String),
+        },
+        supportsStructuredOutputs: true,
+      });
+    });
   });
 
   describe('Unknown provider with custom URL', () => {

--- a/packages/core/src/llm/model/router.ts
+++ b/packages/core/src/llm/model/router.ts
@@ -19,6 +19,7 @@ import type {
 } from './gateways/base.js';
 import { defaultGateways } from './gateways/defaults.js';
 import { GatewayManager } from './gateways/index.js';
+import { applyOpencodeSessionHeader } from './gateways/opencode-session-header.js';
 
 import { createOpenAIWebSocketFetch } from './openai-websocket-fetch.js';
 import type { OpenAIWebSocketFetch } from './openai-websocket-fetch.js';
@@ -522,13 +523,15 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
       return cache.modelInstances.get(key)!;
     }
 
+    const requestHeaders = applyOpencodeSessionHeader(providerId, headers);
+
     // If custom URL is provided, use it directly with openai-compatible
     if (this.config.url) {
       const modelInstance = createOpenAICompatible({
         name: providerId,
         apiKey,
         baseURL: this.config.url,
-        headers,
+        headers: requestHeaders,
         supportsStructuredOutputs: true,
       }).chatModel(modelId);
       cache.modelInstances.set(key, modelInstance);
@@ -544,7 +547,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
           modelId,
           apiKey,
           baseURL,
-          headers,
+          headers: requestHeaders,
           responsesWebSocket,
         });
         cache.modelInstances.set(key, modelInstance);
@@ -558,7 +561,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
       modelId,
       providerId,
       apiKey,
-      headers,
+      headers: requestHeaders,
       transport: resolvedTransport,
       responsesWebSocket,
     });


### PR DESCRIPTION
## Summary
- OpenCode Go returns 400 when `x-opencode-session` is missing, so Mastra never got past routing for models like `opencode-go/deepseek-v4-flash`.
- The model router now sends a stable session ID on OpenCode and OpenCode Go requests: keep an explicit header, reuse `x-thread-id` when present, otherwise generate one.

## Test plan
- [ ] Run `pnpm --filter ./packages/core exec vitest run src/llm/model/gateways/opencode-session-header.test.ts src/llm/model/gateways/models-dev.test.ts src/llm/model/router-custom-provider.test.ts`
- [ ] Call an `opencode-go/*` model and confirm the request no longer fails with `MissingSessionID`
- [ ] In a threaded MastraCode session, confirm later turns keep using the same session id (thread id)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

OpenCode requests now receive a stable session ID. This prevents OpenCode Go errors and keeps threaded conversations connected.

## Changes

- Added `applyOpencodeSessionHeader` for OpenCode providers.
- Reuses `x-thread-id` when available.
- Preserves existing session headers.
- Generates a UUID when no session ID exists.
- Applies the header to custom URL, WebSocket, and gateway model paths.
- Added tests for header handling, provider resolution, and custom providers.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->