### PR TITLE
feat(voice-minimax): add text-to-speech integration

### DIFF
--- a/.changeset/fresh-voices-speak.md
+++ b/.changeset/fresh-voices-speak.md
@@ -1,0 +1,5 @@
+---
+'@mastra/voice-minimax': minor
+---
+
+Added MiniMax text-to-speech with regional endpoints, the current speech model catalog, configurable request settings, and audio response parsing.

--- a/docs/src/content/en/integrations/sidebars.js
+++ b/docs/src/content/en/integrations/sidebars.js
@@ -702,6 +702,11 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'voice/minimax',
+          label: 'MiniMax',
+        },
+        {
+          type: 'doc',
           id: 'voice/mistral',
           label: 'Mistral',
           customProps: { icon: 'https://cdn.simpleicons.org/mistralai?viewbox=auto&size=28' },

--- a/docs/src/content/en/integrations/voice/minimax.mdx
+++ b/docs/src/content/en/integrations/voice/minimax.mdx
@@ -1,0 +1,74 @@
+---
+title: 'MiniMax | Voice'
+description: 'Use MiniMax text-to-speech with Mastra through global or China endpoints.'
+packages:
+  - '@mastra/voice-minimax'
+---
+
+# MiniMax
+
+The MiniMax voice integration converts text into audio with the T2A v2 API. It supports the global and China endpoints and returns generated audio as a Node.js readable stream.
+
+## Install
+
+```bash npm2yarn
+npm install @mastra/voice-minimax
+```
+
+## Configure text-to-speech
+
+Set your API key in `MINIMAX_API_KEY`. You also need a voice ID from your MiniMax account.
+
+```typescript
+import { MiniMaxVoice } from '@mastra/voice-minimax'
+
+const voice = new MiniMaxVoice({
+  speechModel: {
+    name: 'speech-2.8-hd',
+  },
+  speaker: process.env.MINIMAX_VOICE_ID,
+})
+
+const audioStream = await voice.speak('Hello from Mastra')
+audioStream.pipe(destination)
+```
+
+The default speech model is `speech-2.8-hd`. The package also accepts `speech-2.8-turbo`, `speech-2.6-hd`, `speech-2.6-turbo`, `speech-02-hd`, `speech-02-turbo`, `speech-01-hd`, and `speech-01-turbo`.
+
+## Select a regional endpoint
+
+The `global` region sends requests to `https://api.minimax.io/v1/t2a_v2` and is the default. Use `china` to send requests to `https://api.minimaxi.com/v1/t2a_v2`.
+
+```typescript
+const voice = new MiniMaxVoice({
+  speechModel: {
+    region: 'china',
+  },
+  speaker: process.env.MINIMAX_VOICE_ID,
+})
+```
+
+## Configure a request
+
+Set request fields under `properties` at construction or for an individual `speak()` call. Per-call settings override constructor settings.
+
+```typescript
+const audioStream = await voice.speak('Welcome', {
+  properties: {
+    language_boost: 'auto',
+    audio_setting: {
+      format: 'wav',
+      sample_rate: 32000,
+    },
+    pronunciation_dict: {
+      tone: ['Mastra/\u02c8m\u00e6str\u0259/'],
+    },
+    voice_modify: {
+      pitch: 1,
+    },
+    subtitle_enable: true,
+  },
+})
+```
+
+Supported audio formats are `mp3`, `wav`, `flac`, and `pcm`. The integration requests hexadecimal audio and validates the API status before returning decoded bytes.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8829,6 +8829,46 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
 
+  voice/minimax:
+    dependencies:
+      zod:
+        specifier: ^3.25.0 || ^4.0.0
+        version: 3.25.76
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@internal/voice':
+        specifier: workspace:*
+        version: link:../../packages/_internals/voice
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      '@vitest/ui':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      eslint:
+        specifier: ^10.7.0
+        version: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)
+      tsdown:
+        specifier: 0.22.9
+        version: 0.22.9(@volar/typescript@2.4.23(typescript@7.0.2))(oxc-resolver@11.20.0)(tsx@4.23.1)(typescript@7.0.2)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.23.1
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0)(supports-color@10.2.2))(msw@2.14.6(@types/node@22.19.15)(typescript@7.0.2))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
+
   voice/mistral:
     dependencies:
       '@mistralai/mistralai':

