### PR TITLE
fix: attribute coding-agent commits to platform bot

### DIFF
--- a/.changeset/shy-apes-repeat.md
+++ b/.changeset/shy-apes-repeat.md
@@ -1,0 +1,7 @@
+---
+'@mastra/code-sdk': patch
+'mastracode': patch
+'@mastra/core': patch
+---
+
+Use the Mastra Platform bot for default coding-agent commit attribution.

--- a/docs/src/content/en/reference/coding-agent/build-base-prompt.mdx
+++ b/docs/src/content/en/reference/coding-agent/build-base-prompt.mdx
@@ -9,7 +9,7 @@ packages:
 
 `buildBasePrompt()` builds the shared base system prompt for a coding agent: the behavioral instructions that make the agent a good coding assistant. It takes a `PromptContext` describing the current environment (project, platform, git branch, mode, model) and returns the prompt as a string.
 
-Product-specific strings are parameterized through `productName`, `coAuthorName`, and `coAuthorEmail`, so you can rebrand the prompt and commit trailer without forking it. They default to `"Mastra Code"` / `"noreply@mastra.ai"`, so existing callers keep identical output.
+Product-specific strings are parameterized through `productName`, `coAuthorName`, and `coAuthorEmail`, so you can rebrand the prompt and commit trailer without forking it. The co-author defaults to `"mastra-platform[bot]"` and `"284800079+mastra-platform[bot]@users.noreply.github.com"`.
 
 Use this with [`createCodingAgent()`](/reference/coding-agent/create-coding-agent) when you build runtime-defined instructions for the agent.
 
@@ -89,7 +89,7 @@ const prompt = buildBasePrompt({
   {
     name: 'modelId',
     type: 'string',
-    description: 'Identifier of the active model, included in the commit Co-Authored-By line when provided.',
+    description: 'Identifier of the active model.',
     isOptional: true,
   },
   {
@@ -115,14 +115,14 @@ const prompt = buildBasePrompt({
     type: 'string',
     description: 'Name used in the commit Co-Authored-By line.',
     isOptional: true,
-    defaultValue: 'Mastra Code',
+    defaultValue: 'mastra-platform[bot]',
   },
   {
     name: 'coAuthorEmail',
     type: 'string',
     description: 'Email used in the commit Co-Authored-By line.',
     isOptional: true,
-    defaultValue: 'noreply@mastra.ai',
+    defaultValue: '284800079+mastra-platform[bot]@users.noreply.github.com',
   },
 ]}
 />

--- a/mastracode/sdk/src/agents/__tests__/instructions.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/instructions.test.ts
@@ -54,7 +54,7 @@ describe('getDynamicInstructions', () => {
 
     expect(prompt).toContain('Git branch: feature/from-git');
     expect(prompt).toContain(
-      'Include `Co-Authored-By: Mastra Code (anthropic/claude-opus-4-6) <noreply@mastra.ai>` in the message body.',
+      'Include `Co-Authored-By: mastra-platform[bot] <284800079+mastra-platform[bot]@users.noreply.github.com>` in the message body.',
     );
   });
 

--- a/mastracode/sdk/src/agents/__tests__/prompts.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/prompts.test.ts
@@ -206,11 +206,11 @@ describe('buildFullPrompt', () => {
     });
 
     expect(prompt).toContain(
-      'Include `Co-Authored-By: Mastra Code (openai/gpt-5.5) <noreply@mastra.ai>` in the message body.',
+      'Include `Co-Authored-By: mastra-platform[bot] <284800079+mastra-platform[bot]@users.noreply.github.com>` in the message body.',
     );
   });
 
