### PR TITLE
fix(memory): preserve provider details in OM failure events

### DIFF
--- a/.changeset/funky-llamas-pull.md
+++ b/.changeset/funky-llamas-pull.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Preserve provider error messages, HTTP status codes, and nested causes in observational memory failure events instead of only displaying generic errors such as Bad Request.

--- a/packages/memory/src/processors/observational-memory/__tests__/error.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/error.test.ts
@@ -75,6 +75,61 @@ describe('formatOmError', () => {
   });
 });
 
+const malformedErrors = [
+  ...['message', 'statusCode', 'responseBody', 'cause', 'error'].map(property => ({
+    name: `throwing ${property} getter`,
+    create: () =>
+      Object.defineProperty({}, property, {
+        get() {
+          throw new Error('getter failed');
+        },
+      }),
+  })),
+  {
+    name: 'throwing Proxy',
+    create: () =>
+      new Proxy(
+        {},
+        {
+          get() {
+            throw new Error('trap failed');
+          },
+        },
+      ),
+  },
+  {
+    name: 'revoked Proxy',
+    create: () => {
+      const { proxy, revoke } = Proxy.revocable({}, {});
+      revoke();
+      return proxy;
+    },
+  },
+];
+
+describe.each(malformedErrors)('$name', ({ create }) => {
+  it('falls back without throwing during formatting', () => {
+    expect(formatOmError(create())).toBe('Unknown error');
+    expect(formatOmError(new Error('Wrapper', { cause: create() }))).toBe('Unknown error');
+  });
+
+  it.each([createBufferingFailedMarker, createObservationFailedMarker])(
+    'still creates a failure marker',
+    createMarker => {
+      const marker = createMarker({
+        cycleId: 'cycle',
+        operationType: 'observation',
+        startedAt: new Date().toISOString(),
+        tokensAttempted: 100,
+        error: create(),
+        recordId: 'record',
+        threadId: 'thread',
+      });
+      expect(JSON.parse(JSON.stringify(marker)).data.error).toBe('Unknown error');
+    },
+  );
+});
+
 describe.each([createBufferingFailedMarker, createObservationFailedMarker])(
   'OM failure marker diagnostics',
   createMarker => {

--- a/packages/memory/src/processors/observational-memory/__tests__/error.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/error.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { formatOmError } from '../error';
+import { createBufferingFailedMarker, createObservationFailedMarker } from '../markers';
+
+const providerError = () =>
+  Object.assign(new Error('Bad Request'), {
+    statusCode: 400,
+    responseBody: JSON.stringify({
+      error: { message: 'Unsupported parameter: temperature', type: 'invalid_request_error' },
+      request: { prompt: 'private conversation', apiKey: 'secret-key' },
+    }),
+    url: 'https://provider.invalid?key=secret-key',
+    requestBodyValues: { prompt: 'private conversation' },
+    responseHeaders: { authorization: 'Bearer secret-key' },
+  });
+
+const diagnostic = 'Bad Request: HTTP 400: Unsupported parameter: temperature';
+
+describe('formatOmError', () => {
+  it('extracts provider diagnostics without serializing request metadata or the entire response', () => {
+    expect(formatOmError(providerError())).toBe(diagnostic);
+  });
+
+  it('preserves nested causes and plain serialized errors', () => {
+    expect(formatOmError(new Error('Observer failed', { cause: providerError() }))).toBe(
+      `Observer failed: ${diagnostic}`,
+    );
+    expect(formatOmError({ message: 'Observer failed', error: providerError() })).toBe(
+      `Observer failed: ${diagnostic}`,
+    );
+  });
+
+  it('handles top-level and string provider error messages', () => {
+    for (const body of [{ message: 'Model unavailable' }, { error: 'Model unavailable' }]) {
+      expect(formatOmError(Object.assign(new Error('Bad Request'), { responseBody: JSON.stringify(body) }))).toBe(
+        'Bad Request: Model unavailable',
+      );
+    }
+  });
+
+  it('does not include malformed, HTML, or unrecognized response bodies', () => {
+    for (const responseBody of [
+      'secret-key',
+      '<html>private proxy response</html>',
+      '{',
+      '{"prompt":"private"}',
+      'null',
+    ]) {
+      expect(formatOmError(Object.assign(new Error('Bad Request'), { responseBody }))).toBe('Bad Request');
+    }
+  });
+
+  it('deduplicates messages and terminates cyclic causes', () => {
+    const error = Object.assign(new Error('Bad Request'), { cause: providerError() });
+    Object.assign(error.cause, { cause: error });
+    expect(formatOmError(error)).toBe(diagnostic);
+  });
+
+  it('bounds the displayed diagnostic', () => {
+    const result = formatOmError(
+      Object.assign(new Error('Bad Request'), { responseBody: JSON.stringify({ message: 'x'.repeat(4000) }) }),
+    );
+    expect(result).toHaveLength(2000);
+    expect(result.endsWith('...')).toBe(true);
+  });
+
+  it.each([new Error('timeout'), 'timeout', { message: 'timeout' }])('preserves ordinary messages', error => {
+    expect(formatOmError(error)).toBe('timeout');
+  });
+
+  it('handles non-error values', () => {
+    expect(formatOmError(null)).toBe('null');
+    expect(formatOmError(undefined)).toBe('Unknown error');
+    expect(formatOmError({})).toBe('Unknown error');
+  });
+});
+
+describe.each([createBufferingFailedMarker, createObservationFailedMarker])(
+  'OM failure marker diagnostics',
+  createMarker => {
+    it.each(['observation', 'reflection'] as const)('preserves %s diagnostics across JSON transport', operationType => {
+      const marker = createMarker({
+        cycleId: 'cycle',
+        operationType,
+        startedAt: new Date().toISOString(),
+        tokensAttempted: 100,
+        error: providerError(),
+        recordId: 'record',
+        threadId: 'thread',
+      });
+      expect(JSON.parse(JSON.stringify(marker)).data.error).toBe(diagnostic);
+    });
+  },
+);

--- a/packages/memory/src/processors/observational-memory/__tests__/error.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/error.test.ts
@@ -110,7 +110,8 @@ const malformedErrors = [
 describe.each(malformedErrors)('$name', ({ create }) => {
   it('falls back without throwing during formatting', () => {
     expect(formatOmError(create())).toBe('Unknown error');
-    expect(formatOmError(new Error('Wrapper', { cause: create() }))).toBe('Unknown error');
+    expect(formatOmError(new Error('Wrapper', { cause: create() }))).toBe('Wrapper');
+    expect(formatOmError(Object.assign(providerError(), { cause: create() }))).toBe(diagnostic);
   });
 
   it.each([createBufferingFailedMarker, createObservationFailedMarker])(

--- a/packages/memory/src/processors/observational-memory/error.ts
+++ b/packages/memory/src/processors/observational-memory/error.ts
@@ -10,7 +10,7 @@ export function formatOmError(error: unknown): string {
     if (typeof value === 'string' && value.trim()) details.add(value.trim().slice(0, 2000));
   };
 
-  function visit(value: unknown, depth: number) {
+  function collectErrorDetails(value: unknown, depth: number) {
     if (depth > 5) return;
     if (!isRecord(value)) {
       if (value !== undefined) add(String(value));
@@ -35,11 +35,11 @@ export function formatOmError(error: unknown): string {
         // A non-JSON body is not safe to include in a persisted marker.
       }
     }
-    if (value.cause !== undefined) visit(value.cause, depth + 1);
-    if (value.error !== undefined) visit(value.error, depth + 1);
+    if (value.cause !== undefined) collectErrorDetails(value.cause, depth + 1);
+    if (value.error !== undefined) collectErrorDetails(value.error, depth + 1);
   }
 
-  visit(error, 0);
+  collectErrorDetails(error, 0);
   const message = [...details].join(': ') || 'Unknown error';
   return message.length > 2000 ? `${message.slice(0, 1997)}...` : message;
 }

--- a/packages/memory/src/processors/observational-memory/error.ts
+++ b/packages/memory/src/processors/observational-memory/error.ts
@@ -1,0 +1,45 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/** Keep provider diagnostics in streamed/persisted markers, not whole API request/response objects. */
+export function formatOmError(error: unknown): string {
+  const details = new Set<string>();
+  const visited = new Set<object>();
+  const add = (value: unknown) => {
+    if (typeof value === 'string' && value.trim()) details.add(value.trim().slice(0, 2000));
+  };
+
+  function visit(value: unknown, depth: number) {
+    if (depth > 5) return;
+    if (!isRecord(value)) {
+      if (value !== undefined) add(String(value));
+      return;
+    }
+    if (visited.has(value)) return;
+    visited.add(value);
+    add(value.message);
+    if (typeof value.statusCode === 'number') add(`HTTP ${value.statusCode}`);
+
+    // Only extract the provider's diagnostic message. Bodies may also contain
+    // echoed prompts, credentials, headers, or HTML from an upstream proxy.
+    if (typeof value.responseBody === 'string') {
+      try {
+        const body: unknown = JSON.parse(value.responseBody);
+        if (isRecord(body)) {
+          add(body.message);
+          if (isRecord(body.error)) add(body.error.message);
+          else add(body.error);
+        }
+      } catch {
+        // A non-JSON body is not safe to include in a persisted marker.
+      }
+    }
+    if (value.cause !== undefined) visit(value.cause, depth + 1);
+    if (value.error !== undefined) visit(value.error, depth + 1);
+  }
+
+  visit(error, 0);
+  const message = [...details].join(': ') || 'Unknown error';
+  return message.length > 2000 ? `${message.slice(0, 1997)}...` : message;
+}

--- a/packages/memory/src/processors/observational-memory/error.ts
+++ b/packages/memory/src/processors/observational-memory/error.ts
@@ -39,7 +39,12 @@ export function formatOmError(error: unknown): string {
     if (value.error !== undefined) collectErrorDetails(value.error, depth + 1);
   }
 
-  collectErrorDetails(error, 0);
+  try {
+    collectErrorDetails(error, 0);
+  } catch {
+    // Malformed thrown values must not prevent the failure marker from being recorded.
+    return 'Unknown error';
+  }
   const message = [...details].join(': ') || 'Unknown error';
   return message.length > 2000 ? `${message.slice(0, 1997)}...` : message;
 }

--- a/packages/memory/src/processors/observational-memory/error.ts
+++ b/packages/memory/src/processors/observational-memory/error.ts
@@ -42,8 +42,7 @@ export function formatOmError(error: unknown): string {
   try {
     collectErrorDetails(error, 0);
   } catch {
-    // Malformed thrown values must not prevent the failure marker from being recorded.
-    return 'Unknown error';
+    // Stop on malformed thrown values, but preserve diagnostics already collected.
   }
   const message = [...details].join(': ') || 'Unknown error';
   return message.length > 2000 ? `${message.slice(0, 1997)}...` : message;

--- a/packages/memory/src/processors/observational-memory/markers.ts
+++ b/packages/memory/src/processors/observational-memory/markers.ts
@@ -1,3 +1,4 @@
+import { formatOmError } from './error';
 import type {
   DataOmActivationPart,
   DataOmBufferingEndPart,
@@ -86,7 +87,7 @@ export function createObservationFailedMarker(params: {
   operationType: 'observation' | 'reflection';
   startedAt: string;
   tokensAttempted: number;
-  error: string;
+  error: unknown;
   recordId: string;
   threadId: string;
 }): DataOmObservationFailedPart {
@@ -101,7 +102,7 @@ export function createObservationFailedMarker(params: {
       failedAt,
       durationMs,
       tokensAttempted: params.tokensAttempted,
-      error: params.error,
+      error: formatOmError(params.error),
       recordId: params.recordId,
       threadId: params.threadId,
     },
@@ -179,7 +180,7 @@ export function createBufferingFailedMarker(params: {
   operationType: OmOperationType;
   startedAt: string;
   tokensAttempted: number;
-  error: string;
+  error: unknown;
   recordId: string;
   threadId: string;
 }): DataOmBufferingFailedPart {
@@ -194,7 +195,7 @@ export function createBufferingFailedMarker(params: {
       failedAt,
       durationMs,
       tokensAttempted: params.tokensAttempted,
-      error: params.error,
+      error: formatOmError(params.error),
       recordId: params.recordId,
       threadId: params.threadId,
     },

--- a/packages/memory/src/processors/observational-memory/observation-strategies/async-buffer.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/async-buffer.ts
@@ -245,7 +245,7 @@ export class AsyncBufferObservationStrategy extends ObservationStrategy {
       operationType: 'observation',
       startedAt: this.startedAt,
       tokensAttempted,
-      error: error instanceof Error ? error.message : String(error),
+      error,
       recordId: record.id,
       threadId,
     });

--- a/packages/memory/src/processors/observational-memory/observation-strategies/base.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/base.ts
@@ -5,6 +5,7 @@ import xxhash from 'xxhash-wasm';
 
 import type { Memory } from '../../..';
 import { omDebug, omError } from '../debug';
+import { formatOmError } from '../error';
 import { getObservableMessages, stripThreadTags } from '../message-utils';
 import { parseObservationGroups, wrapInObservationGroup } from '../observation-groups';
 import type { ObserverRunner } from '../observer-runner';
@@ -137,7 +138,7 @@ export abstract class ObservationStrategy {
             cycleId,
             operationType: 'observation',
             startedAt: new Date().toISOString(),
-            error: error instanceof Error ? error.message : String(error),
+            error: formatOmError(error),
             recordId: record.id,
             threadId,
           },

--- a/packages/memory/src/processors/observational-memory/observation-strategies/resource-scoped.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/resource-scoped.ts
@@ -517,7 +517,7 @@ export class ResourceScopedObservationStrategy extends ObservationStrategy {
           operationType: 'observation',
           startedAt: this.startedAt,
           tokensAttempted,
-          error: error instanceof Error ? error.message : String(error),
+          error,
           recordId: this.opts.record.id,
           threadId,
         });

--- a/packages/memory/src/processors/observational-memory/observation-strategies/sync.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/sync.ts
@@ -277,7 +277,7 @@ export class SyncObservationStrategy extends ObservationStrategy {
         operationType: 'observation',
         startedAt: this.startedAt,
         tokensAttempted: this.tokensToObserve,
-        error: error instanceof Error ? error.message : String(error),
+        error,
         recordId: this.opts.record.id,
         threadId: this.opts.threadId,
       });

--- a/packages/memory/src/processors/observational-memory/reflector-runner.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-runner.ts
@@ -672,7 +672,7 @@ export class ReflectorRunner {
               operationType: 'reflection',
               startedAt: new Date().toISOString(),
               tokensAttempted: observationTokens,
-              error: reflectionError.message,
+              error,
               recordId: record.id,
               threadId: record.threadId ?? '',
             });
@@ -1382,7 +1382,7 @@ export class ReflectorRunner {
           operationType: 'reflection',
           startedAt: streamContext.startedAt,
           tokensAttempted: observationTokens,
-          error: error instanceof Error ? error.message : String(error),
+          error,
           recordId: record.id,
           threadId,
         });


### PR DESCRIPTION
OM failure events currently keep only the top-level error message, which can hide the provider's explanation behind a generic “Bad Request”. This keeps provider diagnostic messages, HTTP status codes, and nested causes in observation and reflection failure events without dumping whole request/response objects. Output is bounded, and retry/abort behavior is unchanged.

For example, before:
```text
Observational memory observation buffering failed: Bad Request
```

After, when the provider includes these details:
```text
Observational memory observation buffering failed: Bad Request: HTTP 400: Unsupported parameter: temperature
```

Verified with 37 focused tests, the memory typecheck, and changed-file ESLint. Includes regression coverage and a patch changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When observational memory fails, it now records useful provider details instead of only saying that an error occurred. The recorded details stay limited and exclude full request and response objects.

## Changes

- Added `formatOmError` to preserve provider messages, HTTP status codes, and nested or serialized causes.
- Preserved diagnostics collected before malformed error properties throw.
- Added cycle detection, depth limits, truncation, and safe response-body handling.
- Added fallback to `"Unknown error"` when no diagnostic details are available.
- Updated observation and reflection failure markers to receive and format original errors.
- Added regression tests for formatting, serialization, truncation, malformed data, accessor failures, and non-error values.
- Added a patch changeset for `@mastra/memory`.
- Verified 37 focused tests, memory typechecking, and ESLint checks for changed files.
- Retry and abort behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->