--- a/voice/minimax/README.md
+++ b/voice/minimax/README.md
@@ -1,0 +1,43 @@
+# @mastra/voice-minimax
+
+Add MiniMax text-to-speech to Mastra with regional endpoints, current speech models, and configurable audio settings.
+
+## Installation
+
+```bash
+npm install @mastra/voice-minimax
+```
+
+## Usage
+
+Set `MINIMAX_API_KEY`, then provide a voice ID when you create the provider.
+
+```typescript
+import { MiniMaxVoice } from '@mastra/voice-minimax';
+
+const voice = new MiniMaxVoice({
+  speechModel: {
+    name: 'speech-2.8-hd',
+  },
+  speaker: process.env.MINIMAX_VOICE_ID,
+});
+
+const audioStream = await voice.speak('Hello from Mastra');
+audioStream.pipe(destination);
+```
+
+Set `speechModel.region` to `china` to use `https://api.minimaxi.com/v1/t2a_v2`. The default `global` region uses `https://api.minimax.io/v1/t2a_v2`.
+
+Pass request settings through `speechModel.properties` or `speak()` options. Supported audio formats are `mp3`, `wav`, `flac`, and `pcm`.
+
+## Documentation
+
+- [MiniMax voice integration](https://mastra.ai/integrations/voice/minimax)
+
+## Changelog
+
+See the [package changelog](https://github.com/mastra-ai/mastra/blob/main/voice/minimax/CHANGELOG.md) for version history and release notes.
+
+## Support
+
+Join the [Mastra Discord](https://discord.gg/mastra-ai) for help and discussion.

--- a/voice/minimax/eslint.config.js
+++ b/voice/minimax/eslint.config.js
@@ -1,0 +1,25 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [
+  ...config,
+  {
+    files: ['src/**/*.{ts,tsx,js,jsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@mastra/core', '@mastra/core/*'],
+              message:
+                'Voice packages must import shared voice/core primitives from @internal/voice or @internal/core, not @mastra/core.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+];

--- a/voice/minimax/lint-staged.config.js
+++ b/voice/minimax/lint-staged.config.js
@@ -1,0 +1,9 @@
+export default {
+  '*.{ts,tsx}': [
+    'oxlint --fix --deny-warnings',
+    'eslint --fix --max-warnings=0',
+    'oxfmt --no-error-on-unmatched-pattern',
+  ],
+  '*.{js,jsx}': ['oxlint --fix', 'eslint --fix', 'oxfmt --no-error-on-unmatched-pattern'],
+  '*.{json,md,yml,yaml}': ['oxfmt --no-error-on-unmatched-pattern'],
+};

--- a/voice/minimax/package.json
+++ b/voice/minimax/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@mastra/voice-minimax",
+  "version": "0.1.0",
+  "description": "Mastra MiniMax text-to-speech integration",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsdown --silent --config tsdown.config.ts",
+    "prepack": "tsx ../../scripts/generate-package-docs.ts",
+    "build:watch": "tsdown --watch --silent --config tsdown.config.ts",
+    "test": "vitest run",
+    "lint": "oxlint . && eslint .",
+    "lint:fix": "oxlint --fix . && eslint --fix ."
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@internal/voice": "workspace:*",
+    "@types/node": "22.20.1",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "eslint": "^10.7.0",
+    "tsdown": "0.22.9",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.0 || ^4.0.0"
+  },
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "voice/minimax"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/voice/minimax/src/index.test.ts
+++ b/voice/minimax/src/index.test.ts
@@ -1,0 +1,155 @@
+import { Readable } from 'node:stream';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MINIMAX_AUDIO_FORMATS, MINIMAX_SPEECH_MODELS, MiniMaxVoice } from './index';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+function response(payload: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Bad Request',
+    json: async () => payload,
+  } as Response;
+}
+
+describe('MiniMaxVoice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.MINIMAX_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    delete process.env.MINIMAX_API_KEY;
+  });
+
+  it('uses the current default model and complete model catalog', () => {
+    const voice = new MiniMaxVoice({ speaker: 'test-voice' });
+
+    expect(voice.serializeForSpan().speechModel).toEqual({ name: 'speech-2.8-hd' });
+    expect(MINIMAX_SPEECH_MODELS).toEqual([
+      'speech-2.8-hd',
+      'speech-2.8-turbo',
+      'speech-2.6-hd',
+      'speech-2.6-turbo',
+      'speech-02-hd',
+      'speech-02-turbo',
+      'speech-01-hd',
+      'speech-01-turbo',
+    ]);
+    expect(MINIMAX_AUDIO_FORMATS).toEqual(['mp3', 'wav', 'flac', 'pcm']);
+  });
+
+  it('sends the supported request fields to the global endpoint', async () => {
+    fetchMock.mockResolvedValueOnce(
+      response({ data: { audio: '48656c6c6f', status: 2 }, base_resp: { status_code: 0, status_msg: 'success' } }),
+    );
+    const voice = new MiniMaxVoice({
+      speechModel: {
+        apiKey: 'test-key',
+        properties: {
+          stream: false,
+          language_boost: 'auto',
+          pronunciation_dict: { tone: ['hello/hei3 lou2'] },
+          audio_setting: { format: 'flac', sample_rate: 32000 },
+          voice_modify: { pitch: 1 },
+          subtitle_enable: true,
+        },
+      },
+      speaker: 'test-voice',
+    });
+
+    const audio = await voice.speak('Hello');
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+
+    expect(url).toBe('https://api.minimax.io/v1/t2a_v2');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toEqual({ Authorization: 'Bearer test-key', 'Content-Type': 'application/json' });
+    expect(body).toEqual({
+      model: 'speech-2.8-hd',
+      text: 'Hello',
+      stream: false,
+      language_boost: 'auto',
+      output_format: 'hex',
+      voice_setting: { voice_id: 'test-voice' },
+      pronunciation_dict: { tone: ['hello/hei3 lou2'] },
+      audio_setting: { format: 'flac', sample_rate: 32000 },
+      voice_modify: { pitch: 1 },
+      subtitle_enable: true,
+    });
+    await expect(streamToBuffer(audio)).resolves.toEqual(Buffer.from('Hello'));
+  });
+
+  it('uses the China endpoint and accepts stream input and per-call overrides', async () => {
+    fetchMock.mockResolvedValueOnce(
+      response({ data: { audio: '77617665', status: 2 }, base_resp: { status_code: 0 } }),
+    );
+    const voice = new MiniMaxVoice({
+      speechModel: { apiKey: 'test-key', region: 'china' },
+      speaker: 'default-voice',
+    });
+
+    await voice.speak(Readable.from(['Hello', ' world']), {
+      model: 'speech-2.8-turbo',
+      speaker: 'request-voice',
+      properties: { stream: false, audio_setting: { format: 'wav' } },
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(url).toBe('https://api.minimaxi.com/v1/t2a_v2');
+    expect(body).toMatchObject({
+      model: 'speech-2.8-turbo',
+      text: 'Hello world',
+      voice_setting: { voice_id: 'request-voice' },
+      audio_setting: { format: 'wav' },
+    });
+  });
+
+  it('requires an API key and a speaker', async () => {
+    delete process.env.MINIMAX_API_KEY;
+    expect(() => new MiniMaxVoice({ speaker: 'test-voice' })).toThrow('MINIMAX_API_KEY is not set');
+
+    const voice = new MiniMaxVoice({ speechModel: { apiKey: 'test-key' } });
+    await expect(voice.speak('Hello')).rejects.toThrow('A MiniMax speaker voice ID is required');
+  });
+
+  it('reports API status errors', async () => {
+    fetchMock.mockResolvedValueOnce(
+      response({ data: { status: 1 }, base_resp: { status_code: 1004, status_msg: 'Invalid request' } }),
+    );
+    const voice = new MiniMaxVoice({ speaker: 'test-voice' });
+
+    await expect(voice.speak('Hello')).rejects.toThrow('MiniMax TTS request failed: Invalid request');
+  });
+
+  it('rejects incomplete and malformed audio responses', async () => {
+    fetchMock
+      .mockResolvedValueOnce(response({ data: { audio: '4869', status: 1 }, base_resp: { status_code: 0 } }))
+      .mockResolvedValueOnce(response({ data: { audio: 'not-hex', status: 2 }, base_resp: { status_code: 0 } }));
+    const voice = new MiniMaxVoice({ speaker: 'test-voice' });
+
+    await expect(voice.speak('Hello')).rejects.toThrow('unexpected audio status: 1');
+    await expect(voice.speak('Hello')).rejects.toThrow('invalid hex audio data');
+  });
+
+  it('exposes only the configured speaker and does not support listening', async () => {
+    const voice = new MiniMaxVoice({ speaker: 'test-voice' });
+
+    await expect(voice.getSpeakers()).resolves.toEqual([{ voiceId: 'test-voice', name: 'test-voice' }]);
+    await expect(voice.getListener()).resolves.toEqual({ enabled: false });
+    await expect(voice.listen(Readable.from(['audio']))).rejects.toThrow('does not support speech recognition');
+  });
+});
+
+async function streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}

