### PR TITLE
feat(cli): add Langfuse Observations API v2 reader

### DIFF
--- a/.changeset/soft-birds-judge.md
+++ b/.changeset/soft-birds-judge.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Added a Langfuse Observations API v2 reader for trace imports.

--- a/packages/cli/src/commands/traces/import/providers/langfuse/client.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/client.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LangfuseClient, LangfuseReaderError } from './client.js';
+
+const options = {
+  baseUrl: 'https://cloud.langfuse.com',
+  publicKey: 'pk-lf-test',
+  secretKey: 'sk-lf-test',
+};
+
+const observation = {
+  id: 'observation-1',
+  traceId: 'trace-1',
+  startTime: '2026-09-01T10:00:00.000Z',
+  endTime: '2026-09-01T10:00:01.000Z',
+  projectId: 'project-1',
+  parentObservationId: null,
+  type: 'SPAN',
+};
+
+describe('LangfuseClient', () => {
+  it('identifies the project associated with its Basic-auth credentials', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
+      Response.json({
+        data: [{ id: 'project-1', name: 'Customer project', organization: { id: 'org-1', name: 'Customer' } }],
+      }),
+    );
+    const client = new LangfuseClient({ ...options, baseUrl: 'https://cloud.langfuse.com/' }, { fetch });
+
+    await expect(client.identifyProject()).resolves.toEqual({ id: 'project-1', name: 'Customer project' });
+
+    const [url, init] = fetch.mock.calls[0]!;
+    expect(String(url)).toBe('https://cloud.langfuse.com/api/public/projects');
+    expect(init).toMatchObject({ redirect: 'manual' });
+    expect((init?.headers as Record<string, string>).Authorization).toBe(
+      `Basic ${Buffer.from('pk-lf-test:sk-lf-test').toString('base64')}`,
+    );
+  });
+
+  it('builds a bounded Observations API v2 request', async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValue(Response.json({ data: [observation], meta: { cursor: 'next-page' } }));
+    const client = new LangfuseClient(options, { fetch });
+
+    await expect(
+      client.getObservationsPage({
+        fields: 'core,metadata',
+        expandMetadata: '*',
+        limit: 1000,
+        cursor: 'current-page',
+        traceId: 'trace-1',
+        fromStartTime: '2026-08-01T00:00:00.000Z',
+        toStartTime: '2026-09-01T00:00:00.000Z',
+      }),
+    ).resolves.toEqual({ data: [observation], cursor: 'next-page' });
+
+    const url = new URL(String(fetch.mock.calls[0]![0]));
+    expect(url.pathname).toBe('/api/public/v2/observations');
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      fields: 'core,metadata',
+      limit: '1000',
+      cursor: 'current-page',
+      traceId: 'trace-1',
+      fromStartTime: '2026-08-01T00:00:00.000Z',
+      toStartTime: '2026-09-01T00:00:00.000Z',
+      expandMetadata: '*',
+    });
+  });
+
+  it('honors Retry-After when Langfuse rate-limits a request', async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 429, headers: { 'Retry-After': '3' } }))
+      .mockResolvedValueOnce(Response.json({ data: [], meta: { cursor: null } }));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const onRetry = vi.fn();
+    const client = new LangfuseClient(options, { fetch, sleep, onRetry });
+
+    await client.getObservationsPage({ fields: 'core', limit: 1000 });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(3000, undefined);
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('retries temporary network failures', async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce(Response.json({ data: [], meta: { cursor: null } }));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const client = new LangfuseClient(options, { fetch, sleep });
+
+    await expect(client.getObservationsPage({ fields: 'core', limit: 1000 })).resolves.toEqual({
+      data: [],
+      cursor: null,
+    });
+    expect(sleep).toHaveBeenCalledWith(500, undefined);
+  });
+
+  it.each([408, 429, 500, 503])('marks exhausted HTTP %s errors as retryable', async status => {
+    const client = new LangfuseClient(options, {
+      fetch: vi.fn<typeof globalThis.fetch>().mockResolvedValue(new Response(null, { status })),
+      maxAttempts: 1,
+    });
+
+    await expect(client.getObservationsPage({ fields: 'core', limit: 1000 })).rejects.toMatchObject({
+      status,
+      retryable: true,
+    });
+  });
+
+  it.each([401, 403])('does not retry HTTP %s credential failures', async status => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(new Response(null, { status }));
+    const client = new LangfuseClient(options, { fetch });
+
+    await expect(client.identifyProject()).rejects.toMatchObject({ status, retryable: false });
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it('explains the Langfuse v4 requirement when Observations API v2 is missing', async () => {
+    const client = new LangfuseClient(options, {
+      fetch: vi.fn<typeof globalThis.fetch>().mockResolvedValue(new Response(null, { status: 404 })),
+    });
+
+    await expect(client.getObservationsPage({ fields: 'core', limit: 1000 })).rejects.toThrow(
+      'self-hosted Langfuse v4 or later',
+    );
+  });
+
+  it('rejects authenticated redirects and malformed responses', async () => {
+    const redirect = new LangfuseClient(options, {
+      fetch: vi.fn<typeof globalThis.fetch>().mockResolvedValue(new Response(null, { status: 302 })),
+    });
+    await expect(redirect.identifyProject()).rejects.toMatchObject({ status: 302, retryable: false });
+
+    const malformed = new LangfuseClient(options, {
+      fetch: vi.fn<typeof globalThis.fetch>().mockResolvedValue(Response.json({ data: [{}], meta: null })),
+    });
+    await expect(malformed.getObservationsPage({ fields: 'core', limit: 1000 })).rejects.toBeInstanceOf(
+      LangfuseReaderError,
+    );
+  });
+
+  it('rejects ambiguous project credentials', async () => {
+    const client = new LangfuseClient(options, {
+      fetch: vi
+        .fn<typeof globalThis.fetch>()
+        .mockResolvedValue(Response.json({ data: [{ id: 'one' }, { id: 'two' }] })),
+    });
+
+    await expect(client.identifyProject()).rejects.toThrow('exactly one source project');
+  });
+
+  it('rejects responses above the Langfuse API response limit', async () => {
+    const client = new LangfuseClient(options, {
+      fetch: vi.fn<typeof globalThis.fetch>().mockResolvedValue(
+        new Response('{}', {
+          headers: { 'Content-Length': String(5 * 1024 * 1024 + 1) },
+        }),
+      ),
+    });
+
+    await expect(client.identifyProject()).rejects.toThrow('response exceeds');
+  });
+
+  it.each([
+    'http://langfuse.example.com',
+    'https://user:password@langfuse.example.com',
+    'https://langfuse.example.com/api',
+    'https://langfuse.example.com?region=us',
+    'https://langfuse.example.com#settings',
+  ])('rejects unsafe base URL %s', baseUrl => {
+    expect(() => new LangfuseClient({ ...options, baseUrl })).toThrow();
+  });
+
+  it('allows HTTP only for localhost development', () => {
+    expect(new LangfuseClient({ ...options, baseUrl: 'http://localhost:3000' }).baseUrl).toBe('http://localhost:3000');
+  });
+});

