### PR TITLE
fix(server): send display-state snapshot as first agent-controller SSE frame

### DIFF
--- a/.changeset/some-rabbits-notice.md
+++ b/.changeset/some-rabbits-notice.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed the agent-controller SSE stream so clients that connect while a run is already in progress see the current state right away. The stream now sends the session's display state as its first event, so a reloaded page or a second tab immediately shows the running tool, the streaming reply and any pending approval or question instead of waiting for the next event.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptLateJoin.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptLateJoin.msw.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import type { AgentControllerEvent } from '@mastra/client-js';
+import { screen, waitFor, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { releaseSession, renderThread, stubPreparingSession } from './composer-session-test-fixture';
+
+/**
+ * A client that connects mid-run gets the controller's display state as the first SSE frame.
+ * The transcript must draw the in-flight tool and the pending question from that snapshot
+ * alone — before any tool_start / tool_suspended event arrives.
+ */
+describe('Transcript late join', () => {
+  it('draws the running tool and pending question from the first display_state_changed frame', async () => {
+    const session = stubPreparingSession({ materialized: true, autoAgentEnd: false });
+    const { client } = renderThread();
+    await releaseSession(session.finishWorkspace, client);
+
+    await session.emit({
+      type: 'display_state_changed',
+      displayState: {
+        isRunning: true,
+        currentMessage: null,
+        queuedFollowUps: 0,
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        activeTools: {
+          'call-1': { name: 'execute_command', args: { command: 'pnpm build' }, status: 'running' },
+          'call-2': { name: 'ask_user', args: { question: 'Which file should I edit?' }, status: 'running' },
+        },
+        toolInputBuffers: {},
+        pendingApproval: null,
+        pendingSuspensions: {
+          'call-2': {
+            toolCallId: 'call-2',
+            toolName: 'ask_user',
+            args: { question: 'Which file should I edit?' },
+            suspendPayload: { question: 'Which file should I edit?' },
+          },
+        },
+        activeSubagents: {},
+        bufferingMessages: false,
+        bufferingObservations: false,
+        modifiedFiles: {},
+        tasks: [],
+        previousTasks: [],
+      },
+    } as unknown as AgentControllerEvent);
+
+    // Entries reveal with a staggered arrival animation, so give them room to land.
+    const runningRow = await screen.findByRole('group', { name: 'Tool: execute_command' }, { timeout: 5000 });
+    expect(runningRow).toHaveAttribute('aria-busy', 'true');
+    expect(within(runningRow).getByText('pnpm build')).toBeInTheDocument();
+
+    const question = await screen.findByRole('group', { name: 'Question from the agent' }, { timeout: 5000 });
+    expect(within(question).getByText('Which file should I edit?')).toBeInTheDocument();
+    expect(within(question).getByRole('textbox')).toBeInTheDocument();
+
+    // The call resolved elsewhere (another tab answered): tool_end closes the card and drops the prompt.
+    await session.emit({ type: 'tool_end', toolCallId: 'call-2', toolName: 'ask_user', result: 'a.ts', isError: false });
+    await session.emit({
+      type: 'tool_end',
+      toolCallId: 'call-1',
+      toolName: 'execute_command',
+      result: 'done',
+      isError: false,
+    });
+
+    await waitFor(
+      () => {
+        // The answerable prompt card is gone; only the settled ask_user row with its answer remains.
+        const cards = screen.getAllByRole('group', { name: 'Question from the agent' });
+        expect(cards).toHaveLength(1);
+        expect(within(cards[0]!).queryByRole('textbox')).not.toBeInTheDocument();
+        expect(within(cards[0]!).getByText('a.ts')).toBeInTheDocument();
+        expect(screen.getByRole('group', { name: 'Tool: execute_command' })).toHaveAttribute('aria-busy', 'false');
+      },
+      { timeout: 5000 },
+    );
+    expect(screen.getAllByRole('group', { name: 'Tool: execute_command' })).toHaveLength(1);
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -1654,3 +1654,150 @@ describe('live user signals sent by someone else', () => {
     expect(drawable[0]?.id).toMatch(/^local-/);
   });
 });
+
+describe('display_state_changed seeds the in-flight run for a late joiner', () => {
+  const emptyDisplayState = {
+    isRunning: true,
+    currentMessage: null,
+    queuedFollowUps: 0,
+    tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    activeTools: {},
+    toolInputBuffers: {},
+    pendingApproval: null,
+    pendingSuspensions: {},
+    activeSubagents: {},
+    omProgress: undefined,
+    bufferingMessages: false,
+    bufferingObservations: false,
+    modifiedFiles: {},
+    tasks: [],
+    previousTasks: [],
+  };
+
+  function snapshot(overrides: Record<string, unknown>) {
+    return {
+      type: 'event' as const,
+      event: { type: 'display_state_changed' as const, displayState: { ...emptyDisplayState, ...overrides } },
+    } as Parameters<typeof transcriptReducer>[1];
+  }
+
+  function toolsOf(state: ReturnType<typeof transcriptReducer>) {
+    return state.entries.flatMap(e => (e.kind === 'message' ? Object.values(e.runtimeTools ?? {}) : []));
+  }
+
+  it('draws the running tool, partial message, prompts and subagent from the snapshot', () => {
+    const currentMessage = {
+      id: 'assistant-live',
+      role: 'assistant',
+      createdAt: '2026-09-09T10:00:00.000Z',
+      content: { format: 2, parts: [{ type: 'text', text: 'Reading the file…' }] },
+    };
+    const state = transcriptReducer(
+      createInitialTranscript({ messages: [], threadId: 't1' }),
+      snapshot({
+        currentMessage,
+        activeTools: { 'call-1': { name: 'view', args: { path: 'a.ts' }, status: 'running', partialResult: 'so far' } },
+        pendingSuspensions: {
+          'call-2': { toolCallId: 'call-2', toolName: 'ask_user', args: { q: '?' }, suspendPayload: { question: '?' } },
+        },
+        activeSubagents: { 'call-3': { agentType: 'explore', task: 'find it', modelId: 'm', status: 'running' } },
+        queuedFollowUps: 2,
+      }),
+    );
+
+    expect(state.entries.find(e => e.kind === 'message' && e.id === 'assistant-live')).toMatchObject({
+      streaming: true,
+    });
+    expect(toolsOf(state)).toEqual([
+      expect.objectContaining({ toolCallId: 'call-1', toolName: 'view', status: 'running', result: 'so far' }),
+    ]);
+    expect(state.entries).toContainEqual(
+      expect.objectContaining({ kind: 'suspension', id: 'suspension-call-2', toolCallId: 'call-2' }),
+    );
+    expect(state.entries).toContainEqual(
+      expect.objectContaining({ kind: 'subagent', id: 'subagent-call-3', done: false }),
+    );
+    expect(state.followUpCount).toBe(2);
+  });
+
+  it('seeds a pending approval prompt', () => {
+    const state = transcriptReducer(
+      createInitialTranscript({ messages: [], threadId: 't1' }),
+      snapshot({ pendingApproval: { toolCallId: 'call-1', toolName: 'execute_command', args: { command: 'rm' } } }),
+    );
+    expect(state.entries).toContainEqual(
+      expect.objectContaining({ kind: 'approval', id: 'approval-call-1', toolName: 'execute_command' }),
+    );
+  });
+
+  it('never regresses a tool that already ended on the live stream', () => {
+    let state = createInitialTranscript({ messages: [], threadId: 't1' });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: { type: 'tool_start', toolCallId: 'call-1', toolName: 'view', args: { path: 'a.ts' } },
+    });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: { type: 'tool_end', toolCallId: 'call-1', toolName: 'view', result: 'final', isError: false },
+    });
+
+    state = transcriptReducer(
+      state,
+      snapshot({ activeTools: { 'call-1': { name: 'view', args: { path: 'a.ts' }, status: 'running' } } }),
+    );
+
+    expect(toolsOf(state)).toEqual([expect.objectContaining({ toolCallId: 'call-1', status: 'done', result: 'final' })]);
+  });
+
+  it('does not overwrite a message already streaming on screen', () => {
+    let state = createInitialTranscript({ messages: [], threadId: 't1' });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: {
+        type: 'message_update',
+        message: dbMessage('assistant-live', 'assistant', [{ type: 'text', text: 'newer text' }]),
+      },
+    });
+    state = transcriptReducer(
+      state,
+      snapshot({
+        currentMessage: {
+          id: 'assistant-live',
+          role: 'assistant',
+          createdAt: '2026-09-09T10:00:00.000Z',
+          content: { format: 2, parts: [{ type: 'text', text: 'older' }] },
+        },
+      }),
+    );
+    const entry = state.entries.find(e => e.kind === 'message' && e.id === 'assistant-live');
+    expect(messageParts(entry)).toEqual([{ type: 'text', text: 'newer text' }]);
+  });
+
+  it('is a no-op when the same snapshot arrives twice', () => {
+    const action = snapshot({
+      activeTools: { 'call-1': { name: 'view', args: {}, status: 'running' } },
+      pendingSuspensions: { 'call-2': { toolCallId: 'call-2', toolName: 'ask_user', args: {}, suspendPayload: {} } },
+      activeSubagents: { 'call-3': { agentType: 'explore', task: 't', status: 'running' } },
+    });
+    const once = transcriptReducer(createInitialTranscript({ messages: [], threadId: 't1' }), action);
+    const twice = transcriptReducer(once, action);
+    expect(twice.entries).toHaveLength(once.entries.length);
+    expect(toolsOf(twice)).toHaveLength(1);
+  });
+
+  it('drops the prompt when tool_end reports the call resolved elsewhere', () => {
+    let state = transcriptReducer(
+      createInitialTranscript({ messages: [], threadId: 't1' }),
+      snapshot({
+        pendingSuspensions: { 'call-2': { toolCallId: 'call-2', toolName: 'ask_user', args: {}, suspendPayload: {} } },
+      }),
+    );
+    expect(state.entries.some(e => e.kind === 'suspension')).toBe(true);
+
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: { type: 'tool_end', toolCallId: 'call-2', toolName: 'ask_user', result: 'yes', isError: false },
+    });
+    expect(state.entries.some(e => e.kind === 'suspension')).toBe(false);
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -347,12 +347,16 @@ function applyEvent(state: TranscriptState, event: AgentControllerEvent, viewerI
       return withTool(state, event.toolCallId, t => ({ ...t, output: t.output + stripAnsi(event.output) }));
     case 'tool_update':
       return withTool(state, event.toolCallId, t => ({ ...t, result: event.partialResult }));
-    case 'tool_end':
-      return withTool(state, event.toolCallId, t => ({
+    case 'tool_end': {
+      const next = withTool(state, event.toolCallId, t => ({
         ...t,
         status: event.isError ? 'error' : 'done',
         result: event.result,
       }));
+      // A prompt answered elsewhere (another tab, the TUI) never gets a local
+      // resolvePrompt; the call ending is the signal it is no longer pending.
+      return dropPromptsFor(next, event.toolCallId);
+    }
 
     case 'tool_approval_required':
       return pushPrompt(state, {
@@ -490,14 +494,20 @@ function applyEvent(state: TranscriptState, event: AgentControllerEvent, viewerI
     }
 
     // Canonical display-state snapshot — carries the status-line figures
-    // (OM msg/mem budgets and cumulative token usage).
+    // (OM msg/mem budgets and cumulative token usage) and, on connect, the
+    // in-flight run a late joiner missed the events for.
     case 'display_state_changed': {
       const ds = event.displayState;
-      return {
-        ...state,
-        omProgress: ds.omProgress ?? state.omProgress,
-        usage: ds.tokenUsage ?? state.usage,
-      };
+      return seedFromDisplayState(
+        {
+          ...state,
+          omProgress: ds.omProgress ?? state.omProgress,
+          usage: ds.tokenUsage ?? state.usage,
+          followUpCount: ds.queuedFollowUps ?? state.followUpCount,
+        },
+        ds,
+        viewerId,
+      );
     }
 
     // Follow-up queue.
@@ -1236,6 +1246,104 @@ function toolPart(tool: ToolCall): MastraMessagePart {
 function pushPrompt(state: TranscriptState, prompt: PromptEntry): TranscriptState {
   if (state.entries.some(e => 'id' in e && e.id === prompt.id)) return state;
   return { ...state, entries: [...state.entries, prompt] };
+}
+
+function dropPromptsFor(state: TranscriptState, toolCallId: string): TranscriptState {
+  const entries = state.entries.filter(
+    e => !((e.kind === 'approval' || e.kind === 'suspension') && e.toolCallId === toolCallId),
+  );
+  return entries.length === state.entries.length ? state : { ...state, entries };
+}
+
+type DisplayStateSnapshot = Extract<AgentControllerEvent, { type: 'display_state_changed' }>['displayState'];
+
+/**
+ * Fold the controller's display state into the transcript. The bus only forwards
+ * future events, so this snapshot (sent as the first SSE frame, and again on every
+ * live change) is how a late joiner learns about the in-flight tool, the partial
+ * assistant text and the prompt the run is parked on.
+ *
+ * Non-regressive: it may arrive after live events already landed, or after a
+ * reconnect. Anything already on screen wins — a `done` tool never goes back to
+ * `running`, and a streaming message is never overwritten by an older copy.
+ */
+function seedFromDisplayState(
+  state: TranscriptState,
+  ds: DisplayStateSnapshot,
+  viewerId?: string,
+): TranscriptState {
+  let next = state;
+
+  const current = ds.currentMessage;
+  if (current && current.role === 'assistant') {
+    const drawn = next.entries.some(
+      e => e.kind === 'message' && (e.id === current.id || e.message.id === current.id),
+    );
+    if (!drawn) {
+      next = upsertMessage(
+        next,
+        { ...current, createdAt: new Date(current.createdAt) } as MastraDBMessage,
+        true,
+        viewerId,
+      );
+    }
+  }
+
+  for (const [toolCallId, tool] of Object.entries(ds.activeTools ?? {})) {
+    next = withTool(
+      next,
+      toolCallId,
+      t =>
+        t.status !== 'running'
+          ? t
+          : {
+              ...t,
+              toolName: tool.name,
+              args: t.args ?? tool.args,
+              result: t.result ?? tool.result ?? tool.partialResult,
+              status: tool.status === 'completed' ? 'done' : tool.status === 'error' ? 'error' : 'running',
+              createdAt: t.createdAt ?? Date.now(),
+            },
+      { toolName: tool.name, args: tool.args },
+    );
+  }
+
+  if (ds.pendingApproval) {
+    const { toolCallId, toolName, args } = ds.pendingApproval;
+    next = pushPrompt(next, { kind: 'approval', id: `approval-${toolCallId}`, toolCallId, toolName, args });
+  }
+  for (const s of Object.values(ds.pendingSuspensions ?? {})) {
+    next = pushPrompt(next, {
+      kind: 'suspension',
+      id: `suspension-${s.toolCallId}`,
+      toolCallId: s.toolCallId,
+      toolName: s.toolName,
+      args: s.args,
+      suspendPayload: s.suspendPayload,
+    });
+  }
+
+  for (const [toolCallId, sub] of Object.entries(ds.activeSubagents ?? {})) {
+    const id = `subagent-${toolCallId}`;
+    if (next.entries.some(e => e.kind === 'subagent' && e.id === id)) continue;
+    next = {
+      ...next,
+      entries: [
+        ...next.entries,
+        {
+          kind: 'subagent',
+          id,
+          toolCallId,
+          agentType: sub.agentType,
+          task: sub.task,
+          modelId: sub.modelId ?? '',
+          done: sub.status !== 'running',
+        },
+      ],
+    };
+  }
+
+  return next;
 }
 
 function pushNotice(state: TranscriptState, level: 'info' | 'error', text: string): TranscriptState {

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -598,10 +598,18 @@ describe('agent-controller routes', () => {
       const session = await controller.createSession({ resourceId: 'user-ds', id: 'user-ds', ownerId: 'code' });
       session.emit({ type: 'tool_start', toolCallId: 'call-1', toolName: 'read', args: { path: 'a.ts' } });
 
-      let received: unknown;
+      // The first frame is the connect-time snapshot (no tools yet); wait for
+      // the one that carries the tool.
+      let received: any;
       for (let i = 0; i < 10 && received === undefined; i++) {
         const { value } = await reader.read();
-        if (value && typeof value === 'object' && 'type' in value && value.type === 'display_state_changed') {
+        if (
+          value &&
+          typeof value === 'object' &&
+          'type' in value &&
+          value.type === 'display_state_changed' &&
+          (value as any).displayState.activeTools['call-1']
+        ) {
           received = value;
         }
       }
@@ -609,6 +617,36 @@ describe('agent-controller routes', () => {
 
       expect(received).toBeDefined();
       const wire = JSON.parse(JSON.stringify(received));
+      expect(wire.displayState.activeTools['call-1']).toMatchObject({ name: 'read', status: 'running' });
+    });
+
+    it('sends the current display state as the first frame so late joiners see in-flight tools', async () => {
+      const controller = mastra.getAgentController('code')!;
+      await controller.init();
+      const session = await controller.createSession({ resourceId: 'user-late', id: 'user-late', ownerId: 'code' });
+      session.displayState.apply({ type: 'agent_start' } as any);
+      session.displayState.apply({
+        type: 'tool_start',
+        toolCallId: 'call-1',
+        toolName: 'read',
+        args: { path: 'a.ts' },
+      });
+
+      // Client connects after the run started — nothing above went through the bus.
+      const stream = (await STREAM_AGENT_CONTROLLER_SESSION_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-late',
+        abortSignal: new AbortController().signal,
+      } as any)) as ReadableStream<unknown>;
+
+      const reader = stream.getReader();
+      const { value } = await reader.read();
+      await reader.cancel();
+
+      const wire = JSON.parse(JSON.stringify(value));
+      expect(wire.type).toBe('display_state_changed');
+      expect(wire.displayState.isRunning).toBe(true);
       expect(wire.displayState.activeTools['call-1']).toMatchObject({ name: 'read', status: 'running' });
     });
   });

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -561,6 +561,23 @@ export const STREAM_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
             }
           });
 
+          // The bus only forwards future events, so a late-joining client would
+          // otherwise see `running: true` with no in-flight tool, prompt or
+          // streaming text. displayState is the fold of every past event —
+          // send it as the first frame. Subscribe first so nothing is lost in
+          // the gap; the client folds the snapshot non-regressively.
+          try {
+            controller.enqueue(
+              toWireEvent({
+                type: 'display_state_changed',
+                displayState: session.displayState.get(),
+              } as AgentControllerEvent),
+            );
+          } catch {
+            cleanup();
+            return;
+          }
+
           const abortCleanup = () => cleanup(controller);
           abortSignal?.addEventListener('abort', abortCleanup, { once: true });
           scheduleHeartbeat();


### PR DESCRIPTION
When a Factory client connects while a run is already going (page reload, second tab), it only saw \`running: true\` — the tool in flight, the streaming reply and any pending approval or \`ask_user\` question were missing until the next event fired, which never happens for a run parked on a prompt.

The controller already keeps all of that in \`displayState\`, so the agent-controller SSE handler now sends it as a \`display_state_changed\` first frame right after subscribing to the session bus. On the factory-ui side the transcript reducer folds that snapshot in non-regressively: a \`done\` tool never goes back to \`running\`, prompts and messages are deduped by id, so the same event arriving on every live change or after a reconnect is a no-op. \`tool_end\` also removes the matching approval/suspension prompt now, so a prompt answered from another tab or the TUI disappears here too.

Before: reload during a blocked \`ask_user\` → empty transcript, spinner forever.
After: reload → tool card + question visible immediately, answering resumes the run.

Tests: server test asserting the first SSE frame is the snapshot, reducer unit tests for seeding/non-regression/idempotence/prompt cleanup, and an MSW late-join test. No route or schema changes.