### PR TITLE
fix(core): report a whole number of lines when tail is fractional

### DIFF
--- a/.changeset/olive-donkeys-cheat.md
+++ b/.changeset/olive-donkeys-cheat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the workspace command tools reporting a line count they did not return. When a model passed a fractional `tail` (for example `2.5`), `execute_command` and `get_process_output` returned a truncation notice reading "showing last 2.5 of 10 lines" while actually returning 2 lines, so the model was told the output was cut at a boundary that does not exist. The notice now always reports the whole number of lines returned, and `tail` is validated as an integer so a fractional value is rejected instead of silently reshaping the output.

--- a/packages/core/src/workspace/tools/execute-command.ts
+++ b/packages/core/src/workspace/tools/execute-command.ts
@@ -21,7 +21,7 @@ export const executeCommandInputSchema = z.object({
     .describe('Maximum execution time in seconds. Example: 60 for 1 minute.'),
   cwd: z.string().nullish().describe('Working directory for the command'),
   tail: z
-    .preprocess(coerceNumericString, z.number())
+    .preprocess(coerceNumericString, z.number().int())
     .nullish()
     .describe(
       `For foreground commands: limit output to the last N lines, similar to tail -n. Defaults to ${DEFAULT_TAIL_LINES}. Use 0 for no limit.`,

--- a/packages/core/src/workspace/tools/get-process-output.ts
+++ b/packages/core/src/workspace/tools/get-process-output.ts
@@ -16,7 +16,7 @@ Use this after starting a background command with execute_command (background: t
   inputSchema: z.object({
     pid: z.string().describe('The process ID returned when the background command was started'),
     tail: z
-      .preprocess(coerceNumericString, z.number())
+      .preprocess(coerceNumericString, z.number().int())
       .optional()
       .describe(
         `Number of lines to return, similar to tail -n. Positive or negative returns last N lines from end. Defaults to ${DEFAULT_TAIL_LINES}. Use 0 for no limit.`,

--- a/packages/core/src/workspace/tools/output-helpers.test.ts
+++ b/packages/core/src/workspace/tools/output-helpers.test.ts
@@ -172,6 +172,18 @@ describe('applyTail', () => {
   it('handles single line within limit', () => {
     expect(applyTail('only one line', 5)).toBe('only one line');
   });
+
+  it('keeps a whole number of lines when tail is fractional', () => {
+    const result = applyTail(makeLines(10), 2.5);
+    expect(result).toContain('[showing last 2 of 10 lines]');
+  });
+
+  it('keeps exactly as many lines as the notice claims when tail is fractional', () => {
+    const result = applyTail(makeLines(10), 2.5);
+    const [notice, ...body] = result.split('\n');
+    const claimed = Number(/last (\S+) of/.exec(notice)![1]);
+    expect(body).toHaveLength(claimed);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/workspace/tools/output-helpers.ts
+++ b/packages/core/src/workspace/tools/output-helpers.ts
@@ -60,7 +60,9 @@ export function sandboxToModelOutput(output: unknown): unknown {
  */
 export function applyTail(output: string, tail: number | null | undefined): string {
   if (!output) return output;
-  const n = Math.abs(tail ?? DEFAULT_TAIL_LINES);
+  // Floor so a fractional `tail` cannot reach the notice: `slice` truncates
+  // toward zero, so `2.5` would keep 2 lines while claiming 2.5.
+  const n = Math.floor(Math.abs(tail ?? DEFAULT_TAIL_LINES));
   if (n === 0) return output; // 0 = no limit
   // Strip trailing newline before splitting so it doesn't count as a line
   const trailingNewline = output.endsWith('\n');


### PR DESCRIPTION
## Description

`applyTail` derived one value with `Math.abs(tail ?? DEFAULT_TAIL_LINES)` and used it for two different things: it passed the value to `Array.prototype.slice`, and it interpolated the same value into the truncation notice. `slice` truncates a fractional count toward zero, but the notice printed the raw value, so the two disagreed whenever `tail` was not an integer. A `tail` of `2.5` over ten lines returned two lines under the header `[showing last 2.5 of 10 lines]`.

The notice is the only signal the model has about what was removed, so it was told the output stopped at a line boundary that cannot exist, and the count it read did not match the body it received.

The value reached the helper unvalidated. `tail` was typed `z.number()` with no integer constraint on both calling tools, and `coerceNumericString` accepts decimal strings by design (`NUMERIC_STRING_REGEX` is `/^-?\d+(?:\.\d+)?$/`), so both the JSON number `2.5` and the string `"2.5"` passed validation and arrived at `applyTail` unchanged.

## What changed

- **`applyTail` floors the line count.** The notice can now only ever report the number of lines actually returned, regardless of what reaches the helper.
- **`tail` is constrained to `z.number().int()`** on `execute_command` and `get_process_output`, so a fractional value is rejected at the schema instead of silently reshaping the output.

Both halves are deliberate. The schema constraint is the root-cause fix and follows the repo convention in `AGENTS.md` that deterministic input constraints belong in schemas rather than `execute`. The floor in `applyTail` keeps the helper correct on its own, since it is exported and called from `truncateOutput` rather than only from those two schemas.

`tail: 0` (no limit) and negative values keep their currently documented meaning; only non-integers change behaviour.

## Related Issue(s)

Fixes #23445

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Test plan

Two tests were added to the existing `applyTail` suite in `packages/core/src/workspace/tools/output-helpers.test.ts`. **Both fail before this change and pass after it.** The second is the meaningful one: it parses the count out of the notice and asserts the body actually contains that many lines, so it asserts the user-visible consequence rather than the implementation.

Before the fix:

```
FAIL src/workspace/tools/output-helpers.test.ts > applyTail > keeps exactly as many lines as the notice claims when tail is fractional
AssertionError: expected [ 'line 9', 'line 10' ] to have a length of 2.5 but got 2

- Expected
+ Received

- 2.5
+ 2
```

After the fix the file passes in full, 41 tests, up from the 39 on `main`:

```
pnpm --filter @mastra/core exec vitest run src/workspace/tools/output-helpers.test.ts
Test Files  1 passed (1)
     Tests  41 passed (41)
```

The schema change was verified separately against the real `coerceNumericString`: `2.5` and `"2.5"` are now rejected, while `5`, `"5"`, `0` and `-3` are still accepted.

## Notes for the reviewer

Two things I could not verify locally, both pre-existing and unrelated to this change. I confirmed each against a clean tree with `git stash`:

- **`src/workspace/tools` has failures in my checkout that also occur on `main`** at the same commit, from unbuilt workspace dependencies and from Windows symlink permissions in `tree-formatter.test.ts` (`EPERM: operation not permitted, symlink`). `output-helpers.test.ts` itself runs clean. I was not able to execute `__tests__/execute-command.test.ts` at all locally, because it pulls a dependency chain my environment could not resolve, which is why the schema change is covered by the isolated check described above rather than through that file. Worth a look in CI.
- **Prettier reports all four touched files as unformatted, and reports them identically on an unmodified `main`.** That is CRLF from a Windows checkout, not this diff. I deliberately left formatting alone rather than reflow whole files and bury a five-line change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The workspace tools now report the correct whole-number line count when they shorten command output. They also reject fractional `tail` values instead of accepting them.

## Changes

- Floors fractional values in `applyTail` before slicing output and creating the truncation notice.
- Requires integer `tail` values in `execute_command` and `get_process_output` schemas.
- Preserves existing behavior for zero and negative `tail` values.
- Adds regression tests for fractional tail handling.
- Adds a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->