--- a/packages/cli/src/commands/traces/import/providers/langfuse/client.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/client.test.ts
@@ -17,6 +17,15 @@ const observation = {
   type: 'SPAN',
 };
 
+function cancelableResponse(
+  status: number,
+  headers?: HeadersInit,
+): { response: Response; cancel: ReturnType<typeof vi.fn> } {
+  const cancel = vi.fn();
+  const body = new ReadableStream({ cancel });
+  return { response: new Response(body, { status, headers }), cancel };
+}
+
 describe('LangfuseClient', () => {
   it('identifies the project associated with its Basic-auth credentials', async () => {
     const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
@@ -68,9 +77,10 @@ describe('LangfuseClient', () => {
   });
 
   it('honors Retry-After when Langfuse rate-limits a request', async () => {
+    const rateLimit = cancelableResponse(429, { 'Retry-After': '3' });
     const fetch = vi
       .fn<typeof globalThis.fetch>()
-      .mockResolvedValueOnce(new Response(null, { status: 429, headers: { 'Retry-After': '3' } }))
+      .mockResolvedValueOnce(rateLimit.response)
       .mockResolvedValueOnce(Response.json({ data: [], meta: { cursor: null } }));
     const sleep = vi.fn().mockResolvedValue(undefined);
     const onRetry = vi.fn();
@@ -79,6 +89,7 @@ describe('LangfuseClient', () => {
     await client.getObservationsPage({ fields: 'core', limit: 1000 });
 
     expect(fetch).toHaveBeenCalledTimes(2);
+    expect(rateLimit.cancel).toHaveBeenCalledOnce();
     expect(sleep).toHaveBeenCalledWith(3000, undefined);
     expect(onRetry).toHaveBeenCalledOnce();
   });
@@ -118,6 +129,17 @@ describe('LangfuseClient', () => {
     expect(fetch).toHaveBeenCalledOnce();
   });
 
+  it.each([302, 401, 404, 400, 500])('cancels an unread HTTP %s response before throwing', async status => {
+    const result = cancelableResponse(status);
+    const client = new LangfuseClient(options, {
+      fetch: vi.fn<typeof globalThis.fetch>().mockResolvedValue(result.response),
+      maxAttempts: 1,
+    });
+
+    await expect(client.identifyProject()).rejects.toBeInstanceOf(LangfuseReaderError);
+    expect(result.cancel).toHaveBeenCalledOnce();
+  });
+
   it('explains the Langfuse v4 requirement when Observations API v2 is missing', async () => {
     const client = new LangfuseClient(options, {
       fetch: vi.fn<typeof globalThis.fetch>().mockResolvedValue(new Response(null, { status: 404 })),
@@ -153,15 +175,13 @@ describe('LangfuseClient', () => {
   });
 
   it('rejects a response whose content length exceeds the Langfuse API response limit', async () => {
+    const oversized = cancelableResponse(200, { 'Content-Length': String(5 * 1024 * 1024 + 1) });
     const client = new LangfuseClient(options, {
-      fetch: vi.fn<typeof globalThis.fetch>().mockResolvedValue(
-        new Response('{}', {
-          headers: { 'Content-Length': String(5 * 1024 * 1024 + 1) },
-        }),
-      ),
+      fetch: vi.fn<typeof globalThis.fetch>().mockResolvedValue(oversized.response),
     });
 
     await expect(client.identifyProject()).rejects.toBeInstanceOf(LangfuseResponseTooLargeError);
+    expect(oversized.cancel).toHaveBeenCalledOnce();
   });
 
   it('stops reading a streamed response when it exceeds the Langfuse API response limit', async () => {

--- a/packages/cli/src/commands/traces/import/providers/langfuse/client.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { LangfuseClient, LangfuseReaderError } from './client.js';
+import { LangfuseClient, LangfuseReaderError, LangfuseResponseTooLargeError } from './client.js';
 
 const options = {
   baseUrl: 'https://cloud.langfuse.com',
@@ -152,7 +152,7 @@ describe('LangfuseClient', () => {
     await expect(client.identifyProject()).rejects.toThrow('exactly one source project');
   });
 
-  it('rejects responses above the Langfuse API response limit', async () => {
+  it('rejects a response whose content length exceeds the Langfuse API response limit', async () => {
     const client = new LangfuseClient(options, {
       fetch: vi.fn<typeof globalThis.fetch>().mockResolvedValue(
         new Response('{}', {
@@ -161,7 +161,22 @@ describe('LangfuseClient', () => {
       ),
     });
 
-    await expect(client.identifyProject()).rejects.toThrow('response exceeds');
+    await expect(client.identifyProject()).rejects.toBeInstanceOf(LangfuseResponseTooLargeError);
+  });
+
+  it('stops reading a streamed response when it exceeds the Langfuse API response limit', async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(5 * 1024 * 1024));
+        controller.enqueue(new Uint8Array(1));
+        controller.close();
+      },
+    });
+    const client = new LangfuseClient(options, {
+      fetch: vi.fn<typeof globalThis.fetch>().mockResolvedValue(new Response(body)),
+    });
+
+    await expect(client.identifyProject()).rejects.toBeInstanceOf(LangfuseResponseTooLargeError);
   });
 
   it.each([

--- a/packages/cli/src/commands/traces/import/providers/langfuse/client.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/client.test.ts
@@ -94,6 +94,29 @@ describe('LangfuseClient', () => {
     expect(onRetry).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    ['an empty value', '', 500],
+    ['a whitespace-only value', '   ', 500],
+    ['a delay longer than the local backoff cap', '120', 120_000],
+    ['an HTTP date', 'Thu, 10 Sep 2026 12:01:00 GMT', 60_000],
+  ])('handles Retry-After with %s', async (_case, retryAfter, expectedDelay) => {
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-09-10T12:00:00.000Z'));
+    const rateLimit = cancelableResponse(429, { 'Retry-After': retryAfter });
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(rateLimit.response)
+      .mockResolvedValueOnce(Response.json({ data: [], meta: { cursor: null } }));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const client = new LangfuseClient(options, { fetch, sleep });
+
+    try {
+      await client.getObservationsPage({ fields: 'core', limit: 1000 });
+      expect(sleep).toHaveBeenCalledWith(expectedDelay, undefined);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
   it('retries temporary network failures', async () => {
     const fetch = vi
       .fn<typeof globalThis.fetch>()

--- a/packages/cli/src/commands/traces/import/providers/langfuse/client.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/client.ts
@@ -239,11 +239,13 @@ function backoffMilliseconds(attempt: number): number {
 
 function parseRetryAfter(value: string | null, fallback: number): number {
   if (value === null) return fallback;
+  const retryAfter = value.trim();
+  if (retryAfter.length === 0) return fallback;
 
-  const seconds = Number(value);
+  const seconds = Number(retryAfter);
   if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
 
-  const date = Date.parse(value);
+  const date = Date.parse(retryAfter);
   return Number.isFinite(date) ? Math.max(0, date - Date.now()) : fallback;
 }
 

--- a/packages/cli/src/commands/traces/import/providers/langfuse/client.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/client.ts
@@ -1,0 +1,354 @@
+import type { LangfuseObservation, LangfuseObservationsPage, LangfuseProject } from './types.js';
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+
+type Fetch = typeof globalThis.fetch;
+type Sleep = (milliseconds: number, signal?: AbortSignal) => Promise<void>;
+
+export interface LangfuseClientOptions {
+  baseUrl: string;
+  publicKey: string;
+  secretKey: string;
+}
+
+export interface LangfuseClientDependencies {
+  fetch?: Fetch;
+  sleep?: Sleep;
+  maxAttempts?: number;
+  requestTimeoutMs?: number;
+  onRetry?: () => void;
+}
+
+export interface LangfuseObservationQuery {
+  fields: string;
+  limit: number;
+  cursor?: string;
+  traceId?: string;
+  fromStartTime?: string;
+  toStartTime?: string;
+  expandMetadata?: string;
+  signal?: AbortSignal;
+}
+
+export class LangfuseReaderError extends Error {
+  readonly status?: number;
+  readonly retryable: boolean;
+
+  constructor(message: string, options: { status?: number; retryable?: boolean; cause?: unknown } = {}) {
+    super(message, { cause: options.cause });
+    this.name = 'LangfuseReaderError';
+    this.status = options.status;
+    this.retryable = options.retryable ?? false;
+  }
+}
+
+export class LangfuseClient {
+  readonly baseUrl: string;
+
+  private readonly authorization: string;
+  private readonly fetch: Fetch;
+  private readonly sleep: Sleep;
+  private readonly maxAttempts: number;
+  private readonly requestTimeoutMs: number;
+  private readonly onRetry?: () => void;
+
+  constructor(options: LangfuseClientOptions, dependencies: LangfuseClientDependencies = {}) {
+    const publicKey = requireCredential(options.publicKey, 'Langfuse public key');
+    const secretKey = requireCredential(options.secretKey, 'Langfuse secret key');
+
+    this.baseUrl = normalizeBaseUrl(options.baseUrl);
+    this.authorization = `Basic ${Buffer.from(`${publicKey}:${secretKey}`).toString('base64')}`;
+    this.fetch = dependencies.fetch ?? globalThis.fetch;
+    this.sleep = dependencies.sleep ?? sleep;
+    this.maxAttempts = dependencies.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+    this.requestTimeoutMs = dependencies.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.onRetry = dependencies.onRetry;
+
+    if (!Number.isInteger(this.maxAttempts) || this.maxAttempts < 1) {
+      throw new Error('Langfuse max attempts must be a positive integer.');
+    }
+    if (!Number.isFinite(this.requestTimeoutMs) || this.requestTimeoutMs <= 0) {
+      throw new Error('Langfuse request timeout must be greater than zero.');
+    }
+  }
+
+  async identifyProject(signal?: AbortSignal): Promise<LangfuseProject> {
+    const value = await this.requestJson(new URL('/api/public/projects', this.baseUrl), signal);
+    return parseProject(value);
+  }
+
+  async getObservationsPage(query: LangfuseObservationQuery): Promise<LangfuseObservationsPage> {
+    if (!Number.isInteger(query.limit) || query.limit < 1 || query.limit > 1000) {
+      throw new Error('Langfuse observation page size must be between 1 and 1000.');
+    }
+
+    const url = new URL('/api/public/v2/observations', this.baseUrl);
+    url.searchParams.set('fields', query.fields);
+    url.searchParams.set('limit', String(query.limit));
+    setQuery(url, 'cursor', query.cursor);
+    setQuery(url, 'traceId', query.traceId);
+    setQuery(url, 'fromStartTime', query.fromStartTime);
+    setQuery(url, 'toStartTime', query.toStartTime);
+    setQuery(url, 'expandMetadata', query.expandMetadata);
+
+    try {
+      return parseObservationsPage(await this.requestJson(url, query.signal));
+    } catch (error) {
+      if (error instanceof LangfuseReaderError && error.status === 404) {
+        throw new LangfuseReaderError(
+          'Langfuse Observations API v2 was not found. Use Langfuse Cloud or self-hosted Langfuse v4 or later.',
+          { status: 404, cause: error },
+        );
+      }
+      throw error;
+    }
+  }
+
+  private async requestJson(url: URL, signal?: AbortSignal): Promise<unknown> {
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < this.maxAttempts; attempt++) {
+      signal?.throwIfAborted();
+
+      let response: Response;
+      try {
+        const timeoutSignal = AbortSignal.timeout(this.requestTimeoutMs);
+        response = await this.fetch(url, {
+          headers: { Authorization: this.authorization, Accept: 'application/json' },
+          redirect: 'manual',
+          signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
+        });
+      } catch (error) {
+        if (signal?.aborted) throw signal.reason ?? error;
+        lastError = error;
+        if (attempt + 1 < this.maxAttempts) {
+          await this.waitBeforeRetry(backoffMilliseconds(attempt), signal);
+          continue;
+        }
+        throw new LangfuseReaderError('Could not reach Langfuse after the retry limit was exhausted.', {
+          retryable: true,
+          cause: error,
+        });
+      }
+
+      if (response.status >= 300 && response.status < 400) {
+        throw new LangfuseReaderError('Langfuse redirected an authenticated request. Redirects are not followed.', {
+          status: response.status,
+        });
+      }
+
+      if (response.ok) {
+        return parseJson(await readResponseText(response));
+      }
+
+      if (response.status === 401 || response.status === 403) {
+        throw new LangfuseReaderError(`Langfuse rejected the project credentials (HTTP ${response.status}).`, {
+          status: response.status,
+        });
+      }
+
+      if (response.status === 404) {
+        throw new LangfuseReaderError('Langfuse API endpoint was not found.', { status: 404 });
+      }
+
+      if (isRetryableStatus(response.status)) {
+        if (attempt + 1 < this.maxAttempts) {
+          const delay =
+            response.status === 429
+              ? parseRetryAfter(response.headers.get('retry-after'), backoffMilliseconds(attempt))
+              : backoffMilliseconds(attempt);
+          await response.body?.cancel();
+          await this.waitBeforeRetry(delay, signal);
+          continue;
+        }
+        throw new LangfuseReaderError(`Langfuse request failed repeatedly with HTTP ${response.status}.`, {
+          status: response.status,
+          retryable: true,
+        });
+      }
+
+      throw new LangfuseReaderError(`Langfuse request failed with HTTP ${response.status}.`, {
+        status: response.status,
+      });
+    }
+
+    throw new LangfuseReaderError('Langfuse request failed.', { retryable: true, cause: lastError });
+  }
+
+  private async waitBeforeRetry(milliseconds: number, signal?: AbortSignal): Promise<void> {
+    this.onRetry?.();
+    await this.sleep(milliseconds, signal);
+  }
+}
+
+function requireCredential(value: string, label: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${label} is required.`);
+  }
+  return value.trim();
+}
+
+function normalizeBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch (cause) {
+    throw new Error('LANGFUSE_BASE_URL must be a valid URL.', { cause });
+  }
+
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('LANGFUSE_BASE_URL cannot contain credentials, query parameters, or a fragment.');
+  }
+  if (url.pathname !== '/' && url.pathname !== '') {
+    throw new Error('LANGFUSE_BASE_URL must not contain a path.');
+  }
+
+  const localhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]';
+  if (url.protocol !== 'https:' && !(url.protocol === 'http:' && localhost)) {
+    throw new Error('LANGFUSE_BASE_URL must use HTTPS, except when testing against localhost.');
+  }
+
+  return url.origin;
+}
+
+function setQuery(url: URL, key: string, value: string | undefined): void {
+  if (value !== undefined) url.searchParams.set(key, value);
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+function backoffMilliseconds(attempt: number): number {
+  return Math.min(30_000, 500 * 2 ** attempt);
+}
+
+function parseRetryAfter(value: string | null, fallback: number): number {
+  if (value === null) return fallback;
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+
+  const date = Date.parse(value);
+  return Number.isFinite(date) ? Math.max(0, date - Date.now()) : fallback;
+}
+
+async function sleep(milliseconds: number, signal?: AbortSignal): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new DOMException('The operation was aborted.', 'AbortError'));
+      return;
+    }
+
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(signal?.reason ?? new DOMException('The operation was aborted.', 'AbortError'));
+    };
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, milliseconds);
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+async function readResponseText(response: Response): Promise<string> {
+  const contentLength = Number(response.headers.get('content-length'));
+  if (Number.isFinite(contentLength) && contentLength > MAX_RESPONSE_BYTES) {
+    throw new LangfuseReaderError(`Langfuse response exceeds the ${MAX_RESPONSE_BYTES}-byte API limit.`);
+  }
+  if (!response.body) return '';
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = '';
+
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    bytes += chunk.value.byteLength;
+    if (bytes > MAX_RESPONSE_BYTES) {
+      await reader.cancel();
+      throw new LangfuseReaderError(`Langfuse response exceeds the ${MAX_RESPONSE_BYTES}-byte API limit.`);
+    }
+    text += decoder.decode(chunk.value, { stream: true });
+  }
+
+  return text + decoder.decode();
+}
+
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch (cause) {
+    throw new LangfuseReaderError('Langfuse returned invalid JSON.', { cause });
+  }
+}
+
+function parseProject(value: unknown): LangfuseProject {
+  const response = requireRecord(value, 'project response');
+  if (!Array.isArray(response.data) || response.data.length !== 1) {
+    throw new LangfuseReaderError('Langfuse credentials must identify exactly one source project.');
+  }
+
+  const project = requireRecord(response.data[0], 'project');
+  return {
+    id: requireString(project.id, 'project id'),
+    name: project.name === null || project.name === undefined ? null : requireString(project.name, 'project name'),
+  };
+}
+
+function parseObservationsPage(value: unknown): LangfuseObservationsPage {
+  const response = requireRecord(value, 'observations response');
+  const meta = requireRecord(response.meta, 'observations response metadata');
+  if (!Array.isArray(response.data)) {
+    throw new LangfuseReaderError('Langfuse observations response must contain a data array.');
+  }
+
+  const cursor = meta.cursor;
+  if (cursor !== null && cursor !== undefined && (typeof cursor !== 'string' || cursor.length === 0)) {
+    throw new LangfuseReaderError('Langfuse observations response contains an invalid cursor.');
+  }
+
+  return {
+    data: response.data.map(parseObservation),
+    cursor: cursor ?? null,
+  };
+}
+
+function parseObservation(value: unknown): LangfuseObservation {
+  const observation = requireRecord(value, 'observation');
+  return {
+    ...observation,
+    id: requireString(observation.id, 'observation id'),
+    traceId: requireNullableString(observation.traceId, 'observation trace id'),
+    startTime: requireString(observation.startTime, 'observation start time'),
+    endTime: requireNullableString(observation.endTime, 'observation end time'),
+    projectId: requireString(observation.projectId, 'observation project id'),
+    parentObservationId: requireNullableString(observation.parentObservationId, 'parent observation id'),
+    type: requireString(observation.type, 'observation type'),
+  };
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new LangfuseReaderError(`Langfuse returned an invalid ${label}.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new LangfuseReaderError(`Langfuse returned an invalid ${label}.`);
+  }
+  return value;
+}
+
+function requireNullableString(value: unknown, label: string): string | null {
+  if (value === null) return null;
+  return requireString(value, label);
+}

--- a/packages/cli/src/commands/traces/import/providers/langfuse/client.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/client.ts
@@ -141,6 +141,7 @@ export class LangfuseClient {
       }
 
       if (response.status >= 300 && response.status < 400) {
+        await discardResponseBody(response);
         throw new LangfuseReaderError('Langfuse redirected an authenticated request. Redirects are not followed.', {
           status: response.status,
         });
@@ -151,12 +152,14 @@ export class LangfuseClient {
       }
 
       if (response.status === 401 || response.status === 403) {
+        await discardResponseBody(response);
         throw new LangfuseReaderError(`Langfuse rejected the project credentials (HTTP ${response.status}).`, {
           status: response.status,
         });
       }
 
       if (response.status === 404) {
+        await discardResponseBody(response);
         throw new LangfuseReaderError('Langfuse API endpoint was not found.', { status: 404 });
       }
 
@@ -166,16 +169,18 @@ export class LangfuseClient {
             response.status === 429
               ? parseRetryAfter(response.headers.get('retry-after'), backoffMilliseconds(attempt))
               : backoffMilliseconds(attempt);
-          await response.body?.cancel();
+          await discardResponseBody(response);
           await this.waitBeforeRetry(delay, signal);
           continue;
         }
+        await discardResponseBody(response);
         throw new LangfuseReaderError(`Langfuse request failed repeatedly with HTTP ${response.status}.`, {
           status: response.status,
           retryable: true,
         });
       }
 
+      await discardResponseBody(response);
       throw new LangfuseReaderError(`Langfuse request failed with HTTP ${response.status}.`, {
         status: response.status,
       });
@@ -262,9 +267,18 @@ async function sleep(milliseconds: number, signal?: AbortSignal): Promise<void> 
   });
 }
 
+async function discardResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Cleanup must not replace the request error that the caller needs.
+  }
+}
+
 async function readResponseText(response: Response): Promise<string> {
   const contentLength = Number(response.headers.get('content-length'));
   if (Number.isFinite(contentLength) && contentLength > MAX_RESPONSE_BYTES) {
+    await discardResponseBody(response);
     throw new LangfuseResponseTooLargeError();
   }
   if (!response.body) return '';

--- a/packages/cli/src/commands/traces/import/providers/langfuse/client.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/client.ts
@@ -44,6 +44,13 @@ export class LangfuseReaderError extends Error {
   }
 }
 
+export class LangfuseResponseTooLargeError extends LangfuseReaderError {
+  constructor() {
+    super(`Langfuse response exceeds the ${MAX_RESPONSE_BYTES}-byte API limit.`);
+    this.name = 'LangfuseResponseTooLargeError';
+  }
+}
+
 export class LangfuseClient {
   readonly baseUrl: string;
 
@@ -258,7 +265,7 @@ async function sleep(milliseconds: number, signal?: AbortSignal): Promise<void> 
 async function readResponseText(response: Response): Promise<string> {
   const contentLength = Number(response.headers.get('content-length'));
   if (Number.isFinite(contentLength) && contentLength > MAX_RESPONSE_BYTES) {
-    throw new LangfuseReaderError(`Langfuse response exceeds the ${MAX_RESPONSE_BYTES}-byte API limit.`);
+    throw new LangfuseResponseTooLargeError();
   }
   if (!response.body) return '';
 
@@ -273,7 +280,7 @@ async function readResponseText(response: Response): Promise<string> {
     bytes += chunk.value.byteLength;
     if (bytes > MAX_RESPONSE_BYTES) {
       await reader.cancel();
-      throw new LangfuseReaderError(`Langfuse response exceeds the ${MAX_RESPONSE_BYTES}-byte API limit.`);
+      throw new LangfuseResponseTooLargeError();
     }
     text += decoder.decode(chunk.value, { stream: true });
   }

--- a/packages/cli/src/commands/traces/import/providers/langfuse/reader.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/reader.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LangfuseObservationsReader } from './reader.js';
+import { LANGFUSE_OBSERVATION_FIELDS } from './types.js';
+
+const clientOptions = {
+  baseUrl: 'https://cloud.langfuse.com',
+  publicKey: 'pk-lf-test',
+  secretKey: 'sk-lf-test',
+};
+
+const root = {
+  id: 'root',
+  traceId: 'trace-1',
+  startTime: '2026-09-01T10:00:00.000Z',
+  endTime: '2026-09-01T10:00:05.000Z',
+  projectId: 'project-1',
+  parentObservationId: null,
+  type: 'SPAN',
+  name: 'root',
+};
+
+const child = {
+  ...root,
+  id: 'child',
+  parentObservationId: 'root',
+  type: 'GENERATION',
+  name: 'child',
+  metadata: { transcript: 'x'.repeat(300) },
+};
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const value of iterable) values.push(value);
+  return values;
+}
+
+describe('LangfuseObservationsReader', () => {
+  it('discovers unique trace IDs across every cursor page', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async input => {
+      const url = new URL(String(input));
+      const cursor = url.searchParams.get('cursor');
+      if (cursor === null) {
+        return Response.json({
+          data: [root, { ...root, id: 'orphan', traceId: null }],
+          meta: { cursor: 'next-page' },
+        });
+      }
+      return Response.json({ data: [child, { ...root, id: 'other', traceId: 'trace-2' }], meta: { cursor: null } });
+    });
+    const reader = new LangfuseObservationsReader(clientOptions, { fetch });
+
+    await expect(
+      collect(
+        reader.discoverTraces({
+          projectId: 'project-1',
+          cutoffAt: '2026-08-02T00:00:00.000Z',
+          snapshotAt: '2026-09-01T12:00:00.000Z',
+        }),
+      ),
+    ).resolves.toEqual([
+      { kind: 'trace', traceId: 'trace-1' },
+      { kind: 'missing-trace-id', observationId: 'orphan' },
+      { kind: 'trace', traceId: 'trace-2' },
+    ]);
+
+    const urls = fetch.mock.calls.map(([input]) => new URL(String(input)));
+    expect(urls).toHaveLength(2);
+    expect(urls[0]!.searchParams.get('fields')).toBe('core');
+    expect(urls[0]!.searchParams.get('limit')).toBe('1000');
+    expect(urls[0]!.searchParams.get('fromStartTime')).toBe('2026-08-02T00:00:00.000Z');
+    expect(urls[0]!.searchParams.get('toStartTime')).toBe('2026-09-01T12:00:00.000Z');
+    expect(urls[1]!.searchParams.get('cursor')).toBe('next-page');
+  });
+
+  it('fetches every page of one trace with all fields and full metadata', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async input => {
+      const url = new URL(String(input));
+      return url.searchParams.has('cursor')
+        ? Response.json({ data: [child], meta: { cursor: null } })
+        : Response.json({ data: [root], meta: { cursor: 'next-page' } });
+    });
+    const reader = new LangfuseObservationsReader(clientOptions, { fetch });
+
+    await expect(reader.readTrace({ traceId: 'trace-1', projectId: 'project-1' })).resolves.toEqual({
+      traceId: 'trace-1',
+      observations: [root, child],
+    });
+
+    const urls = fetch.mock.calls.map(([input]) => new URL(String(input)));
+    expect(urls).toHaveLength(2);
+    for (const url of urls) {
+      expect(url.searchParams.get('fields')).toBe(LANGFUSE_OBSERVATION_FIELDS);
+      expect(url.searchParams.get('expandMetadata')).toBe('*');
+      expect(url.searchParams.get('traceId')).toBe('trace-1');
+      expect(url.searchParams.has('fromStartTime')).toBe(false);
+      expect(url.searchParams.has('toStartTime')).toBe(false);
+    }
+  });
+
+  it.each([
+    [
+      'discovery',
+      (reader: LangfuseObservationsReader) =>
+        collect(
+          reader.discoverTraces({
+            projectId: 'project-1',
+            cutoffAt: '2026-08-02T00:00:00.000Z',
+            snapshotAt: '2026-09-01T12:00:00.000Z',
+          }),
+        ),
+    ],
+    [
+      'detail',
+      (reader: LangfuseObservationsReader) => reader.readTrace({ traceId: 'trace-1', projectId: 'project-1' }),
+    ],
+  ] as const)('rejects a repeated %s cursor', async (_stage, read) => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockImplementation(async () => Response.json({ data: [root], meta: { cursor: 'same-cursor' } }));
+    const reader = new LangfuseObservationsReader(clientOptions, { fetch });
+
+    await expect(read(reader)).rejects.toThrow('repeated pagination cursor');
+  });
+
+  it('rejects observations returned for another project or trace', async () => {
+    const wrongProject = new LangfuseObservationsReader(clientOptions, {
+      fetch: vi
+        .fn<typeof globalThis.fetch>()
+        .mockResolvedValue(Response.json({ data: [{ ...root, projectId: 'project-2' }], meta: { cursor: null } })),
+    });
+    await expect(wrongProject.readTrace({ traceId: 'trace-1', projectId: 'project-1' })).rejects.toThrow(
+      'different project',
+    );
+
+    const wrongTrace = new LangfuseObservationsReader(clientOptions, {
+      fetch: vi
+        .fn<typeof globalThis.fetch>()
+        .mockResolvedValue(Response.json({ data: [{ ...root, traceId: 'trace-2' }], meta: { cursor: null } })),
+    });
+    await expect(wrongTrace.readTrace({ traceId: 'trace-1', projectId: 'project-1' })).rejects.toThrow(
+      'different trace',
+    );
+  });
+
+  it('validates the discovery window before making a request', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>();
+    const reader = new LangfuseObservationsReader(clientOptions, { fetch });
+
+    await expect(
+      collect(
+        reader.discoverTraces({
+          projectId: 'project-1',
+          cutoffAt: '2026-09-02T00:00:00.000Z',
+          snapshotAt: '2026-09-01T00:00:00.000Z',
+        }),
+      ),
+    ).rejects.toThrow('cutoffAt before snapshotAt');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('stops before the next page when aborted', async () => {
+    const controller = new AbortController();
+    const fetch = vi.fn<typeof globalThis.fetch>().mockImplementation(async () => {
+      controller.abort(new Error('cancelled'));
+      return Response.json({ data: [root], meta: { cursor: 'next-page' } });
+    });
+    const reader = new LangfuseObservationsReader(clientOptions, { fetch });
+
+    await expect(
+      collect(
+        reader.discoverTraces({
+          projectId: 'project-1',
+          cutoffAt: '2026-08-02T00:00:00.000Z',
+          snapshotAt: '2026-09-01T00:00:00.000Z',
+          signal: controller.signal,
+        }),
+      ),
+    ).rejects.toThrow('cancelled');
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cli/src/commands/traces/import/providers/langfuse/reader.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/reader.test.ts
@@ -97,6 +97,47 @@ describe('LangfuseObservationsReader', () => {
     }
   });
 
+  it('retries an oversized page with a smaller limit without losing or duplicating observations', async () => {
+    const grandchild = { ...child, id: 'grandchild', parentObservationId: 'child' };
+    const oversizedBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(5 * 1024 * 1024));
+        controller.enqueue(new Uint8Array(1));
+        controller.close();
+      },
+    });
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(Response.json({ data: [root], meta: { cursor: 'next-page' } }))
+      .mockResolvedValueOnce(new Response(oversizedBody))
+      .mockResolvedValueOnce(Response.json({ data: [child], meta: { cursor: 'final-page' } }))
+      .mockResolvedValueOnce(Response.json({ data: [grandchild], meta: { cursor: null } }));
+    const onRetry = vi.fn();
+    const reader = new LangfuseObservationsReader(clientOptions, { fetch, onRetry });
+
+    await expect(reader.readTrace({ traceId: 'trace-1', projectId: 'project-1' })).resolves.toEqual({
+      traceId: 'trace-1',
+      observations: [root, child, grandchild],
+    });
+
+    const urls = fetch.mock.calls.map(([input]) => new URL(String(input)));
+    expect(urls.map(url => url.searchParams.get('limit'))).toEqual(['1000', '1000', '500', '500']);
+    expect(urls.map(url => url.searchParams.get('cursor'))).toEqual([null, 'next-page', 'next-page', 'final-page']);
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('fails when one observation exceeds the response limit', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockImplementation(async () => {
+      return new Response(null, { headers: { 'Content-Length': String(5 * 1024 * 1024 + 1) } });
+    });
+    const reader = new LangfuseObservationsReader(clientOptions, { fetch });
+
+    await expect(reader.readTrace({ traceId: 'trace-1', projectId: 'project-1' })).rejects.toThrow('response exceeds');
+
+    const limits = fetch.mock.calls.map(([input]) => new URL(String(input)).searchParams.get('limit'));
+    expect(limits).toEqual(['1000', '500', '250', '125', '62', '31', '15', '7', '3', '1']);
+  });
+
   it.each([
     [
       'discovery',

--- a/packages/cli/src/commands/traces/import/providers/langfuse/reader.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/reader.ts
@@ -1,0 +1,140 @@
+import {
+  LangfuseClient,
+  type LangfuseClientDependencies,
+  type LangfuseClientOptions,
+  type LangfuseObservationQuery,
+} from './client.js';
+import {
+  LANGFUSE_EXPAND_ALL_METADATA,
+  LANGFUSE_OBSERVATION_FIELDS,
+  type LangfuseObservation,
+  type LangfuseProject,
+  type LangfuseSourceTrace,
+  type LangfuseTraceDiscovery,
+} from './types.js';
+
+const PAGE_SIZE = 1000;
+
+export interface LangfuseReadWindow {
+  cutoffAt: string;
+  snapshotAt: string;
+  projectId: string;
+  signal?: AbortSignal;
+}
+
+export interface LangfuseTraceReadOptions {
+  traceId: string;
+  projectId: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Reads raw Langfuse observations. Tree validation and conversion into Mastra
+ * spans belong to the Langfuse adapter implemented by the next ticket.
+ */
+export class LangfuseObservationsReader {
+  private readonly client: LangfuseClient;
+
+  constructor(options: LangfuseClientOptions, dependencies: LangfuseClientDependencies = {}) {
+    this.client = new LangfuseClient(options, dependencies);
+  }
+
+  get baseUrl(): string {
+    return this.client.baseUrl;
+  }
+
+  identify(signal?: AbortSignal): Promise<LangfuseProject> {
+    return this.client.identifyProject(signal);
+  }
+
+  /**
+   * Finds each unique trace with at least one observation starting inside the
+   * selected window. Rows without a trace ID remain visible to the adapter so
+   * it can report them instead of silently dropping them.
+   */
+  async *discoverTraces(window: LangfuseReadWindow): AsyncGenerator<LangfuseTraceDiscovery> {
+    assertWindow(window);
+    const seenTraceIds = new Set<string>();
+
+    for await (const page of this.pages({
+      fields: 'core',
+      limit: PAGE_SIZE,
+      fromStartTime: window.cutoffAt,
+      toStartTime: window.snapshotAt,
+      signal: window.signal,
+    })) {
+      for (const observation of page) {
+        assertProject(observation, window.projectId);
+        if (observation.traceId === null || observation.traceId.trim().length === 0) {
+          yield { kind: 'missing-trace-id', observationId: observation.id };
+        } else if (!seenTraceIds.has(observation.traceId)) {
+          seenTraceIds.add(observation.traceId);
+          yield { kind: 'trace', traceId: observation.traceId };
+        }
+      }
+    }
+  }
+
+  /**
+   * Fetches the complete currently available observation set for one selected
+   * trace. The detail request intentionally has no date filter: a child can
+   * start outside the discovery window and still belong to the selected tree.
+   */
+  async readTrace(options: LangfuseTraceReadOptions): Promise<LangfuseSourceTrace> {
+    if (options.traceId.trim().length === 0) throw new Error('Langfuse trace ID is required.');
+    if (options.projectId.trim().length === 0) throw new Error('Langfuse project ID is required.');
+
+    const observations: LangfuseObservation[] = [];
+    for await (const page of this.pages({
+      fields: LANGFUSE_OBSERVATION_FIELDS,
+      expandMetadata: LANGFUSE_EXPAND_ALL_METADATA,
+      limit: PAGE_SIZE,
+      traceId: options.traceId,
+      signal: options.signal,
+    })) {
+      for (const observation of page) {
+        assertProject(observation, options.projectId);
+        if (observation.traceId !== options.traceId) {
+          throw new Error(`Langfuse returned observation ${observation.id} for a different trace.`);
+        }
+        observations.push(observation);
+      }
+    }
+
+    return { traceId: options.traceId, observations };
+  }
+
+  private async *pages(query: Omit<LangfuseObservationQuery, 'cursor'>): AsyncGenerator<LangfuseObservation[]> {
+    const seenCursors = new Set<string>();
+    let cursor: string | undefined;
+
+    do {
+      query.signal?.throwIfAborted();
+      const page = await this.client.getObservationsPage({ ...query, cursor });
+      yield page.data;
+
+      cursor = page.cursor ?? undefined;
+      if (cursor !== undefined) {
+        if (seenCursors.has(cursor)) {
+          throw new Error('Langfuse returned a repeated pagination cursor.');
+        }
+        seenCursors.add(cursor);
+      }
+    } while (cursor !== undefined);
+  }
+}
+
+function assertWindow(window: LangfuseReadWindow): void {
+  const cutoff = Date.parse(window.cutoffAt);
+  const snapshot = Date.parse(window.snapshotAt);
+  if (!Number.isFinite(cutoff) || !Number.isFinite(snapshot) || cutoff >= snapshot) {
+    throw new Error('Langfuse import window must contain valid timestamps with cutoffAt before snapshotAt.');
+  }
+  if (window.projectId.trim().length === 0) throw new Error('Langfuse project ID is required.');
+}
+
+function assertProject(observation: LangfuseObservation, projectId: string): void {
+  if (observation.projectId !== projectId) {
+    throw new Error(`Langfuse returned observation ${observation.id} from a different project.`);
+  }
+}

--- a/packages/cli/src/commands/traces/import/providers/langfuse/reader.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/reader.ts
@@ -3,11 +3,13 @@ import {
   type LangfuseClientDependencies,
   type LangfuseClientOptions,
   type LangfuseObservationQuery,
+  LangfuseResponseTooLargeError,
 } from './client.js';
 import {
   LANGFUSE_EXPAND_ALL_METADATA,
   LANGFUSE_OBSERVATION_FIELDS,
   type LangfuseObservation,
+  type LangfuseObservationsPage,
   type LangfuseProject,
   type LangfuseSourceTrace,
   type LangfuseTraceDiscovery,
@@ -34,9 +36,11 @@ export interface LangfuseTraceReadOptions {
  */
 export class LangfuseObservationsReader {
   private readonly client: LangfuseClient;
+  private readonly onRetry?: () => void;
 
   constructor(options: LangfuseClientOptions, dependencies: LangfuseClientDependencies = {}) {
     this.client = new LangfuseClient(options, dependencies);
+    this.onRetry = dependencies.onRetry;
   }
 
   get baseUrl(): string {
@@ -106,11 +110,25 @@ export class LangfuseObservationsReader {
 
   private async *pages(query: Omit<LangfuseObservationQuery, 'cursor'>): AsyncGenerator<LangfuseObservation[]> {
     const seenCursors = new Set<string>();
+    let limit = query.limit;
     let cursor: string | undefined;
 
     do {
       query.signal?.throwIfAborted();
-      const page = await this.client.getObservationsPage({ ...query, cursor });
+      let page: LangfuseObservationsPage;
+      while (true) {
+        try {
+          page = await this.client.getObservationsPage({ ...query, cursor, limit });
+          break;
+        } catch (error) {
+          if (!(error instanceof LangfuseResponseTooLargeError) || limit === 1) throw error;
+
+          // The cursor identifies the last returned observation independently
+          // of the requested limit, so the page can safely be retried smaller.
+          limit = Math.max(1, Math.floor(limit / 2));
+          this.onRetry?.();
+        }
+      }
       yield page.data;
 
       cursor = page.cursor ?? undefined;

--- a/packages/cli/src/commands/traces/import/providers/langfuse/types.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/types.ts
@@ -1,0 +1,86 @@
+export const LANGFUSE_OBSERVATION_FIELDS = [
+  'core',
+  'basic',
+  'time',
+  'io',
+  'metadata',
+  'model',
+  'usage',
+  'prompt',
+  'metrics',
+  'trace_context',
+].join(',');
+
+/**
+ * The API accepts a comma-separated list of metadata keys. Langfuse v4 treats
+ * `*` as a request for the non-truncated metadata row, which is required when
+ * the source keys are not known before reading the observation.
+ */
+export const LANGFUSE_EXPAND_ALL_METADATA = '*';
+
+/** Core fields are always present in an Observations API v2 response. */
+export interface LangfuseObservation {
+  id: string;
+  traceId: string | null;
+  startTime: string;
+  endTime: string | null;
+  projectId: string;
+  parentObservationId: string | null;
+  type: string;
+
+  name?: string | null;
+  level?: string | null;
+  statusMessage?: string | null;
+  version?: string | null;
+  environment?: string | null;
+  bookmarked?: boolean | null;
+  public?: boolean | null;
+  userId?: string | null;
+  sessionId?: string | null;
+  isRootObservation?: boolean | null;
+  completionStartTime?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  input?: unknown;
+  output?: unknown;
+  metadata?: unknown;
+  model?: string | null;
+  providedModelName?: string | null;
+  internalModelId?: string | null;
+  modelId?: string | null;
+  modelParameters?: unknown;
+  usageDetails?: Record<string, number> | null;
+  costDetails?: Record<string, number> | null;
+  totalCost?: number | null;
+  usagePricingTierName?: string | null;
+  promptId?: string | null;
+  promptName?: string | null;
+  promptVersion?: string | number | null;
+  latency?: number | null;
+  timeToFirstToken?: number | null;
+  tags?: string[] | null;
+  release?: string | null;
+  traceName?: string | null;
+
+  /** Preserve fields added by a newer Langfuse version for the mapper. */
+  [field: string]: unknown;
+}
+
+export interface LangfuseObservationsPage {
+  data: LangfuseObservation[];
+  cursor: string | null;
+}
+
+export interface LangfuseProject {
+  id: string;
+  name: string | null;
+}
+
+export type LangfuseTraceDiscovery =
+  | { kind: 'trace'; traceId: string }
+  | { kind: 'missing-trace-id'; observationId: string };
+
+export interface LangfuseSourceTrace {
+  traceId: string;
+  observations: LangfuseObservation[];
+}


### PR DESCRIPTION
Implements OBS-311 as a stacked change on #23413. It adds the raw Langfuse Observations API v2 reader for project identification, bounded 30-day trace discovery, cursor pagination, full per-trace observation reads, complete metadata expansion, retries, and API response limits. Mapping to Mastra spans remains in OBS-312.

Verified with the full CLI test suite, CLI lint/typecheck/build, focused reader tests, and a read-only hosted Langfuse run using real credentials. The hosted run discovered 34 traces and fetched all 12 observations for a selected complex trace with matching project and trace IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR lets the CLI import traces and observations from Langfuse. It finds the correct project, reads results safely, and retries requests when needed.

## Summary

- Added a Langfuse Observations API v2 client and reader.
- Added project identification and bounded 30-day trace discovery.
- Added cursor pagination and per-trace observation reads with metadata expansion.
- Added retries for rate limits, network failures, timeouts, and oversized responses.
- Retries oversized pages from the same cursor with smaller page sizes.
- Added response-size limits for buffered and streamed bodies.
- Added safeguards for repeated cursors, invalid identifiers, malformed responses, redirects, and abort signals.
- Added typed Langfuse models, query types, reader options, and error classes.
- Added comprehensive client and reader tests, including oversized-response recovery.
- Added a patch changeset for the new reader.
- Observation-to-Mastra span mapping remains deferred to OBS-312.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->