### PR TITLE
fix(memory): preserve session and tracing context in observational memory

### DIFF
--- a/.changeset/strict-memes-sink.md
+++ b/.changeset/strict-memes-sink.md
@@ -1,0 +1,5 @@
+---
+'@mastra/langfuse': patch
+---
+
+Fixed Observational Memory session grouping in Langfuse, including observer and reflector spans received before their parent spans.

--- a/.changeset/tiny-aliens-begin.md
+++ b/.changeset/tiny-aliens-begin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed Observational Memory observer and reflector traces to stay in the caller's conversation session, including when child spans arrive before their parents. Internal execution threads remain isolated.

--- a/.changeset/tiny-aliens-begin.md
+++ b/.changeset/tiny-aliens-begin.md
@@ -2,5 +2,5 @@
 '@mastra/memory': patch
 ---
 
-- Fixed Langfuse session correlation for Observational Memory observer and reflector traces, including spans received before their parent spans.
+- Preserved caller thread identity in Observational Memory traces without assigning a session ID for other observability integrations.
 - Preserved the supplied observability context when explicitly triggering asynchronous observation buffering.

--- a/.changeset/tiny-aliens-begin.md
+++ b/.changeset/tiny-aliens-begin.md
@@ -2,4 +2,4 @@
 '@mastra/memory': patch
 ---
 
-Fixed Observational Memory observer and reflector traces to stay in the caller's conversation session, including when child spans arrive before their parents. Internal execution threads remain isolated.
+Fixed Observational Memory observer and reflector traces to stay in the caller's conversation session, including when child spans arrive before their parents. Internal execution threads remain isolated. Also preserved the supplied observability context when explicitly triggering asynchronous observation buffering.

--- a/.changeset/tiny-aliens-begin.md
+++ b/.changeset/tiny-aliens-begin.md
@@ -2,4 +2,5 @@
 '@mastra/memory': patch
 ---
 
-Fixed Observational Memory observer and reflector traces to stay in the caller's conversation session, including when child spans arrive before their parents. Internal execution threads remain isolated. Also preserved the supplied observability context when explicitly triggering asynchronous observation buffering.
+- Fixed Langfuse session correlation for Observational Memory observer and reflector traces, including spans received before their parent spans.
+- Preserved the supplied observability context when explicitly triggering asynchronous observation buffering.

--- a/docs/src/content/en/integrations/observability/langfuse.mdx
+++ b/docs/src/content/en/integrations/observability/langfuse.mdx
@@ -213,7 +213,9 @@ Notes:
 
 The exporter maps span metadata to Langfuse sessions using `sessionId`, or `threadId` when `sessionId` is absent or `null`. An explicit empty `sessionId` suppresses this fallback and sends no session ID.
 
-[Observational Memory](/docs/memory/observational-memory) keeps observer and reflector spans in the caller's session, even when child spans arrive before their parents. It preserves the caller span's explicit `sessionId`, including an empty string. Otherwise, it uses the caller span's non-empty `threadId`, falling back to the original request's thread ID. Without either identity, it adds no session ID.
+For [Observational Memory](/docs/memory/observational-memory), the Langfuse exporter keeps observer and reflector spans in the caller's session, even when child spans arrive before their parents. An explicit `sessionId`, including an empty string, takes precedence. Otherwise, the exporter uses the original caller thread carried by Observational Memory before falling back to the span's own `threadId`. Observational Memory captures that caller identity from the caller span's non-empty `threadId`, or the original request's thread ID. Nested observation preserves the outer caller identity.
+
+This thread-to-session fallback is specific to Langfuse. Observational Memory doesn't synthesize generic `sessionId` metadata from a thread ID for other exporters.
 
 Internal observer and reflector execution threads remain separate. Multi-thread observation uses the invoking caller's session, not the first thread in the batch. This session behavior applies regardless of the `bufferOnIdle` setting and doesn't change buffering or span parentage.
 

