### PR TITLE
fix(core): preserve durable step continuation state

### DIFF
--- a/packages/core/src/agent/durable/__tests__/durable-agent-channel-render.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-channel-render.test.ts
@@ -73,6 +73,46 @@ function replyingModel() {
   });
 }
 
+function toolThenReplyingModel() {
+  return new MockLanguageModelV2({
+    doStream: async ({ prompt }) => {
+      const hasToolResult = JSON.stringify(prompt).includes('tool-result-payload');
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream<any>(
+          hasToolResult
+            ? [
+                { type: 'stream-start', warnings: [] },
+                { type: 'response-metadata', id: 'reply-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+                { type: 'text-start', id: 'reply-text' },
+                { type: 'text-delta', id: 'reply-text', delta: 'The tool answer' },
+                { type: 'text-end', id: 'reply-text' },
+                { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+              ]
+            : [
+                { type: 'stream-start', warnings: [] },
+                { type: 'response-metadata', id: 'tool-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+                {
+                  type: 'tool-call',
+                  toolCallType: 'function',
+                  toolCallId: 'call-1',
+                  toolName: 'getAnswer',
+                  input: '{}',
+                  providerExecuted: false,
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'tool-calls',
+                  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                },
+              ],
+        ),
+      };
+    },
+  });
+}
+
 /** A thread as the channel edge leaves it: the platform and external id are what the rebuild reads. */
 async function seedChannelThread(storage: InMemoryStore) {
   const memoryStore = await storage.getStore('memory');
@@ -102,15 +142,20 @@ async function untilChatReady(agent: Agent) {
 }
 
 /** Builds a plain and durable agent pair backed by a seeded channel thread. */
-async function channelBackedAgent(id: string, outputProcessors?: any[]) {
+async function channelBackedAgent(
+  id: string,
+  outputProcessors?: any[],
+  options: { model?: unknown; tools?: Record<string, unknown>; instructions?: string } = {},
+) {
   const { adapter, postMessage } = createMockAdapter();
   const storage = new InMemoryStore();
   const agent = new Agent({
     id,
     name: id,
-    instructions: 'Answer briefly.',
-    model: replyingModel() as any,
+    instructions: options.instructions ?? 'Answer briefly.',
+    model: (options.model ?? replyingModel()) as any,
     memory: new MockMemory(),
+    tools: options.tools as any,
     outputProcessors,
     channels: { adapters: { [PLATFORM]: { adapter, streaming: false } } },
   });
@@ -205,6 +250,24 @@ describe('a run on a channel-backed thread posts its answer to the channel', () 
     await drain(await durableAgent.stream('hi', { memory: { thread: THREAD_ID, resource: RESOURCE_ID } }));
 
     expect(postMessage).toHaveBeenCalled();
+  });
+
+  it('posts the final answer after a durable tool step', async () => {
+    const getAnswer = createTool({
+      id: 'getAnswer',
+      description: 'Returns the answer payload.',
+      inputSchema: z.object({}),
+      execute: async () => 'tool-result-payload',
+    });
+    const { durableAgent, postMessage } = await channelBackedAgent('channel-render-durable-tool', undefined, {
+      model: toolThenReplyingModel(),
+      tools: { getAnswer },
+      instructions: 'Use the tool, then answer.',
+    });
+
+    await drain(await durableAgent.stream('use the tool', { memory: { thread: THREAD_ID, resource: RESOURCE_ID } }));
+
+    expect(postMessage.mock.calls.length).toBeGreaterThan(1);
   });
 
   it("passes the caller's request context to durable output processors", async () => {

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -1212,7 +1212,18 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 // is added to messageList.
                 if (pubsub && rawChunk.type !== 'error') {
                   if (rawChunk.type === 'step-finish') {
-                    deferredStepFinishChunk = clientChunk;
+                    const payload = (clientChunk as any).payload;
+                    const finishReason = payload?.stepResult?.reason ?? payload?.finishReason;
+                    deferredStepFinishChunk = {
+                      ...clientChunk,
+                      payload: {
+                        ...payload,
+                        stepResult: {
+                          ...payload?.stepResult,
+                          isContinued: toolCalls.length > 0 && finishReason !== 'stop',
+                        },
+                      },
+                    };
                   } else {
                     await emitChunkEvent(pubsub, runId, clientChunk);
                   }


### PR DESCRIPTION
## Description

Durable agent streams omitted `stepResult.isContinued` on deferred `step-finish` chunks, so channel rendering treated a tool step as terminal and dropped the following answer. This preserves continuation metadata and adds regression coverage for a tool call followed by a final answer.

## Related issue(s)

Closes #23341

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The durable agent now remembers whether more steps follow after a tool call. This allows it to continue rendering and post the final assistant response.

## Changes

- Preserve `stepResult.isContinued` in deferred durable `step-finish` chunks.
- Set continuation state from tool calls and the finish reason.
- Add regression coverage for a tool call followed by a final response.
- Add configurable model, tool, and instruction support to the channel-backed test agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->