--- a/voice/minimax/src/index.ts
+++ b/voice/minimax/src/index.ts
@@ -1,0 +1,207 @@
+import { Readable } from 'node:stream';
+
+import { MastraVoice } from '@internal/voice';
+
+export const MINIMAX_TTS_ENDPOINTS = {
+  global: 'https://api.minimax.io/v1/t2a_v2',
+  china: 'https://api.minimaxi.com/v1/t2a_v2',
+} as const;
+
+export const MINIMAX_SPEECH_MODELS = [
+  'speech-2.8-hd',
+  'speech-2.8-turbo',
+  'speech-2.6-hd',
+  'speech-2.6-turbo',
+  'speech-02-hd',
+  'speech-02-turbo',
+  'speech-01-hd',
+  'speech-01-turbo',
+] as const;
+
+export const MINIMAX_AUDIO_FORMATS = ['mp3', 'wav', 'flac', 'pcm'] as const;
+
+export type MiniMaxRegion = keyof typeof MINIMAX_TTS_ENDPOINTS;
+export type MiniMaxSpeechModel = (typeof MINIMAX_SPEECH_MODELS)[number];
+export type MiniMaxAudioFormat = (typeof MINIMAX_AUDIO_FORMATS)[number];
+
+export interface MiniMaxVoiceSetting {
+  voice_id: string;
+  [key: string]: unknown;
+}
+
+export interface MiniMaxPronunciationDictionary {
+  [key: string]: unknown;
+}
+
+export interface MiniMaxAudioSetting {
+  format: MiniMaxAudioFormat;
+  [key: string]: unknown;
+}
+
+export interface MiniMaxVoiceModify {
+  [key: string]: unknown;
+}
+
+export interface MiniMaxSpeechRequest {
+  model: MiniMaxSpeechModel;
+  text: string;
+  stream: boolean;
+  language_boost?: string;
+  output_format: 'hex';
+  voice_setting: MiniMaxVoiceSetting;
+  pronunciation_dict?: MiniMaxPronunciationDictionary;
+  audio_setting: MiniMaxAudioSetting;
+  voice_modify?: MiniMaxVoiceModify;
+  subtitle_enable?: boolean;
+}
+
+export type MiniMaxSpeechProperties = Partial<
+  Omit<MiniMaxSpeechRequest, 'model' | 'text' | 'output_format' | 'voice_setting' | 'audio_setting'>
+> & {
+  voice_setting?: Omit<MiniMaxVoiceSetting, 'voice_id'>;
+  audio_setting?: Partial<MiniMaxAudioSetting>;
+};
+
+export interface MiniMaxConfig {
+  name?: MiniMaxSpeechModel;
+  apiKey?: string;
+  region?: MiniMaxRegion;
+  properties?: MiniMaxSpeechProperties;
+}
+
+export interface MiniMaxSpeakOptions {
+  speaker?: string;
+  model?: MiniMaxSpeechModel;
+  properties?: MiniMaxSpeechProperties;
+}
+
+interface MiniMaxSpeechResponse {
+  data?: {
+    audio?: string;
+    status?: number;
+  };
+  base_resp?: {
+    status_code?: number;
+    status_msg?: string;
+  };
+}
+
+export class MiniMaxVoice extends MastraVoice<unknown, MiniMaxSpeakOptions> {
+  private readonly apiKey: string;
+  private readonly endpoint: (typeof MINIMAX_TTS_ENDPOINTS)[MiniMaxRegion];
+  private readonly properties: MiniMaxSpeechProperties;
+
+  constructor({ speechModel, speaker }: { speechModel?: MiniMaxConfig; speaker?: string } = {}) {
+    const apiKey = speechModel?.apiKey ?? process.env.MINIMAX_API_KEY;
+
+    super({
+      speechModel: {
+        name: speechModel?.name ?? 'speech-2.8-hd',
+        apiKey,
+      },
+      speaker,
+    });
+
+    if (!apiKey) {
+      throw new Error('MINIMAX_API_KEY is not set');
+    }
+
+    this.apiKey = apiKey;
+    this.endpoint = MINIMAX_TTS_ENDPOINTS[speechModel?.region ?? 'global'];
+    this.properties = speechModel?.properties ?? { stream: false };
+  }
+
+  async speak(
+    input: string | NodeJS.ReadableStream,
+    options: MiniMaxSpeakOptions = {},
+  ): Promise<NodeJS.ReadableStream> {
+    const text = typeof input === 'string' ? input : await this.streamToString(input);
+    const speaker = options.speaker ?? this.speaker;
+
+    if (!speaker) {
+      throw new Error('A MiniMax speaker voice ID is required');
+    }
+
+    const properties = {
+      ...this.properties,
+      ...options.properties,
+      voice_setting: {
+        ...this.properties.voice_setting,
+        ...options.properties?.voice_setting,
+      },
+      audio_setting: {
+        ...this.properties.audio_setting,
+        ...options.properties?.audio_setting,
+      },
+    };
+
+    if (properties.stream) {
+      throw new Error('MiniMax streaming responses are not supported by this voice integration');
+    }
+
+    const request: MiniMaxSpeechRequest = {
+      model: options.model ?? (this.speechModel?.name as MiniMaxSpeechModel),
+      text,
+      stream: false,
+      language_boost: properties.language_boost,
+      output_format: 'hex',
+      voice_setting: {
+        ...properties.voice_setting,
+        voice_id: speaker,
+      },
+      pronunciation_dict: properties.pronunciation_dict,
+      audio_setting: {
+        ...properties.audio_setting,
+        format: properties.audio_setting.format ?? 'mp3',
+      },
+      voice_modify: properties.voice_modify,
+      subtitle_enable: properties.subtitle_enable,
+    };
+
+    const response = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(request),
+    });
+    const result = (await response.json()) as MiniMaxSpeechResponse;
+
+    if (!response.ok || result.base_resp?.status_code !== 0) {
+      const message = result.base_resp?.status_msg ?? `${response.status} ${response.statusText}`;
+      throw new Error(`MiniMax TTS request failed: ${message}`);
+    }
+
+    if (result.data?.status !== 2) {
+      throw new Error(`MiniMax TTS returned unexpected audio status: ${result.data?.status ?? 'missing'}`);
+    }
+
+    const audio = result.data.audio;
+    if (!audio || audio.length % 2 !== 0 || !/^[0-9a-f]+$/i.test(audio)) {
+      throw new Error('MiniMax TTS returned invalid hex audio data');
+    }
+
+    return Readable.from([Buffer.from(audio, 'hex')]);
+  }
+
+  async getSpeakers() {
+    return this.speaker ? [{ voiceId: this.speaker, name: this.speaker }] : [];
+  }
+
+  async getListener() {
+    return { enabled: false };
+  }
+
+  async listen(_input: NodeJS.ReadableStream): Promise<string> {
+    throw new Error('MiniMax voice integration does not support speech recognition');
+  }
+
+  private async streamToString(stream: NodeJS.ReadableStream): Promise<string> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks).toString('utf8');
+  }
+}

