### PR TITLE
fix(schema-compat): let optional enum and const accept null

### DIFF
--- a/.changeset/quiet-doors-listen.md
+++ b/.changeset/quiet-doors-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed optional enum and const properties in OpenAI strict schemas so they accept null like other optional properties.

--- a/packages/schema-compat/src/provider-compats/openai-optional-scalar-null.test.ts
+++ b/packages/schema-compat/src/provider-compats/openai-optional-scalar-null.test.ts
@@ -1,0 +1,61 @@
+import Ajv from 'ajv';
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import type { ModelInformation } from '../types';
+import { OpenAISchemaCompatLayer } from './openai';
+
+describe('OpenAISchemaCompatLayer - optional scalar enum/const nullability', () => {
+  const modelInfo: ModelInformation = {
+    provider: 'openai',
+    modelId: 'gpt-4o',
+    supportsStructuredOutputs: false,
+  };
+
+  const compat = new OpenAISchemaCompatLayer(modelInfo);
+
+  const expectWireAccepts = (schema: unknown, value: unknown) => {
+    const ajv = new Ajv({ strict: false, allErrors: true });
+    const validate = ajv.compile(schema as object);
+    expect(validate(value)).toBe(true);
+  };
+
+  const expectWireRejects = (schema: unknown, value: unknown) => {
+    const ajv = new Ajv({ strict: false, allErrors: true });
+    const validate = ajv.compile(schema as object);
+    expect(validate(value)).toBe(false);
+  };
+
+  it('accepts null for an optional enum property in strict mode', () => {
+    const schema = z.object({
+      encoding: z.enum(['utf8', 'base64']).optional(),
+    });
+
+    const wireSchema = compat.processToJSONSchema(schema) as Record<string, any>;
+    const encoding = wireSchema.properties.encoding;
+
+    expect(encoding.anyOf.map((branch: any) => branch.type)).toEqual(['string', 'null']);
+    expect(encoding).not.toHaveProperty('enum');
+    expect(encoding.anyOf[0].enum).toEqual(['utf8', 'base64']);
+
+    expectWireAccepts(wireSchema, { encoding: null });
+    expectWireAccepts(wireSchema, { encoding: 'base64' });
+    expectWireRejects(wireSchema, { encoding: 'hex' });
+  });
+
+  it('accepts null for an optional const property in strict mode', () => {
+    const schema = z.object({
+      kind: z.literal('fixed').optional(),
+    });
+
+    const wireSchema = compat.processToJSONSchema(schema) as Record<string, any>;
+    const kind = wireSchema.properties.kind;
+
+    expect(kind.anyOf.map((branch: any) => branch.type)).toEqual(['string', 'null']);
+    expect(kind).not.toHaveProperty('const');
+    expect(kind.anyOf[0].const).toBe('fixed');
+
+    expectWireAccepts(wireSchema, { kind: null });
+    expectWireAccepts(wireSchema, { kind: 'fixed' });
+    expectWireRejects(wireSchema, { kind: 'other' });
+  });
+});

--- a/packages/schema-compat/src/provider-compats/openai.ts
+++ b/packages/schema-compat/src/provider-compats/openai.ts
@@ -308,6 +308,8 @@ export class OpenAISchemaCompatLayer extends SchemaCompatLayer {
               delete propSchema.anyOf;
               delete propSchema.type;
               delete prop.type;
+              delete prop.const;
+              delete prop.enum;
               prop.anyOf = [
                 {
                   ...propSchema,


### PR DESCRIPTION
## Description

OpenAI strict schemas convert optional properties into required nullable properties. This fix keeps enum and const constraints on the non-null branch so optional scalar properties accept null without allowing invalid values.

## Related issue(s)

Fixes #23173

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Suggested reviewers

@wardpeet, @abhiaiyer91, @tylerbarnes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Optional settings with allowed values can now be left empty when OpenAI requires every field. The system still rejects invalid values and converts empty inputs to the expected internal form.

## Changes

- Fixed `OpenAISchemaCompatLayer` handling for optional scalar `enum` and `const` properties.
- Moved `enum` and `const` constraints to the non-null `anyOf` branch.
- Removed outer constraints that incorrectly rejected `null`.
- Added AJV regression tests for valid and invalid enum and literal values.
- Added a patch changeset for `@mastra/schema-compat`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->