### PR TITLE
fix(core): enforce completion scorer deadlines and preserve errors

### DIFF
--- a/.changeset/soft-bikes-count.md
+++ b/.changeset/soft-bikes-count.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed completion scoring deadlines so unfinished checks return a timeout failure, late scores cannot mark a task complete, and settled checks do not leave deadline timers running.

--- a/.changeset/soft-bikes-count.md
+++ b/.changeset/soft-bikes-count.md
@@ -3,3 +3,5 @@
 ---
 
 Fixed completion scoring deadlines so unfinished checks return a timeout failure, late scores cannot mark a task complete, and settled checks do not leave deadline timers running.
+
+Fixed completion scorer failures with non-Error rejection values so they remain visible without crashing the error handler.

--- a/packages/core/src/loop/network/validation.test.ts
+++ b/packages/core/src/loop/network/validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import type { CompletionContext, CompletionRunResult, StreamCompletionContext } from './validation';
 import {
@@ -41,6 +41,135 @@ function createMockContext(overrides: Partial<CompletionContext> = {}): Completi
 describe('runCompletionScorers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('deadlines', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it.each([true, false])('returns at the deadline with an unfinished scorer (parallel: %s)', async parallel => {
+      let resolveLate!: (value: { score: number }) => void;
+      const slow = {
+        id: 'slow',
+        run: vi.fn(
+          () =>
+            new Promise<{ score: number }>(resolve => {
+              resolveLate = resolve;
+            }),
+        ),
+      };
+      const next = createMockScorer('next', 1);
+      let observed: CompletionRunResult | undefined;
+      const pending = runCompletionScorers([slow, next], createMockContext(), { parallel, timeout: 10 }).then(
+        result => {
+          observed = result;
+        },
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      expect(observed).toMatchObject({ complete: false, timedOut: true, totalDuration: 10 });
+      expect(observed?.scorers.find(s => s.scorerId === 'slow')).toMatchObject({ passed: false, errored: true });
+      if (!parallel) expect(next.run).not.toHaveBeenCalled();
+      const snapshot = structuredClone(observed);
+      resolveLate({ score: 1 });
+      await vi.advanceTimersByTimeAsync(0);
+      await pending;
+      expect(observed).toEqual(snapshot);
+      if (!parallel) expect(next.run).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it.each(['all', 'any'] as const)(
+      'keeps completed evidence but never accepts a timed-out %s campaign',
+      async strategy => {
+        const fast = createMockScorer('fast', 1, 'Verified first result');
+        const stuck = { id: 'stuck', run: vi.fn(() => new Promise(() => {})) };
+        let observed: CompletionRunResult | undefined;
+        void runCompletionScorers([fast, stuck], createMockContext(), { strategy, timeout: 10 }).then(result => {
+          observed = result;
+        });
+        await vi.advanceTimersByTimeAsync(10);
+        expect(observed).toMatchObject({ complete: false, timedOut: true });
+        expect(observed?.scorers[0]).toMatchObject({ scorerId: 'fast', score: 1, reason: 'Verified first result' });
+        expect(observed?.scorers[1]).toMatchObject({ scorerId: 'stuck', score: 0, errored: true });
+        expect(observed?.completionReason).toMatch(/timed out/i);
+      },
+    );
+
+    it.each([true, false])('clears the default deadline after success (parallel: %s)', async parallel => {
+      const result = await runCompletionScorers([createMockScorer('fast', 1)], createMockContext(), { parallel });
+      expect(result).toMatchObject({ complete: true, timedOut: false });
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('shares one deadline across sequential scorers', async () => {
+      const delayed = (id: string) => ({
+        id,
+        run: vi.fn(async () => {
+          await new Promise(resolve => setTimeout(resolve, 6));
+          return { score: 1 };
+        }),
+      });
+      const first = delayed('first');
+      const second = delayed('second');
+      const third = createMockScorer('third', 1);
+      const pending = runCompletionScorers([first, second, third], createMockContext(), {
+        parallel: false,
+        timeout: 10,
+      });
+      await vi.advanceTimersByTimeAsync(10);
+      const result = await pending;
+      expect(result).toMatchObject({ complete: false, timedOut: true, totalDuration: 10 });
+      expect(result.scorers[0]).toMatchObject({ scorerId: 'first', passed: true });
+      expect(result.scorers[1]).toMatchObject({ scorerId: 'second', errored: true });
+      expect(third.run).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(2);
+      expect(third.run).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('handles a late rejection without changing the timeout result', async () => {
+      let rejectLate!: (reason: Error) => void;
+      const scorer = {
+        id: 'late-rejection',
+        run: vi.fn(
+          () =>
+            new Promise((_, reject) => {
+              rejectLate = reject;
+            }),
+        ),
+      };
+      const pending = runCompletionScorers([scorer], createMockContext(), { timeout: 10 });
+      await vi.advanceTimersByTimeAsync(10);
+      const result = await pending;
+      const snapshot = structuredClone(result);
+      expect(result).toMatchObject({ complete: false, timedOut: true });
+      rejectLate(new Error('Late read failure'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(result).toEqual(snapshot);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('clears the deadline after a scorer rejects', async () => {
+      const scorer = { id: 'failed', run: vi.fn().mockRejectedValue(new Error('Read unavailable')) };
+      const result = await runCompletionScorers([scorer], createMockContext());
+      expect(result).toMatchObject({ complete: false, timedOut: false });
+      expect(result.scorers[0].errored).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('rejects a late result even when the deadline callback has not run yet', async () => {
+      const scorer = {
+        id: 'blocking',
+        run: vi.fn(async () => {
+          vi.setSystemTime(Date.now() + 20);
+          return { score: 1 };
+        }),
+      };
+      const result = await runCompletionScorers([scorer], createMockContext(), { timeout: 10 });
+      expect(result).toMatchObject({ complete: false, timedOut: true });
+      expect(result.scorers[0].errored).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    });
   });
 
   describe('strategy: all (default)', () => {

--- a/packages/core/src/loop/network/validation.test.ts
+++ b/packages/core/src/loop/network/validation.test.ts
@@ -174,6 +174,39 @@ describe('runCompletionScorers', () => {
       expect(vi.getTimerCount()).toBe(0);
     });
 
+    it.each([
+      {
+        label: 'message object',
+        value: { message: 'Read unavailable' },
+        expected: 'Scorer threw an error: Read unavailable',
+      },
+      {
+        label: 'numeric message',
+        value: { message: 503 },
+        expected: 'Scorer threw an error: 503',
+      },
+      {
+        label: 'null prototype',
+        value: Object.create(null),
+        expected: 'Scorer threw an error that could not be converted to text',
+      },
+      {
+        label: 'throwing message',
+        value: Object.defineProperty({}, 'message', {
+          get() {
+            throw new Error('Unreadable message');
+          },
+        }),
+        expected: 'Scorer threw an error that could not be converted to text',
+      },
+    ])('preserves a failure for a $label rejection', async ({ value, expected }) => {
+      const scorer = { id: 'object-error', run: vi.fn().mockRejectedValue(value) };
+      const result = await runCompletionScorers([scorer], createMockContext());
+      expect(result).toMatchObject({ complete: false, timedOut: false });
+      expect(result.scorers[0]).toMatchObject({ passed: false, errored: true, reason: expected });
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
     it('rejects a late result even when the deadline callback has not run yet', async () => {
       const scorer = {
         id: 'blocking',

--- a/packages/core/src/loop/network/validation.test.ts
+++ b/packages/core/src/loop/network/validation.test.ts
@@ -127,8 +127,12 @@ describe('runCompletionScorers', () => {
       expect(vi.getTimerCount()).toBe(0);
     });
 
-    it('handles a late rejection without changing the timeout result', async () => {
-      let rejectLate!: (reason: Error) => void;
+    it.each([
+      { label: 'Error', reason: new Error('Late read failure') },
+      { label: 'null', reason: null },
+      { label: 'undefined', reason: undefined },
+    ])('handles a late $label rejection without changing the timeout result', async ({ reason }) => {
+      let rejectLate!: (reason: unknown) => void;
       const scorer = {
         id: 'late-rejection',
         run: vi.fn(
@@ -143,7 +147,7 @@ describe('runCompletionScorers', () => {
       const result = await pending;
       const snapshot = structuredClone(result);
       expect(result).toMatchObject({ complete: false, timedOut: true });
-      rejectLate(new Error('Late read failure'));
+      rejectLate(reason);
       await vi.advanceTimersByTimeAsync(0);
       expect(result).toEqual(snapshot);
       expect(vi.getTimerCount()).toBe(0);
@@ -154,6 +158,19 @@ describe('runCompletionScorers', () => {
       const result = await runCompletionScorers([scorer], createMockContext());
       expect(result).toMatchObject({ complete: false, timedOut: false });
       expect(result.scorers[0].errored).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it.each([null, undefined, 'Read unavailable'])('reports a non-Error rejection: %s', async reason => {
+      const scorer = { id: 'non-error', run: vi.fn().mockRejectedValue(reason) };
+      const result = await runCompletionScorers([scorer], createMockContext());
+      expect(result).toMatchObject({ complete: false, timedOut: false });
+      expect(result.scorers[0]).toMatchObject({
+        score: 0,
+        passed: false,
+        errored: true,
+        reason: `Scorer threw an error: ${String(reason)}`,
+      });
       expect(vi.getTimerCount()).toBe(0);
     });
 

--- a/packages/core/src/loop/network/validation.ts
+++ b/packages/core/src/loop/network/validation.ts
@@ -220,10 +220,21 @@ async function runSingleScorer(
       duration: Date.now() - start,
     };
   } catch (error: unknown) {
+    let reason = 'Scorer threw an error that could not be converted to text';
+    try {
+      const message =
+        error && (typeof error === 'object' || typeof error === 'function') && 'message' in error
+          ? error.message
+          : error;
+      reason = `Scorer threw an error: ${String(message)}`;
+    } catch {
+      // Rejection values can have throwing getters or no string conversion.
+      // Keep the failure visible even when its details cannot be read.
+    }
     return {
       score: 0,
       passed: false,
-      reason: `Scorer threw an error: ${error instanceof Error ? error.message : String(error)}`,
+      reason,
       scorerId: scorer.id,
       scorerName: scorer.name ?? scorer.id,
       duration: Date.now() - start,

--- a/packages/core/src/loop/network/validation.ts
+++ b/packages/core/src/loop/network/validation.ts
@@ -249,52 +249,66 @@ export async function runCompletionScorers(
   const timeout = options?.timeout ?? 600000;
 
   const startTime = Date.now();
-  const results: ScorerResult[] = [];
+  const settledResults: (ScorerResult | undefined)[] = new Array(scorers.length);
   let timedOut = false;
-
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<'timeout'>(resolve => {
-    setTimeout(() => resolve('timeout'), timeout);
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      resolve('timeout');
+    }, timeout);
   });
 
-  if (parallel) {
-    const scorerPromises = scorers.map(scorer => runSingleScorer(scorer, context));
-    const raceResult = await Promise.race([Promise.all(scorerPromises), timeoutPromise]);
-
-    if (raceResult === 'timeout') {
-      timedOut = true;
-      const settledResults = await Promise.allSettled(scorerPromises);
-      for (const settled of settledResults) {
-        if (settled.status === 'fulfilled') {
-          results.push(settled.value);
-        }
-      }
+  const runScorer = async (scorer: MastraScorer<any, any, any, any>, index: number) => {
+    const result = await runSingleScorer(scorer, context);
+    if (Date.now() - startTime >= timeout) timedOut = true;
+    // A late result cannot change the returned verdict or its evidence.
+    if (!timedOut) settledResults[index] = result;
+    return result;
+  };
+  const runScorers = async () => {
+    if (parallel) {
+      await Promise.all(scorers.map(runScorer));
     } else {
-      results.push(...raceResult);
-    }
-  } else {
-    for (const scorer of scorers) {
-      if (Date.now() - startTime > timeout) {
-        timedOut = true;
-        break;
+      for (const [index, scorer] of scorers.entries()) {
+        if (timedOut) break;
+        const result = await runScorer(scorer, index);
+        if (strategy === 'all' && !result.passed) break;
+        if (strategy === 'any' && result.passed) break;
       }
-
-      const result = await runSingleScorer(scorer, context);
-      results.push(result);
-
-      // Short-circuit
-      if (strategy === 'all' && !result.passed) break;
-      if (strategy === 'any' && result.passed) break;
     }
+  };
+  try {
+    await Promise.race([runScorers(), timeoutPromise]);
+  } finally {
+    clearTimeout(timeoutId);
   }
 
+  // Scorer.run has no cancellation contract. Return on time without waiting
+  // for an uncooperative scorer, and expose unfinished checks as errors.
+  const results: ScorerResult[] = timedOut
+    ? scorers.map(
+        (scorer, index) =>
+          settledResults[index] ?? {
+            score: 0,
+            passed: false,
+            errored: true,
+            scorerId: scorer.id,
+            scorerName: scorer.name ?? scorer.id,
+            reason: `Completion scoring timed out after ${timeout}ms before this scorer returned.`,
+            duration: Date.now() - startTime,
+          },
+      )
+    : settledResults.filter((result): result is ScorerResult => result !== undefined);
   const complete =
-    strategy === 'all'
+    !timedOut &&
+    (strategy === 'all'
       ? results.length === scorers.length && results.every(r => r.passed)
-      : results.some(r => r.passed);
+      : results.some(r => r.passed));
 
   // Get reason from first passing scorer (or first failing if none passed)
   const relevantScorer = results.find(r => r.passed) || results[0];
-  const completionReason = relevantScorer?.reason;
+  const completionReason = timedOut ? `Completion scoring timed out after ${timeout}ms.` : relevantScorer?.reason;
 
   return {
     complete,

--- a/packages/core/src/loop/network/validation.ts
+++ b/packages/core/src/loop/network/validation.ts
@@ -219,11 +219,11 @@ async function runSingleScorer(
       scorerName: scorer.name ?? scorer.id,
       duration: Date.now() - start,
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
     return {
       score: 0,
       passed: false,
-      reason: `Scorer threw an error: ${error.message}`,
+      reason: `Scorer threw an error: ${error instanceof Error ? error.message : String(error)}`,
       scorerId: scorer.id,
       scorerName: scorer.name ?? scorer.id,
       duration: Date.now() - start,


### PR DESCRIPTION
Fixes #23449

With a 150 ms scorer and `{ timeout: 10 }`, `runCompletionScorers` waited about 164 ms and returned `complete: true` together with `timedOut: true`. Sequential scoring could also return a late pass without reporting the timeout. A scorer that never settled kept the parallel timeout path waiting indefinitely, and successful checks left the default ten-minute timer active.

This change uses one deadline for parallel and sequential scoring, returns an incomplete result at that deadline, retains finished evidence, and marks unfinished checks as errors. Late results cannot change the returned verdict. The timer is cleared on completion. Already-running scorers are not cancelled because `Scorer.run` does not expose a cancellation contract.

Review also exposed that `null`/`undefined` scorer rejections crashed the error handler, while a string rejection lost its message. The handler now preserves readable message fields and guards property access and text conversion, so plain objects, null-prototype objects, and throwing getters also remain explicit failures. No extra no-op catch is needed around `Promise.race`, which already observes both outcomes of each input promise; a late-null public-API probe reported zero unhandled rejections.

All 58 tests in `validation.test.ts` pass. The two timer-cleanup cases fail against the original source, and three non-Error rejection cases fail before the error-handler repair. The native build, core type check, scoped ESLint/Oxlint and formatting checks pass. A built public-API probe returns timeout failure in about 10 ms and exits normally after its synthetic scorer finishes. A second probe now returns an explicit failure for a null rejection. No Khayalek installed package or deployed runtime was changed.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes completion scoring stop at its deadline. It keeps results that finish on time, reports unfinished checks as errors, and preserves useful failure details.

## Changes

- Applies one deadline to parallel and sequential scoring.
- Returns an incomplete result when the deadline expires.
- Preserves evidence from completed scorers.
- Marks unfinished checks as timeout errors.
- Prevents late scorer results from changing the returned verdict.
- Clears timeout timers after successful completion.
- Preserves failures for non-`Error` values, including `null`, `undefined`, strings, objects, null-prototype objects, throwing getters, and unsafe text conversions.
- Does not cancel running scorers because `Scorer.run` has no cancellation contract.

## Validation

- Added deadline, timeout, late-result, error-preservation, and timer-cleanup tests.
- 58 validation tests pass.
- Build, type-check, lint, formatting, and public-API probes pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->