-  it('uses the model-less commit co-author fallback when no model id is available', () => {
+  it('uses the platform bot commit co-author when no model id is available', () => {
     const prompt = buildFullPrompt({
       projectPath: '/tmp/project',
       projectName: 'test-project',
@@ -227,8 +227,10 @@ describe('buildFullPrompt', () => {
       },
     });
 
-    expect(prompt).toContain('Include `Co-Authored-By: Mastra Code <noreply@mastra.ai>` in the message body.');
-    expect(prompt).not.toContain('Co-Authored-By: Mastra Code ()');
+    expect(prompt).toContain(
+      'Include `Co-Authored-By: mastra-platform[bot] <284800079+mastra-platform[bot]@users.noreply.github.com>` in the message body.',
+    );
+    expect(prompt).not.toContain('Co-Authored-By: mastra-platform[bot] ()');
   });
 
   it('includes common binary availability in environment details', () => {

--- a/mastracode/tui/e2e/fixtures/commit-attribution-prompt.json
+++ b/mastracode/tui/e2e/fixtures/commit-attribution-prompt.json
@@ -13,7 +13,7 @@
             "id": "call_commit_attribution_git_commit",
             "name": "execute_command",
             "arguments": {
-              "command": "printf 'commit attribution e2e\\n' > commit-attribution-e2e.txt && git add commit-attribution-e2e.txt && git commit -m 'test: commit attribution e2e' -m 'Co-Authored-By: Mastra Code (openai/gpt-5.4-mini) <noreply@mastra.ai>'",
+              "command": "printf 'commit attribution e2e\\n' > commit-attribution-e2e.txt && git add commit-attribution-e2e.txt && git commit -m 'test: commit attribution e2e' -m 'Co-Authored-By: mastra-platform[bot] <284800079+mastra-platform[bot]@users.noreply.github.com>'",
               "timeout": 10,
               "cwd": null,
               "tail": 40,

--- a/mastracode/tui/e2e/tui/commit-attribution-prompt.ts
+++ b/mastracode/tui/e2e/tui/commit-attribution-prompt.ts
@@ -2,14 +2,14 @@ import { expect } from './expect.js';
 
 import type { McE2eScenario } from './types.js';
 
-const MODEL_ATTRIBUTION = 'Co-Authored-By: Mastra Code (openai/gpt-5.4-mini) <noreply@mastra.ai>';
-const FALLBACK_ATTRIBUTION = 'Co-Authored-By: Mastra Code <noreply@mastra.ai>';
+const PLATFORM_BOT_ATTRIBUTION =
+  'Co-Authored-By: mastra-platform[bot] <284800079+mastra-platform[bot]@users.noreply.github.com>';
 
 export const commitAttributionPromptScenario: McE2eScenario = {
   name: 'commit-attribution-prompt',
   description:
-    'Verify real TUI prompts include model-specific commit attribution guidance and the model-authored commit records it.',
-  testName: 'includes selected model ID in commit attribution prompt guidance and committed history',
+    'Verify real TUI prompts include platform bot commit attribution guidance and the authored commit records it.',
+  testName: 'includes platform bot commit attribution prompt guidance and committed history',
   projectFixture: 'long-branch',
   useOpenAIModel: true,
   aimockFixture: 'commit-attribution-prompt.json',
@@ -25,7 +25,7 @@ export const commitAttributionPromptScenario: McE2eScenario = {
     terminal.submit('!git log -1 --format=%B');
     await runtime.waitForScreenText(/test: commit attribution e2e/i, terminal, 10_000);
     await runtime.waitForScreenText(
-      /Co-Authored-By: Mastra Code \(openai\/gpt-5\.4-mini\) <noreply@mastra\.ai>/i,
+      /Co-Authored-By: mastra-platform\[bot\] <284800079\+mastra-platform\[bot\]@users\.noreply\.github\.com>/i,
       terminal,
       10_000,
     );
@@ -37,8 +37,7 @@ export const commitAttributionPromptScenario: McE2eScenario = {
       throw new Error(`Expected commit attribution scenario to make 2 AIMock requests, received ${requests.length}`);
     }
     const body = JSON.stringify(requests);
-    expect(body).toContain(MODEL_ATTRIBUTION);
+    expect(body).toContain(PLATFORM_BOT_ATTRIBUTION);
     expect(body).toContain('git commit');
-    expect(body).not.toContain(FALLBACK_ATTRIBUTION);
   },
 };

--- a/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
+++ b/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
@@ -140,22 +140,27 @@ describe('createCodingAgent', () => {
 });
 
 describe('buildBasePrompt', () => {
-  it('defaults the product name to "Mastra Code"', () => {
+  it('defaults the product name and co-author to Mastra Code and the platform bot', () => {
     const prompt = buildBasePrompt(promptContext());
     expect(prompt).toContain('You are Mastra Code, an interactive CLI coding agent');
-    expect(prompt).toContain('Co-Authored-By: Mastra Code <noreply@mastra.ai>');
+    expect(prompt).toContain(
+      'Co-Authored-By: mastra-platform[bot] <284800079+mastra-platform[bot]@users.noreply.github.com>',
+    );
   });
 
   it('parameterizes productName and coAuthorName', () => {
     const prompt = buildBasePrompt(promptContext({ productName: 'Acme Coder', coAuthorName: 'Acme Bot' }));
     expect(prompt).toContain('You are Acme Coder, an interactive CLI coding agent');
     expect(prompt).toContain('Acme Coder has a goal mode');
-    expect(prompt).toContain('Co-Authored-By: Acme Bot <noreply@mastra.ai>');
+    expect(prompt).toContain('Co-Authored-By: Acme Bot <284800079+mastra-platform[bot]@users.noreply.github.com>');
   });
 
-  it('includes the model id in the Co-Authored-By line when provided', () => {
+  it('does not include the model id in the Co-Authored-By line', () => {
     const prompt = buildBasePrompt(promptContext({ modelId: 'openai/gpt-4o' }));
-    expect(prompt).toContain('Co-Authored-By: Mastra Code (openai/gpt-4o) <noreply@mastra.ai>');
+    expect(prompt).toContain(
+      'Co-Authored-By: mastra-platform[bot] <284800079+mastra-platform[bot]@users.noreply.github.com>',
+    );
+    expect(prompt).not.toContain('Co-Authored-By: mastra-platform[bot] (openai/gpt-4o)');
   });
 
   it('parameterizes the Co-Authored-By email', () => {

--- a/packages/core/src/coding-agent/prompt.ts
+++ b/packages/core/src/coding-agent/prompt.ts
@@ -3,8 +3,7 @@
  * This is the "brain" that makes the agent a good coding assistant.
  *
  * Product-specific strings (the agent's display name and the commit
- * `Co-Authored-By` name) are parameterized via `productName` / `coAuthorName`
- * and default to "Mastra Code" so existing callers keep identical output.
+ * `Co-Authored-By` name) are parameterized via `productName` / `coAuthorName`.
  */
 
 export interface PromptContext {
@@ -22,17 +21,17 @@ export interface PromptContext {
   hasSubagents?: boolean;
   /** Display name used in the prompt header. Default: "Mastra Code". */
   productName?: string;
-  /** Name used in the commit `Co-Authored-By` line. Default: "Mastra Code". */
+  /** Name used in the commit `Co-Authored-By` line. Default: "mastra-platform[bot]". */
   coAuthorName?: string;
-  /** Email used in the commit `Co-Authored-By` line. Default: "noreply@mastra.ai". */
+  /** Email used in the commit `Co-Authored-By` line. Default: the mastra-platform bot noreply address. */
   coAuthorEmail?: string;
 }
 
 export function buildBasePrompt(ctx: PromptContext): string {
   const commonBinaries = formatCommonBinaries(ctx.commonBinaries);
   const productName = ctx.productName ?? 'Mastra Code';
-  const coAuthorName = ctx.coAuthorName ?? 'Mastra Code';
-  const coAuthorEmail = ctx.coAuthorEmail ?? 'noreply@mastra.ai';
+  const coAuthorName = ctx.coAuthorName ?? 'mastra-platform[bot]';
+  const coAuthorEmail = ctx.coAuthorEmail ?? '284800079+mastra-platform[bot]@users.noreply.github.com';
 
   return `You are ${productName}, an interactive CLI coding agent that helps users with software engineering tasks.
 
@@ -87,7 +86,7 @@ ${ctx.toolGuidance}
 Don't commit files likely to contain secrets (\`.env\`, \`*.key\`, \`credentials.json\`). Warn if asked.
 
 ## Commits
-Write commit messages that explain WHY, not just WHAT. Match the repo's existing style. Include \`Co-Authored-By: ${coAuthorName}${ctx.modelId ? ` (${ctx.modelId})` : ''} <${coAuthorEmail}>\` in the message body.
+Write commit messages that explain WHY, not just WHAT. Match the repo's existing style. Include \`Co-Authored-By: ${coAuthorName} <${coAuthorEmail}>\` in the message body.
 
 ## Pull Requests
 Use \`gh pr create\`. Include a summary of what changed and a test plan. Word the pull request title/description to explain the entire unit of work being shipped, worded to explain it to someone who doesn't know anything about the work being shipped. Do not add details of fixes that were needed along the way.


### PR DESCRIPTION
Updates Mastra Code’s default commit trailer so GitHub associates agent contributions with the Mastra Platform bot profile.

Before: `Co-Authored-By: Mastra Code <noreply@mastra.ai>`

After: `Co-Authored-By: mastra-platform[bot] <284800079+mastra-platform[bot]@users.noreply.github.com>`

The core prompt tests, SDK prompt tests, and TUI attribution scenario cover the updated trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Mastra Code now labels its commits as created with the Mastra Platform bot. Tests and documentation confirm the new GitHub attribution.

## Changes

- Changed the default commit trailer to:
  `Co-Authored-By: mastra-platform[bot] <284800079+mastra-platform[bot]`@users.noreply.github.com`>`
- Removed `modelId` from the commit trailer.
- Updated core, SDK, and TUI attribution tests.
- Updated coding-agent documentation.
- Added a patch changeset for `@mastra/code-sdk`, `mastracode`, and `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->