### PR TITLE
feat(docs): Add footer

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1201,6 +1201,15 @@ html.plugin-id-integrations.docs-doc-id-index {
     gap: 2rem;
   }
 
+  .theme-layout-footer {
+    max-width: 62.25rem;
+    margin: 0 auto;
+  }
+
+  .footer > .container {
+    max-width: 62.25rem;
+  }
+
   .menu__caret {
     &::before {
       background: var(--ifm-menu-link-sublist-icon) center;
@@ -1375,11 +1384,7 @@ html.plugin-id-integrations.docs-doc-id-index {
   background: transparent;
   color: var(--mastra-text-secondary);
   padding: 2.5rem 1rem;
-}
-
-.footer > .container {
-  max-width: none;
-  padding: 0;
+  max-width: var(--ifm-container-width);
 }
 
 .footer__links {
@@ -1428,7 +1433,7 @@ html.plugin-id-integrations.docs-doc-id-index {
 
 @media (min-width: 996px) {
   .footer {
-    padding: 5rem 2.5rem 3rem;
+    padding: 5rem 1rem 3rem;
   }
 }
 
@@ -1571,11 +1576,6 @@ html.plugin-id-integrations.docs-doc-id-index {
   }
 
   /* ==================== DOC MAIN CONTAINER ==================== */
-  .container {
-    padding-top: 2rem !important;
-    padding-bottom: 5rem !important;
-  }
-
   header h1 {
     text-wrap: balance;
   }

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1366,31 +1366,101 @@ html.plugin-id-integrations.docs-doc-id-index {
   [data-theme='dark'] .theme-doc-sidebar-container {
     border-right-color: var(--border);
   }
+}
 
-  /* ==================== FOOTER ==================== */
+/* ==================== FOOTER ==================== */
+.footer {
+  container: docs-footer / inline-size;
+  width: 100%;
+  background: transparent;
+  color: var(--mastra-text-secondary);
+  padding: 2.5rem 1rem;
+}
+
+.footer > .container {
+  max-width: none;
+  padding: 0;
+}
+
+.footer__links {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2rem 1rem;
+  margin: 0;
+}
+
+.footer__col {
+  min-width: 0;
+  width: auto;
+  margin: 0;
+  padding: 0;
+}
+
+.footer__title {
+  margin-bottom: 1rem;
+  color: var(--mastra-text-primary);
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.footer__item {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.75;
+}
+
+.footer__link-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: var(--mastra-text-tertiary);
+  font-size: 0.875rem;
+  font-weight: 400;
+  overflow-wrap: anywhere;
+  transition: color 150ms ease;
+}
+
+.footer__link-item:hover,
+.footer__link-item:focus-visible {
+  color: var(--mastra-text-primary);
+  text-decoration: none;
+}
+
+@media (min-width: 996px) {
   .footer {
-    background-color: var(--ifm-navbar-background-color);
-    border-top: var(--border-sm) solid var(--border);
-    color: var(--mastra-text-secondary);
-    padding: 2rem 0;
-    display: none !important;
+    padding: 5rem 2.5rem 3rem;
   }
+}
 
-  .footer__link-item {
-    color: var(--mastra-text-tertiary);
-    font-weight: 400;
+@container docs-footer (min-width: 32rem) {
+  .footer__links {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    column-gap: 2.5rem;
   }
+}
 
-  .footer__link-item:hover {
-    color: var(--mastra-text-primary);
-    text-decoration: none;
+@container docs-footer (min-width: 56rem) {
+  .footer__links {
+    grid-template-columns: repeat(5, max-content);
+    justify-content: space-between;
+    column-gap: 1rem;
   }
+}
 
-  .footer__copyright {
-    color: var(--mastra-text-tertiary);
-    font-size: 0.8125rem;
+@container docs-footer (min-width: 75rem) {
+  .footer__links {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    justify-content: stretch;
+    column-gap: 2.5rem;
   }
+}
 
+.footer__copyright {
+  color: var(--mastra-text-tertiary);
+  font-size: 0.8125rem;
+}
+
+@media (min-width: 62.25rem) {
   /* ==================== TYPOGRAPHY ==================== */
 
   article h1,

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -3,7 +3,7 @@ import prismMastraDark from './src/theme/prism-mastra-dark.js'
 import prismMastraLight from './src/theme/prism-mastra-light.js'
 import remarkModelTokens from './src/plugins/remark-model-tokens'
 import type { Config } from '@docusaurus/types'
-import type { ThemeConfig } from '@docusaurus/preset-classic'
+import type { Options as PresetOptions, ThemeConfig } from '@docusaurus/preset-classic'
 import type { AlgoliaPluginOptions } from '@mastra/docusaurus-plugin-algolia'
 import type { KapaPluginOptions } from '@mastra/docusaurus-plugin-kapa'
 import { normalizeSiteSectionRoot, SITE_SECTION_ROOTS } from './src/utils/canonical-url'
@@ -202,7 +202,7 @@ const config: Config = {
 
             return items.map(item => ({ ...item, url: normalizeSiteSectionRoot(item.url) }))
           },
-        },
+        } satisfies PresetOptions['sitemap'],
       },
     ],
   ],
@@ -220,6 +220,58 @@ const config: Config = {
     },
     mermaid: {
       theme: { light: 'base', dark: 'base' },
+    },
+    footer: {
+      links: [
+        {
+          title: 'Product',
+          items: [
+            { label: 'Framework', to: '/ai-agent-framework' },
+            { label: 'Observability', to: '/platform-observability' },
+            { label: 'Studio', to: '/studio' },
+            { label: 'Factory', to: '/factory' },
+            { label: 'Agent Builder', to: '/agent-builder' },
+            { label: 'Server', to: '/ai-agent-deployment' },
+          ],
+        },
+        {
+          title: 'Documentation',
+          items: [
+            { label: 'Mastra', to: '/docs' },
+            { label: 'Factory', href: 'https://factory.mastra.ai' },
+            { label: 'Mastra Code', href: 'https://code.mastra.ai' },
+            { label: 'Agent Builder', href: 'https://agent-builder.mastra.ai' },
+          ],
+        },
+        {
+          title: 'Resources',
+          items: [
+            { label: 'Blog', to: '/blog' },
+            { label: 'Changelog', href: 'https://github.com/mastra-ai/mastra/releases' },
+            { label: 'Research', to: '/research' },
+            { label: 'Podcast · Agent Hour', to: '/podcasts' },
+          ],
+        },
+        {
+          title: 'Company',
+          items: [
+            { label: 'About', to: '/about' },
+            { label: 'Customers', to: '/customers' },
+            { label: 'Careers', to: '/careers' },
+            { label: 'Newsletter', to: '/newsletter' },
+          ],
+        },
+        {
+          title: 'Connect',
+          items: [
+            { label: 'Contact Us', to: '/contact' },
+            { label: 'GitHub', href: 'https://github.com/mastra-ai/mastra' },
+            { label: 'Discord', href: 'https://discord.gg/BTYqqHKUrf' },
+            { label: 'YouTube', href: 'https://www.youtube.com/@mastra-ai' },
+            { label: 'X (Twitter)', href: 'https://x.com/@mastra' },
+          ],
+        },
+      ],
     },
   } satisfies ThemeConfig,
 }

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -231,7 +231,6 @@ const config: Config = {
             { label: 'Studio', to: '/studio' },
             { label: 'Factory', to: '/factory' },
             { label: 'Agent Builder', to: '/agent-builder' },
-            { label: 'Server', to: '/ai-agent-deployment' },
           ],
         },
         {
@@ -250,6 +249,7 @@ const config: Config = {
             { label: 'Changelog', href: 'https://github.com/mastra-ai/mastra/releases' },
             { label: 'Research', to: '/research' },
             { label: 'Podcast · Agent Hour', to: '/podcasts' },
+            { label: 'License', to: '/docs/license' },
           ],
         },
         {

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -226,11 +226,11 @@ const config: Config = {
         {
           title: 'Product',
           items: [
-            { label: 'Framework', to: '/ai-agent-framework' },
-            { label: 'Observability', to: '/platform-observability' },
-            { label: 'Studio', to: '/studio' },
-            { label: 'Factory', to: '/factory' },
-            { label: 'Agent Builder', to: '/agent-builder' },
+            { label: 'Framework', href: 'https://mastra.ai/ai-agent-framework' },
+            { label: 'Observability', href: 'https://mastra.ai/platform-observability' },
+            { label: 'Studio', href: 'https://mastra.ai/studio' },
+            { label: 'Factory', href: 'https://mastra.ai/factory' },
+            { label: 'Agent Builder', href: 'https://mastra.ai/agent-builder' },
           ],
         },
         {
@@ -245,26 +245,26 @@ const config: Config = {
         {
           title: 'Resources',
           items: [
-            { label: 'Blog', to: '/blog' },
+            { label: 'Blog', href: 'https://mastra.ai/blog' },
             { label: 'Changelog', href: 'https://github.com/mastra-ai/mastra/releases' },
-            { label: 'Research', to: '/research' },
-            { label: 'Podcast · Agent Hour', to: '/podcasts' },
+            { label: 'Research', href: 'https://mastra.ai/research' },
+            { label: 'Podcast · Agent Hour', href: 'https://mastra.ai/podcasts' },
             { label: 'License', to: '/docs/license' },
           ],
         },
         {
           title: 'Company',
           items: [
-            { label: 'About', to: '/about' },
-            { label: 'Customers', to: '/customers' },
-            { label: 'Careers', to: '/careers' },
-            { label: 'Newsletter', to: '/newsletter' },
+            { label: 'About', href: 'https://mastra.ai/about' },
+            { label: 'Customers', href: 'https://mastra.ai/customers' },
+            { label: 'Careers', href: 'https://mastra.ai/careers' },
+            { label: 'Newsletter', href: 'https://mastra.ai/newsletter' },
           ],
         },
         {
           title: 'Connect',
           items: [
-            { label: 'Contact Us', to: '/contact' },
+            { label: 'Contact Us', href: 'https://mastra.ai/contact' },
             { label: 'GitHub', href: 'https://github.com/mastra-ai/mastra' },
             { label: 'Discord', href: 'https://discord.gg/BTYqqHKUrf' },
             { label: 'YouTube', href: 'https://www.youtube.com/@mastra-ai' },

--- a/docs/src/content/en/docs/license.mdx
+++ b/docs/src/content/en/docs/license.mdx
@@ -1,6 +1,10 @@
 ---
 title: "License"
 description: "Understand Mastra’s dual-license model, including which core packages use Apache License 2.0 and which enterprise features use the Mastra Enterprise License."
+hide_table_of_contents: true
+pagination_next: null
+pagination_prev: null
+custom_edit_url: null
 ---
 
 # License

--- a/docs/src/theme/Footer/LinkItem/index.tsx
+++ b/docs/src/theme/Footer/LinkItem/index.tsx
@@ -1,0 +1,27 @@
+import React, { type ReactNode } from 'react'
+import clsx from 'clsx'
+import Link from '@docusaurus/Link'
+import useBaseUrl from '@docusaurus/useBaseUrl'
+import type { Props } from '@theme/Footer/LinkItem'
+
+export default function FooterLinkItem({ item }: Props): ReactNode {
+  const { to, href, label, prependBaseUrlToHref, className, ...props } = item
+  const toUrl = useBaseUrl(to)
+  const normalizedHref = useBaseUrl(href, { forcePrependBaseUrl: true })
+
+  return (
+    <Link
+      className={clsx('footer__link-item', className)}
+      {...(href
+        ? {
+            href: prependBaseUrlToHref ? normalizedHref : href,
+          }
+        : {
+            to: toUrl,
+          })}
+      {...props}
+    >
+      {label}
+    </Link>
+  )
+}

--- a/docs/src/theme/Layout/index.tsx
+++ b/docs/src/theme/Layout/index.tsx
@@ -5,7 +5,6 @@ import { useLocation } from '@docusaurus/router'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
 import AnnouncementBar from '@theme/AnnouncementBar'
 import ErrorPageContent from '@theme/ErrorPageContent'
-import Footer from '@theme/Footer'
 import type { Props } from '@theme/Layout'
 import LayoutProvider from '@theme/Layout/Provider'
 import Navbar from '@theme/Navbar'
@@ -18,7 +17,6 @@ import { normalizeSiteSectionRoot } from '@site/src/utils/canonical-url'
 export default function Layout(props: Props): ReactNode {
   const {
     children,
-    noFooter,
     wrapperClassName,
     // Not really layout-related, but kept for convenience/retro-compatibility
     title,
@@ -56,8 +54,6 @@ export default function Layout(props: Props): ReactNode {
       >
         <ErrorBoundary fallback={params => <ErrorPageContent {...params} />}>{children}</ErrorBoundary>
       </div>
-
-      {!noFooter && <Footer />}
     </LayoutProvider>
   )
 }


### PR DESCRIPTION
## Description

Add footer to our docs to link to other docs pages and important internal links. Has the same style as our footers on the main site and other docs pages.

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The documentation site now has a footer with links to useful pages and resources. The footer matches the site style and adapts to different screen sizes.

## Changes

- Added Product, Documentation, Resources, Company, and Connect links to the Docusaurus footer.
- Added responsive footer styles with constrained widths, adaptive columns, link states, and copyright styling.
- Added `FooterLinkItem` to support base URLs and internal or external navigation.
- Removed the custom footer render from the layout so Docusaurus controls footer rendering.
- Updated the License page to hide its table of contents, pagination links, and edit link.
- Added `PresetOptions` typing for the sitemap configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->