### PR TITLE
fix(editor): resolve template variables against own keys only

### DIFF
--- a/.changeset/great-pumas-shave.md
+++ b/.changeset/great-pumas-shave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/editor': patch
+---
+
+Fixed prompt block templates resolving inherited JavaScript properties instead of context data. A placeholder naming a built-in, such as `{{constructor}}` or `{{toString}}`, resolved to the value inherited from `Object.prototype` and interpolated text like `function Object() { [native code] }` into the rendered instructions. Because the inherited member read as defined, any fallback on that placeholder was skipped, so `{{constructor || 'none'}}` rendered the built-in rather than `none`. Template variables now resolve only against the context's own keys, and a placeholder with no matching key is left in place or falls back as documented. A context key that deliberately shadows a built-in name still resolves normally.

--- a/packages/editor/src/template-engine.test.ts
+++ b/packages/editor/src/template-engine.test.ts
@@ -147,4 +147,24 @@ describe('renderTemplate', () => {
       expect(renderTemplate('{{{name}}}', { name: 'Alice' })).toBe('{Alice}');
     });
   });
+
+  describe('inherited properties', () => {
+    it('should leave an inherited member unresolved', () => {
+      expect(renderTemplate('{{constructor}}', { name: 'Alice' })).toBe('{{constructor}}');
+    });
+
+    it('should use the fallback for an inherited member', () => {
+      expect(renderTemplate("{{toString || 'none'}}", { name: 'Alice' })).toBe('none');
+    });
+
+    it('should leave an inherited member unresolved mid-path', () => {
+      expect(renderTemplate('{{user.constructor.name}}', { user: { name: 'Alice' } })).toBe(
+        '{{user.constructor.name}}',
+      );
+    });
+
+    it('should still resolve an own property that shadows a built-in', () => {
+      expect(renderTemplate('{{toString}}', { toString: 'shadowed' })).toBe('shadowed');
+    });
+  });
 });

--- a/packages/editor/src/template-engine.ts
+++ b/packages/editor/src/template-engine.ts
@@ -21,6 +21,12 @@ function resolvePath(context: Record<string, unknown>, path: string): unknown {
     if (current === null || current === undefined || typeof current !== 'object') {
       return undefined;
     }
+    // Only resolve the context's own keys: an inherited member such as
+    // `constructor` or `toString` is not context data, and treating it as
+    // resolved would interpolate a built-in and suppress the fallback.
+    if (!Object.prototype.hasOwnProperty.call(current, segment)) {
+      return undefined;
+    }
     current = (current as Record<string, unknown>)[segment];
   }
 


### PR DESCRIPTION
## Description

`resolvePath` in the prompt block template engine walked each dot-separated segment with a plain property read and no own-key check. A plain object literal inherits from `Object.prototype`, so a placeholder naming an inherited member resolved to that built-in instead of to context data. Rendering `{{constructor}}` against any context interpolated `function Object() { [native code] }` into the agent's instructions; `{{toString}}` and `{{valueOf}}` behaved the same way.

The fallback path made it worse. `renderTemplate` treats any value that is neither `undefined` nor `null` as a successful resolution, and an inherited function is neither, so the `String(resolved)` branch won and the `||` fallback below it was never reached:

```ts
const resolved = resolvePath(context, variablePath);

if (resolved !== undefined && resolved !== null) {
  // ...
  return String(resolved);
}

// Use fallback if provided        <-- unreachable for inherited members
const fallback = singleFallback ?? doubleFallback;
```

So `{{constructor || 'none'}}` rendered the native-code string rather than `none`. An author who wrote that fallback specifically to handle a missing value got a built-in instead, with no error and nothing in the output to indicate the placeholder had been mishandled.

This matters because `renderTemplate` is exported from the package entry point and is what `instruction-builder.ts` uses to build stored-agent instructions, so the injected text lands in the system prompt actually sent to the model. The variable pattern is `[a-zA-Z_][\w.]*`, which reaches every inherited member of `Object.prototype`.

## What changed

`resolvePath` now checks `Object.prototype.hasOwnProperty` on each segment before descending. A segment the context does not own is unresolved, which restores the behaviour documented at the top of the file ("Variables that cannot be resolved (and have no fallback) are left as-is") in both directions: the placeholder is left in place when no fallback is given, and the fallback is used when one is.

The check is per-segment rather than only on the first, so a mid-path inherited member such as `{{user.constructor.name}}` is also unresolved.

`hasOwnProperty` is called via `Object.prototype` rather than on `current` directly, since the context is caller-supplied and may itself define a `hasOwnProperty` key.

## Related Issue(s)

Fixes #23447

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Test plan

Four tests were added to the existing `template-engine.test.ts` suite, in a new `inherited properties` block.

**Two fail before this change and pass after it:**

```
FAIL src/template-engine.test.ts > renderTemplate > inherited properties > should leave an inherited member unresolved
AssertionError: expected 'function Object() { [native code] }' to be '{{constructor}}'

FAIL src/template-engine.test.ts > renderTemplate > inherited properties > should use the fallback for an inherited member
AssertionError: expected 'function toString() { [native code] }' to be 'none'
```

The other two pass both before and after, deliberately. They guard the edges of the fix rather than the bug: one covers a mid-path inherited member, the other asserts that a context key which intentionally shadows a built-in name (`{ toString: 'shadowed' }`) still resolves to its own value, so the fix does not overreach into legitimate data.

After the change the file passes in full, 34 tests, up from the 30 on `main`:

```
pnpm --filter @mastra/editor exec vitest run src/template-engine.test.ts
Test Files  1 passed (1)
     Tests  34 passed (34)
```

## Notes for the reviewer

`src/instruction-builder.test.ts`, the nearest consumer of this function, does not run in my checkout: it fails to resolve `@mastra/core/storage` because that workspace dependency is not built locally. I confirmed with `git stash` that it fails identically on an unmodified `main`, so it is a pre-existing environment issue rather than something this diff introduces. Worth confirming in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The template engine no longer treats JavaScript built-in properties as user data. Missing variables stay unchanged or use their fallback, while intentionally defined values still work.

## Changes

- Updated `resolvePath` to require own properties for every path segment.
- Prevented inherited members such as `constructor`, `toString`, and `valueOf` from entering agent instructions.
- Preserved fallback behavior for unresolved variables.
- Added four regression tests for inherited, nested, and shadowed properties.
- Added a patch changeset for `@mastra/editor`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->