--- a/docs/src/content/en/integrations/observability/langfuse.mdx
+++ b/docs/src/content/en/integrations/observability/langfuse.mdx
@@ -200,7 +200,7 @@ const tracingOptions = {
 
 This example produces `langfuse.trace.metadata.customerId` and `langfuse.trace.metadata.tier`.
 
-Metadata on the root span is also forwarded. Mastra sets `runId` and `resourceId` on every agent and workflow root span, and you can add your own keys through `tracingOptions.metadata`. The exporter forwards each of these root span keys to `langfuse.trace.metadata.<key>`. Keys that map to a dedicated Langfuse field (`userId`, `sessionId`, `threadId`, `traceName`, and `version`) are not duplicated as trace metadata. Metadata on child spans stays on the observation and never changes the trace.
+Metadata on the root span is also forwarded. Mastra sets `runId` and `resourceId` on every agent and workflow root span, and you can add your own keys through `tracingOptions.metadata`. The exporter forwards each of these root span keys to `langfuse.trace.metadata.<key>`. Keys that map to a dedicated Langfuse field (`userId`, `sessionId`, `threadId`, `traceName`, and `version`) are not duplicated as trace metadata. Other metadata on child spans stays on the observation. Dedicated fields such as session IDs follow their own mapping rules.
 
 Notes:
 
@@ -208,6 +208,14 @@ Notes:
 - The reserved identity keys `agentId`, `agentName`, `workflowId`, and `workflowName` are set from the root span and take precedence over custom values with the same name.
 - Keys under `langfuse` take precedence over root span metadata with the same name.
 - Values are sent as strings, because Langfuse maps trace metadata attributes as strings. Numbers, booleans, and objects are serialized with JSON. Langfuse Cloud restores them to their original types on ingestion.
+
+## Conversation sessions
+
+The exporter maps span metadata to Langfuse sessions using `sessionId`, or `threadId` when `sessionId` is absent or `null`. An explicit empty `sessionId` suppresses this fallback and sends no session ID.
+
+[Observational Memory](/docs/memory/observational-memory) keeps observer and reflector spans in the caller's session, even when child spans arrive before their parents. It preserves the caller span's explicit `sessionId`, including an empty string. Otherwise, it uses the caller span's non-empty `threadId`, falling back to the original request's thread ID. Without either identity, it adds no session ID.
+
+Internal observer and reflector execution threads remain separate. Multi-thread observation uses the invoking caller's session, not the first thread in the batch. This session behavior doesn't change buffering or span parentage, and applies when `bufferOnIdle` is `false`.
 
 ## Prompt linking
 

--- a/docs/src/content/en/integrations/observability/langfuse.mdx
+++ b/docs/src/content/en/integrations/observability/langfuse.mdx
@@ -215,7 +215,7 @@ The exporter maps span metadata to Langfuse sessions using `sessionId`, or `thre
 
 [Observational Memory](/docs/memory/observational-memory) keeps observer and reflector spans in the caller's session, even when child spans arrive before their parents. It preserves the caller span's explicit `sessionId`, including an empty string. Otherwise, it uses the caller span's non-empty `threadId`, falling back to the original request's thread ID. Without either identity, it adds no session ID.
 
-Internal observer and reflector execution threads remain separate. Multi-thread observation uses the invoking caller's session, not the first thread in the batch. This session behavior doesn't change buffering or span parentage, and applies when `bufferOnIdle` is `false`.
+Internal observer and reflector execution threads remain separate. Multi-thread observation uses the invoking caller's session, not the first thread in the batch. This session behavior applies regardless of the `bufferOnIdle` setting and doesn't change buffering or span parentage.
 
 ## Prompt linking
 

--- a/observability/langfuse/src/session-correlation.test.ts
+++ b/observability/langfuse/src/session-correlation.test.ts
@@ -42,7 +42,7 @@ describe.each(['root-first', 'child-first'] as const)('real session conversion: 
     const wrapper = root.createChildSpan({
       type: SpanType.MEMORY_OPERATION,
       name: 'memory: observe',
-      metadata: { sessionId },
+      metadata: { __mastraObservationalMemoryCallerThreadId: 'caller-thread' },
       attributes: { operationType: 'observe' },
     });
     const agent = wrapper.createChildSpan({
@@ -58,7 +58,8 @@ describe.each(['root-first', 'child-first'] as const)('real session conversion: 
     const spans = [root, wrapper, agent, model];
     for (const span of [...spans].reverse()) span.end();
     expect(agent.metadata?.threadId).toBe('isolated-observer-thread');
-    expect(agent.metadata?.sessionId).toBe(sessionId);
+    expect(agent.metadata?.sessionId).toBe(sessionId === 'caller-thread' ? undefined : sessionId);
+    expect(agent.metadata?.__mastraObservationalMemoryCallerThreadId).toBe('caller-thread');
     expect(root.metadata?.threadId).toBe('caller-thread');
     for (const span of order === 'root-first' ? spans : [...spans].reverse()) {
       await exporter.onTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: span.exportSpan() });
@@ -66,6 +67,7 @@ describe.each(['root-first', 'child-first'] as const)('real session conversion: 
     expect(processed).toHaveLength(4);
     for (const span of processed) {
       expect(span.spanContext().traceId).toBe(root.traceId);
+      expect(span.attributes).not.toHaveProperty('mastra.metadata.__mastraObservationalMemoryCallerThreadId');
       expect(span.attributes['session.id']).toBe(sessionId || undefined);
       if (sessionId) {
         expect(span.attributes).not.toHaveProperty('mastra.metadata.sessionId');
@@ -79,6 +81,56 @@ describe.each(['root-first', 'child-first'] as const)('real session conversion: 
       expect(convertedAgent.attributes['mastra.metadata.sessionId']).toBe('');
       expect(convertedAgent.attributes['mastra.metadata.threadId']).toBe('isolated-observer-thread');
     }
+    await exporter.shutdown();
+    await observability.shutdown();
+  });
+
+  it.each([
+    ['valid hint', undefined, 'caller-thread', 'caller-thread'],
+    ['null session', null, 'caller-thread', 'caller-thread'],
+    ['empty session', '', 'caller-thread', undefined],
+    ['false session', false, 'caller-thread', undefined],
+    ['zero session', 0, 'caller-thread', undefined],
+    ['explicit session', 'explicit', 'caller-thread', 'explicit'],
+    ['object hint', undefined, { invalid: true }, 'execution-thread'],
+    ['array hint', undefined, ['invalid'], 'execution-thread'],
+    ['numeric hint', undefined, 42, 'execution-thread'],
+    ['empty hint', undefined, '', 'execution-thread'],
+  ])('handles raw session/hint precedence: %s', async (_name, sessionId, hint, expected) => {
+    const observability = new DefaultObservabilityInstance({ name: 'test', serviceName: 'test', exporters: [] });
+    const root = observability.startSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'caller',
+      metadata: { sessionId, threadId: 'execution-thread', __mastraObservationalMemoryCallerThreadId: hint },
+    });
+    root.end();
+    const exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+    await exporter.onTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: root.exportSpan() });
+    expect(processed[0]!.attributes['session.id']).toBe(expected);
+    expect(processed[0]!.attributes).not.toHaveProperty('mastra.metadata.__mastraObservationalMemoryCallerThreadId');
+    expect(processed[0]!.attributes).not.toHaveProperty(
+      'langfuse.trace.metadata.__mastraObservationalMemoryCallerThreadId',
+    );
+    if (sessionId === '' || sessionId === false || sessionId === 0) {
+      expect(processed[0]!.attributes['mastra.metadata.sessionId']).toBe(sessionId);
+      expect(processed[0]!.attributes['mastra.metadata.threadId']).toBe('execution-thread');
+    }
+    await exporter.shutdown();
+    await observability.shutdown();
+  });
+
+  it('does not reinterpret ordinary user caller-thread metadata as a session override', async () => {
+    const observability = new DefaultObservabilityInstance({ name: 'test', serviceName: 'test', exporters: [] });
+    const root = observability.startSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'caller',
+      metadata: { threadId: 'T', omCallerThreadId: 'user-custom-value' },
+    });
+    root.end();
+    const exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+    await exporter.onTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: root.exportSpan() });
+    expect(processed[0]!.attributes['session.id']).toBe('T');
+    expect(processed[0]!.attributes['langfuse.trace.metadata.omCallerThreadId']).toBe('user-custom-value');
     await exporter.shutdown();
     await observability.shutdown();
   });
@@ -127,16 +179,34 @@ describe.each(['root-first', 'child-first'] as const)('real session conversion: 
       name: 'nested caller',
       metadata: { threadId: 'nested-thread' },
     });
+    const wrapper = caller.createChildSpan({
+      type: SpanType.MEMORY_OPERATION,
+      name: 'memory: observe',
+      metadata: { __mastraObservationalMemoryCallerThreadId: 'nested-thread' },
+      attributes: { operationType: 'observe' },
+    });
+    const internal = wrapper.createChildSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'internal',
+      metadata: { threadId: 'isolated-thread' },
+    });
     const exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+    internal.end();
+    wrapper.end();
     caller.end();
     root.end();
-    for (const span of order === 'root-first' ? [root, caller] : [caller, root]) {
+    const spans = [root, caller, wrapper, internal];
+    for (const span of order === 'root-first' ? spans : [...spans].reverse()) {
       await exporter.onTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: span.exportSpan() });
     }
     expect(processed.find(span => span.spanContext().spanId === root.id)?.attributes['session.id']).toBeUndefined();
     const child = processed.find(span => span.spanContext().spanId === caller.id)!;
     expect(child.attributes['session.id']).toBe('nested-thread');
     expect(child.parentSpanContext?.spanId).toBe(root.id);
+    expect(internal.metadata?.sessionId).toBeUndefined();
+    const convertedInternal = processed.find(span => span.spanContext().spanId === internal.id)!;
+    expect(convertedInternal.attributes['session.id']).toBe('nested-thread');
+    expect(convertedInternal.parentSpanContext?.spanId).toBe(wrapper.id);
     await exporter.shutdown();
     await observability.shutdown();
   });

--- a/observability/langfuse/src/session-correlation.test.ts
+++ b/observability/langfuse/src/session-correlation.test.ts
@@ -1,0 +1,143 @@
+import { SpanType, TracingEventType } from '@mastra/core/observability';
+import { DefaultObservabilityInstance } from '@mastra/observability';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { LangfuseExporter } from './tracing';
+
+const processed: ReadableSpan[] = [];
+vi.mock('@langfuse/otel', () => ({
+  LangfuseSpanProcessor: class {
+    onStart() {}
+    onEnd(span: ReadableSpan) {
+      processed.push(span);
+    }
+    async forceFlush() {}
+    async shutdown() {}
+  },
+}));
+
+afterEach(() => {
+  processed.length = 0;
+});
+
+describe.each(['root-first', 'child-first'] as const)('real session conversion: %s', order => {
+  it.each([
+    ['implicit caller session', 'caller-thread'],
+    ['explicit caller session', 'custom-session'],
+    ['empty session suppression', ''],
+  ])('%s survives isolated OM execution threads', async (_label, sessionId) => {
+    const observability = new DefaultObservabilityInstance({
+      name: 'session-test',
+      serviceName: 'session-test',
+      exporters: [],
+    });
+    const instance = observability;
+    const exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+    const root = instance.startSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'caller',
+      metadata: { threadId: 'caller-thread', ...(sessionId !== 'caller-thread' ? { sessionId } : {}) },
+    });
+    const wrapper = root.createChildSpan({
+      type: SpanType.MEMORY_OPERATION,
+      name: 'memory: observe',
+      metadata: { sessionId },
+      attributes: { operationType: 'observe' },
+    });
+    const agent = wrapper.createChildSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'observer',
+      metadata: { threadId: 'isolated-observer-thread' },
+    });
+    const model = agent.createChildSpan({
+      type: SpanType.MODEL_GENERATION,
+      name: 'model',
+      attributes: { model: 'gpt-4.1-mini', provider: 'openai' },
+    });
+    const spans = [root, wrapper, agent, model];
+    for (const span of [...spans].reverse()) span.end();
+    expect(agent.metadata?.threadId).toBe('isolated-observer-thread');
+    expect(agent.metadata?.sessionId).toBe(sessionId);
+    expect(root.metadata?.threadId).toBe('caller-thread');
+    for (const span of order === 'root-first' ? spans : [...spans].reverse()) {
+      await exporter.onTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: span.exportSpan() });
+    }
+    expect(processed).toHaveLength(4);
+    for (const span of processed) {
+      expect(span.spanContext().traceId).toBe(root.traceId);
+      expect(span.attributes['session.id']).toBe(sessionId || undefined);
+      if (sessionId) {
+        expect(span.attributes).not.toHaveProperty('mastra.metadata.sessionId');
+        expect(span.attributes).not.toHaveProperty('mastra.metadata.threadId');
+      }
+    }
+    const convertedAgent = processed.find(span => span.spanContext().spanId === agent.id)!;
+    expect(convertedAgent.parentSpanContext?.spanId).toBe(wrapper.id);
+    expect(processed.find(span => span.spanContext().spanId === model.id)?.parentSpanContext?.spanId).toBe(agent.id);
+    if (!sessionId) {
+      expect(convertedAgent.attributes['mastra.metadata.sessionId']).toBe('');
+      expect(convertedAgent.attributes['mastra.metadata.threadId']).toBe('isolated-observer-thread');
+    }
+    await exporter.shutdown();
+    await observability.shutdown();
+  });
+
+  it('does not invent a session from an external parent', async () => {
+    const observability = new DefaultObservabilityInstance({
+      name: 'session-test',
+      serviceName: 'session-test',
+      exporters: [],
+    });
+    const root = observability.startSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'external caller',
+      tracingOptions: { traceId: '1234567890abcdef1234567890abcdef', parentSpanId: 'abcdef1234567890' },
+    });
+    const child = root.createChildSpan({
+      type: SpanType.MEMORY_OPERATION,
+      name: 'memory: reflect',
+      attributes: { operationType: 'reflect' },
+    });
+    child.end();
+    root.end();
+    const exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+    for (const span of order === 'root-first' ? [root, child] : [child, root]) {
+      await exporter.onTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: span.exportSpan() });
+    }
+    expect(processed).toHaveLength(2);
+    for (const span of processed) expect(span.attributes['session.id']).toBeUndefined();
+    expect(processed.find(span => span.spanContext().spanId === root.id)?.parentSpanContext?.spanId).toBe(
+      'abcdef1234567890',
+    );
+    expect(processed.find(span => span.spanContext().spanId === child.id)?.parentSpanContext?.spanId).toBe(root.id);
+    await exporter.shutdown();
+    await observability.shutdown();
+  });
+
+  it('keeps generic nested-agent grouping under a threadless workflow root', async () => {
+    const observability = new DefaultObservabilityInstance({
+      name: 'session-test',
+      serviceName: 'session-test',
+      exporters: [],
+    });
+    const root = observability.startSpan({ type: SpanType.WORKFLOW_RUN, name: 'workflow' });
+    const caller = root.createChildSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'nested caller',
+      metadata: { threadId: 'nested-thread' },
+    });
+    const exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+    caller.end();
+    root.end();
+    for (const span of order === 'root-first' ? [root, caller] : [caller, root]) {
+      await exporter.onTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: span.exportSpan() });
+    }
+    expect(processed.find(span => span.spanContext().spanId === root.id)?.attributes['session.id']).toBeUndefined();
+    const child = processed.find(span => span.spanContext().spanId === caller.id)!;
+    expect(child.attributes['session.id']).toBe('nested-thread');
+    expect(child.parentSpanContext?.spanId).toBe(root.id);
+    await exporter.shutdown();
+    await observability.shutdown();
+  });
+});

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -18,7 +18,16 @@ import { SpanConverter } from '@mastra/otel-exporter';
 const LOG_PREFIX = '[LangfuseExporter]';
 const MASTRA_METADATA_PREFIX = 'mastra.metadata.';
 /** Metadata keys mapped to dedicated Langfuse fields; never forwarded as trace metadata. */
-const DEDICATED_METADATA_KEYS = new Set(['userId', 'sessionId', 'threadId', 'traceName', 'version', 'langfuse']);
+const OM_CALLER_THREAD_ID = '__mastraObservationalMemoryCallerThreadId';
+const DEDICATED_METADATA_KEYS = new Set([
+  'userId',
+  'sessionId',
+  'threadId',
+  'traceName',
+  'version',
+  'langfuse',
+  OM_CALLER_THREAD_ID,
+]);
 
 export const LANGFUSE_DEFAULT_BASE_URL = 'https://cloud.langfuse.com';
 
@@ -340,8 +349,15 @@ function mapMastraToLangfuseAttributes(
     delete attributes['mastra.metadata.userId'];
   }
 
-  // Session ID: mastra.metadata.sessionId or threadId → session.id
-  const sessionId = attributes['mastra.metadata.sessionId'] ?? attributes['mastra.metadata.threadId'];
+  // OM keeps caller identity separate from its isolated execution thread. Read
+  // the raw hint: conversion serializes malformed objects/arrays into strings.
+  const omCallerThreadId = span.metadata?.[OM_CALLER_THREAD_ID];
+  const sessionId =
+    attributes['mastra.metadata.sessionId'] ??
+    (typeof omCallerThreadId === 'string' && omCallerThreadId
+      ? omCallerThreadId
+      : attributes['mastra.metadata.threadId']);
+  delete attributes[`${MASTRA_METADATA_PREFIX}${OM_CALLER_THREAD_ID}`];
   if (sessionId) {
     attributes['session.id'] = sessionId;
     delete attributes['mastra.metadata.sessionId'];

--- a/packages/memory/src/processors/observational-memory/__tests__/internal-request-context.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/internal-request-context.test.ts
@@ -192,8 +192,10 @@ describe.each(['observer', 'multi-thread-observer', 'reflector'] as const)('%s t
       expect(stream).toHaveBeenCalledTimes(1);
       expect(parent.createChildSpan).toHaveBeenCalledTimes(1);
       const spanOptions = parent.createChildSpan.mock.calls[0]!;
-      if (hasIdentity) expect(spanOptions[0].metadata.sessionId).toBe('invoking-caller');
-      else expect(spanOptions[0].metadata).not.toHaveProperty('sessionId');
+      expect(spanOptions[0].metadata).not.toHaveProperty('sessionId');
+      if (hasIdentity)
+        expect(spanOptions[0].metadata.__mastraObservationalMemoryCallerThreadId).toBe('invoking-caller');
+      else expect(spanOptions[0].metadata).not.toHaveProperty('__mastraObservationalMemoryCallerThreadId');
       expect(requestContext.get(MASTRA_THREAD_ID_KEY)).toBe(hasIdentity ? 'parent-thread' : undefined);
       expect(caller.tracingContext).toBe(tracing);
       expect(caller.tracingContext?.currentSpan).toBe(parent);

--- a/packages/memory/src/processors/observational-memory/__tests__/internal-request-context.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/internal-request-context.test.ts
@@ -1,4 +1,6 @@
 import type { MastraDBMessage } from '@mastra/core/agent';
+import type { ObservabilityContext } from '@mastra/core/observability';
+import { createObservabilityContext } from '@mastra/core/observability';
 import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY, RequestContext } from '@mastra/core/request-context';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
@@ -116,6 +118,88 @@ describe('withOmInternalThreadId', () => {
 
     expect((requestContext.get('MastraMemory') as { resourceId?: string })?.resourceId).toBe('resource-1');
   });
+});
+
+describe.each(['observer', 'multi-thread-observer', 'reflector'] as const)('%s tracing handoff', role => {
+  it.each([true, false])(
+    'preserves caller session without changing execution identity (caller identity: %s)',
+    async hasIdentity => {
+      const requestContext = hasIdentity ? createParentRequestContext() : new RequestContext();
+      const child = {
+        end: vi.fn(),
+        error: vi.fn(),
+        executeInContext: <T>(fn: () => Promise<T>) => fn(),
+      };
+      const parent = {
+        metadata: hasIdentity ? { threadId: 'invoking-caller' } : {},
+        createChildSpan: vi.fn((_options: { metadata: Record<string, unknown> }) => child),
+      };
+      const caller = createObservabilityContext({ currentSpan: parent } as unknown as Parameters<
+        typeof createObservabilityContext
+      >[0]);
+      const tracing = caller.tracingContext;
+      const runner = role === 'reflector' ? createReflectorRunner() : createObserverRunner();
+      const id = role === 'multi-thread-observer' ? role : `observational-memory-${role}`;
+      const stream = vi.fn(
+        async (_prompt: unknown, options: ObservabilityContext & { requestContext?: RequestContext }) => {
+          expect(options.tracingContext).not.toBe(tracing);
+          expect(options.tracing).toBe(options.tracingContext);
+          expect(options.tracingContext?.currentSpan).toBe(child);
+          expect(caller.tracingContext).toBe(tracing);
+          expect(tracing?.currentSpan).toBe(parent);
+          expect(options.requestContext).not.toBe(requestContext);
+          expect(options.requestContext?.get(MASTRA_THREAD_ID_KEY)).toBe(
+            hasIdentity ? `parent-thread-${id}` : undefined,
+          );
+          return {
+            getFullOutput: async () => ({
+              text: '<observations>\n<thread id="batch-thread">\n- learned something\n</thread>\n</observations>',
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            }),
+          };
+        },
+      );
+      vi.spyOn(runner as any, 'createAgent').mockReturnValue({ id, stream });
+      if (runner instanceof ReflectorRunner) {
+        await runner.call(
+          'existing observations',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          0,
+          requestContext,
+          undefined,
+          caller,
+        );
+      } else if (role === 'multi-thread-observer') {
+        await runner.callMultiThread(
+          undefined,
+          new Map([['batch-thread', [createMessage('msg-1', 'batch-thread')]]]),
+          ['batch-thread'],
+          undefined,
+          requestContext,
+          undefined,
+          caller,
+        );
+      } else {
+        await runner.call(undefined, [createMessage('msg-1')], undefined, {
+          requestContext,
+          observabilityContext: caller,
+        });
+      }
+      expect(stream).toHaveBeenCalledTimes(1);
+      expect(parent.createChildSpan).toHaveBeenCalledTimes(1);
+      const spanOptions = parent.createChildSpan.mock.calls[0]!;
+      if (hasIdentity) expect(spanOptions[0].metadata.sessionId).toBe('invoking-caller');
+      else expect(spanOptions[0].metadata).not.toHaveProperty('sessionId');
+      expect(requestContext.get(MASTRA_THREAD_ID_KEY)).toBe(hasIdentity ? 'parent-thread' : undefined);
+      expect(caller.tracingContext).toBe(tracing);
+      expect(caller.tracingContext?.currentSpan).toBe(parent);
+      expect(child.end).toHaveBeenCalledTimes(1);
+    },
+  );
 });
 
 describe('OM internal agent request contexts', () => {

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
@@ -13,6 +13,7 @@
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import type { MastraDBMessage, MastraMessageContentV2 } from '@mastra/core/agent';
 import { getThreadOMMetadata, setThreadOMMetadata } from '@mastra/core/memory';
+import { createObservabilityContext } from '@mastra/core/observability';
 import { InMemoryMemory, InMemoryDB } from '@mastra/core/storage';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
@@ -20,6 +21,7 @@ import { BufferingCoordinator } from '../buffering-coordinator';
 import { Extractor } from '../extractor';
 import { ModelByInputTokens } from '../model-by-input-tokens';
 import { ObservationalMemory } from '../observational-memory';
+import { ObserverRunner } from '../observer-runner';
 import type { ContinuationHintsConfig, ObserveHooks } from '../types';
 
 // =============================================================================
@@ -3904,6 +3906,35 @@ describe('config-level hooks', () => {
       }),
     );
     expect(hooks.onObservationEnd.mock.calls[0]![0].error.message).toMatch(/Observer failed/);
+  });
+
+  it('forwards the caller observability context through triggerAsyncBuffering to the observer', async () => {
+    const observabilityContext = createObservabilityContext({});
+    const observerCall = vi.spyOn(ObserverRunner.prototype, 'call');
+    try {
+      const om = createOM(storage, { messageTokens: 500, bufferTokens: 0.2 });
+      const messages = createBulkMessages(5, threadId);
+      await storage.saveMessages({ messages });
+      const status = await om.getStatus({ threadId, messages });
+
+      expect(
+        await om.triggerAsyncBuffering({
+          threadId,
+          record: status.record,
+          pendingTokens: status.pendingTokens,
+          unbufferedPendingTokens: status.pendingTokens,
+          unobservedMessages: messages,
+          threshold: status.threshold,
+          observabilityContext,
+        }),
+      ).toBe(true);
+      await om.waitForBuffering(threadId, undefined, 5000);
+
+      expect(observerCall).toHaveBeenCalledOnce();
+      expect(observerCall.mock.calls[0]?.[3]?.observabilityContext).toBe(observabilityContext);
+    } finally {
+      observerCall.mockRestore();
+    }
   });
 
   it('fires config-level hooks on the fire-and-forget triggerAsyncBuffering lane', async () => {

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -2347,6 +2347,7 @@ ${formattedMessages}
           opts.writer,
           opts.unbufferedPendingTokens,
           opts.requestContext,
+          opts.observabilityContext,
         ),
       );
     }

--- a/packages/memory/src/processors/observational-memory/tracing.test.ts
+++ b/packages/memory/src/processors/observational-memory/tracing.test.ts
@@ -41,8 +41,8 @@ const baseArgs = {
 
 describe.each(['observer', 'observer-multi-thread', 'reflector'] as const)('%s session correlation', phase => {
   const cases: Array<[string, Record<string, unknown>, unknown, unknown]> = [
-    ['explicit session', { sessionId: 'custom', threadId: 'T' }, 'T', 'custom'],
-    ['empty session suppression', { sessionId: '', threadId: 'T' }, 'T', ''],
+    ['explicit session', { sessionId: 'custom', threadId: 'T' }, 'T', 'T'],
+    ['empty session suppression', { sessionId: '', threadId: 'T' }, 'T', 'T'],
     ['null session', { sessionId: null, threadId: 'T' }, 'T', 'T'],
     ['undefined session', { sessionId: undefined, threadId: 'T' }, 'T', 'T'],
     ['absent session', { threadId: 'T' }, 'T', 'T'],
@@ -51,11 +51,11 @@ describe.each(['observer', 'observer-multi-thread', 'reflector'] as const)('%s s
     ['empty caller thread', { threadId: '' }, 'T', 'T'],
     ['no identity', {}, undefined, undefined],
     ['empty request thread', {}, '', undefined],
-    ['false session unchanged', { sessionId: false, threadId: 'T' }, 'T', false],
-    ['zero session unchanged', { sessionId: 0, threadId: 'T' }, 'T', 0],
-    ['object session unchanged', { sessionId: { malformed: true } }, 'T', { malformed: true }],
-    ['array session unchanged', { sessionId: ['malformed'] }, 'T', ['malformed']],
-    ['numeric session unchanged', { sessionId: 42 }, 'T', 42],
+    ['false session unchanged', { sessionId: false, threadId: 'T' }, 'T', 'T'],
+    ['zero session unchanged', { sessionId: 0, threadId: 'T' }, 'T', 'T'],
+    ['object session unchanged', { sessionId: { malformed: true } }, 'T', 'T'],
+    ['array session unchanged', { sessionId: ['malformed'] }, 'T', 'T'],
+    ['numeric session unchanged', { sessionId: 42 }, 'T', 'T'],
     ['false caller thread ignored', { threadId: false }, 'T', 'T'],
     ['numeric caller thread ignored', { threadId: 42 }, 'T', 'T'],
     ['object caller thread ignored', { threadId: {} }, 'T', 'T'],
@@ -63,7 +63,7 @@ describe.each(['observer', 'observer-multi-thread', 'reflector'] as const)('%s s
     ['malformed request ignored', {}, 42, undefined],
   ];
 
-  it.each(cases)('%s', async (_name, metadata, requestThread, expected) => {
+  it.each(cases)('%s', async (_name, metadata, requestThread, expectedThread) => {
     const { child, parent, observabilityContext } = createFakeSpanTree(metadata);
     observabilityContext.tracing = observabilityContext.tracingContext;
     const before = { ...observabilityContext };
@@ -98,12 +98,46 @@ describe.each(['observer', 'observer-multi-thread', 'reflector'] as const)('%s s
     checkCaller();
     expect(parent.createChildSpan).toHaveBeenCalledWith(
       expect.objectContaining({
-        metadata: expected === undefined ? wrapperMetadata : { ...wrapperMetadata, sessionId: expected },
+        metadata:
+          expectedThread === undefined
+            ? wrapperMetadata
+            : { ...wrapperMetadata, __mastraObservationalMemoryCallerThreadId: expectedThread },
       }),
     );
     expect(wrapperMetadata).toEqual({ diagnostic: 'preserved' });
     expect(child.end).toHaveBeenCalledTimes(1);
     expect(child.error).not.toHaveBeenCalled();
+  });
+
+  it('preserves the outer caller hint through nested OM and overrides wrapper collisions', async () => {
+    const { parent, observabilityContext } = createFakeSpanTree({
+      threadId: 'T-observer',
+      __mastraObservationalMemoryCallerThreadId: 'T',
+    });
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_THREAD_ID_KEY, 'T-observer');
+    await withOmTracingSpan({
+      ...baseArgs,
+      phase,
+      observabilityContext,
+      requestContext,
+      metadata: { __mastraObservationalMemoryCallerThreadId: 'collision' },
+      callback: async () => {},
+    });
+    expect(parent.createChildSpan).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { __mastraObservationalMemoryCallerThreadId: 'T' } }),
+    );
+  });
+
+  it.each([false, 0, {}, [], ''])('ignores malformed inherited hints: %j', async hint => {
+    const { parent, observabilityContext } = createFakeSpanTree({
+      threadId: 'T',
+      __mastraObservationalMemoryCallerThreadId: hint,
+    });
+    await withOmTracingSpan({ ...baseArgs, phase, observabilityContext, callback: async () => {} });
+    expect(parent.createChildSpan).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { __mastraObservationalMemoryCallerThreadId: 'T' } }),
+    );
   });
 
   it('does not create a root just to attach a request session', async () => {
@@ -158,7 +192,7 @@ describe.each(['observer', 'observer-multi-thread', 'reflector'] as const)('%s s
       callback: async () => {},
     });
     expect(canonical.parent.createChildSpan).toHaveBeenCalledWith(
-      expect.objectContaining({ metadata: { sessionId: 'canonical' } }),
+      expect.objectContaining({ metadata: { __mastraObservationalMemoryCallerThreadId: 'canonical' } }),
     );
     expect(legacy.parent.createChildSpan).not.toHaveBeenCalled();
     expect(canonical.observabilityContext.tracing).toBe(legacy.observabilityContext.tracingContext);

--- a/packages/memory/src/processors/observational-memory/tracing.test.ts
+++ b/packages/memory/src/processors/observational-memory/tracing.test.ts
@@ -1,4 +1,5 @@
 import type { ObservabilityContext } from '@mastra/core/observability';
+import { MASTRA_THREAD_ID_KEY, RequestContext } from '@mastra/core/request-context';
 import { describe, expect, it, vi } from 'vitest';
 
 import { withOmTracingSpan } from './tracing';
@@ -11,7 +12,7 @@ import { withOmTracingSpan } from './tracing';
  * traces (and their payloads) in exporters that hold a trace open until every
  * span finishes.
  */
-function createFakeSpanTree() {
+function createFakeSpanTree(metadata: Record<string, unknown> = {}) {
   const child = {
     end: vi.fn(),
     error: vi.fn(),
@@ -19,10 +20,13 @@ function createFakeSpanTree() {
   };
 
   const parent = {
+    metadata,
     createChildSpan: vi.fn(() => child),
   };
 
   const observabilityContext = {
+    loggerVNext: {},
+    metrics: {},
     tracingContext: { currentSpan: parent },
   } as unknown as ObservabilityContext;
 
@@ -34,6 +38,132 @@ const baseArgs = {
   model: 'openai/gpt-4.1-mini',
   inputTokens: 123,
 };
+
+describe.each(['observer', 'observer-multi-thread', 'reflector'] as const)('%s session correlation', phase => {
+  const cases: Array<[string, Record<string, unknown>, unknown, unknown]> = [
+    ['explicit session', { sessionId: 'custom', threadId: 'T' }, 'T', 'custom'],
+    ['empty session suppression', { sessionId: '', threadId: 'T' }, 'T', ''],
+    ['null session', { sessionId: null, threadId: 'T' }, 'T', 'T'],
+    ['undefined session', { sessionId: undefined, threadId: 'T' }, 'T', 'T'],
+    ['absent session', { threadId: 'T' }, 'T', 'T'],
+    ['caller thread wins', { threadId: 'T' }, 'different', 'T'],
+    ['request fallback', {}, 'T', 'T'],
+    ['empty caller thread', { threadId: '' }, 'T', 'T'],
+    ['no identity', {}, undefined, undefined],
+    ['empty request thread', {}, '', undefined],
+    ['false session unchanged', { sessionId: false, threadId: 'T' }, 'T', false],
+    ['zero session unchanged', { sessionId: 0, threadId: 'T' }, 'T', 0],
+    ['object session unchanged', { sessionId: { malformed: true } }, 'T', { malformed: true }],
+    ['array session unchanged', { sessionId: ['malformed'] }, 'T', ['malformed']],
+    ['numeric session unchanged', { sessionId: 42 }, 'T', 42],
+    ['false caller thread ignored', { threadId: false }, 'T', 'T'],
+    ['numeric caller thread ignored', { threadId: 42 }, 'T', 'T'],
+    ['object caller thread ignored', { threadId: {} }, 'T', 'T'],
+    ['array caller thread ignored', { threadId: [] }, 'T', 'T'],
+    ['malformed request ignored', {}, 42, undefined],
+  ];
+
+  it.each(cases)('%s', async (_name, metadata, requestThread, expected) => {
+    const { child, parent, observabilityContext } = createFakeSpanTree(metadata);
+    observabilityContext.tracing = observabilityContext.tracingContext;
+    const before = { ...observabilityContext };
+    const beforeMetadata = { ...metadata };
+    const requestContext = new RequestContext();
+    if (requestThread !== undefined) requestContext.set(MASTRA_THREAD_ID_KEY, requestThread);
+    const wrapperMetadata = { diagnostic: 'preserved' };
+    const checkCaller = () => {
+      expect(observabilityContext.tracingContext).toBe(before.tracingContext);
+      expect(observabilityContext.tracing).toBe(before.tracing);
+      expect(observabilityContext.tracingContext?.currentSpan).toBe(parent);
+      expect(observabilityContext.loggerVNext).toBe(before.loggerVNext);
+      expect(observabilityContext.metrics).toBe(before.metrics);
+      expect(parent.metadata).toBe(metadata);
+      expect(metadata).toEqual(beforeMetadata);
+      expect(requestContext.get(MASTRA_THREAD_ID_KEY)).toBe(requestThread);
+    };
+    await withOmTracingSpan({
+      ...baseArgs,
+      phase,
+      observabilityContext,
+      requestContext,
+      metadata: wrapperMetadata,
+      callback: async context => {
+        checkCaller();
+        expect(context).not.toBe(observabilityContext);
+        expect(context.tracingContext).not.toBe(before.tracingContext);
+        expect(context.tracing).toBe(context.tracingContext);
+        expect(context.tracingContext?.currentSpan).toBe(child);
+      },
+    });
+    checkCaller();
+    expect(parent.createChildSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expected === undefined ? wrapperMetadata : { ...wrapperMetadata, sessionId: expected },
+      }),
+    );
+    expect(wrapperMetadata).toEqual({ diagnostic: 'preserved' });
+    expect(child.end).toHaveBeenCalledTimes(1);
+    expect(child.error).not.toHaveBeenCalled();
+  });
+
+  it('does not create a root just to attach a request session', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_THREAD_ID_KEY, 'T');
+    await withOmTracingSpan({
+      ...baseArgs,
+      phase,
+      requestContext,
+      callback: async context => {
+        expect(context.tracingContext?.currentSpan).toBeUndefined();
+        expect(context.tracing?.currentSpan).toBeUndefined();
+      },
+    });
+  });
+
+  it('keeps caller references and metadata intact after failure', async () => {
+    const { child, parent, observabilityContext } = createFakeSpanTree({ threadId: 'T' });
+    observabilityContext.tracing = observabilityContext.tracingContext;
+    const before = { ...observabilityContext };
+    const metadata = parent.metadata;
+    const failure = new Error('model failed');
+    await expect(
+      withOmTracingSpan({
+        ...baseArgs,
+        phase,
+        observabilityContext,
+        callback: async () => {
+          throw failure;
+        },
+      }),
+    ).rejects.toBe(failure);
+    expect(observabilityContext.tracingContext).toBe(before.tracingContext);
+    expect(observabilityContext.tracing).toBe(before.tracing);
+    expect(observabilityContext.tracingContext?.currentSpan).toBe(parent);
+    expect(observabilityContext.loggerVNext).toBe(before.loggerVNext);
+    expect(observabilityContext.metrics).toBe(before.metrics);
+    expect(parent.metadata).toBe(metadata);
+    expect(metadata).toEqual({ threadId: 'T' });
+    expect(child.error).toHaveBeenCalledExactlyOnceWith({ error: failure, endSpan: true });
+    expect(child.end).not.toHaveBeenCalled();
+  });
+
+  it('preserves tracingContext-first precedence when aliases conflict', async () => {
+    const canonical = createFakeSpanTree({ threadId: 'canonical' });
+    const legacy = createFakeSpanTree({ threadId: 'legacy' });
+    canonical.observabilityContext.tracing = legacy.observabilityContext.tracingContext;
+    await withOmTracingSpan({
+      ...baseArgs,
+      phase,
+      observabilityContext: canonical.observabilityContext,
+      callback: async () => {},
+    });
+    expect(canonical.parent.createChildSpan).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { sessionId: 'canonical' } }),
+    );
+    expect(legacy.parent.createChildSpan).not.toHaveBeenCalled();
+    expect(canonical.observabilityContext.tracing).toBe(legacy.observabilityContext.tracingContext);
+  });
+});
 
 describe('withOmTracingSpan', () => {
   it('ends the span once the callback resolves', async () => {

--- a/packages/memory/src/processors/observational-memory/tracing.ts
+++ b/packages/memory/src/processors/observational-memory/tracing.ts
@@ -1,5 +1,6 @@
 import type { MemoryOperationAttributes, ObservabilityContext } from '@mastra/core/observability';
 import { createObservabilityContext, EntityType, getOrCreateSpan, SpanType } from '@mastra/core/observability';
+import { MASTRA_THREAD_ID_KEY } from '@mastra/core/request-context';
 import type { RequestContext } from '@mastra/core/request-context';
 
 import type { ModelByInputTokens } from './model-by-input-tokens';
@@ -57,6 +58,18 @@ export async function withOmTracingSpan<T>({
   callback: (observabilityContext: ObservabilityContext) => Promise<T>;
 }): Promise<T> {
   const config = PHASE_CONFIG[phase];
+  const tracingContext = observabilityContext?.tracingContext ?? observabilityContext?.tracing;
+  const callerMetadata = tracingContext?.currentSpan?.metadata;
+  const callerThreadId = callerMetadata?.threadId;
+  const requestThreadId = requestContext?.get(MASTRA_THREAD_ID_KEY);
+  // Internal agents use isolated execution threads, but belong to the caller's tracing session.
+  const sessionId =
+    callerMetadata?.sessionId ??
+    (typeof callerThreadId === 'string' && callerThreadId
+      ? callerThreadId
+      : typeof requestThreadId === 'string' && requestThreadId
+        ? requestThreadId
+        : undefined);
   // GENERIC is reserved for spans ingested from outside Mastra, where the shape
   // is unknown. These are memory's own model passes, so they carry the memory
   // operation type and its typed attributes rather than an untyped metadata bag.
@@ -70,14 +83,14 @@ export async function withOmTracingSpan<T>({
     name: config.name,
     entityType: EntityType.MEMORY,
     entityName: config.entityName,
-    tracingContext: observabilityContext?.tracingContext ?? observabilityContext?.tracing,
+    tracingContext,
     attributes: {
       operationType: config.operationType,
       inputTokens,
       selectedModel: typeof model === 'string' ? model : '(dynamic-model)',
       ...(config.multiThread ? { multiThread: true } : {}),
     },
-    metadata,
+    metadata: sessionId !== undefined ? { ...metadata, sessionId } : metadata,
     requestContext,
   });
   const childObservabilityContext = createObservabilityContext({ currentSpan: span });

--- a/packages/memory/src/processors/observational-memory/tracing.ts
+++ b/packages/memory/src/processors/observational-memory/tracing.ts
@@ -60,16 +60,19 @@ export async function withOmTracingSpan<T>({
   const config = PHASE_CONFIG[phase];
   const tracingContext = observabilityContext?.tracingContext ?? observabilityContext?.tracing;
   const callerMetadata = tracingContext?.currentSpan?.metadata;
+  const inheritedCallerThreadId = callerMetadata?.__mastraObservationalMemoryCallerThreadId;
   const callerThreadId = callerMetadata?.threadId;
   const requestThreadId = requestContext?.get(MASTRA_THREAD_ID_KEY);
-  // Internal agents use isolated execution threads, but belong to the caller's tracing session.
-  const sessionId =
-    callerMetadata?.sessionId ??
-    (typeof callerThreadId === 'string' && callerThreadId
-      ? callerThreadId
-      : typeof requestThreadId === 'string' && requestThreadId
-        ? requestThreadId
-        : undefined);
+  // Preserve caller identity separately from isolated execution threads. Exporters
+  // decide whether to use this reserved internal hint as a session fallback.
+  const omCallerThreadId =
+    typeof inheritedCallerThreadId === 'string' && inheritedCallerThreadId
+      ? inheritedCallerThreadId
+      : typeof callerThreadId === 'string' && callerThreadId
+        ? callerThreadId
+        : typeof requestThreadId === 'string' && requestThreadId
+          ? requestThreadId
+          : undefined;
   // GENERIC is reserved for spans ingested from outside Mastra, where the shape
   // is unknown. These are memory's own model passes, so they carry the memory
   // operation type and its typed attributes rather than an untyped metadata bag.
@@ -90,7 +93,10 @@ export async function withOmTracingSpan<T>({
       selectedModel: typeof model === 'string' ? model : '(dynamic-model)',
       ...(config.multiThread ? { multiThread: true } : {}),
     },
-    metadata: sessionId !== undefined ? { ...metadata, sessionId } : metadata,
+    metadata:
+      omCallerThreadId !== undefined
+        ? { ...metadata, __mastraObservationalMemoryCallerThreadId: omCallerThreadId }
+        : metadata,
     requestContext,
   });
   const childObservabilityContext = createObservabilityContext({ currentSpan: span });


### PR DESCRIPTION
## Summary

Observational Memory's observer and reflector use isolated execution threads. When their spans reach Langfuse before the caller's spans, those internal thread IDs can temporarily become the trace's session ID. The reproduced baseline converges to the caller session after enclosing spans arrive; this fixes the in-flight misassignment rather than claiming a persistent production split.

- Preserve original caller thread identity through OM in a reserved internal correlation hint, separate from the isolated execution `threadId`.
- Keep thread-to-session fallback in **Langfuse**, not generic OM `sessionId` metadata. Explicit session values take precedence, including empty-string suppression. Langfuse otherwise uses the inherited caller hint, then its existing thread fallback. Nested OM preserves the outer caller identity.
- Leave generic `sessionId` unchanged for other exporters. They may receive the opaque internal caller-thread hint as metadata, but no session ID is synthesized for them.
- Forward the supplied `observabilityContext` through the explicit `triggerAsyncBuffering` handoff instead of dropping it. Do not synthesize context when absent.

Internal execution threads, span parentage, buffering defaults, scheduling, and caller-context references are preserved. No ancestor caches, suffix/name parsing, root-only session mapping, core runtime changes, other exporter changes, or dependency additions.

Includes separate memory/Langfuse patch changesets and Langfuse session documentation.

## Test plan

- [x] Focused memory tracing/internal-context regressions: 105 passed, including observer, multi-thread observer, reflector, aliases, lifecycle, nested hint precedence, collisions, malformed metadata and no-root execution.
- [x] Package-wide Langfuse tests: 99 passed, including real span/converter/exporter path, raw hint validation, explicit/empty/falsy/nullish precedence, workflow nesting, external parents and both export orders.
- [x] Full memory unit suite: 1,629 passed, one existing TODO. Existing public async-buffering regression remains included.
- [x] Relevant memory/Langfuse builds, typechecks and lint; MDX formatting, Remark and Vale; diff whitespace checks.
- [x] Fresh isolated consumers installed all seven workspace runtime packages from separate baseline/redesign tarballs; normalized dependency parity, drift negative control, entry/tarball hashes and realpath containment passed.
- [x] Real Langfuse proof with public packed Agent + Memory, synthetic deterministic model inference and `bufferOnIdle: false`. Each side invoked caller, observer and reflector three times and retained 15 stable context-reference samples.
- [x] All six natural/replay runs returned 58 observations with verified parentage. Redesign retained caller session at every one of 11 checked stages in both replay orders. Baseline child-first reproduced the transient internal-session mismatch.
- [x] Raw formatter captures independently confirmed **no synthesized generic `sessionId`** on either side. Final manifest, ledgers and transcripts were checked for consistency.
- [x] Adversarial review: no remaining must-fixes.

Live-service artifacts are retained locally, not committed. The live proof covers normal Agent+OM execution and exporter replay, not the standalone explicit async-buffering entry point; that handoff has public-API regression coverage. The aggregate `pnpm test:memory` previously hit an integration-harness setup blocker (missing `execa`); the full unit suite was run separately. No claim of universal tracing-context immutability or repair of pre-existing disconnected traces.
