### PR TITLE
fix(factory): restore messages when reconnecting to a session

### DIFF
--- a/.changeset/plain-jokes-boil.md
+++ b/.changeset/plain-jokes-boil.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent controller snapshots to retain the current run’s input and reply messages so reconnecting clients can restore the conversation before history is saved.

--- a/.changeset/tricky-hotels-cheat.md
+++ b/.changeset/tricky-hotels-cheat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Fixed date hydration for messages restored from agent controller display snapshots.

--- a/client-sdks/client-js/src/resources/agent-controller.test.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.test.ts
@@ -335,6 +335,32 @@ describe('AgentController Resource', () => {
     }
   });
 
+  it('hydrates every message carried by a display snapshot', async () => {
+    const createdAt = '2026-09-09T10:00:00.000Z';
+    const message = { id: 'reply', role: 'assistant', createdAt, content: { format: 2, parts: [] } };
+    mockSse([
+      `data: ${JSON.stringify({
+        type: 'display_state_changed',
+        displayState: { currentMessage: message, messages: [{ message, streaming: true }] },
+      })}\n\n`,
+    ]);
+    const received: KnownAgentControllerEvent[] = [];
+    const subscription = await client
+      .getAgentController('code')
+      .session('user-1')
+      .subscribe({
+        onEvent: event => {
+          if (isKnownAgentControllerEvent(event)) received.push(event);
+        },
+      });
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+    subscription.unsubscribe();
+    const snapshot = received[0];
+    if (snapshot?.type !== 'display_state_changed') throw new Error('Expected display snapshot');
+    expect(snapshot.displayState.currentMessage?.createdAt).toEqual(new Date(createdAt));
+    expect(snapshot.displayState.messages?.[0]?.message.createdAt).toEqual(new Date(createdAt));
+  });
+
   it('hydrates thread timestamps from SSE events', async () => {
     const createdAt = '2026-01-01T00:00:00.000Z';
     const updatedAt = '2026-01-02T03:04:05.000Z';

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentControllerDisplayState,
   AgentControllerThread,
   AgentControllerWireEvent,
   MastraDBMessage,
@@ -81,7 +82,12 @@ type Hydrated<T> = T extends { type: 'thread_created' }
   ? Omit<T, 'thread'> & { thread: AgentControllerThread }
   : T extends { type: 'message_start' | 'message_update' | 'message_end' }
     ? Omit<T, 'message'> & { message: MastraDBMessage }
-    : T;
+    : T extends { type: 'display_state_changed'; displayState: infer DisplayState }
+      ? Omit<T, 'displayState'> & {
+          displayState: Omit<DisplayState, 'currentMessage' | 'messages'> &
+            Pick<AgentControllerDisplayState, 'currentMessage' | 'messages'>;
+        }
+      : T;
 
 /**
  * AgentController events the SDK types explicitly: the wire union `@mastra/core`
@@ -196,6 +202,15 @@ function hydrateKnownEvent(event: AgentControllerWireEvent | NotificationEvent):
       return { ...event, message: hydrateMessage(event.message) };
     case 'thread_created':
       return { ...event, thread: hydrateThread(event.thread) };
+    case 'display_state_changed':
+      return {
+        ...event,
+        displayState: {
+          ...event.displayState,
+          currentMessage: event.displayState.currentMessage ? hydrateMessage(event.displayState.currentMessage) : null,
+          messages: event.displayState.messages?.map(entry => ({ ...entry, message: hydrateMessage(entry.message) })),
+        },
+      };
     default:
       return event;
   }

--- a/docs/src/content/en/reference/agent-controller/session.mdx
+++ b/docs/src/content/en/reference/agent-controller/session.mdx
@@ -783,6 +783,8 @@ Return the current `AgentControllerDisplayState` snapshot for UI rendering.
 const displayState = session.displayState.get()
 ```
 
+`displayState.messages` contains the current run's messages in order, including input signals that haven't been saved to history yet. Each entry contains `message` and `streaming`. Entries remain available after the run finishes and reset when a new run starts or the thread changes. Use them with persisted history when restoring a conversation after reconnecting.
+
 ### `session.displayState.restoreTasks(tasks)`
 
 Restore the task portion of the snapshot after a UI replays persisted task tool history. This is a pure update of the snapshot and doesn't emit an event, so re-render explicitly after calling it.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptMessagesLateJoin.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptMessagesLateJoin.msw.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import type { KnownAgentControllerEvent, MastraDBMessage } from '@mastra/client-js';
+import { defaultDisplayState } from '@mastra/core/agent-controller';
+import { screen, waitFor } from '@testing-library/react';
+import { expect, it } from 'vitest';
+
+import { releaseSession, renderThread, stubPreparingSession } from './composer-session-test-fixture';
+
+it('restores the prompt and reply from the session snapshot before any new tool result', async () => {
+  const session = stubPreparingSession({ materialized: true, autoAgentEnd: false });
+  const { client } = renderThread();
+  await releaseSession(session.finishWorkspace, client);
+  const prompt: MastraDBMessage = {
+    id: 'prompt',
+    role: 'signal',
+    createdAt: new Date(),
+    content: {
+      format: 2,
+      parts: [{ type: 'data-user-message', data: { id: 'prompt', type: 'user', contents: 'Review this PR' } }],
+      metadata: { signal: { id: 'prompt', type: 'user' } },
+    },
+  };
+  const reply: MastraDBMessage = {
+    id: 'reply',
+    role: 'assistant',
+    createdAt: new Date(),
+    content: { format: 2, parts: [{ type: 'text', text: 'Checking out the PR.' }] },
+  };
+  const snapshot: Extract<KnownAgentControllerEvent, { type: 'display_state_changed' }> = {
+    type: 'display_state_changed',
+    displayState: {
+      ...defaultDisplayState(),
+      isRunning: true,
+      currentMessage: reply,
+      messages: [
+        { message: prompt, streaming: false },
+        { message: reply, streaming: true },
+      ],
+      activeTools: { checkout: { name: 'execute_command', args: { command: 'sleep 30' }, status: 'running' } },
+      toolInputBuffers: {},
+      pendingSuspensions: {},
+      activeSubagents: {},
+      modifiedFiles: {},
+    },
+  };
+  await session.emit(snapshot);
+  expect(await screen.findByText('Review this PR')).toBeVisible();
+  const replyText = (_: string, element: Element | null) =>
+    element?.tagName === 'P' && element.textContent === 'Checking out the PR.';
+  expect(await screen.findByText(replyText, {}, { timeout: 5000 })).toBeVisible();
+  expect(await screen.findByRole('group', { name: 'Tool: execute_command' })).toHaveAttribute('aria-busy', 'true');
+  await session.emit(snapshot);
+  expect(screen.getAllByText('Review this PR')).toHaveLength(1);
+  expect(screen.getAllByText(replyText)).toHaveLength(1);
+  await session.emit({
+    ...snapshot,
+    displayState: {
+      ...snapshot.displayState,
+      isRunning: false,
+      messages: [
+        { message: prompt, streaming: false },
+        { message: reply, streaming: false },
+      ],
+      activeTools: {
+        checkout: { name: 'execute_command', args: { command: 'sleep 30' }, status: 'completed', result: 'done' },
+      },
+    },
+  });
+  await waitFor(() => expect(screen.getAllByRole('button', { name: 'Copy message' })).toHaveLength(2));
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript-message-snapshot.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript-message-snapshot.test.ts
@@ -1,0 +1,142 @@
+import type { KnownAgentControllerEvent, MastraDBMessage } from '@mastra/client-js';
+import { defaultDisplayState } from '@mastra/core/agent-controller';
+import { expect, it } from 'vitest';
+
+import { createInitialTranscript, transcriptReducer } from '../transcript';
+
+type Snapshot = Extract<KnownAgentControllerEvent, { type: 'display_state_changed' }>;
+
+const prompt: MastraDBMessage = {
+  id: 'prompt',
+  role: 'signal',
+  createdAt: new Date(),
+  content: {
+    format: 2,
+    parts: [{ type: 'data-user-message', data: { id: 'prompt', type: 'user', contents: 'Review this PR' } }],
+    metadata: { signal: { id: 'prompt', type: 'user' } },
+  },
+};
+const reply: MastraDBMessage = {
+  id: 'reply',
+  role: 'assistant',
+  createdAt: new Date(),
+  content: { format: 2, parts: [{ type: 'text', text: 'Checking out the PR.' }] },
+};
+
+function snapshot(overrides: Partial<Snapshot['displayState']> = {}): Snapshot {
+  return {
+    type: 'display_state_changed',
+    displayState: {
+      ...defaultDisplayState(),
+      isRunning: true,
+      currentMessage: reply,
+      messages: [
+        { message: prompt, streaming: false },
+        { message: reply, streaming: true },
+      ],
+      activeTools: {},
+      toolInputBuffers: {},
+      pendingSuspensions: {},
+      activeSubagents: {},
+      modifiedFiles: {},
+      ...overrides,
+    },
+  };
+}
+
+it('restores the prompt before an already visible reply and deduplicates repeated snapshots and history', () => {
+  let state = createInitialTranscript({ messages: [reply] });
+  state = transcriptReducer(state, { type: 'event', event: snapshot() });
+  state = transcriptReducer(state, { type: 'event', event: snapshot() });
+  state = transcriptReducer(state, { type: 'mergeWindow', messages: [prompt, reply] });
+  expect(state.entries).toMatchObject([
+    { kind: 'message', message: { role: 'user', content: { parts: [{ type: 'text', text: 'Review this PR' }] } } },
+    { kind: 'message', message: { id: 'reply' } },
+  ]);
+});
+
+it.each(['', 'Checking out'])('fills a known reply whose text was %j without waiting for another live event', text => {
+  const partial: MastraDBMessage = { ...reply, content: { format: 2, parts: [{ type: 'text', text }] } };
+  const state = transcriptReducer(createInitialTranscript({ messages: [partial] }), {
+    type: 'event',
+    event: snapshot(),
+  });
+  expect(state.entries).toContainEqual(
+    expect.objectContaining({
+      message: expect.objectContaining({ content: reply.content }),
+    }),
+  );
+});
+
+it('preserves newer live text when an older snapshot arrives', () => {
+  const newer: MastraDBMessage = {
+    ...reply,
+    content: { format: 2, parts: [{ type: 'text', text: 'Checking out the PR. Done.' }] },
+  };
+  let state = transcriptReducer(createInitialTranscript(), {
+    type: 'event',
+    event: { type: 'message_update', message: newer },
+  });
+  state = transcriptReducer(state, { type: 'event', event: snapshot() });
+  expect(state.entries).toContainEqual(expect.objectContaining({ message: newer, streaming: true }));
+});
+
+it('settles a reply when its completion was missed, including after history reconciliation', () => {
+  let state = transcriptReducer(createInitialTranscript(), {
+    type: 'event',
+    event: { type: 'message_update', message: reply },
+  });
+  state = transcriptReducer(state, { type: 'event', event: snapshot({ isRunning: false }) });
+  state = transcriptReducer(state, { type: 'mergeWindow', messages: [prompt, reply] });
+  expect(state.entries.filter(entry => entry.kind === 'message').every(entry => !entry.streaming)).toBe(true);
+});
+
+it('keeps a finished message settled when another message in the run is still streaming', () => {
+  const nextReply: MastraDBMessage = { ...reply, id: 'next-reply' };
+  const state = transcriptReducer(createInitialTranscript(), {
+    type: 'event',
+    event: snapshot({
+      currentMessage: nextReply,
+      messages: [
+        { message: prompt, streaming: false },
+        { message: reply, streaming: false },
+        { message: nextReply, streaming: true },
+      ],
+    }),
+  });
+  expect(state.entries).toMatchObject([{ streaming: false }, { streaming: false }, { streaming: true }]);
+});
+
+it('reconciles the composer echo with the restored prompt and its later live echo', () => {
+  let state = transcriptReducer(createInitialTranscript(), { type: 'localUser', text: 'Review this PR' });
+  state = transcriptReducer(state, { type: 'event', event: snapshot() });
+  state = transcriptReducer(state, { type: 'event', event: { type: 'message_end', message: prompt } });
+  state = transcriptReducer(state, { type: 'mergeWindow', messages: [prompt, reply] });
+  const userEntries = state.entries.filter(entry => entry.kind === 'message' && entry.message.role === 'user');
+  expect(userEntries).toHaveLength(1);
+  expect(userEntries[0]).toMatchObject({
+    message: { id: 'prompt', content: { parts: [{ type: 'text', text: 'Review this PR' }] } },
+  });
+});
+
+it('accepts snapshots from older servers without the run messages field', () => {
+  const state = transcriptReducer(createInitialTranscript(), {
+    type: 'event',
+    event: snapshot({ messages: undefined, isRunning: false }),
+  });
+  expect(state.entries).toMatchObject([{ message: reply, streaming: false }]);
+});
+
+it('keeps repeated prompts and replies from separate runs as separate messages', () => {
+  const previousPrompt: MastraDBMessage = { ...prompt, id: 'previous-prompt' };
+  const previousReply: MastraDBMessage = { ...reply, id: 'previous-reply' };
+  let state = createInitialTranscript({ messages: [previousPrompt, previousReply] });
+  state = transcriptReducer(state, { type: 'event', event: snapshot() });
+  state = transcriptReducer(state, { type: 'event', event: snapshot() });
+  expect(state.entries.map(entry => entry.kind === 'message' && entry.message.id)).toEqual([
+    'previous-prompt',
+    'previous-reply',
+    'prompt',
+    'reply',
+  ]);
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -1,11 +1,11 @@
-import { stripAnsi } from '@mastra/playground-ui/components/ai/tool-call';
-import type { ToolCallStatus } from '@mastra/playground-ui/components/ai/tool-call';
 import type { AgentControllerEvent, AgentControllerTaskSnapshot } from '@mastra/client-js';
 import { isKnownAgentControllerEvent } from '@mastra/client-js';
 import type { MastraDBMessage, MastraMessagePart, TokenUsage } from '@mastra/core/agent-controller';
+import type { ToolCallStatus } from '@mastra/playground-ui/components/ai/tool-call';
+import { stripAnsi } from '@mastra/playground-ui/components/ai/tool-call';
 
-import type { OMBudgets } from './runtime';
 import { sentByOther } from './message-author';
+import type { OMBudgets } from './runtime';
 
 /**
  * Transcript model + reducer.
@@ -506,7 +506,6 @@ function applyEvent(state: TranscriptState, event: AgentControllerEvent, viewerI
           followUpCount: ds.queuedFollowUps ?? state.followUpCount,
         },
         ds,
-        viewerId,
       );
     }
 
@@ -636,10 +635,13 @@ function persistedSuspensionPrompts(message: MastraDBMessage): SuspensionPrompt[
  * runs both ways: load-more delivers older history, revalidation after a route
  * revisit delivers everything the run produced meanwhile.
  */
-function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]): TranscriptState {
+function mergeServerWindow(
+  state: TranscriptState,
+  messages: MastraDBMessage[],
+  onScreenIndex = claimOnScreenEntries(state.entries, messages),
+): TranscriptState {
   if (messages.length === 0) return state;
 
-  const onScreenIndex = claimOnScreenEntries(state.entries, messages);
   const confirmed = confirmPendingUserMessages(state, onScreenIndex);
   const reconciled = reconcileToolResults(adoptCoveringWindowCopies(confirmed, onScreenIndex), messages);
 
@@ -682,7 +684,7 @@ function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]):
 function claimOnScreenEntries(
   entries: TimelineEntry[],
   messages: MastraDBMessage[],
-  eligible?: (entry: MessageEntry) => boolean,
+  canMatchText?: (entry: MessageEntry) => boolean,
 ): Map<MastraDBMessage, number> {
   const onScreen = entries.map(indexMessageEntry);
   const anchors = new Map<MastraDBMessage, number>();
@@ -696,12 +698,13 @@ function claimOnScreenEntries(
     const textClaim = (index: number) => `${index} ${texts.join('\n')}`;
 
     for (const [index, candidate] of onScreen.entries()) {
-      if (!candidate || (eligible && !eligible(candidate.entry))) continue;
+      if (!candidate) continue;
       const sameMessage =
         candidate.entry.id === message.id ||
         candidate.entry.message.id === message.id ||
         toolCallIds.some(toolCallId => candidate.toolCallIds.has(toolCallId));
-      const alreadyDrawn = redrawsEntry(candidate, displayed, texts, toolCallIds);
+      const alreadyDrawn =
+        (!canMatchText || canMatchText(candidate.entry)) && redrawsEntry(candidate, displayed, texts, toolCallIds);
 
       const claimsIdentity = sameMessage && !claimedEntries.has(index);
       const claimsText = alreadyDrawn && !claimedTexts.has(textClaim(index));
@@ -721,11 +724,15 @@ function isUnconfirmedSteer(entry: MessageEntry): boolean {
   return entry.deliveryStatus === 'pending' || entry.deliveryStatus === 'failed';
 }
 
+function isUnconfirmedUserMessage(entry: MessageEntry): boolean {
+  return isUnconfirmedSteer(entry) || (entry.message.role === 'user' && entry.message.id.startsWith('local-'));
+}
+
 function confirmPendingUserMessages(state: TranscriptState, anchors: Map<MastraDBMessage, number>): TranscriptState {
   const confirmed = new Map<number, MessageEntry>();
   for (const [message, index] of anchors) {
     const current = state.entries[index];
-    if (current?.kind !== 'message' || !isUnconfirmedSteer(current)) continue;
+    if (current?.kind !== 'message' || !isUnconfirmedUserMessage(current)) continue;
     const canonical = toMessageEntry(preserveOptimisticUserContent(message, current.message), {
       streaming: current.streaming,
       runtimeTools: current.runtimeTools,
@@ -901,23 +908,6 @@ function reconcileToolResults(state: TranscriptState, messages: MastraDBMessage[
   return changed ? { ...state, entries } : state;
 }
 
-/**
- * A user signal reaches us in two shapes. The persisted message carries ordinary
- * `text` parts, but the live `data-user-message` event carries the signal payload
- * as a single data part and keeps the text inside `data.contents`. Only the first
- * shape has a part the transcript knows how to draw, so a message that arrived
- * from a channel rendered as an empty row until the thread was refetched.
- *
- * Project the data part onto the persisted shape so both paths render the same
- * row — and so the live row does not visibly change when history catches up.
- *
- * Applied to signals the viewer did not type here (see `sentByOther`). A message
- * sent from the web composer is already on screen as an optimistic local echo
- * under a `local-…` id, while this event carries the signal's own id — two ids
- * mean `upsertMessage` cannot dedupe them, so drawing both yields a duplicate
- * bubble. Leaving composer-origin events unrenderable keeps the local echo the
- * single bubble until history replaces it.
- */
 function withRenderableSignalText(message: MastraDBMessage): MastraDBMessage {
   const parts = message.content.parts ?? [];
   const hasDrawableText = parts.some(part => part.type === 'text' && part.text.trim().length > 0);
@@ -970,8 +960,7 @@ function toMessageEntry(
     signal?.attributes && typeof signal.attributes === 'object' && !Array.isArray(signal.attributes)
       ? (signal.attributes as Record<string, unknown>)
       : undefined;
-  const normalized =
-    isUserSignal && sentByOther(message, options.viewerId) ? withRenderableSignalText(message) : message;
+  const normalized = isUserSignal ? withRenderableSignalText(message) : message;
   const displayMessage = isUserSignal ? { ...normalized, role: 'user' as const } : normalized;
   const steer = options.steer ?? (isUserSignal ? attributes?.delivery === 'while-active' : undefined);
 
@@ -1015,7 +1004,7 @@ function upsertMessage(
   );
   if (message.role === 'assistant' && idx === -1) idx = indexOfSameTurn(entries, message);
   if (message.role === 'signal' && idx === -1 && !sentByOther(message, viewerId)) {
-    idx = claimOnScreenEntries(entries, [message], isUnconfirmedSteer).get(message) ?? -1;
+    idx = claimOnScreenEntries(entries, [message], isUnconfirmedUserMessage).get(message) ?? -1;
   }
   const prev = idx !== -1 ? entries[idx] : undefined;
   const prevEntry = prev?.kind === 'message' ? prev : undefined;
@@ -1257,37 +1246,34 @@ function dropPromptsFor(state: TranscriptState, toolCallId: string): TranscriptS
 
 type DisplayStateSnapshot = Extract<AgentControllerEvent, { type: 'display_state_changed' }>['displayState'];
 
-/**
- * Fold the controller's display state into the transcript. The bus only forwards
- * future events, so this snapshot (sent as the first SSE frame, and again on every
- * live change) is how a late joiner learns about the in-flight tool, the partial
- * assistant text and the prompt the run is parked on.
- *
- * Non-regressive: it may arrive after live events already landed, or after a
- * reconnect. Anything already on screen wins — a `done` tool never goes back to
- * `running`, and a streaming message is never overwritten by an older copy.
- */
-function seedFromDisplayState(
-  state: TranscriptState,
-  ds: DisplayStateSnapshot,
-  viewerId?: string,
-): TranscriptState {
-  let next = state;
-
-  const current = ds.currentMessage;
-  if (current && current.role === 'assistant') {
-    const drawn = next.entries.some(
-      e => e.kind === 'message' && (e.id === current.id || e.message.id === current.id),
-    );
-    if (!drawn) {
-      next = upsertMessage(
-        next,
-        { ...current, createdAt: new Date(current.createdAt) } as MastraDBMessage,
-        true,
-        viewerId,
-      );
-    }
+function restoreSnapshotMessages(state: TranscriptState, ds: DisplayStateSnapshot): TranscriptState {
+  const messages = ds.messages ?? (ds.currentMessage ? [{ message: ds.currentMessage, streaming: ds.isRunning }] : []);
+  const snapshots = messages.map(entry => entry.message);
+  const previousAnchors = claimOnScreenEntries(state.entries, snapshots, isUnconfirmedUserMessage);
+  const reconciled = mergeServerWindow(state, snapshots, previousAnchors);
+  const anchors = claimOnScreenEntries(reconciled.entries, snapshots, isUnconfirmedUserMessage);
+  const streamingByIndex = new Map<number, boolean>();
+  for (const snapshot of messages) {
+    const index = anchors.get(snapshot.message);
+    if (index === undefined) continue;
+    const previousIndex = previousAnchors.get(snapshot.message);
+    const previous = previousIndex === undefined ? undefined : state.entries[previousIndex];
+    const alreadyFinished = previous?.kind === 'message' && previous.streaming === false;
+    streamingByIndex.set(index, ds.isRunning && snapshot.streaming && !alreadyFinished);
   }
+  return {
+    ...reconciled,
+    pending: ds.isRunning && reconciled.pending,
+    entries: reconciled.entries.map((entry, index) => {
+      if (entry.kind !== 'message') return entry;
+      const streaming = ds.isRunning ? (streamingByIndex.get(index) ?? entry.streaming) : false;
+      return streaming === entry.streaming ? entry : { ...entry, streaming };
+    }),
+  };
+}
+
+function seedFromDisplayState(state: TranscriptState, ds: DisplayStateSnapshot): TranscriptState {
+  let next = restoreSnapshotMessages(state, ds);
 
   for (const [toolCallId, tool] of Object.entries(ds.activeTools ?? {})) {
     next = withTool(

--- a/packages/core/src/agent-controller/display-state-messages.test.ts
+++ b/packages/core/src/agent-controller/display-state-messages.test.ts
@@ -1,0 +1,47 @@
+import { expect, it } from 'vitest';
+import type { MastraDBMessage } from '../agent';
+import { createTestSession } from './test-utils';
+
+it('retains the input and each reply fragment in run order without duplicate updates', async () => {
+  const { session } = await createTestSession();
+  const prompt: MastraDBMessage = {
+    id: 'prompt',
+    role: 'signal',
+    createdAt: new Date(),
+    content: { format: 2, parts: [{ type: 'text', text: 'Review this PR' }] },
+  };
+  const reply: MastraDBMessage = {
+    ...prompt,
+    id: 'reply',
+    role: 'assistant',
+    content: { format: 2, parts: [{ type: 'text', text: 'Checking out' }] },
+  };
+  session.emit({ type: 'agent_start' });
+  session.emit({ type: 'message_start', message: prompt });
+  session.emit({ type: 'message_end', message: prompt });
+  session.emit({ type: 'message_start', message: reply });
+  session.emit({ type: 'message_update', message: reply });
+  expect(session.displayState.get().messages).toEqual([
+    { message: prompt, streaming: false },
+    { message: reply, streaming: true },
+  ]);
+  session.emit({ type: 'message_end', message: reply });
+  expect(session.displayState.get().messages?.every(entry => !entry.streaming)).toBe(true);
+  session.emit({ type: 'agent_end', reason: 'complete' });
+  expect(session.displayState.get().messages).toHaveLength(2);
+  session.emit({ type: 'agent_start' });
+  expect(session.displayState.get().messages).toEqual([]);
+});
+
+it('settles interrupted messages and clears them when switching threads', async () => {
+  const { session } = await createTestSession();
+  session.emit({ type: 'agent_start' });
+  session.emit({
+    type: 'message_update',
+    message: { id: 'reply', role: 'assistant', createdAt: new Date(), content: { format: 2, parts: [] } },
+  });
+  session.emit({ type: 'agent_end', reason: 'aborted' });
+  expect(session.displayState.get().messages?.[0]?.streaming).toBe(false);
+  session.displayState.resetThread();
+  expect(session.displayState.get().messages).toEqual([]);
+});

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -2293,6 +2293,7 @@ export class SessionDisplayState {
     ds.pendingSuspensions = new Map();
     ds.activeSubagents = new Map();
     ds.currentMessage = null;
+    ds.messages = [];
     this.deps.clearFollowUps();
     ds.queuedFollowUps = 0;
     ds.modifiedFiles = new Map();
@@ -2318,6 +2319,7 @@ export class SessionDisplayState {
         ds.activeTools = new Map();
         ds.toolInputBuffers = new Map();
         ds.currentMessage = null;
+        ds.messages = [];
         ds.pendingApproval = null;
         // Parked tool suspensions are intentionally NOT cleared here: resuming
         // one parked tool restarts the run (a fresh agent_start) and the other
@@ -2326,6 +2328,7 @@ export class SessionDisplayState {
 
       case 'agent_end':
         ds.isRunning = false;
+        for (const entry of ds.messages ?? []) entry.streaming = false;
         ds.pendingApproval = null;
         // A suspended run keeps its pending tool suspensions alive so the UI can
         // still render the prompts (e.g. `ask_user`, which pauses via the native
@@ -2345,16 +2348,16 @@ export class SessionDisplayState {
 
       // ── Message streaming ──────────────────────────────────────────────
       case 'message_start':
-        ds.currentMessage = event.message;
-        break;
-
       case 'message_update':
+      case 'message_end': {
         ds.currentMessage = event.message;
+        const messages = (ds.messages ??= []);
+        const index = messages.findIndex(entry => entry.message.id === event.message.id);
+        const entry = { message: event.message, streaming: event.type !== 'message_end' };
+        if (index === -1) messages.push(entry);
+        else messages[index] = entry;
         break;
-
-      case 'message_end':
-        ds.currentMessage = event.message;
-        break;
+      }
 
       // ── Tool lifecycle ─────────────────────────────────────────────────
       case 'tool_input_start': {

--- a/packages/core/src/agent-controller/types.ts
+++ b/packages/core/src/agent-controller/types.ts
@@ -640,6 +640,7 @@ export interface AgentControllerDisplayState {
    * mutates as deltas arrive; copy it before retaining a point-in-time value.
    */
   currentMessage: MastraDBMessage | null;
+  messages?: { message: MastraDBMessage; streaming: boolean }[];
 
   // ── Follow-up queue ──────────────────────────────────────────────────
   /** Number of follow-up messages queued locally by the AgentController */
@@ -715,6 +716,7 @@ export function defaultDisplayState(): AgentControllerDisplayState {
   return {
     isRunning: false,
     currentMessage: null,
+    messages: [],
     queuedFollowUps: 0,
     tokenUsage: createEmptyTokenUsage(),
     activeTools: new Map(),

--- a/packages/server/src/server/handlers/agent-controller-subscription.test.ts
+++ b/packages/server/src/server/handlers/agent-controller-subscription.test.ts
@@ -1,0 +1,166 @@
+import { Agent } from '@mastra/core/agent';
+import { AgentController } from '@mastra/core/agent-controller';
+import { Mastra } from '@mastra/core/mastra';
+import { MockMemory } from '@mastra/core/memory';
+import { RequestContext } from '@mastra/core/request-context';
+import { InMemoryStore } from '@mastra/core/storage';
+import { MastraLanguageModelV2Mock } from '@mastra/core/test-utils/llm-mock';
+import { createTool } from '@mastra/core/tools';
+import { Workspace } from '@mastra/core/workspace';
+import { expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { STREAM_AGENT_CONTROLLER_SESSION_ROUTE } from './agent-controller';
+
+it('opens a browser stream during a real tool execution with the prompt and current message, then streams its completion', async () => {
+  const checkout = Promise.withResolvers<void>();
+  const toolStarted = Promise.withResolvers<void>();
+  const storage = new InMemoryStore();
+  let modelCalls = 0;
+  const agent = new Agent({
+    id: 'checkout-agent',
+    name: 'Checkout agent',
+    instructions: 'Check out the pull request.',
+    memory: new MockMemory({ storage }),
+    model: new MastraLanguageModelV2Mock({
+      doStream: async () => ({
+        stream: new ReadableStream({
+          start(stream) {
+            stream.enqueue({ type: 'stream-start', warnings: [] });
+            if (modelCalls++ === 0) {
+              stream.enqueue({ type: 'text-start', id: 'intro' });
+              stream.enqueue({ type: 'text-delta', id: 'intro', delta: 'Checking out the pull request.' });
+              stream.enqueue({ type: 'text-end', id: 'intro' });
+              stream.enqueue({ type: 'tool-call', toolCallId: 'checkout-1', toolName: 'checkout', input: '{}' });
+              stream.enqueue({
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              });
+            } else {
+              stream.enqueue({ type: 'text-start', id: 'done' });
+              stream.enqueue({ type: 'text-delta', id: 'done', delta: 'Checkout complete.' });
+              stream.enqueue({ type: 'text-end', id: 'done' });
+              stream.enqueue({
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              });
+            }
+            stream.close();
+          },
+        }),
+      }),
+    }),
+    tools: {
+      checkout: createTool({
+        id: 'checkout',
+        description: 'Check out the pull request',
+        inputSchema: z.object({}),
+        execute: async () => {
+          toolStarted.resolve();
+          await checkout.promise;
+          return 'Checked out';
+        },
+      }),
+    },
+  });
+  const controller = new AgentController({
+    id: 'code',
+    storage,
+    workspace: new Workspace({ name: 'test-workspace', skills: ['/tmp/test-skills'] }),
+    modes: [{ id: 'build', agent, default: true }],
+    initialState: { yolo: true },
+  });
+  const mastra = new Mastra({ agentControllers: { code: controller }, storage, logger: false });
+  await controller.init();
+  const session = await controller.createSession({ id: 'mid-run', resourceId: 'mid-run', ownerId: 'code' });
+  await mastra.startWorkers();
+  await session.thread.create();
+  const run = session.sendMessage({ content: 'Check out this pull request' });
+  let reader: ReadableStreamDefaultReader<unknown> | undefined;
+  try {
+    await toolStarted.promise;
+    await vi.waitFor(() => expect(session.displayState.get().activeTools.get('checkout-1')?.status).toBe('running'));
+    const stream = await STREAM_AGENT_CONTROLLER_SESSION_ROUTE.handler({
+      mastra,
+      controllerId: 'code',
+      resourceId: 'mid-run',
+      requestContext: new RequestContext(),
+      abortSignal: new AbortController().signal,
+    });
+    expect(stream).toBeInstanceOf(ReadableStream);
+    if (!(stream instanceof ReadableStream)) throw new Error('Expected session stream');
+    reader = stream.getReader();
+    const initial = await reader.read();
+    expect(await session.thread.listActiveMessages()).toEqual([]);
+    expect(initial.value).toMatchObject({
+      type: 'display_state_changed',
+      displayState: {
+        isRunning: true,
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            streaming: false,
+            message: expect.objectContaining({
+              role: 'signal',
+              content: expect.objectContaining({
+                parts: expect.arrayContaining([
+                  expect.objectContaining({
+                    type: 'data-user-message',
+                    data: expect.objectContaining({ contents: 'Check out this pull request' }),
+                  }),
+                ]),
+              }),
+            }),
+          }),
+          expect.objectContaining({ streaming: true, message: expect.objectContaining({ role: 'assistant' }) }),
+        ]),
+        activeTools: { 'checkout-1': { name: 'checkout', status: 'running' } },
+        currentMessage: {
+          role: 'assistant',
+          content: {
+            parts: expect.arrayContaining([
+              {
+                type: 'tool-invocation',
+                toolInvocation: expect.objectContaining({ toolCallId: 'checkout-1', state: 'call' }),
+              },
+            ]),
+          },
+        },
+      },
+    });
+    checkout.resolve();
+    await run;
+    const events: unknown[] = [];
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      events.push(value);
+      if (typeof value === 'object' && value !== null && 'type' in value && value.type === 'agent_end') break;
+    }
+    expect(events).toContainEqual(expect.objectContaining({ type: 'tool_end', toolCallId: 'checkout-1' }));
+    expect(events).toContainEqual(expect.objectContaining({ type: 'message_end' }));
+    expect(initial.value).toMatchObject({
+      displayState: { isRunning: true, activeTools: { 'checkout-1': { status: 'running' } } },
+    });
+    await reader.cancel();
+    const reconnected = await STREAM_AGENT_CONTROLLER_SESSION_ROUTE.handler({
+      mastra,
+      controllerId: 'code',
+      resourceId: 'mid-run',
+      requestContext: new RequestContext(),
+      abortSignal: new AbortController().signal,
+    });
+    if (!(reconnected instanceof ReadableStream)) throw new Error('Expected session stream');
+    reader = reconnected.getReader();
+    expect((await reader.read()).value).toMatchObject({
+      type: 'display_state_changed',
+      displayState: { isRunning: false },
+    });
+  } finally {
+    checkout.resolve();
+    await run;
+    await reader?.cancel();
+    await mastra.shutdown();
+  }
+}, 30_000);


### PR DESCRIPTION
## Description

Stacked on #23423, targeting `sturdy-fog`.

Reopening a Factory thread during checkout can restore the tool while still missing the prompt or part of the reply. This extends the existing display snapshot with the current run's messages and reconciles them with the transcript.

Opening a thread during a run
&nbsp;&nbsp;├─ **was**: the prompt could be missing before history was saved
&nbsp;&nbsp;└─ **now**: the prompt and partial replies appear with the tools

Reconnecting after missing reply events
&nbsp;&nbsp;├─ **was**: an existing reply could stay incomplete or streaming
&nbsp;&nbsp;└─ **now**: text catches up and finished replies settle

The controller retains only the current run's messages, including their completion state, until the next run or thread change. This adds to the existing snapshot payload; it grows with the current run. Factory preserves newer live text and keeps repeated prompts from separate runs distinct.

## Related issue(s)

Follows #23423 and the mid-run message issue discussed in #23267.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

---

> ██████████████████ **tests** `+452` (84% of additions)
> ███ **source** `+74 −68`
> █ **changesets** `+10`
> █ **docs** `+2`
