### PR TITLE
fix(observability): support filtering exported spans

### DIFF
--- a/.changeset/pink-clouds-teach.md
+++ b/.changeset/pink-clouds-teach.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Allow SensitiveDataFilter to redact exported spans.

--- a/observability/mastra/src/span_processors/sensitive-data-filter.ts
+++ b/observability/mastra/src/span_processors/sensitive-data-filter.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import type { SpanOutputProcessor, AnySpan } from '@mastra/core/observability';
+import type { SpanOutputProcessor, AnyExportedSpan, AnySpan } from '@mastra/core/observability';
 
 export type RedactionStyle = 'full' | 'partial' | 'indexed';
 
@@ -115,10 +115,14 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
    * Process a span by filtering sensitive data across its key fields.
    * Fields processed: attributes, metadata, input, output, errorInfo, requestContext.
    *
-   * @param span - The input span to filter
-   * @returns A new span with sensitive values redacted
+   * @param span - The live or exported span to filter
+   * @returns The span with sensitive values redacted
    */
-  process(span: AnySpan): AnySpan {
+  process(span?: AnySpan): AnySpan | undefined;
+  process(span: AnyExportedSpan): AnyExportedSpan;
+  process(span?: AnySpan | AnyExportedSpan): AnySpan | AnyExportedSpan | undefined {
+    if (!span) return undefined;
+
     const indexedState = this.redactionStyle === 'indexed' ? this.getTraceState(span.traceId) : undefined;
     span.attributes = this.tryFilter(span.attributes, indexedState);
     span.metadata = this.tryFilter(span.metadata, indexedState);

--- a/observability/mastra/src/span_processors/senstive-data-filter.test.ts
+++ b/observability/mastra/src/span_processors/senstive-data-filter.test.ts
@@ -1,4 +1,4 @@
-import type { TracingEvent, ObservabilityExporter } from '@mastra/core/observability';
+import type { AnyExportedSpan, TracingEvent, ObservabilityExporter } from '@mastra/core/observability';
 import { SpanType, SamplingStrategyType } from '@mastra/core/observability';
 import { RequestContext } from '@mastra/core/request-context';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -39,6 +39,30 @@ describe('Tracing', () => {
 
   describe('Sensitive Data Filtering', () => {
     describe('SensitiveDataFilter Processor', () => {
+      it('redacts exported spans', () => {
+        const span: AnyExportedSpan = {
+          id: 'exported-span',
+          traceId: 'exported-trace',
+          name: 'exported span',
+          type: SpanType.AGENT_RUN,
+          startTime: new Date(),
+          isEvent: false,
+          isRootSpan: true,
+          metadata: {
+            password: 'secret123',
+            visible: 'value',
+          },
+        };
+
+        const filtered = new SensitiveDataFilter().process(span);
+
+        expect(filtered).toBe(span);
+        expect(filtered.metadata).toEqual({
+          password: '[REDACTED]',
+          visible: 'value',
+        });
+      });
+
       describe('JSON candidates', () => {
         const markers = [
           '[MaxDepth]',


### PR DESCRIPTION
Exporter `customSpanFormatter` receives `AnyExportedSpan`, but `SensitiveDataFilter.process` is typed only for live `AnySpan`. The filter already redacts fields shared by both (`attributes`, `metadata`, `input`, `output`, `errorInfo`, `requestContext`), so callers that format exported spans currently need a cast even though the runtime path is the same.

This adds an `AnyExportedSpan` overload so formatters can filter exported spans without a cast, plus a typed regression test that redacts an exported span in place.

Validated with the SensitiveDataFilter test file (54 tests), the `@mastra/observability` build, and oxfmt.
