### PR TITLE
perf(core): avoid per-chunk workflow runs for generated stream processors

### DIFF
--- a/.changeset/vast-ideas-play.md
+++ b/.changeset/vast-ideas-play.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed excessive CPU and allocation overhead when streaming through output processors by avoiding a workflow run for every chunk in generated processor chains.

--- a/packages/core/src/agent/__tests__/processor-workflow-stream-execution.test.ts
+++ b/packages/core/src/agent/__tests__/processor-workflow-stream-execution.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from 'vitest';
+import { noopLogger } from '../../logger';
+import type { Processor } from '../../processors';
+import { isProcessorWorkflow } from '../../processors';
+import { ProcessorRunner, ProcessorState } from '../../processors/runner';
+import { RequestContext } from '../../request-context';
+import { ChunkFrom } from '../../stream/types';
+import { Agent } from '../agent';
+import { MessageList } from '../message-list';
+
+function textPart(text: string) {
+  return { type: 'text-delta' as const, runId: 'run', from: ChunkFrom.AGENT, payload: { id: 'text', text } };
+}
+
+async function setup(processors: Processor[]) {
+  const agent = new Agent({
+    id: 'stream-processors',
+    name: 'stream-processors',
+    instructions: 'test',
+    model: 'openai/gpt-4o',
+    outputProcessors: processors,
+  });
+  const resolved = await agent.listResolvedOutputProcessors();
+  const workflow = resolved[0]!;
+  if (!isProcessorWorkflow(workflow)) throw new Error('Expected generated workflow');
+  const createRun = vi.spyOn(workflow, 'createRun');
+  const states = new Map<string, ProcessorState<unknown>>();
+  const runner = new ProcessorRunner({
+    outputProcessors: resolved,
+    inputProcessors: [],
+    agentName: 'test',
+    logger: noopLogger,
+    processorStates: states,
+    agent,
+  });
+  return { agent, workflow, createRun, states, runner, messages: new MessageList() };
+}
+
+describe('generated processor workflows with stream hooks', () => {
+  it.each([1, 100])('runs hooks without creating workflow runs for %i chunks', async count => {
+    const received: number[] = [];
+    const stream = vi.fn<NonNullable<Processor['processOutputStream']>>(({ part, state, streamParts }) => {
+      state.count = Number(state.count ?? 0) + 1;
+      received.push(streamParts.length);
+      return part;
+    });
+    const final = vi.fn<NonNullable<Processor['processOutputResult']>>(({ messages, state }) => {
+      expect(state.count).toBe(count);
+      return messages;
+    });
+    const otherFinal = vi.fn<NonNullable<Processor['processOutputResult']>>(({ messages }) => messages);
+    const { runner, states, messages, createRun } = await setup([
+      { id: 'stream', processOutputStream: stream, processOutputResult: final },
+      ...Array.from({ length: 6 }, (_, i) => ({ id: `final-${i}`, processOutputResult: otherFinal })),
+    ]);
+
+    for (let i = 0; i < count; i++) {
+      const part = textPart('x');
+      expect(await runner.processPart(part, states, undefined, undefined, messages)).toEqual({ part, blocked: false });
+    }
+    expect(stream).toHaveBeenCalledTimes(count);
+    expect(received).toEqual(Array.from({ length: count }, (_, i) => i + 1));
+    expect(createRun.mock.calls).toHaveLength(0);
+    expect(final).not.toHaveBeenCalled();
+    await runner.runOutputProcessors(messages);
+    expect(createRun).toHaveBeenCalledTimes(1);
+    expect(final).toHaveBeenCalledTimes(1);
+    expect(otherFinal).toHaveBeenCalledTimes(6);
+  });
+
+  it('preserves order, shared stream history, request context, writer and dropped parts', async () => {
+    const context = new RequestContext();
+    context.set('test', 'value');
+    const custom = vi.fn(async () => {});
+    const seen: string[] = [];
+    const { runner, states, messages, createRun } = await setup([
+      {
+        id: 'first',
+        async processOutputStream({ part, writer, requestContext, messageList, retryCount }) {
+          expect(requestContext).toBe(context);
+          expect(messageList).toBe(messages);
+          expect(retryCount).toBe(2);
+          if (part.type !== 'text-delta') return part;
+          await writer?.custom({ type: 'data-status', data: { phase: 'streaming' } });
+          if (part.payload.text === 'drop') return null;
+          return { ...part, payload: { ...part.payload, text: part.payload.text.toUpperCase() } };
+        },
+      },
+      {
+        id: 'second',
+        processOutputStream({ part, streamParts }) {
+          if (part.type === 'text-delta') seen.push(part.payload.text);
+          expect(streamParts[0]).toEqual(textPart('hello'));
+          return part;
+        },
+      },
+    ]);
+    const first = await runner.processPart(textPart('hello'), states, undefined, context, messages, 2, { custom });
+    expect(first.part).toEqual(textPart('HELLO'));
+    const dropped = await runner.processPart(textPart('drop'), states, undefined, context, messages, 2, { custom });
+    expect(dropped.part).toBeNull();
+    expect(seen).toEqual(['HELLO']);
+    expect(custom).toHaveBeenCalledTimes(2);
+    expect(createRun.mock.calls).toHaveLength(0);
+  });
+
+  it('preserves tripwire details and does not run downstream hooks', async () => {
+    const downstream = vi.fn<NonNullable<Processor['processOutputStream']>>(({ part }) => part);
+    const { runner, states, messages, createRun } = await setup([
+      {
+        id: 'guard',
+        processOutputStream({ abort }) {
+          return abort('blocked', { retry: true, metadata: { rule: 'test' } });
+        },
+      },
+      { id: 'downstream', processOutputStream: downstream },
+    ]);
+    expect(await runner.processPart(textPart('hello'), states, undefined, undefined, messages)).toEqual({
+      part: null,
+      blocked: true,
+      reason: 'blocked',
+      tripwireOptions: { retry: true, metadata: { rule: 'test' } },
+      processorId: 'guard',
+    });
+    expect(downstream).not.toHaveBeenCalled();
+    expect(createRun.mock.calls).toHaveLength(0);
+  });
+
+  it.each([null, undefined])('stops the chain when a hook returns %s', async dropped => {
+    const downstream = vi.fn<NonNullable<Processor['processOutputStream']>>(({ part }) => part);
+    const { runner, states, messages } = await setup([
+      { id: 'drop', processOutputStream: () => dropped },
+      { id: 'downstream', processOutputStream: downstream },
+    ]);
+    expect((await runner.processPart(textPart('hello'), states, undefined, undefined, messages)).part).toBe(dropped);
+    expect(downstream).not.toHaveBeenCalled();
+  });
+
+  it('keeps the original part on a hook error and does not run downstream hooks', async () => {
+    const downstream = vi.fn<NonNullable<Processor['processOutputStream']>>(({ part }) => part);
+    const { runner, states, messages } = await setup([
+      {
+        id: 'throws',
+        processOutputStream() {
+          throw new Error('processor failed');
+        },
+      },
+      { id: 'downstream', processOutputStream: downstream },
+    ]);
+    const part = textPart('hello');
+    expect(await runner.processPart(part, states, undefined, undefined, messages)).toEqual({ part, blocked: false });
+    expect(downstream).not.toHaveBeenCalled();
+  });
+
+  it('reprocesses stashed parts through the complete chain and provides sendSignal', async () => {
+    const { runner, states, messages, createRun } = await setup([
+      {
+        id: 'stash',
+        async processOutputStream({ part, state, sendSignal }) {
+          if (part.type === 'text-delta' && part.payload.text === 'hello') {
+            state.__mastraReprocessPart = textPart('stashed');
+            await sendSignal?.({ type: 'system-reminder', contents: 'synthetic reminder' });
+          }
+          return part;
+        },
+      },
+      {
+        id: 'uppercase',
+        processOutputStream({ part }) {
+          return part.type === 'text-delta'
+            ? { ...part, payload: { ...part.payload, text: part.payload.text.toUpperCase() } }
+            : part;
+        },
+      },
+    ]);
+    const addSignal = vi.spyOn(messages, 'addSignal');
+    expect((await runner.processPart(textPart('hello'), states, undefined, undefined, messages)).part).toEqual(
+      textPart('HELLO'),
+    );
+    expect(addSignal).toHaveBeenCalledTimes(1);
+    expect(await runner.drainReprocessParts(states, undefined, undefined, messages)).toEqual([
+      { part: textPart('STASHED'), blocked: false },
+    ]);
+    expect(states.get('stash')?.customState.__mastraReprocessPart).toBeUndefined();
+    expect(createRun.mock.calls).toHaveLength(0);
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1783,6 +1783,7 @@ export class Agent<
     workflow.__setLogger(this.logger);
 
     const stateSignalProcessors: Processor[] = [];
+    const streamSteps: NonNullable<ProcessorWorkflow['__executeOutputStream']>[] = [];
 
     for (const [index, processorOrWorkflow] of validProcessors.entries()) {
       // Convert processor to step, or use workflow directly (nested workflows are allowed)
@@ -1796,6 +1797,12 @@ export class Agent<
         processor.processorIndex = index;
         // Cast needed because TypeScript can't narrow after isProcessorWorkflow check
         step = createStep(processor as unknown as Parameters<typeof createStep>[0]);
+        if (processor.processOutputStream) {
+          // The processor adapter only reads inputData, requestContext, tracingContext and
+          // outputWriter. Reuse it to preserve processor state, spans, signals and data-part
+          // filtering without running the workflow engine for every streamed chunk.
+          streamSteps.push(step.execute as NonNullable<ProcessorWorkflow['__executeOutputStream']>);
+        }
         const toolProvider = processor as ProcessorLoadedToolsProvider;
         if (typeof toolProvider.getLoadedToolsForRequestContext === 'function') {
           (step as ProcessorLoadedToolsProvider).getLoadedToolsForRequestContext =
@@ -1813,6 +1820,16 @@ export class Agent<
       committedWorkflow.__processOutputStream = validProcessors.some(
         processor => isProcessorWorkflow(processor) || !!processor.processOutputStream,
       );
+      // Opaque/nested workflows may contain arbitrary steps and must use the workflow engine.
+      if (validProcessors.every(processor => !isProcessorWorkflow(processor))) {
+        committedWorkflow.__executeOutputStream = async ({ inputData, ...context }) => {
+          for (const execute of streamSteps) {
+            if (!inputData.part) break;
+            inputData = await execute({ ...context, inputData });
+          }
+          return inputData;
+        };
+      }
     }
     // Register the parent Mastra instance on this internal processor workflow so that its
     // createRun() -> getWorkflowRunById() can read configured storage instead of logging

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -10,12 +10,13 @@ import type { ModelRouterModelId } from '../llm/model';
 import type { MastraLanguageModel, OpenAICompatibleConfig, SharedProviderOptions } from '../llm/model/shared.types';
 import type { Mastra } from '../mastra';
 import type { MastraMemory } from '../memory/memory';
-import type { ObservabilityContext, ProcessorSpanType, SpanTypeMap } from '../observability';
+import type { ObservabilityContext, ProcessorSpanType, SpanTypeMap, TracingContext } from '../observability';
 import type { RequestContext } from '../request-context';
 import type { InferStandardSchemaOutput, StandardSchemaWithJSON } from '../schema';
 import type { ChunkType } from '../stream';
 import type { DataChunkType, LanguageModelUsage, LLMStepResult, ProviderMetadata } from '../stream/types';
 import type { Workflow } from '../workflows';
+import type { OutputWriter } from '../workflows/types';
 import type { StructuredOutputOptions } from './processors';
 import type { ProcessorStepOutput } from './step-schema';
 
@@ -932,6 +933,13 @@ export type ProcessorWorkflow = Workflow<any, any, string, any, ProcessorStepOut
   __stateSignalProcessors?: Processor[];
   /** @internal Whether a framework-generated workflow needs per-chunk execution. Unknown workflows always execute. */
   __processOutputStream?: boolean;
+  /** @internal Execute a generated linear stream processor chain without a workflow run. */
+  __executeOutputStream?: (args: {
+    inputData: ProcessorStepOutput;
+    requestContext?: RequestContext;
+    tracingContext?: TracingContext;
+    outputWriter?: OutputWriter;
+  }) => Promise<ProcessorStepOutput>;
 };
 
 /**

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -590,6 +590,22 @@ export class ProcessorRunner {
     // user-supplied processor workflow keeps the persisting defaults, so the opt-out is
     // applied per run here — leaving the same workflow's standalone runs untouched.
     const isPerChunkPhase = input.phase === 'outputStream';
+    // Runtime-only fields are shared with the processor step adapters in either path.
+    const inputData = {
+      ...input,
+      processorStates: this.processorStates,
+      abortSignal,
+      agent: this.agent,
+    } as ProcessorStepOutput;
+
+    if (isPerChunkPhase && workflow.__executeOutputStream) {
+      return workflow.__executeOutputStream({
+        inputData,
+        tracingContext: observabilityContext?.tracingContext,
+        requestContext,
+        outputWriter: writer ? chunk => writer.custom(chunk) : undefined,
+      });
+    }
 
     // Create a run and start the workflow
     const run = await workflow.createRun(
@@ -601,16 +617,7 @@ export class ProcessorRunner {
         : undefined,
     );
     const result = await run.start({
-      // Cast to allow processorStates/abortSignal - passed through to workflow processor steps
-      // but not part of the official ProcessorStepOutput schema
-      inputData: {
-        ...input,
-        // Pass the processorStates map so workflow processor steps can access their state
-        processorStates: this.processorStates,
-        // Pass abortSignal so processors can cancel in-flight work
-        abortSignal,
-        agent: this.agent,
-      } as ProcessorStepOutput,
+      inputData,
       ...observabilityContext,
       requestContext,
       outputWriter: writer ? chunk => writer.custom(chunk) : undefined,


### PR DESCRIPTION
An `outputProcessors` array with even a pass-through `processOutputStream` hook currently creates a workflow run for every chunk. Final-only adapters in the same chain also go through the workflow engine. This leaves substantial CPU and allocation overhead after #23147 and #23251.

This change executes the existing processor step adapters directly during the stream phase of generated linear chains. Reusing the adapters preserves state/history, ordering, data-part filtering, writer output, signals, spans and tripwire handling. Explicit or nested user workflows stay on the workflow engine, as do final and other processor phases. No public configuration change is needed.

Fixes #23408

The linked issue includes the source chain, a runnable synthetic benchmark, exact validation commands and the distinction from the earlier fixes.

For 5,000 mock reasoning deltas producing exactly 1,000,000 characters, the full `Agent.stream()` reproduction makes the same 5,005 stream-hook calls while per-chunk processor workflow runs drop from 5,005 to zero. Native `structuredClone` calls drop from 320,654 to 40,366; the two non-stream output workflow runs and final reasoning are unchanged. This uses synthetic metadata and a no-op exporter, with no external model or database. Timing details are in the issue; the regression tests assert run counts rather than elapsed-time thresholds.

Added eight regression cases and a patch changeset for `@mastra/core`. Validation passed: 251 focused core tests, 44 observability tests with 2 existing skips, `pnpm build:core`, `pnpm --filter ./packages/core check`, `pnpm --filter @mastra/core typecheck`, and the staged-file oxlint/ESLint/oxfmt hook. Observability coverage includes processor spans, declared span types, terminal cleanup and durable-agent tracing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Streaming now processes each piece directly instead of starting a new workflow each time. This reduces overhead while preserving existing output and behavior.

## What changed

- Generated linear processor chains execute stream-capable adapters directly.
- Final processing, explicit workflows, and nested processor workflows still use the workflow engine.
- Preserved processor state, history, ordering, transformations, filtering, writer output, signals, tracing, errors, and tripwire handling.
- Added regression coverage for stream execution, run counts, cleanup, persistence, reprocessing, and observability.
- Added a `@mastra/core` patch changeset.

## Performance

- Reduced per-chunk processor workflow runs from 5,005 to zero in the benchmark.
- Reduced `structuredClone` calls from 320,654 to 40,366.
- Non-stream workflow runs and final reasoning remain unchanged.

## Validation

Focused tests, observability tests, build, checks, typechecking, and staged lint and format hooks passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->