--- a/voice/minimax/tsconfig.build.json
+++ b/voice/minimax/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "src/**/*.mock.ts"]
+}

--- a/voice/minimax/tsconfig.json
+++ b/voice/minimax/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsdown.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/voice/minimax/tsdown.config.ts
+++ b/voice/minimax/tsdown.config.ts
@@ -1,0 +1,19 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  fixedExtension: false,
+  nodeProtocol: 'strip',
+  clean: true,
+  dts: false,
+  treeshake: true,
+  sourcemap: true,
+  deps: {
+    alwaysBundle: ['@internal/voice'],
+  },
+  onSuccess: async () => {
+    await generateTypes(process.cwd(), new Set(['@internal/voice']));
+  },
+});

--- a/voice/minimax/vitest.config.ts
+++ b/voice/minimax/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'e2e:voice/minimax',
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
Reason: Add a MiniMax voice integration using regional T2A v2 endpoints, the current speech model catalog, configurable request fields, and validated audio response parsing.

Adds `@mastra/voice-minimax` with global and China endpoint selection, typed synthesis settings, hex audio decoding, unit coverage, and an integration guide.

Checks: `../../node_modules/.bin/vitest run`; `../../node_modules/.bin/oxlint . && ./node_modules/.bin/eslint .`; `./node_modules/.bin/turbo run build --filter=@mastra/voice-minimax`; `./node_modules/.bin/oxfmt-mdx --check src/content/en/integrations/voice/minimax.mdx`; `./node_modules/.bin/remark --no-stdout --frail --quiet --ext mdx src/content/en/integrations/voice/minimax.mdx`; docs validation scripts; `./node_modules/.bin/docusaurus build`; `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds MiniMax text-to-speech support to Mastra. It lets users choose global or China endpoints and receive generated audio in supported formats.

## What changed

- Added the `@mastra/voice-minimax` package.
- Added regional MiniMax T2A v2 endpoints.
- Added current speech models and audio formats.
- Added typed synthesis settings and per-request options.
- Decoded MiniMax hex audio responses into readable streams.
- Added API-key, speaker, response, and audio validation.
- Added unit tests for core behavior and error cases.
- Added package and integration documentation.
- Added a minor-release changeset.

## Validation

- Tests
- Linting
- Formatting
- Package build
- Documentation checks
- Docusaurus build
- Whitespace checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->