### PR TITLE
feat(factory): keep the Org-wide scope visible but greyed for members

### DIFF
--- a/.changeset/scope-switch-disabled-reason.md
+++ b/.changeset/scope-switch-disabled-reason.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+The Provider access section keeps the Org-wide scope visible for members who cannot manage org-wide credentials. It renders greyed out with a tooltip saying why, instead of disappearing and leaving only a Personal badge with no explanation.

--- a/mastracode/factory-ui/src/ui/domains/settings/components/ProviderAccessSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/ProviderAccessSection.tsx
@@ -31,6 +31,7 @@ type CredentialScope = 'user' | 'org';
 type Credential = NonNullable<ProviderInfo['userCredential']>;
 
 const CREDENTIAL_LABEL: Record<Credential, string> = { oauth: 'Signed in', api_key: 'Key saved' };
+const ORG_SCOPE_MEMBER_REASON = 'Only organization admins can manage org-wide credentials.';
 
 interface ActiveOAuthSession {
   provider: string;
@@ -118,8 +119,8 @@ export function ProviderAccessSection({ description }: { description?: string })
   const providers = providersQuery.data ?? [];
   const authEnabled = authQuery.data?.authEnabled === true;
   const canWriteOrgKey = !authEnabled || (orgKeyAdminQuery.data ?? true);
-  const scopeOptions: SettingsScope[] = authEnabled && canWriteOrgKey ? ['personal', 'org'] : ['personal'];
-  const scopeControl = useScopeControl(scopeOptions);
+  const scopeOptions: SettingsScope[] = authEnabled ? ['personal', 'org'] : ['personal'];
+  const scopeControl = useScopeControl(scopeOptions, canWriteOrgKey ? undefined : { org: ORG_SCOPE_MEMBER_REASON });
   const scope: CredentialScope = scopeControl.shown === 'org' ? 'org' : 'user';
   const rowScope: RowScope = { scope, authEnabled };
   const scopeArg = authEnabled ? { scope } : {};

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsScope.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsScope.tsx
@@ -125,7 +125,8 @@ export function useScopeControl(
   // A permission answer lands after first paint, so a scope picked meanwhile
   // falls back rather than editing one the caller may not write.
   const pickable = (scope: SettingsScope) => options.includes(scope) && disabledReasons?.[scope] === undefined;
-  const offered = (scope: SettingsScope) => (pickable(scope) ? scope : (options[0] ?? 'personal'));
+  const offered = (scope: SettingsScope) =>
+    pickable(scope) ? scope : (options.find(pickable) ?? options[0] ?? 'personal');
   const value = offered(picked);
   const shown = offered(revealed);
 

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsScope.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsScope.tsx
@@ -1,5 +1,6 @@
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import type { BadgeVariant } from '@mastra/playground-ui/components/Badge';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { focusRing, transitions } from '@mastra/playground-ui/primitives/transitions';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { Building2, CircleUserRound, Server, Users } from 'lucide-react';
@@ -13,6 +14,7 @@ export type SettingsScope = 'personal' | 'factory' | 'org' | 'deployment';
 export type ScopeControl = {
   value: SettingsScope;
   options: readonly SettingsScope[];
+  disabledReasons?: Partial<Record<SettingsScope, string>>;
   onChange: (scope: SettingsScope) => void;
 };
 
@@ -32,40 +34,68 @@ export function ScopeBadge({ scope }: { scope: SettingsScope }) {
   );
 }
 
-export function ScopeSwitch({ value, options, onChange }: ScopeControl) {
+export function ScopeSwitch({ value, options, disabledReasons, onChange }: ScopeControl) {
   return (
     <div
       role="group"
       aria-label="Who these settings apply to"
       className="border-border1 inline-flex items-center gap-0.5 rounded-[9px] border p-0.5"
     >
-      {options.map(scope => {
-        const { label, icon: Icon } = SCOPE_BADGE[scope];
-        const selected = scope === value;
-        return (
-          <button
-            key={scope}
-            type="button"
-            aria-pressed={selected}
-            onClick={() => onChange(scope)}
-            className={cn(
-              'text-icon3 hover:text-icon5 inline-flex h-5 cursor-pointer items-center rounded-[7px] outline-none',
-              focusRing.visible,
-              transitions.colors,
-            )}
-          >
-            {selected ? (
-              <ScopeBadge scope={scope} />
-            ) : (
-              <span className="text-ui-xs inline-flex h-5 items-center gap-1 px-1.5 font-medium">
-                <Icon aria-hidden="true" className="h-icon-sm w-icon-sm" />
-                {label}
-              </span>
-            )}
-          </button>
-        );
-      })}
+      {options.map(scope => (
+        <ScopeOption
+          key={scope}
+          scope={scope}
+          selected={scope === value}
+          disabledReason={disabledReasons?.[scope]}
+          onPick={() => onChange(scope)}
+        />
+      ))}
     </div>
+  );
+}
+
+function ScopeOption({
+  scope,
+  selected,
+  disabledReason,
+  onPick,
+}: {
+  scope: SettingsScope;
+  selected: boolean;
+  disabledReason?: string;
+  onPick: () => void;
+}) {
+  const { label, icon: Icon } = SCOPE_BADGE[scope];
+  const disabled = disabledReason !== undefined;
+  const button = (
+    <button
+      type="button"
+      aria-pressed={selected}
+      aria-disabled={disabled || undefined}
+      onClick={disabled ? undefined : onPick}
+      className={cn(
+        'text-icon3 hover:text-icon5 inline-flex h-5 cursor-pointer items-center rounded-[7px] outline-none',
+        'aria-disabled:hover:text-icon3 aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+        focusRing.visible,
+        transitions.colors,
+      )}
+    >
+      {selected ? (
+        <ScopeBadge scope={scope} />
+      ) : (
+        <span className="text-ui-xs inline-flex h-5 items-center gap-1 px-1.5 font-medium">
+          <Icon aria-hidden="true" className="h-icon-sm w-icon-sm" />
+          {label}
+        </span>
+      )}
+    </button>
+  );
+  if (!disabled) return button;
+  return (
+    <Tooltip>
+      <TooltipTrigger render={button} />
+      <TooltipContent>{disabledReason}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -86,20 +116,21 @@ export type ScopeSwapControl = ScopeControl & { shown: SettingsScope; bodyRef: R
 /** `value` follows the switch at once; `shown` follows once the current body has slid out, so render the body from `shown` inside `ScopeSwap`. */
 export function useScopeControl(
   options: readonly SettingsScope[],
-  initial: SettingsScope = 'personal',
+  disabledReasons?: ScopeControl['disabledReasons'],
 ): ScopeSwapControl {
-  const [picked, setPicked] = useState(initial);
-  const [revealed, setRevealed] = useState(initial);
+  const [picked, setPicked] = useState<SettingsScope>('personal');
+  const [revealed, setRevealed] = useState<SettingsScope>('personal');
   const bodyRef = useRef<HTMLDivElement>(null);
 
-  // Options shrink when a permission answer lands, so a scope picked while the
-  // answer was pending falls back rather than editing a scope no longer offered.
-  const offered = (scope: SettingsScope) => (options.includes(scope) ? scope : (options[0] ?? initial));
+  // A permission answer lands after first paint, so a scope picked meanwhile
+  // falls back rather than editing one the caller may not write.
+  const pickable = (scope: SettingsScope) => options.includes(scope) && disabledReasons?.[scope] === undefined;
+  const offered = (scope: SettingsScope) => (pickable(scope) ? scope : (options[0] ?? 'personal'));
   const value = offered(picked);
   const shown = offered(revealed);
 
   const onChange = (next: SettingsScope) => {
-    if (next === value) return;
+    if (next === value || !pickable(next)) return;
     setPicked(next);
     const dx = options.indexOf(next) > options.indexOf(value) ? SLIDE_PX : -SLIDE_PX;
     const exit = animate(
@@ -127,7 +158,7 @@ export function useScopeControl(
     );
   };
 
-  return { value, shown, options, onChange, bodyRef };
+  return { value, shown, options, disabledReasons, onChange, bodyRef };
 }
 
 /** Clips the slide horizontally: a translate on a full-width body widens the page, and every scrollable ancestor answers with a scrollbar. */

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ProviderAccessSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ProviderAccessSection.msw.test.tsx
@@ -461,8 +461,9 @@ describe('ProviderAccessSection', () => {
       expect(orgWide()).toHaveAttribute('aria-pressed', 'false');
     });
 
-    it('offers members without org rights only the personal view, with org coverage visible per row', async () => {
+    it('shows members without org rights the org view greyed with the reason, org coverage visible per row', async () => {
       window.__MASTRACODE_CONFIG__ = { authEnabled: true };
+      const user = userEvent.setup();
       server.use(
         authenticated(),
         http.get(PROVIDERS_URL, () =>
@@ -484,8 +485,12 @@ describe('ProviderAccessSection', () => {
       renderWithProviders(<ProviderAccessSection />);
 
       await screen.findByText('Anthropic');
-      await waitFor(() => expect(screen.getByText('Personal')).toBeInTheDocument());
-      expect(screen.queryByRole('button', { name: 'Org-wide' })).not.toBeInTheDocument();
+      await waitFor(() => expect(orgWide()).toHaveAttribute('aria-disabled', 'true'));
+      expect(personal()).toHaveAttribute('aria-pressed', 'true');
+      await user.hover(orgWide());
+      expect(await screen.findByRole('tooltip')).toHaveTextContent(
+        'Only organization admins can manage org-wide credentials.',
+      );
       expect(within(rowFor('anthropic')).getByText('Covered by org')).toBeInTheDocument();
       expect(within(rowFor('anthropic')).getByRole('button', { name: 'Sign in to Anthropic' })).toBeInTheDocument();
       expect(

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsSubsection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsSubsection.msw.test.tsx
@@ -1,14 +1,25 @@
+import { TooltipProvider } from '@mastra/playground-ui/components/Tooltip';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { useScopeControl } from '../SettingsScope';
-import type { SettingsScope } from '../SettingsScope';
+import type { ScopeControl, SettingsScope } from '../SettingsScope';
 import { SettingsSubsection } from '../SettingsSubsection';
 
-function ScopeHarness({ options }: { options: SettingsScope[] }) {
-  const control = useScopeControl(options);
-  return <SettingsSubsection scope={control} title="Provider access" />;
+function ScopeHarness({
+  options,
+  disabledReasons,
+}: {
+  options: SettingsScope[];
+  disabledReasons?: ScopeControl['disabledReasons'];
+}) {
+  const control = useScopeControl(options, disabledReasons);
+  return (
+    <TooltipProvider delayDuration={0}>
+      <SettingsSubsection scope={control} title="Provider access" />
+    </TooltipProvider>
+  );
 }
 
 describe('SettingsSubsection', () => {
@@ -81,6 +92,35 @@ describe('SettingsSubsection', () => {
 
       expect(screen.queryByRole('button', { name: 'Org-wide' })).not.toBeInTheDocument();
       expect(screen.getByText('Personal')).toBeInTheDocument();
+    });
+  });
+
+  describe('given a scope the caller may not pick', () => {
+    it('keeps it visible but greyed, ignores the click, and says why on hover', async () => {
+      const user = userEvent.setup();
+      render(<ScopeHarness options={['personal', 'org']} disabledReasons={{ org: 'Admins only' }} />);
+
+      const orgWide = screen.getByRole('button', { name: 'Org-wide' });
+      expect(orgWide).toHaveAttribute('aria-disabled', 'true');
+
+      await user.hover(orgWide);
+      expect(await screen.findByRole('tooltip')).toHaveTextContent('Admins only');
+
+      await user.click(orgWide);
+      expect(screen.getByRole('button', { name: 'Personal' })).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('falls back when the permission answer takes the picked scope away', async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(<ScopeHarness options={['personal', 'org']} />);
+
+      await user.click(screen.getByRole('button', { name: 'Org-wide' }));
+      expect(screen.getByRole('button', { name: 'Org-wide' })).toHaveAttribute('aria-pressed', 'true');
+
+      rerender(<ScopeHarness options={['personal', 'org']} disabledReasons={{ org: 'Admins only' }} />);
+
+      expect(screen.getByRole('button', { name: 'Personal' })).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByRole('button', { name: 'Org-wide' })).toHaveAttribute('aria-disabled', 'true');
     });
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsSubsection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsSubsection.msw.test.tsx
@@ -110,6 +110,13 @@ describe('SettingsSubsection', () => {
       expect(screen.getByRole('button', { name: 'Personal' })).toHaveAttribute('aria-pressed', 'true');
     });
 
+    it('lands on the first scope the caller may pick, not the first listed', () => {
+      render(<ScopeHarness options={['personal', 'org']} disabledReasons={{ personal: 'Unavailable' }} />);
+
+      expect(screen.getByRole('button', { name: 'Org-wide' })).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByRole('button', { name: 'Personal' })).toHaveAttribute('aria-disabled', 'true');
+    });
+
     it('falls back when the permission answer takes the picked scope away', async () => {
       const user = userEvent.setup();
       const { rerender } = render(<ScopeHarness options={['personal', 'org']} />);


### PR DESCRIPTION
**─────── TLDR ───────**
> Members who cannot manage org-wide credentials now see the Org-wide scope greyed with the reason, instead of a lone Personal badge that says nothing.

On a factory whose org lists you as `member`, Provider access showed a single Personal badge and no switch. Nothing said an Org-wide view existed, or why you were not getting it.

The switch now keeps every scope the server offers. A scope the caller may not write stays in place, greyed, and its tooltip carries the reason; the server's `orgKeyAdmin` answer decides which one.

### Behavior changed

member of the factory's org, Provider access
&nbsp;&nbsp;├─ **was** — a Personal badge, no switch
&nbsp;&nbsp;└─ **now** — Personal | Org-wide, Org-wide greyed, tooltip "Only organization admins can manage org-wide credentials."

org admin
&nbsp;&nbsp;└─ **unchanged** — both scopes, both clickable

Org-wide picked before the permission answer lands
&nbsp;&nbsp;├─ **was** — the option vanished, the view fell back to Personal
&nbsp;&nbsp;└─ **now** — the option greys in place, the view still falls back to Personal

### Shape changed

what `SettingsSubsection` callers now hold
&nbsp;&nbsp;&nbsp;&nbsp;`ScopeControl.disabledReasons?: Partial<Record<SettingsScope, string>>` · `useScopeControl(options, disabledReasons?)`
removed: the unused `initial` parameter of `useScopeControl`; every caller started on `personal`.

### Decisions

- **`aria-disabled` and a no-op click, not `disabled`** — a native disabled button emits no pointer events, so its tooltip never opens; the DS `Tab` makes the same call
- **generic tooltip text** — the factory's `/auth/me` carries the org id but not its name, so "of Mastra Internal" would need a new field; one string away if you want it

### Not verified

- [ ] the greyed switch in a real browser — my local factory answers `orgKeyAdmin: true` and the cloud one cannot be flipped, so only jsdom exercised the hover

---

> ██████████████████ **source** `+70 −37` — 52% of the additions
> ███████████████ **tests** `+59 −7`
> █ **changeset** `+5`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

People who cannot manage organization-wide credentials can still see that option, but they cannot select it. The interface explains why and keeps their view on Personal.

## Changes

- Keep Org-wide visible for unauthorized members.
- Show a disabled style and tooltip that explains only organization admins can manage Org-wide credentials.
- Keep both scopes active for organization admins.
- Fall back to the first scope without a disabled reason when the selected scope becomes unavailable.
- Add `disabledReasons` to `ScopeControl`.
- Update `useScopeControl` to handle disabled scopes and remove the unused `initial` parameter.
- Use `aria-disabled` and ignore clicks instead of the native `disabled` attribute so tooltips remain accessible.
- Add tests for visibility, tooltips, ignored clicks, fallback behavior, and provider access coverage.
- Add a changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->