### PR TITLE
feat(playground): nest agent chat threads under the agent tabs as a Chat tab

### DIFF
--- a/.changeset/agent-chat-tab.md
+++ b/.changeset/agent-chat-tab.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Moved the Studio agent chat page under the agent tabs. Opening a thread at `/agents/:agentId/threads/:threadId` now keeps the Studio sidebar and the agent tab bar visible, with a new **Chat** tab selected, and shows the thread list in a resizable side panel. Rows in the agents table now open a new chat for the agent instead of its overview page.

--- a/.changeset/thread-list-spacing.md
+++ b/.changeset/thread-list-spacing.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added spacing between the "New Chat" button and the thread list in `ThreadList`.

--- a/packages/playground-ui/src/ds/components/ThreadList/thread-list.tsx
+++ b/packages/playground-ui/src/ds/components/ThreadList/thread-list.tsx
@@ -21,7 +21,7 @@ export const ThreadList = ({ children, 'aria-label': ariaLabel = 'Threads', embe
       <nav
         aria-label={ariaLabel}
         className={cn(
-          'h-full overflow-y-auto p-1',
+          'flex h-full flex-col gap-1 overflow-y-auto p-1',
           !embedded && 'rounded-studio-panel border border-border1/50 bg-surface3',
         )}
       >
@@ -40,7 +40,7 @@ export interface ThreadListNewItemProps {
 
 export const ThreadListNewItem = ({ as, href, to, children }: ThreadListNewItemProps) => {
   return (
-    <Button as={as} href={href} to={to} variant="ghost" className="w-full justify-start rounded-xl">
+    <Button as={as} href={href} to={to} variant="ghost" className="w-full justify-start rounded-xl px-3">
       {children}
     </Button>
   );
@@ -55,7 +55,7 @@ export interface ThreadListItemsProps {
 }
 
 export const ThreadListItems = ({ children }: ThreadListItemsProps) => (
-  <ol className="flex flex-col gap-px" data-testid="thread-list">
+  <ol className="flex flex-col gap-1" data-testid="thread-list">
     {children}
   </ol>
 );
@@ -92,7 +92,7 @@ export const ThreadListItem = ({
         onClick={onClick}
         variant="ghost"
         className={cn(
-          'h-auto! min-h-form-md w-full min-w-0 justify-start rounded-xl px-3 py-2 text-left',
+          'w-full min-w-0 justify-start rounded-xl px-3 text-left',
           onDelete && 'pr-9',
           isActive && 'bg-surface4 text-neutral6',
           className,

--- a/packages/playground/e2e/tests/agents/$agentId/browser-stream.spec.ts
+++ b/packages/playground/e2e/tests/agents/$agentId/browser-stream.spec.ts
@@ -45,7 +45,7 @@ test.describe('Browser stream WebSocket gating', () => {
       await page.goto('/agents/weather-agent/chat/1234');
 
       // Wait for the agent page to settle.
-      await expect(page.getByTestId('thread-sidebar-back')).toContainText('Weather Agent');
+      await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');
       await expect(page.locator('a:has-text("New Chat")')).toBeVisible();
 
       // Negative assertion: poll for any browser traffic and fail fast if it appears.
@@ -89,7 +89,7 @@ test.describe('Browser stream WebSocket gating', () => {
 
       await page.goto('/agents/weather-agent/chat/1234');
 
-      await expect(page.getByTestId('thread-sidebar-back')).toContainText('Weather Agent');
+      await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');
 
       // The probe should fire once the agent details resolve and the gate flips on.
       await expect

--- a/packages/playground/e2e/tests/agents/$agentId/page.spec.ts
+++ b/packages/playground/e2e/tests/agents/$agentId/page.spec.ts
@@ -18,10 +18,9 @@ test.describe('Agent detail page', () => {
       await expect(newChatButton).toHaveAttribute('href', /agents\/weather-agent\/threads\/.*/);
       await expect(page.getByTestId('thread-list')).toBeAttached();
 
-      // Back link leads to the agent overview with its settings details
-      const backLink = page.getByRole('link', { name: 'Back to Weather Agent' });
-      await expect(backLink).toHaveAttribute('href', /\/agents\/weather-agent\/overview$/);
-      await backLink.click();
+      // The chat page lives under the agent tabs; Chat is selected and Overview leads to settings details
+      await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');
+      await page.getByRole('tab', { name: 'Overview' }).click();
       await expect(page).toHaveURL(/\/agents\/weather-agent\/overview$/);
       await expect(page.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-selected', 'true');
       await expect(page.getByRole('heading', { name: /^Tools/ })).toBeVisible({ timeout: 10000 });

--- a/packages/playground/e2e/tests/agents/$agentId/page.spec.ts
+++ b/packages/playground/e2e/tests/agents/$agentId/page.spec.ts
@@ -16,7 +16,10 @@ test.describe('Agent detail page', () => {
       const newChatButton = page.locator('a:has-text("New Chat")');
       await expect(newChatButton).toBeVisible();
       await expect(newChatButton).toHaveAttribute('href', /agents\/weather-agent\/threads\/.*/);
-      await expect(page.getByTestId('thread-list')).toBeAttached();
+      // Thread history: either stored threads or the empty state on a fresh database
+      await expect(
+        page.getByTestId('thread-list').or(page.getByText('Your conversations will appear here')),
+      ).toBeAttached();
 
       // The chat page lives under the agent tabs; Chat is selected and Overview leads to settings details
       await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');

--- a/packages/playground/e2e/tests/agents/observability-tabs.spec.ts
+++ b/packages/playground/e2e/tests/agents/observability-tabs.spec.ts
@@ -90,7 +90,7 @@ test.describe('Agent observability tabs', () => {
       await page.goto('/agents/weather-agent/overview');
       await expect(page.getByRole('tab', { name: 'Evaluate' })).toBeVisible();
       await expect(page.getByRole('tab', { name: 'Review' })).toBeVisible();
-      await page.getByRole('tab', { name: 'Traces' }).click();
+      await page.getByRole('tab', { name: 'Agent traces' }).click();
 
       // The traces tab navigates to /agents/:id/traces; the page then enriches the URL
       // with scope filter params, so we assert the path without anchoring on $.
@@ -110,7 +110,7 @@ test.describe('Agent observability tabs', () => {
       await mockSystemPackages(page, false);
 
       await page.goto('/agents/weather-agent/overview');
-      await page.getByRole('tab', { name: 'Traces' }).hover();
+      await page.getByRole('tab', { name: 'Agent traces' }).hover();
 
       await expect(page.getByRole('tooltip').getByText('Add @mastra/observability to enable this tab.')).toBeVisible();
     });

--- a/packages/playground/e2e/tests/agents/observational-memory.spec.ts
+++ b/packages/playground/e2e/tests/agents/observational-memory.spec.ts
@@ -44,7 +44,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
       await page.goto('/agents/om-agent/chat/new');
 
       // Wait for the page to load and OM to initialize
-      await expect(page.getByTestId('thread-sidebar-back')).toContainText('OM Agent');
+      await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');
 
       // Open the live Memory sidebar to see OM status.
       await openMemorySidebar(page);
@@ -69,7 +69,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
       await page.goto('/agents/om-agent/chat/new');
 
       // Wait for page to load
-      await expect(page.getByTestId('thread-sidebar-back')).toContainText('OM Agent');
+      await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');
 
       // Open the live Memory sidebar to see OM status.
       await openMemorySidebar(page);
@@ -107,7 +107,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
       await page.goto('/agents/om-agent/chat/new');
 
       // Wait for page to load
-      await expect(page.getByTestId('thread-sidebar-back')).toContainText('OM Agent');
+      await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');
 
       // ACT: Send a message to trigger the agent
       const chatInput = page.locator('textarea[placeholder*="message"]').first();
@@ -211,7 +211,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
       await page.goto('/agents/om-agent/chat/new');
 
       // Wait for page to load
-      await expect(page.getByTestId('thread-sidebar-back')).toContainText('OM Agent');
+      await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');
 
       const chatInput = page.locator('textarea[placeholder*="message"]').first();
       const threadWrapper = page.locator('[data-testid="thread-wrapper"]');
@@ -238,7 +238,9 @@ test.describe('Observational Memory - Behavior Tests', () => {
       await page.reload();
 
       // Wait for page to reload
-      await expect(page.getByTestId('thread-sidebar-back')).toContainText('OM Agent', { timeout: 10000 });
+      await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true', {
+        timeout: 10000,
+      });
 
       const urlAfterReload = page.url();
       console.log('URL after reload:', urlAfterReload);
@@ -271,7 +273,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
       await page.goto('/agents/om-agent/chat/new');
 
       // Wait for page to load
-      await expect(page.getByTestId('thread-sidebar-back')).toContainText('OM Agent');
+      await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');
 
       const chatInput = page.locator('textarea[placeholder*="message"]').first();
       const threadWrapper = page.locator('[data-testid="thread-wrapper"]');
@@ -309,7 +311,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
       await page.goto('/agents/om-adaptive-agent/chat/new');
 
       // Wait for page to load
-      await expect(page.getByTestId('thread-sidebar-back')).toContainText('OM Adaptive Agent');
+      await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');
 
       // Open the live Memory sidebar to see OM status.
       await openMemorySidebar(page);
@@ -398,7 +400,9 @@ test.describe('Observational Memory - Edge Cases', () => {
       await page.goto('/agents/om-agent/chat/new');
 
       // ASSERT: Page should load without stuck loading states
-      await expect(page.getByTestId('thread-sidebar-back')).toContainText('OM Agent', { timeout: 10000 });
+      await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true', {
+        timeout: 10000,
+      });
 
       // Open the live Memory sidebar to see OM status.
       await openMemorySidebar(page);
@@ -420,7 +424,7 @@ test.describe('Observational Memory - Edge Cases', () => {
 
       // Create first thread
       await page.goto('/agents/om-agent/chat/new');
-      await expect(page.getByTestId('thread-sidebar-back')).toContainText('OM Agent');
+      await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');
 
       const chatInput = page.locator('textarea[placeholder*="message"]').first();
       await chatInput.fill('Message in thread 1');
@@ -432,7 +436,7 @@ test.describe('Observational Memory - Edge Cases', () => {
 
       // ACT: Create second thread
       await page.goto('/agents/om-agent/chat/new');
-      await expect(page.getByTestId('thread-sidebar-back')).toContainText('OM Agent');
+      await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');
 
       // Open the live Memory sidebar to see OM status.
       await openMemorySidebar(page);
@@ -446,7 +450,9 @@ test.describe('Observational Memory - Edge Cases', () => {
       await page.goto(thread1Url);
 
       // First thread should still have its state
-      await expect(page.getByTestId('thread-sidebar-back')).toContainText('OM Agent', { timeout: 10000 });
+      await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true', {
+        timeout: 10000,
+      });
     });
   });
 });

--- a/packages/playground/e2e/tests/agents/page.spec.ts
+++ b/packages/playground/e2e/tests/agents/page.spec.ts
@@ -27,7 +27,7 @@ test.describe('Agents list page', () => {
       const el = page.locator('a:has-text("Weather Agent")');
       await el.click();
 
-      await expect(page).toHaveURL(/\/agents\/weather-agent\/overview/);
+      await expect(page).toHaveURL(/\/agents\/weather-agent\/threads\/new/);
     });
   });
 });

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -308,8 +308,6 @@ export const routes: RouteObject[] = [
     children: [
       { path: '/agents/:agentId/session', element: <AgentSession /> },
       { path: '/agents/:agentId/session/:threadId', element: <AgentSession /> },
-      { path: '/agents/:agentId/threads', loader: agentThreadsIndexLoader },
-      { path: '/agents/:agentId/threads/:threadId', element: <AgentThread /> },
     ],
   },
   {
@@ -432,6 +430,8 @@ export const routes: RouteObject[] = [
           },
           { path: 'chat', loader: legacyAgentChatLoader },
           { path: 'chat/:threadId', loader: legacyAgentChatLoader },
+          { path: 'threads', loader: agentThreadsIndexLoader },
+          { path: 'threads/:threadId', element: <AgentThread /> },
           { path: 'overview', element: <Agent /> },
           { path: 'settings', loader: legacyAgentSettingsLoader },
           ...(isExperimentalFeatures

--- a/packages/playground/src/domains/agents/agent-layout.tsx
+++ b/packages/playground/src/domains/agents/agent-layout.tsx
@@ -4,6 +4,7 @@ import { useParams, useLocation } from 'react-router';
 import { AgentPageTabs } from '@/domains/agents/components/agent-page-tabs';
 import type { AgentPageTab } from '@/domains/agents/components/agent-page-tabs';
 import { AgentTopBarRunOptions } from '@/domains/agents/components/agent-top-bar-controls';
+import { ThreadTracesToggle } from '@/domains/agents/components/thread-traces-toggle';
 import { PlaygroundModelProvider } from '@/domains/agents/context/playground-model-context';
 import { ReviewQueueProvider } from '@/domains/agents/context/review-queue-context';
 import { useAgent } from '@/domains/agents/hooks/use-agent';
@@ -30,17 +31,19 @@ export const AgentLayout = ({ children }: { children: React.ReactNode }) => {
   const defaultModel = agent?.modelId ?? '';
   const requestContextSchema = agent?.requestContextSchema;
 
-  const activeTab: AgentPageTab | 'none' = location.pathname.includes('/editor')
-    ? 'versions'
-    : location.pathname.includes('/evaluate')
-      ? 'evaluate'
-      : location.pathname.includes('/review')
-        ? 'review'
-        : location.pathname.includes('/traces')
-          ? 'traces'
-          : location.pathname.includes('/overview')
-            ? 'overview'
-            : 'none';
+  const activeTab: AgentPageTab | 'none' = location.pathname.includes('/threads')
+    ? 'chat'
+    : location.pathname.includes('/editor')
+      ? 'versions'
+      : location.pathname.includes('/evaluate')
+        ? 'evaluate'
+        : location.pathname.includes('/review')
+          ? 'review'
+          : location.pathname.includes('/traces')
+            ? 'traces'
+            : location.pathname.includes('/overview')
+              ? 'overview'
+              : 'none';
 
   const showTopBarRunOptions =
     (activeTab === 'evaluate' || activeTab === 'review') && (showPlayground || showObservability);
@@ -53,7 +56,11 @@ export const AgentLayout = ({ children }: { children: React.ReactNode }) => {
         showPlayground={showPlayground}
         showObservability={showObservability}
         rightSlot={
-          showTopBarRunOptions ? <AgentTopBarRunOptions requestContextSchema={requestContextSchema} /> : undefined
+          activeTab === 'chat' ? (
+            <ThreadTracesToggle />
+          ) : showTopBarRunOptions ? (
+            <AgentTopBarRunOptions requestContextSchema={requestContextSchema} />
+          ) : undefined
         }
       />
       {children}

--- a/packages/playground/src/domains/agents/components/__tests__/agent-page-tabs.msw.test.tsx
+++ b/packages/playground/src/domains/agents/components/__tests__/agent-page-tabs.msw.test.tsx
@@ -103,12 +103,22 @@ describe('AgentLayout tool tabs', () => {
     renderLayout();
 
     expect(await screen.findByText('Overview')).not.toBeNull();
-    expect(screen.getByText('Traces')).not.toBeNull();
-    expect(screen.queryByText('Chat')).toBeNull();
+    expect(screen.getByText('Agent traces')).not.toBeNull();
+    expect(screen.getByRole('tab', { name: 'Chat' })).not.toBeNull();
 
     // Channels is configuration, not a tool: no tab and no platforms fetch from the tab bar.
     await waitFor(() => expect(screen.queryByText('Channels')).toBeNull());
     expect(onPlatforms).not.toHaveBeenCalled();
+  });
+
+  it('highlights the Chat tab on the thread routes', async () => {
+    server.use(...commonHandlers());
+
+    renderLayout('/agents/agent-1/threads/new');
+
+    const chatTab = await screen.findByRole('tab', { name: 'Chat' });
+    expect(chatTab.getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: 'Overview' }).getAttribute('aria-selected')).toBe('false');
   });
 
   it('lets the tab list keep the full row width on mobile by wrapping the right-slot controls', async () => {

--- a/packages/playground/src/domains/agents/components/agent-list/__tests__/agents-list.keyboard.test.tsx
+++ b/packages/playground/src/domains/agents/components/agent-list/__tests__/agents-list.keyboard.test.tsx
@@ -48,9 +48,9 @@ describe('AgentsList keyboard navigation', () => {
     renderList();
 
     expect(interactiveRows().map(row => row.getAttribute('href'))).toEqual([
-      '/agents/agent-a',
-      '/agents/agent-b',
-      '/agents/agent-c',
+      '/agents/agent-a/threads/new',
+      '/agents/agent-b/threads/new',
+      '/agents/agent-c/threads/new',
     ]);
   });
 });

--- a/packages/playground/src/domains/agents/components/agent-list/agents-list.tsx
+++ b/packages/playground/src/domains/agents/components/agent-list/agents-list.tsx
@@ -65,7 +65,12 @@ export function AgentsList({ agents, isLoading, hasSearch }: AgentsListProps) {
 
         return (
           <EntityList.RowWrapper key={agent.id}>
-            <EntityList.RowLink colEnd={3} to={paths.agentLink(agent.id)} LinkComponent={Link} {...getRowProps(index)}>
+            <EntityList.RowLink
+              colEnd={3}
+              to={paths.agentNewThreadLink(agent.id)}
+              LinkComponent={Link}
+              {...getRowProps(index)}
+            >
               <EntityList.Cell className="text-neutral4 min-w-0 overflow-visible text-left">
                 <span
                   title={agent.name}

--- a/packages/playground/src/domains/agents/components/agent-page-tabs.tsx
+++ b/packages/playground/src/domains/agents/components/agent-page-tabs.tsx
@@ -2,12 +2,13 @@ import { Tab, TabList, Tabs } from '@mastra/playground-ui/components/Tabs';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
-import { ExternalLink, EyeIcon, FlaskConical, ClipboardCheck, GitBranch, LayoutPanelLeft } from 'lucide-react';
+import { TraceIcon } from '@mastra/playground-ui/icons/TraceIcon';
+import { ExternalLink, FlaskConical, ClipboardCheck, GitBranch, LayoutPanelLeft, MessageSquare } from 'lucide-react';
 
 import { useLinkComponent } from '@/lib/framework';
 
 /** Tabs that render a pill in the bar. Routes without a pill pass `'none'`. */
-export type AgentPageTab = 'overview' | 'versions' | 'evaluate' | 'review' | 'traces';
+export type AgentPageTab = 'chat' | 'overview' | 'versions' | 'evaluate' | 'review' | 'traces';
 
 interface AgentPageTabsProps {
   agentId: string;
@@ -108,6 +109,7 @@ export function AgentPageTabs({
   ) : undefined;
 
   const hrefMap: Record<AgentPageTab, string> = {
+    chat: `/agents/${agentId}/threads/new`,
     overview: `/agents/${agentId}/overview`,
     versions: `/agents/${agentId}/editor`,
     evaluate: `/agents/${agentId}/evaluate`,
@@ -131,6 +133,7 @@ export function AgentPageTabs({
         className="min-w-0 flex-1 max-lg:flex-auto"
       >
         <TabList variant="pill-ghost">
+          <AgentTab value="chat" icon={<MessageSquare />} label="Chat" />
           <AgentTab value="overview" icon={<LayoutPanelLeft />} label="Overview" />
           <AgentTab
             value="versions"
@@ -156,8 +159,8 @@ export function AgentPageTabs({
           />
           <AgentTab
             value="traces"
-            icon={<EyeIcon />}
-            label="Traces"
+            icon={<TraceIcon />}
+            label="Agent traces"
             disabled={!showObservability}
             disabledReason={observabilityDisabledReason}
           />

--- a/packages/playground/src/domains/agents/components/agent-view-header.tsx
+++ b/packages/playground/src/domains/agents/components/agent-view-header.tsx
@@ -2,7 +2,7 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { TooltipProvider } from '@mastra/playground-ui/components/Tooltip';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
-import { Check, Link as LinkIcon, MessageSquarePlus, Pencil } from 'lucide-react';
+import { Check, Link as LinkIcon, Pencil } from 'lucide-react';
 
 import { useAgent } from '../hooks/use-agent';
 import { AgentEntityHeader } from './agent-entity-header';
@@ -57,18 +57,6 @@ export function AgentViewHeader({ agentId }: AgentViewHeaderProps) {
           >
             <Icon size="sm">{isShareCopied ? <Check /> : <LinkIcon />}</Icon>
             Share
-          </Button>
-          <Button
-            variant="primary"
-            size="sm"
-            as={FrameworkLink}
-            to={paths.agentNewThreadLink(agentId)}
-            data-testid="agent-view-header-new-chat"
-          >
-            <Icon size="sm">
-              <MessageSquarePlus />
-            </Icon>
-            Open chat
           </Button>
         </div>
       </div>

--- a/packages/playground/src/domains/agents/components/sidebar-panel.tsx
+++ b/packages/playground/src/domains/agents/components/sidebar-panel.tsx
@@ -5,7 +5,7 @@ export function SidebarPanel({ children, className }: { children: ReactNode; cla
   return (
     <div
       className={cn(
-        'bg-surface3 border-t border-r border-border1/50 flex h-full w-full min-h-0 min-w-0 flex-col overflow-hidden',
+        'bg-surface3 border-t border-r border-border1/50 rounded-tr-studio-panel flex h-full w-full min-h-0 min-w-0 flex-col overflow-hidden',
         className,
       )}
     >

--- a/packages/playground/src/domains/agents/components/thread-traces-toggle.tsx
+++ b/packages/playground/src/domains/agents/components/thread-traces-toggle.tsx
@@ -1,0 +1,37 @@
+import { Switch } from '@mastra/playground-ui/components/Switch';
+import { useParams, useSearchParams } from 'react-router';
+
+/**
+ * "Show traces" switch for the Chat tab. State lives in the URL (`?variant=advanced`)
+ * so it can be rendered from the tab bar without sharing state with the thread page.
+ */
+export const ThreadTracesToggle = () => {
+  const { threadId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // "new" is not a stored thread yet, so there is nothing to trace.
+  if (!threadId || threadId === 'new') return null;
+
+  const isAdvancedVariant = searchParams.get('variant') === 'advanced';
+  const setAdvancedVariant = (enabled: boolean) => {
+    setSearchParams(
+      params => {
+        const next = new URLSearchParams(params);
+        if (enabled) next.set('variant', 'advanced');
+        else next.delete('variant');
+        return next;
+      },
+      // Toggling the view is not a navigation: don't stack history entries.
+      { replace: true },
+    );
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <Switch id="thread-advanced-view" checked={isAdvancedVariant} onCheckedChange={setAdvancedVariant} />
+      <label htmlFor="thread-advanced-view" className="text-ui-sm text-neutral4">
+        Show thread traces
+      </label>
+    </div>
+  );
+};

--- a/packages/playground/src/domains/traces/components/__tests__/thread-view-by-trace.msw.test.tsx
+++ b/packages/playground/src/domains/traces/components/__tests__/thread-view-by-trace.msw.test.tsx
@@ -150,6 +150,21 @@ describe('ThreadViewByTrace', () => {
     expect(rows).toEqual(['trace-a', 'trace-b']);
   });
 
+  it('rounds the top of the timeline column on the first trace only', async () => {
+    installHandlers();
+    const { queryClient } = renderView();
+
+    expect(await screen.findByText('Chef agent follow-up')).not.toBeNull();
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+
+    const [first, second] = screen.getAllByTestId('trace-row-timeline').map(el => el.parentElement!);
+    expect(first.className).toContain('rounded-tl-xl');
+    expect(first.className).toContain('border-t');
+    expect(first.className).not.toContain('rounded-bl-xl');
+    expect(second.className).not.toContain('rounded-tl-xl');
+    expect(second.className).toContain('rounded-bl-xl');
+  });
+
   it('shows an empty state when the thread has no traces', async () => {
     installHandlers({ list: emptyThreadTracesList });
     renderView();
@@ -246,15 +261,6 @@ describe('ThreadViewByTrace', () => {
       expect(screen.queryByRole('button', { name: 'Show less' })).toBeNull();
       vi.unstubAllGlobals();
     });
-  });
-
-  it('links each turn to its trace on the traces page', async () => {
-    installHandlers();
-    const { queryClient } = renderView();
-
-    const [link] = await screen.findAllByRole('link', { name: 'Go to trace' });
-    expect(link.getAttribute('href')).toBe('/traces?traceId=trace-a');
-    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
   });
 
   it('keeps the row of the selected span highlighted while its details are open', async () => {

--- a/packages/playground/src/domains/traces/components/thread-view-by-trace.tsx
+++ b/packages/playground/src/domains/traces/components/thread-view-by-trace.tsx
@@ -12,11 +12,10 @@ import { useTraceSpanNavigation } from '@mastra/playground-ui/domains/traces/hoo
 import { useTraceSpans } from '@mastra/playground-ui/domains/traces/hooks/use-trace-spans';
 import { useTraces } from '@mastra/playground-ui/domains/traces/hooks/use-traces';
 import { useMeasuredAutoHeight } from '@mastra/playground-ui/hooks/use-measured-auto-height';
-import { TraceIcon } from '@mastra/playground-ui/icons/TraceIcon';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { MessageSquare } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { Link, useSearchParams } from 'react-router';
+import { useSearchParams } from 'react-router';
 
 import { TraceFeedbackTab } from '@/domains/traces/components/trace-feedback-tab';
 import { TraceThreadItemView } from '@/domains/traces/components/trace-thread-item-view';
@@ -152,7 +151,7 @@ function LoadedThreadViewByTrace({ traces, setEndOfListElement }: LoadedThreadVi
       )}
     >
       <div ref={listRef} className="min-h-0 overflow-y-auto" data-testid="thread-view-by-trace">
-        <div className="relative min-h-full">
+        <div className="relative min-h-full py-4">
           {/* Same rail as the chat page: one stop per turn, pinned mid-height while the page scrolls. */}
           <div className="pointer-events-none absolute inset-y-0 left-4 z-20">
             <ThreadRail
@@ -166,10 +165,12 @@ function LoadedThreadViewByTrace({ traces, setEndOfListElement }: LoadedThreadVi
           {/* Pages load older traces, and the list reads oldest-first, so the sentinel sits at the top.
               Scroll anchoring keeps the viewport in place when a page is prepended. */}
           <div ref={setEndOfListElement} />
-          {traces.map(trace => (
+          {traces.map((trace, index) => (
             <TraceThreadRow
               key={trace.traceId}
               traceId={trace.traceId}
+              isFirst={index === 0}
+              isLast={index === traces.length - 1}
               selectedSpanId={selected?.traceId === trace.traceId ? selected.spanId : undefined}
               featuredSpanIds={highlight?.traceId === trace.traceId ? highlight.spanIds : undefined}
               isCurrent={currentTraceId === trace.traceId}
@@ -201,6 +202,10 @@ interface TraceThreadRowProps {
   featuredSpanIds?: string[];
   isCurrent: boolean;
   isExpanded: boolean;
+  /** The oldest trace; its timeline column gets the rounded top edge of the list. */
+  isFirst: boolean;
+  /** The newest trace; its timeline column gets the rounded bottom edge. Can be the same row as `isFirst`. */
+  isLast: boolean;
   /** The row the reader came from via "View full thread"; scrolled into view once it mounts. */
   isAnchor: boolean;
   onExpandedChange: (expanded: boolean) => void;
@@ -219,6 +224,8 @@ function TraceThreadRow({
   featuredSpanIds,
   isCurrent,
   isExpanded,
+  isFirst,
+  isLast,
   isAnchor,
   onExpandedChange,
   onSpanSelect,
@@ -255,9 +262,9 @@ function TraceThreadRow({
       data-active={isActive || undefined}
       ref={isAnchor ? scrollIntoViewOnMount : undefined}
     >
-      {/* The messages column has no bottom border so consecutive turns read as one
-          continuous conversation; the vertical border separates it from the trace. */}
-      <div className="border-border1 relative min-h-[240px] min-w-0 border-r pr-4">
+      {/* The messages column has no borders so consecutive turns read as one continuous
+          conversation; the timeline column carries the divider and the bottom border. */}
+      <div className="relative min-h-[240px] min-w-0 pr-4">
         {/* Sticky within the row, so a long trace on the right never scrolls its messages away. */}
         <div ref={messages.ref} className="sticky top-0 flex flex-col gap-2 py-4" data-testid="trace-row-messages">
           <div
@@ -275,16 +282,6 @@ function TraceThreadRow({
             >
               <MessageSquare />
             </Button>
-            <Button
-              as={Link}
-              to={`/traces?traceId=${encodeURIComponent(traceId)}`}
-              variant="ghost"
-              size="icon-sm"
-              tooltip="Go to trace"
-              aria-label="Go to trace"
-            >
-              <TraceIcon />
-            </Button>
           </div>
           <div className="min-h-0">
             <TraceThreadItemView traceId={traceId} onHighlightSpans={onHighlightSpans} />
@@ -296,7 +293,13 @@ function TraceThreadRow({
           )}
         </div>
       </div>
-      <div className="border-border1 min-w-0 border-b">
+      <div
+        className={cn(
+          'border-border1 min-w-0 overflow-hidden border-b border-l',
+          isFirst && 'rounded-tl-xl border-t',
+          isLast && 'rounded-bl-xl',
+        )}
+      >
         <div
           className="relative overflow-hidden"
           style={isClamped ? { maxHeight: messages.height ?? undefined } : undefined}

--- a/packages/playground/src/pages/agents/__tests__/index.msw.test.tsx
+++ b/packages/playground/src/pages/agents/__tests__/index.msw.test.tsx
@@ -114,6 +114,16 @@ describe('Agents page', () => {
       expect(await screen.findByText('Find reliable sources and summarize the evidence.')).not.toBeNull();
     });
 
+    it('links each table row to a new chat thread for the agent', async () => {
+      useAgentsResponse();
+      renderPage();
+
+      fireEvent.click(await screen.findByRole('button', { name: 'List view' }));
+
+      const row = await screen.findByRole('link', { name: /Research Agent/ });
+      expect(row.getAttribute('href')).toBe(paths.agentNewThreadLink('researcher'));
+    });
+
     it('shows model details when the provider is hovered', async () => {
       useAgentsResponse();
       renderPage();

--- a/packages/playground/src/pages/agents/agent/__tests__/overview-page.msw.test.tsx
+++ b/packages/playground/src/pages/agents/agent/__tests__/overview-page.msw.test.tsx
@@ -171,31 +171,25 @@ describe('Agent overview page', () => {
       expect(screen.queryByText('Failed to load agent')).toBeNull();
     });
 
-    it('shows the Overview tab first and active', async () => {
+    it('shows the Chat tab first and the Overview tab active', async () => {
       installHandlers();
       renderAt(`/agents/${AGENT_ID}/overview`);
 
       const tabs = await screen.findAllByRole('tab');
-      expect(tabs[0].textContent).toContain('Overview');
-      await waitFor(() => expect(tabs[0].getAttribute('aria-selected')).toBe('true'));
+      expect(tabs[0].textContent).toContain('Chat');
+      const overviewTab = screen.getByRole('tab', { name: 'Overview' });
+      await waitFor(() => expect(overviewTab.getAttribute('aria-selected')).toBe('true'));
+      expect(tabs[0].getAttribute('aria-selected')).toBe('false');
     });
 
-    it('does not render a Chat tab', async () => {
+    it('opens a new chat from the Chat tab', async () => {
       installHandlers();
       renderAt(`/agents/${AGENT_ID}/overview`);
 
-      await screen.findAllByRole('tab');
-      expect(screen.queryByRole('tab', { name: 'Chat' })).toBeNull();
-    });
+      const chatTab = await screen.findByRole('tab', { name: 'Chat' });
+      expect(screen.queryByText('Open chat')).toBeNull();
 
-    it('opens a new chat from the button next to the agent header', async () => {
-      installHandlers();
-      renderAt(`/agents/${AGENT_ID}/overview`);
-
-      const newChatButton = await screen.findByTestId('agent-view-header-new-chat');
-      expect(newChatButton.getAttribute('href')).toBe(`/agents/${AGENT_ID}/threads/new`);
-
-      fireEvent.click(newChatButton);
+      fireEvent.click(chatTab);
 
       await waitFor(() =>
         expect(screen.getByTestId('location-probe').textContent).toBe(`/agents/${AGENT_ID}/threads/new`),

--- a/packages/playground/src/pages/agents/agent/__tests__/thread-page.msw.test.tsx
+++ b/packages/playground/src/pages/agents/agent/__tests__/thread-page.msw.test.tsx
@@ -3,10 +3,11 @@ import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
-import { createMemoryRouter, RouterProvider, useLocation } from 'react-router';
+import { createMemoryRouter, Outlet, RouterProvider, useLocation } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import AgentThread from '../thread';
+import { AgentLayout } from '@/domains/agents/agent-layout';
 import {
   emptyThreadTracesList,
   threadTracesList,
@@ -31,19 +32,25 @@ const buildRouter = (initialEntry: string) =>
   createMemoryRouter(
     [
       {
+        // Mirrors App.tsx: the thread page is a child of the agent tabs layout.
+        path: '/agents/:agentId',
         element: (
           <>
             <LocationProbe />
-            <AgentThread />
+            <AgentLayout>
+              <Outlet />
+            </AgentLayout>
           </>
         ),
-        path: '/agents/:agentId/threads/:threadId',
+        children: [
+          { index: true, loader: agentIndexLoader },
+          { path: 'chat', loader: legacyAgentChatLoader },
+          { path: 'chat/:threadId', loader: legacyAgentChatLoader },
+          { path: 'threads', loader: agentThreadsIndexLoader },
+          { path: 'threads/:threadId', element: <AgentThread /> },
+          { path: 'overview', element: <div data-testid="overview-page" /> },
+        ],
       },
-      { path: '/agents/:agentId/threads', loader: agentThreadsIndexLoader },
-      { path: '/agents/:agentId', loader: agentIndexLoader },
-      { path: '/agents/:agentId/overview', element: <LocationProbe /> },
-      { path: '/agents/:agentId/chat', loader: legacyAgentChatLoader },
-      { path: '/agents/:agentId/chat/:threadId', loader: legacyAgentChatLoader },
     ],
     { initialEntries: [initialEntry] },
   );
@@ -137,6 +144,7 @@ function installHandlers() {
       HttpResponse.json({ enabled: false, modelPolicy: { active: false } }),
     ),
     http.get(`${BASE_URL}/api/editor/builder/models/available`, () => HttpResponse.json({ providers: [] })),
+    http.get(`${BASE_URL}/api/system/packages`, () => HttpResponse.json({})),
   );
 }
 
@@ -188,24 +196,29 @@ describe('Standalone thread page', () => {
 
       renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);
 
-      expect(await screen.findByTestId('thread-list-skeleton')).not.toBeNull();
-      // The overview-page sidebar skeleton (with its memory card) must not be reused here.
-      expect(screen.queryByTestId('agent-route-sidebar-skeleton')).toBeNull();
+      expect(await screen.findByTestId('agent-route-sidebar-skeleton')).not.toBeNull();
 
       releaseThreads();
       expect(await screen.findByText('Sushi ideas')).not.toBeNull();
-      expect(screen.queryByTestId('thread-list-skeleton')).toBeNull();
+      expect(screen.queryByTestId('agent-route-sidebar-skeleton')).toBeNull();
     });
   });
 
-  it('shows the Mastra logo and a back link to the agent overview in the sidebar', async () => {
+  it('highlights the Chat tab in the agent tab bar', async () => {
     installHandlers();
     renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);
 
     await screen.findByText('Tonight we cook carbonara.');
-    const back = screen.getByTestId('thread-sidebar-back');
-    expect(back.getAttribute('href')).toBe(`/agents/${AGENT_ID}/overview`);
-    expect(back.textContent).toContain('Back to');
+    expect(screen.getByRole('tab', { name: 'Chat' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: 'Overview' }).getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('highlights the Chat tab on /threads/new', async () => {
+    installHandlers();
+    renderAt(`/agents/${AGENT_ID}/threads/new`);
+
+    await screen.findByText('Sushi ideas');
+    expect(screen.getByRole('tab', { name: 'Chat' }).getAttribute('aria-selected')).toBe('true');
   });
 
   it('navigates to another thread when clicked in the list', async () => {
@@ -218,14 +231,6 @@ describe('Standalone thread page', () => {
     await waitFor(() =>
       expect(screen.getByTestId('location-probe').textContent).toBe(`/agents/${AGENT_ID}/threads/thread-2`),
     );
-  });
-
-  it('does not render the agent page tabs (full-screen page)', async () => {
-    installHandlers();
-    renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);
-
-    await screen.findByText('Tonight we cook carbonara.');
-    expect(screen.queryByRole('tab')).toBeNull();
   });
 
   it('redirects /agents/:agentId/threads to /threads/new', async () => {
@@ -274,12 +279,12 @@ describe('Standalone thread page', () => {
     expect(onTracesRequest).not.toHaveBeenCalled();
   });
 
-  it('does not render the "Show traces" switch nor fetch traces on /new', async () => {
+  it('does not render the "Show thread traces" switch nor fetch traces on /new', async () => {
     installHandlers();
     renderAt(`/agents/${AGENT_ID}/threads/new`);
 
-    await screen.findByTestId('thread-sidebar-back');
-    expect(screen.queryByRole('switch', { name: 'Show traces' })).toBeNull();
+    await screen.findByText('Sushi ideas');
+    expect(screen.queryByRole('switch', { name: 'Show thread traces' })).toBeNull();
     expect(screen.queryByRole('button', { name: /traces/i })).toBeNull();
     expect(onTracesRequest).not.toHaveBeenCalled();
   });
@@ -330,7 +335,7 @@ describe('Standalone thread page', () => {
       renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);
       await screen.findByText('Sushi ideas');
 
-      const deleteButtons = screen.getAllByRole('button', { name: 'Delete thread' });
+      const deleteButtons = screen.getAllByRole('button', { name: /delete thread/i });
       expect(deleteButtons).toHaveLength(2);
       fireEvent.click(deleteButtons[1]);
 
@@ -355,7 +360,7 @@ describe('Standalone thread page', () => {
       renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);
       await screen.findByText('Pasta night');
 
-      fireEvent.click(screen.getAllByRole('button', { name: 'Delete thread' })[0]);
+      fireEvent.click(screen.getAllByRole('button', { name: /delete thread/i })[0]);
       fireEvent.click(await screen.findByRole('button', { name: 'Continue' }));
 
       await waitFor(() =>
@@ -380,7 +385,7 @@ describe('Standalone thread page', () => {
       renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);
       await screen.findByText('Sushi ideas');
 
-      expect(screen.queryByRole('button', { name: 'Delete thread' })).toBeNull();
+      expect(screen.queryByRole('button', { name: /delete thread/i })).toBeNull();
     });
   });
 
@@ -413,16 +418,15 @@ describe('Standalone thread page', () => {
 
       expect(await screen.findByText('Sushi ideas')).not.toBeNull();
       expect(screen.queryByTestId('thread-view-by-trace')).toBeNull();
-      expect(screen.queryByRole('switch', { name: 'Show traces' })).toBeNull();
+      expect(screen.queryByRole('switch', { name: 'Show thread traces' })).toBeNull();
     });
 
-    it('is toggled from the "Show traces" switch in the Thread header', async () => {
+    it('is toggled from the "Show thread traces" switch in the tab bar', async () => {
       installHandlers();
       installTraceHandlers();
       renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);
 
-      expect(await screen.findByRole('heading', { name: 'Thread' })).not.toBeNull();
-      const toggle = screen.getByRole('switch', { name: 'Show traces' });
+      const toggle = await screen.findByRole('switch', { name: 'Show thread traces' });
       expect(toggle.getAttribute('aria-checked')).toBe('false');
 
       fireEvent.click(toggle);
@@ -433,7 +437,7 @@ describe('Standalone thread page', () => {
       );
       expect(await screen.findByTestId('thread-view-by-trace')).not.toBeNull();
 
-      fireEvent.click(screen.getByRole('switch', { name: 'Show traces' }));
+      fireEvent.click(screen.getByRole('switch', { name: 'Show thread traces' }));
       await waitFor(() =>
         expect(screen.getByTestId('location-probe').textContent).toBe(`/agents/${AGENT_ID}/threads/${THREAD_ID}`),
       );

--- a/packages/playground/src/pages/agents/agent/thread.tsx
+++ b/packages/playground/src/pages/agents/agent/thread.tsx
@@ -1,22 +1,17 @@
 import { v4 as uuid } from '@lukeed/uuid';
-import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
-import { Button } from '@mastra/playground-ui/components/Button';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
-import { Header, HeaderAction, HeaderTitle } from '@mastra/playground-ui/components/Header';
-import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
-import { MainContentLayout } from '@mastra/playground-ui/components/MainContent';
-import { MainSidebar, MainSidebarProvider, useMainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
-import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
-import { Switch } from '@mastra/playground-ui/components/Switch';
 import { is401UnauthorizedError, is403ForbiddenError, is404NotFoundError } from '@mastra/playground-ui/utils/errors';
-import { ArrowLeft, Plus, X } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
+import { AgentSidebar } from '@/domains/agents/agent-sidebar';
 import { AgentChat } from '@/domains/agents/components/agent-chat';
-import { AgentChatLoadingSkeleton } from '@/domains/agents/components/agent-loading-skeletons';
-import { MemorySidebarBody } from '@/domains/agents/components/memory-sidebar/memory-sidebar';
+import { AgentLayout } from '@/domains/agents/components/agent-layout';
+import {
+  AgentChatLoadingSkeleton,
+  AgentSidebarLoadingSkeleton,
+} from '@/domains/agents/components/agent-loading-skeletons';
 import { ActivatedSkillsProvider } from '@/domains/agents/context/activated-skills-context';
 import { AgentSettingsProvider } from '@/domains/agents/context/agent-context';
 import { ObservationalMemoryProvider } from '@/domains/agents/context/agent-observational-memory-context';
@@ -24,22 +19,16 @@ import { WorkingMemoryProvider } from '@/domains/agents/context/agent-working-me
 import { BrowserSessionProvider } from '@/domains/agents/context/browser-session-provider';
 import { BrowserToolCallsProvider } from '@/domains/agents/context/browser-tool-calls-context';
 import { MemoryTimelineProvider } from '@/domains/agents/context/memory-timeline-context';
-import { PlaygroundModelProvider } from '@/domains/agents/context/playground-model-context';
 import { useAgent } from '@/domains/agents/hooks/use-agent';
 import { buildAgentDefaultSettings } from '@/domains/agents/utils/agent-default-settings';
 import { getAgentSuggestedPrompts } from '@/domains/agents/utils/agent-suggested-prompts';
-import { usePermissions } from '@/domains/auth/hooks/use-permissions';
 import { ThreadInputProvider } from '@/domains/conversation/context/ThreadInputContext';
-import { cleanProviderId } from '@/domains/llm/utils';
-import { useDeleteThread, useMemory, useThreads } from '@/domains/memory/hooks/use-memory';
-import { TracingSettingsProvider } from '@/domains/observability/context/tracing-settings-context';
-import { SchemaRequestContextProvider } from '@/domains/request-context/context/schema-request-context';
+import { useMemory, useThreads } from '@/domains/memory/hooks/use-memory';
 import { ThreadViewByTrace } from '@/domains/traces/components/thread-view-by-trace';
-import { useLinkComponent } from '@/lib/framework';
 
 function AgentThread() {
   const { agentId, threadId } = useParams();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const { data: agent, isLoading: isAgentLoading, error } = useAgent(agentId!);
   const { data: memory } = useMemory(agentId!);
   const navigate = useNavigate();
@@ -73,18 +62,6 @@ function AgentThread() {
   const messageId = searchParams.get('messageId') ?? undefined;
   // A new thread has no traces yet, so the advanced (trace-based) view falls back to the chat.
   const isAdvancedVariant = searchParams.get('variant') === 'advanced' && !isNewThread;
-  const setAdvancedVariant = (enabled: boolean) => {
-    setSearchParams(
-      params => {
-        const next = new URLSearchParams(params);
-        if (enabled) next.set('variant', 'advanced');
-        else next.delete('variant');
-        return next;
-      },
-      // Toggling the view is not a navigation: don't stack history entries.
-      { replace: true },
-    );
-  };
   const suggestedPrompts = getAgentSuggestedPrompts(agent?.metadata);
 
   const defaultSettings = useMemo(() => buildAgentDefaultSettings(agent), [agent]);
@@ -134,266 +111,68 @@ function AgentThread() {
     }
   };
 
-  // This page lives outside AgentLayout, so it must provide the model selection
-  // context itself or the composer model switcher never renders.
-  const defaultProvider = cleanProviderId(agent.provider ?? '');
-  const defaultModel = agent.modelId ?? '';
-
   return (
-    <TracingSettingsProvider entityId={agentId!} entityType="agent">
-      <AgentSettingsProvider agentId={agentId!} defaultSettings={defaultSettings}>
-        <SchemaRequestContextProvider>
-          <PlaygroundModelProvider
-            key={`${agentId}:${defaultProvider}/${defaultModel}`}
-            defaultProvider={defaultProvider}
-            defaultModel={defaultModel}
+    <AgentSettingsProvider agentId={agentId!} defaultSettings={defaultSettings}>
+      <WorkingMemoryProvider agentId={agentId!} threadId={actualThreadId} resourceId={agentId!}>
+        <BrowserToolCallsProvider key={`browser-${agentId}-${actualThreadId}`}>
+          <BrowserSessionProvider
+            key={`session-${agentId}-${actualThreadId}`}
+            agentId={agentId!}
+            threadId={actualThreadId}
+            enabled={Boolean(agent?.hasBrowser ?? agent?.browserTools?.length)}
           >
-            <WorkingMemoryProvider agentId={agentId!} threadId={actualThreadId} resourceId={agentId!}>
-              <BrowserToolCallsProvider key={`browser-${agentId}-${actualThreadId}`}>
-                <BrowserSessionProvider
-                  key={`session-${agentId}-${actualThreadId}`}
-                  agentId={agentId!}
-                  threadId={actualThreadId}
-                  enabled={Boolean(agent?.hasBrowser ?? agent?.browserTools?.length)}
-                >
-                  <ThreadInputProvider>
-                    <ObservationalMemoryProvider>
-                      <MemoryTimelineProvider key={`memory-timeline-${agentId}-${actualThreadId}`}>
-                        <ActivatedSkillsProvider key={`${agentId}-${actualThreadId}`}>
-                          <MainSidebarProvider storageKey="agent-thread">
-                            <div className="bg-surface1 h-full lg:grid lg:grid-cols-[auto_1fr] lg:grid-rows-[1fr]">
-                              <ThreadSidebar
-                                agentId={agentId!}
-                                agentName={agent.name}
-                                threads={sidebarThreads}
-                                threadId={actualThreadId}
-                                isLoading={isThreadsLoading}
-                              />
-                              <div key={actualThreadId} className="relative flex h-full min-h-0 flex-col">
-                                <div className="rounded-studio-frame border-border1 bg-surface2 shadow-main-frame m-1.5 flex min-h-0 flex-1 flex-col overflow-hidden border [--studio-frame-inset:0.5rem] [--studio-frame-radius:1.5rem] lg:m-2 lg:ml-0">
-                                  <Header>
-                                    <MainSidebar.MobileTrigger className="-ml-1" />
-                                    <HeaderTitle>Thread</HeaderTitle>
-                                    {/* "new" is not a stored thread yet, so there is nothing to trace. */}
-                                    {!isNewThread && (
-                                      <HeaderAction>
-                                        <Switch
-                                          id="thread-advanced-view"
-                                          checked={isAdvancedVariant}
-                                          onCheckedChange={setAdvancedVariant}
-                                        />
-                                        <label htmlFor="thread-advanced-view" className="text-ui-sm text-neutral4">
-                                          Show traces
-                                        </label>
-                                      </HeaderAction>
-                                    )}
-                                  </Header>
-                                  <div className="relative grid min-h-0 flex-1">
-                                    {isAdvancedVariant ? (
-                                      <ThreadViewByTrace threadId={actualThreadId} />
-                                    ) : (
-                                      <AgentChat
-                                        agentId={agentId!}
-                                        agentName={agent?.name}
-                                        modelVersion={agent?.modelVersion}
-                                        supportsMemory={agent?.supportsMemory}
-                                        threadId={actualThreadId}
-                                        memory={hasMemory}
-                                        refreshThreadList={handleRefreshThreadList}
-                                        modelList={agent?.modelList}
-                                        messageId={messageId}
-                                        suggestedPrompts={suggestedPrompts}
-                                        isNewThread={isNewThread}
-                                      />
-                                    )}
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </MainSidebarProvider>
-                        </ActivatedSkillsProvider>
-                      </MemoryTimelineProvider>
-                    </ObservationalMemoryProvider>
-                  </ThreadInputProvider>
-                </BrowserSessionProvider>
-              </BrowserToolCallsProvider>
-            </WorkingMemoryProvider>
-          </PlaygroundModelProvider>
-        </SchemaRequestContextProvider>
-      </AgentSettingsProvider>
-    </TracingSettingsProvider>
+            <ThreadInputProvider>
+              <ObservationalMemoryProvider>
+                <MemoryTimelineProvider key={`memory-timeline-${agentId}-${actualThreadId}`}>
+                  <ActivatedSkillsProvider key={`${agentId}-${actualThreadId}`}>
+                    <AgentLayout
+                      agentId={agentId!}
+                      leftSlot={
+                        isThreadsLoading ? (
+                          <AgentSidebarLoadingSkeleton />
+                        ) : (
+                          <AgentSidebar agentId={agentId!} threadId={actualThreadId} threads={sidebarThreads} />
+                        )
+                      }
+                      leftDrawerLabel="Threads"
+                    >
+                      <div key={actualThreadId} className="relative flex h-full min-h-0 flex-col">
+                        <div className="relative grid min-h-0 flex-1">
+                          {isAdvancedVariant ? (
+                            <ThreadViewByTrace threadId={actualThreadId} />
+                          ) : (
+                            <AgentChat
+                              agentId={agentId!}
+                              agentName={agent?.name}
+                              modelVersion={agent?.modelVersion}
+                              supportsMemory={agent?.supportsMemory}
+                              threadId={actualThreadId}
+                              memory={hasMemory}
+                              refreshThreadList={handleRefreshThreadList}
+                              modelList={agent?.modelList}
+                              messageId={messageId}
+                              suggestedPrompts={suggestedPrompts}
+                              isNewThread={isNewThread}
+                            />
+                          )}
+                        </div>
+                      </div>
+                    </AgentLayout>
+                  </ActivatedSkillsProvider>
+                </MemoryTimelineProvider>
+              </ObservationalMemoryProvider>
+            </ThreadInputProvider>
+          </BrowserSessionProvider>
+        </BrowserToolCallsProvider>
+      </WorkingMemoryProvider>
+    </AgentSettingsProvider>
   );
 }
 
 export default AgentThread;
 
-interface ThreadSidebarProps {
-  agentId: string;
-  agentName?: string;
-  threads: Array<{ id: string; title?: string; createdAt: Date }>;
-  threadId: string;
-  isLoading: boolean;
-}
-
-const ThreadSidebar = ({ agentId, agentName, threads, threadId, isLoading }: ThreadSidebarProps) => {
-  const { Link } = useLinkComponent();
-  const { state } = useMainSidebar();
-  const navigate = useNavigate();
-  const { canDelete } = usePermissions();
-  const { mutateAsync: deleteThread } = useDeleteThread();
-  const [deleteId, setDeleteId] = useState<string | null>(null);
-
-  const canDeleteThread = canDelete('memory');
-
-  const handleDelete = async () => {
-    if (!deleteId) return;
-    await deleteThread({ threadId: deleteId, agentId });
-    if (deleteId === threadId) {
-      void navigate(`/agents/${agentId}/threads/new`);
-    }
-    setDeleteId(null);
-  };
-
-  const threadsNav = (
-    <MainSidebar.Nav>
-      <MainSidebar.NavSection>
-        <MainSidebar.NavHeader state={state}>Threads</MainSidebar.NavHeader>
-        {isLoading ? (
-          <ThreadListLoadingSkeleton />
-        ) : (
-          <MainSidebar.NavList data-testid="thread-list">
-            {threads.map(thread => (
-              <MainSidebar.NavLink
-                key={thread.id}
-                LinkComponent={Link}
-                state={state}
-                isActive={thread.id === threadId}
-                link={{ name: threadDisplayName(thread), url: `/agents/${agentId}/threads/${thread.id}` }}
-                className="group/thread-row"
-                action={
-                  canDeleteThread ? (
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      className="shrink-0 opacity-0 transition-opacity group-focus-within/thread-row:opacity-100 group-hover/thread-row:opacity-100"
-                      onClick={() => setDeleteId(thread.id)}
-                      aria-label="Delete thread"
-                    >
-                      <X />
-                    </Button>
-                  ) : undefined
-                }
-              />
-            ))}
-          </MainSidebar.NavList>
-        )}
-      </MainSidebar.NavSection>
-    </MainSidebar.Nav>
-  );
-
-  return (
-    <>
-      <DeleteThreadDialog
-        open={!!deleteId}
-        onOpenChange={() => setDeleteId(null)}
-        onDelete={() => void handleDelete()}
-      />
-      <MainSidebar>
-        <div className="mb-1.5 pt-2.5">
-          <span className="flex h-7 items-center gap-2 pr-2 pl-3">
-            <LogoWithoutText className="h-[1.5rem] w-[1.5rem] shrink-0" />
-            <span className="font-display truncate text-sm font-semibold tracking-tight whitespace-nowrap">
-              Mastra Studio
-            </span>
-          </span>
-        </div>
-
-        <div className="mb-1">
-          <MainSidebar.NavList>
-            <MainSidebar.NavLink state={state} asChild>
-              <Link href={`/agents/${agentId}/overview`} data-testid="thread-sidebar-back">
-                <ArrowLeft />
-                <MainSidebar.NavLabel state={state}>Back to {agentName ?? 'agent'}</MainSidebar.NavLabel>
-              </Link>
-            </MainSidebar.NavLink>
-            <MainSidebar.NavLink state={state} asChild>
-              <Link href={`/agents/${agentId}/threads/new`} data-testid="thread-sidebar-new-chat">
-                <Plus />
-                <MainSidebar.NavLabel state={state}>New Chat</MainSidebar.NavLabel>
-              </Link>
-            </MainSidebar.NavLink>
-          </MainSidebar.NavList>
-        </div>
-
-        {state === 'collapsed' ? (
-          threadsNav
-        ) : (
-          // The memory body wraps the threads nav so the Memory card docks at the
-          // bottom and expands over the thread list (same UX as the old sidebar).
-          <div className="min-h-0 flex-1">
-            <MemorySidebarBody agentId={agentId} threadId={threadId} threadsSlot={threadsNav} />
-          </div>
-        )}
-      </MainSidebar>
-    </>
-  );
-};
-
-const DeleteThreadDialog = ({
-  open,
-  onOpenChange,
-  onDelete,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onDelete: () => void;
-}) => (
-  <AlertDialog open={open} onOpenChange={onOpenChange}>
-    <AlertDialog.Content>
-      <AlertDialog.Header>
-        <AlertDialog.Title>Are you absolutely sure?</AlertDialog.Title>
-        <AlertDialog.Description>
-          This action cannot be undone. This will permanently delete your chat and remove it from our servers.
-        </AlertDialog.Description>
-      </AlertDialog.Header>
-      <AlertDialog.Footer>
-        <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-        <AlertDialog.Action onClick={onDelete}>Continue</AlertDialog.Action>
-      </AlertDialog.Footer>
-    </AlertDialog.Content>
-  </AlertDialog>
-);
-
-/** Compact skeleton matching the thread NavLink rows — the overview sidebar skeleton doesn't fit here. */
-const ThreadListLoadingSkeleton = () => (
-  <div className="flex flex-col gap-px" data-testid="thread-list-skeleton" aria-busy="true">
-    {['w-32', 'w-24', 'w-36', 'w-28'].map(width => (
-      <div key={width} className="flex h-9 items-center px-3">
-        <Skeleton className={`h-3 ${width}`} />
-      </div>
-    ))}
-  </div>
-);
-
-const DEFAULT_THREAD_NAME = /^New Thread \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
-
-function threadDisplayName(thread: { id: string; title?: string; createdAt: Date }): string {
-  if (thread.title && !DEFAULT_THREAD_NAME.test(thread.title)) return thread.title;
-  return new Date(thread.createdAt)
-    .toLocaleString('en-us', {
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
-      hour12: true,
-    })
-    .replace(',', ' at');
-}
-
 const AgentThreadLoadingSkeleton = () => (
-  <MainContentLayout className="grid-rows-[1fr]">
-    <div className="relative grid h-full overflow-y-auto pt-6" data-testid="agent-thread-skeleton" aria-busy="true">
-      <AgentChatLoadingSkeleton />
-    </div>
-  </MainContentLayout>
+  <div className="relative grid h-full overflow-y-auto pt-6" data-testid="agent-thread-skeleton" aria-busy="true">
+    <AgentChatLoadingSkeleton />
+  </div>
 );


### PR DESCRIPTION

<img width="3024" height="1964" alt="CleanShot 2026-09-09 at 19 55 35@2x" src="https://github.com/user-attachments/assets/14697b06-1255-4861-a479-eee5c4acc9bb" />


## Summary

Opening an agent thread in Studio (`/agents/:agentId/threads/:threadId`) previously rendered a standalone full-screen page with its own sidebar, losing the Studio app sidebar and the agent tab bar and duplicating thread-list logic.

This PR moves the thread page under the `/agents/:agentId` route so it renders inside the normal Studio shell with a new **Chat** tab selected. The thread list now lives in the resizable left panel (reusing `AgentLayout` + `AgentSidebar`), with the memory card at the bottom. All URLs are unchanged; legacy `/agents/:id/chat/:threadId` links still redirect.

Additional UI adjustments:
- "Show thread traces" toggle moved to the tab bar (top-right), only shown on stored threads
- Removed the redundant "Open chat" button on the overview header and the "Go to trace" button in the trace view
- Traces tab renamed to "Agent traces" with the sidebar trace icon
- Agents table rows now open a new chat for the agent
- Thread list spacing/heights aligned; trace timeline column gets rounded first/last edges with padding

## Test plan

- [x] `thread-page`, `agent-page-tabs`, `overview-page`, `thread-view-by-trace`, `voice-call*`, `ThreadList` MSW/unit tests pass
- [x] `typecheck` and `lint` clean on touched packages
- [ ] Manual: open an agent → Chat tab → app sidebar + tab bar visible, thread list in left panel, New chat / delete work, traces toggle on stored threads only, mobile Threads drawer, legacy `/chat/:threadId` redirects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Agent chats now open inside the normal agent page. Users keep the sidebar and agent tabs while viewing chat threads, and agent rows open a new chat directly.

## Changes

- Added a Chat tab under each agent.
- Rendered thread pages with the shared `AgentLayout` and `AgentSidebar`.
- Added a resizable thread list with the memory card at the bottom.
- Preserved existing URLs and legacy chat redirects.
- Moved “Show thread traces” to the tab bar for stored threads.
- Renamed “Traces” to “Agent traces.”
- Removed redundant chat and trace navigation buttons.
- Updated agent table rows to open new chats.
- Adjusted thread-list spacing and trace-timeline styling.
- Added and updated unit, MSW, and E2E tests.
- Added changesets for the agent chat tab and thread-list spacing.

Tests, type checking, and linting pass for the touched packages. Manual testing remains pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->