### PR TITLE
fix(core): preserve original input when resuming saved durable runs

### DIFF
--- a/.changeset/plain-cycles-remain.md
+++ b/.changeset/plain-cycles-remain.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed saved durable runs repeating initial input checks after a process restart.

--- a/packages/core/src/agent/durable/__tests__/resume-api.test.ts
+++ b/packages/core/src/agent/durable/__tests__/resume-api.test.ts
@@ -22,6 +22,7 @@ import { InMemoryStore } from '../../../storage';
 import { createTool } from '../../../tools';
 import type { WorkflowRunState } from '../../../workflows/types';
 import { Agent } from '../../agent';
+import { MessageList } from '../../message-list';
 import { DurableStepIds } from '../constants';
 import { createDurableAgent } from '../create-durable-agent';
 
@@ -90,6 +91,8 @@ async function seedSuspendedRun(
   status: WorkflowRunState['status'] = 'suspended',
 ) {
   const workflows = (await store.getStore('workflows'))!;
+  const messageList = new MessageList(memory);
+  messageList.add({ id: 'saved-input', role: 'user', content: 'The original request' }, 'input');
   await workflows.persistWorkflowSnapshot({
     workflowName: DurableStepIds.AGENTIC_LOOP,
     runId,
@@ -103,7 +106,7 @@ async function seedSuspendedRun(
           __workflowKind: 'durable-agent',
           runId,
           agentId,
-          messageListState: { memoryInfo: memory },
+          messageListState: messageList.serialize(),
           requestContextEntries: { tenantId: 'tenant-1' },
           state: memory,
         },
@@ -223,21 +226,65 @@ describe('Resume API', () => {
 
       const result = await durableAgent.resume(runId, { approved: true });
 
-      expect(prepareSpy).toHaveBeenCalledOnce();
-      expect(prepareSpy).toHaveBeenCalledWith(
-        [],
-        expect.objectContaining({
-          runId,
-          memory: { thread: 'cold-thread', resource: 'cold-resource' },
-          requestContext: expect.anything(),
-        }),
-      );
-      expect(prepareSpy.mock.calls[0]?.[1]?.requestContext?.get('tenantId')).toBe('tenant-1');
+      expect(prepareSpy).not.toHaveBeenCalled();
+      expect(durableAgent.runRegistry.get(runId)?.requestContext?.get('tenantId')).toBe('tenant-1');
       expect(durableAgent.runRegistry.has(runId)).toBe(true);
       expect(result.runId).toBe(runId);
       expect(result.threadId).toBe('cold-thread');
       expect(result.resourceId).toBe('cold-resource');
       result.cleanup();
+    });
+
+    it('does not run initial input processors again when restoring a saved run', async () => {
+      const processInput = vi.fn(({ messages }) => messages);
+      const store = new InMemoryStore();
+      const baseAgent = new Agent({
+        id: 'cold-input-processors-agent',
+        name: 'Cold Input Processors Agent',
+        instructions: 'Resume the saved request',
+        model: createTextModel('Resumed') as LanguageModelV2,
+        inputProcessors: [{ id: 'initial-input-check', processInput }],
+      });
+      const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+      void new Mastra({ agents: { durableAgent }, storage: store, logger: false });
+      const runId = 'saved-input-processors-run';
+      await seedSuspendedRun(store, runId, durableAgent.id, {
+        threadId: 'saved-input-thread',
+        resourceId: 'saved-input-resource',
+      });
+
+      const result = await durableAgent.resume(runId, { approved: true });
+      try {
+        expect(processInput).not.toHaveBeenCalled();
+        expect(
+          durableAgent.runRegistry
+            .getMessageList(runId)
+            ?.getPersisted.input.db()
+            .map(message => message.id),
+        ).toEqual(['saved-input']);
+      } finally {
+        result.cleanup();
+      }
+    });
+
+    it('still checks fresh input once and does not repeat it on a warm resume', async () => {
+      const processInput = vi.fn(({ messages }) => messages);
+      const baseAgent = new Agent({
+        id: 'fresh-input-processors-agent',
+        name: 'Fresh Input Processors Agent',
+        instructions: 'Check fresh input',
+        model: createTextModel('Resumed') as LanguageModelV2,
+        inputProcessors: [{ id: 'initial-input-check', processInput }],
+      });
+      const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+      const { runId } = await durableAgent.prepare('A new request');
+      expect(processInput).toHaveBeenCalledOnce();
+      const result = await durableAgent.resume(runId, { approved: true });
+      try {
+        expect(processInput).toHaveBeenCalledOnce();
+      } finally {
+        result.cleanup();
+      }
     });
 
     it('rejects a persisted run that is not suspended before rehydrating', async () => {

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -21,6 +21,7 @@ import type { AgentExecutionOptions } from '../agent.types';
 import { beginGoalActivity, stopGoalActivity } from '../goal';
 import { MessageList } from '../message-list';
 import type { MessageListInput } from '../message-list';
+import type { SerializedMessageListState } from '../message-list/state';
 import { SaveQueueManager } from '../save-queue';
 import { AgentThreadLeaseConflictError, agentThreadStreamRuntime } from '../thread-stream-runtime';
 import type { AgentThreadRunRegistration } from '../thread-stream-runtime';
@@ -2153,15 +2154,19 @@ export class DurableAgent<
           }
         : options?.memory;
 
-      await this.prepare([], {
-        ...(options as AgentExecutionOptions<TOutput>),
-        runId,
-        requestContext: options?.requestContext ?? snapshotRequestContext,
-        memory,
-        // Restore the original run's flag from the persisted snapshot so a
-        // cross-process resume still returns scoringData; caller override wins.
-        returnScorerData: options?.returnScorerData ?? workflowInput.options?.returnScorerData,
-      });
+      await this.#prepareForExecution(
+        [],
+        {
+          ...(options as AgentExecutionOptions<TOutput>),
+          runId,
+          requestContext: options?.requestContext ?? snapshotRequestContext,
+          memory,
+          // Restore the original run's flag from the persisted snapshot so a
+          // cross-process resume still returns scoringData; caller override wins.
+          returnScorerData: options?.returnScorerData ?? workflowInput.options?.returnScorerData,
+        },
+        workflowInput.messageListState,
+      );
       entry = this.#runRegistry.get(runId);
     }
     if (!entry) {
@@ -3534,10 +3539,19 @@ export class DurableAgent<
    * Prepare for durable execution without starting it.
    */
   async prepare(messages: MessageListInput, options?: AgentExecutionOptions<TOutput>) {
+    return this.#prepareForExecution(messages, options);
+  }
+
+  async #prepareForExecution(
+    messages: MessageListInput,
+    options?: AgentExecutionOptions<TOutput>,
+    resumeMessageListState?: SerializedMessageListState,
+  ) {
     const preparation = await prepareForDurableExecution<TOutput>({
       agent: this.#wrappedAgent as Agent<string, any, TOutput>,
       messages,
       options,
+      resumeMessageListState,
       // Forward the caller-provided runId (mirrors stream()). Without this,
       // prepareForDurableExecution mints a fresh id, so prepare() registers a
       // different run than requested and a follow-up resume(runId) — e.g. when

--- a/packages/core/src/agent/durable/preparation.ts
+++ b/packages/core/src/agent/durable/preparation.ts
@@ -25,6 +25,7 @@ import type { AgentExecutionOptions, DelegationConfig } from '../agent.types';
 import { assertThreadOwnedByResource } from '../memory-thread-ownership';
 import { MessageList } from '../message-list';
 import type { MessageListInput } from '../message-list';
+import type { SerializedMessageListState } from '../message-list/state';
 import { SaveQueueManager } from '../save-queue';
 import type { CreatedAgentSignal } from '../signals';
 import { mastraDBMessageToSignal } from '../signals';
@@ -177,6 +178,8 @@ export interface PreparationResult<_OUTPUT = undefined> {
  * Options for preparation phase
  */
 export interface PreparationOptions<OUTPUT = undefined> {
+  /** Already-processed native input used only to rebuild a saved run's runtime resources. */
+  resumeMessageListState?: SerializedMessageListState;
   /** The agent instance (wrapped agent — used for config resolution: tools, model, instructions, memory) */
   agent: Agent<string, any, OUTPUT>;
   /** User messages to process */
@@ -239,6 +242,7 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
     methodType = 'stream',
     durableAgentId,
     durableAgentName,
+    resumeMessageListState,
   } = options;
 
   // Public-facing identity: use the durable wrapper's ID/name for all
@@ -353,6 +357,7 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
 
   // Add user messages
   messageList.add(messages, 'input');
+  if (resumeMessageListState) messageList.deserialize(resumeMessageListState);
 
   // 6. Establish the memory/thread context BEFORE resolving input processors.
   //
@@ -458,7 +463,10 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
   // above, before processor resolution, so processors that need it (working
   // memory, OM, message history) can access it here.
   let tripwireData: RunRegistryEntry['tripwire'];
-  if (inputProcessors.length > 0) {
+  // A saved run already processed its input. Cold resume rebuilds live handles,
+  // not a new request; running these hooks again can repeat side effects or
+  // reject an empty input before the durable workflow restores its messages.
+  if (inputProcessors.length > 0 && !resumeMessageListState) {
     try {
       const { ProcessorRunner } = await import('../../processors/runner');
       const runner = new ProcessorRunner({
@@ -524,7 +532,7 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
 
   // Client-executed results fire only after processors accept the request and
   // the required runtime model has resolved.
-  if (!tripwireData) {
+  if (!tripwireData && !resumeMessageListState) {
     await fireClientToolOutputHooks({
       messages,
       tools,
@@ -742,7 +750,7 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
     // Signal messages already in the messageList at run start (from persisted
     // history). Echoed as data-signal parts on the first LLM step so the client
     // sees them without refetching. Spliced once, never re-emitted.
-    initialSignalEchoes: getInitialSignalEchoes(messageList),
+    initialSignalEchoes: resumeMessageListState ? [] : getInitialSignalEchoes(messageList),
     // Agent-level goal config (judge resolver, tools resolver, scorer).
     // Non-serializable — cross-process engines skip goal evaluation.
     goal: agent.__getGoalConfig(),


### PR DESCRIPTION
A cold `DurableAgent.resume(runId)` calls preparation with an empty message list before restoring the workflow. This repeats `processInput` and client input hooks against an empty request even though the original input is saved. Rebuild runtime resources from the native saved message state and skip only those initial-input effects. Fresh preparation and per-step processors keep their existing checks; the public API is unchanged.

Based on current main `748d4ed53823810e9c71fa3d1827c48730f1ea49`. The 31 resume tests, 16 build tasks, Core type check and focused ESLint pass locally. A separate pinned contribution also passed five real process-restart cases against its published archive: approve, decline and blocked-message recovery each observed an actual model call with the original saved input ID; Stop and navigation observed none. [Pinned archive evidence](https://github.com/hassnalalshaikh/mastra/releases/tag/session-reliability-a349d28a) is additional evidence, not a claim that those archives are built from this PR's current-main head. No new pending-state storage or billing bypass is introduced.
