### PR TITLE
docs(factory): clarify optional platform services

### DIFF
--- a/mastracode/mastra-factory/template/README.md
+++ b/mastracode/mastra-factory/template/README.md
@@ -8,7 +8,9 @@ Read the [documentation](https://factory.mastra.ai/) or [watch the Mastra Factor
 
 ## Start the Factory Server
 
-New projects use Mastra platform for authentication, storage, and sandboxes by default. Before connecting a model provider, check for `FACTORY_CREDENTIAL_ENCRYPTION_KEY` in `.env`. If it's missing, generate a key once for this project:
+Using Mastra platform services is optional. The installer configures them for authentication, storage, and sandboxes by default, but you can replace each service independently or run the server without a platform connection. Pass `--no-platform` to `npm create factory` to skip platform provisioning.
+
+Before connecting a model provider, check for `FACTORY_CREDENTIAL_ENCRYPTION_KEY` in `.env`. If it's missing, generate a key once for this project:
 
 ```bash
 openssl rand -base64 32
@@ -22,9 +24,9 @@ From the Factory project directory, start the server:
 npm run dev
 ```
 
-Open the local URL printed by the server, then sign in through Mastra platform. One server serves both the Factory UI and API. After login you'll see an onboarding wizard, select the repository agents should change. Use **Manage GitHub connection** to grant the GitHub App access if the repository is missing. Optionally add Linear. Connect a model provider using an API key or a supported subscription, then choose the Factory model.
+With the default setup, open the local URL printed by the server and sign in through Mastra platform. One server serves both the Factory UI and API. After login you'll see an onboarding wizard, select the repository agents should change. Use **Manage GitHub connection** to grant the GitHub App access if the repository is missing. Optionally add Linear. Connect a model provider using an API key or a supported subscription, then choose the Factory model.
 
-If you skipped platform setup during installation, follow [Get started](https://factory.mastra.ai/) to complete configuration.
+If you skipped platform setup during installation, follow [Get started](https://factory.mastra.ai/) to configure alternative authentication, storage, and sandbox providers.
 
 ## Run your first issue
 


### PR DESCRIPTION
## Description

Clarifies that Mastra platform services are the default Factory setup, not a requirement. The README now points to `--no-platform` and explains that authentication, storage, and sandboxes can be replaced independently.

Verified: `pnpm --filter create-factory exec vitest run src/sync-template.test.ts --reporter=dot --bail=1` passes with 5 tests; `git diff --check` passes.

## Related issue(s)

Internal README feedback. No GitHub issue.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory setups can use Mastra platform services by default, but they do not have to. The README now explains how to skip or replace these services.

## Changes

- Documented the `--no-platform` installer option.
- Explained that authentication, storage, and sandboxes can be replaced independently.
- Clarified that the documented sign-in flow is the default path.
- Added provider configuration guidance for installations without platform services.

## Verification

- Passed the specified `create-factory` test.
- Passed `git diff --check`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->