### PR TITLE
fix(ci): run E2E for UI and server changes

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -225,6 +225,9 @@ jobs:
               !file.startsWith('e2e-tests/experiment-worker/') &&
               !file.startsWith('e2e-tests/_local-registry-setup/')) ||
             file.startsWith('packages/playground/e2e/') ||
+            file.startsWith('packages/playground-ui/') ||
+            file.startsWith('server-adapters/hono/') ||
+            file.startsWith('packages/server/') ||
             file === '.github/workflows/e2e-tests.yml' ||
             file === 'pnpm-lock.yaml'
           );


### PR DESCRIPTION
Trigger the E2E workflow explicitly when `packages/playground-ui/`, `server-adapters/hono/`, or `packages/server/` changes, so UI browser coverage does not depend on affected-test discovery. This addresses the skipped UI E2E run observed in #23404. Existing markdown-only exclusions stay unchanged.

Before: a `packages/playground-ui/src/...` change could select only unit tests and skip E2E. After: changes in any of the three directories also trigger the shared E2E workflow, including `packages/playground/e2e/`.

Verified both new server triggers fail to route before the fix and route afterward; all nine routing checks pass. Prettier and `git diff --check` also pass. CI will run the actual E2E suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This change tells CI to run browser tests when important UI or server code changes. This prevents affected-test detection from missing required coverage.

## Changes

- Updated `.github/workflows/prebuild.yml` to treat changes in these paths as E2E-affecting:
  - `packages/playground-ui/`
  - `server-adapters/hono/`
  - `packages/server/`
  - `packages/playground/e2e/`
- Preserved existing markdown-only exclusions.
- Verified routing checks, Prettier, and `git diff --check`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->