### PR TITLE
fix(deployer): make tool bundle ids and order deterministic so `mastra build` is reproducible

### DIFF
--- a/.changeset/deterministic-tool-bundle-ids.md
+++ b/.changeset/deterministic-tool-bundle-ids.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Make `mastra build` output reproducible: tool bundles are now named from a hash of the tool's project-relative entry path instead of a random UUID, and the tool glob is sorted before ids are assigned, so two builds of the same sources emit the same `tools/*.mjs`, `tools.mjs` and chunk graph.

--- a/packages/deployer/src/bundler/index.test.ts
+++ b/packages/deployer/src/bundler/index.test.ts
@@ -3,7 +3,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { SourceDependencyConstraints } from './index';
-import { Bundler, applySourceDependencyRange, getSourceDependencyConstraints, isRegistryVersionSpec } from './index';
+import {
+  Bundler,
+  applySourceDependencyRange,
+  getSourceDependencyConstraints,
+  isRegistryVersionSpec,
+  toolIdForEntry,
+} from './index';
 
 const tempDirs: string[] = [];
 
@@ -68,6 +74,41 @@ const createSourceApp = async ({
 
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Bundler.listToolsInputOptions', () => {
+  it('returns the same tool ids, in the same order, for the same sources on every call', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'mastra-bundler-tools-'));
+    tempDirs.push(tempDir);
+    const toolsDir = join(tempDir, 'src', 'mastra', 'tools');
+    await mkdir(join(toolsDir, 'nested', 'c'), { recursive: true });
+    // Written out of alphabetical order on purpose: the map must not follow write or glob order.
+    for (const file of ['b.ts', 'a.ts', join('nested', 'c', 'index.ts')]) {
+      await writeFile(join(toolsDir, file), 'export {}', 'utf-8');
+    }
+
+    const bundler = new TestBundler('Test');
+    const first = await bundler.listToolsInputOptions([join(toolsDir, '**/*.ts')]);
+    const second = await bundler.listToolsInputOptions([join(toolsDir, '**/*.ts')]);
+
+    expect(second).toEqual(first);
+    expect(Object.keys(second)).toEqual(Object.keys(first));
+    const entryFiles = Object.values(first);
+    expect(entryFiles).toEqual([...entryFiles].sort());
+    for (const key of Object.keys(first)) {
+      expect(key).toMatch(/^tools\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    }
+  });
+});
+
+describe('toolIdForEntry', () => {
+  it('is a pure function of the relative path', () => {
+    expect(toolIdForEntry('src/mastra/tools/weather.ts')).toBe(toolIdForEntry('src/mastra/tools/weather.ts'));
+    expect(toolIdForEntry('src/mastra/tools/weather.ts')).not.toBe(toolIdForEntry('src/mastra/tools/search.ts'));
+    expect(toolIdForEntry('src/mastra/tools/weather.ts')).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
 });
 
 describe('Bundler.writePackageJson', () => {

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -1,7 +1,8 @@
 import { execSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { readFile, rm, stat, writeFile } from 'node:fs/promises';
-import { dirname, join, posix } from 'node:path';
+import { dirname, join, posix, relative } from 'node:path';
 import { MastraBundler } from '@mastra/core/bundler';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
 import type { Config } from '@mastra/core/mastra';
@@ -281,6 +282,15 @@ export const applySourceDependencyRange = (
 
   return { ...dependencyInfo, version: declared };
 };
+
+/**
+ * A UUID-shaped identifier derived from a tool's project-relative entry path. The same path yields
+ * the same id on every machine, so `mastra build` output is reproducible.
+ */
+export function toolIdForEntry(relativeEntryFile: string): string {
+  const digest = createHash('sha256').update(relativeEntryFile).digest('hex');
+  return `${digest.slice(0, 8)}-${digest.slice(8, 12)}-${digest.slice(12, 16)}-${digest.slice(16, 20)}-${digest.slice(20, 32)}`;
+}
 
 export abstract class Bundler extends MastraBundler {
   protected analyzeOutputDir = '.build';
@@ -579,6 +589,9 @@ export abstract class Bundler extends MastraBundler {
         absolute: true,
         expandDirectories: false,
       });
+      // The glob returns entries in filesystem order, which differs between machines and runs;
+      // the order decides the rollup input map and therefore the emitted chunk graph.
+      expandedPaths.sort();
 
       for (const path of expandedPaths) {
         if (await fsExtra.pathExists(path)) {
@@ -595,9 +608,13 @@ export abstract class Bundler extends MastraBundler {
             continue;
           }
 
-          const uniqueToolID = crypto.randomUUID();
           // Normalize Windows paths to forward slashes for consistent handling
           const normalizedEntryFile = entryFile.replaceAll('\\', '/');
+          // The id only has to be unique within one build. Deriving it from the entry file's
+          // project-relative path (instead of a random UUID) makes two builds of the same sources
+          // emit the same tool bundle names and the same chunk graph. Kept UUID-shaped so nothing
+          // that reads `tools/<id>` sees a different format.
+          const uniqueToolID = toolIdForEntry(relative(process.cwd(), entryFile).replaceAll('\\', '/'));
           inputs[`tools/${uniqueToolID}`] = normalizedEntryFile;
         } else {
           this.logger.warn('Tool path does not exist, skipping', { path });


### PR DESCRIPTION
## Description

Fixes #23478.

`Bundler.listToolsInputOptions` keyed every tool as `tools/${crypto.randomUUID()}` and took the tool glob in filesystem order. Both feed rollup's input map, so two builds of identical sources emitted differently named `output/tools/*.mjs` files, a different `tools.mjs`, and a different chunk graph, and the output could never be compared or reused.

This change:

- derives the id from the tool's project-relative entry path (`sha256`, formatted like a UUID so any consumer of `tools/<id>` sees the same shape), via a small exported `toolIdForEntry`;
- sorts the glob result before ids are assigned, so the input map order is stable across machines.

Nothing about the emitted code changes; only names and order become a function of the sources.

## Verification

- New tests: `listToolsInputOptions` returns the same map, in sorted order, on two calls over the same tree; `toolIdForEntry` is a pure function of the path and UUID-shaped.
- On a 115-tool application (`@mastra/deployer` 1.24.1 with this change applied as a patch): three consecutive clean builds produced an identical 1332-file `.mastra` tree (including `.build/`), where before every build differed in all 115 tool files, `tools.mjs` and the intermediate chunks. A second application in the same monorepo behaved the same.
- `vitest run src/bundler/index.test.ts` in `packages/deployer`: 105 passed (103 existing + the 2 new cases).

## Notes for reviewers

- The relative path is taken from `process.cwd()`, which is the project root when `mastra build` runs. Any project-relative anchor works; the requirement is only that it is the same on every machine that builds the same sources.
- Related: #20357 covers the other reproducibility gap (the bundle's dependency resolution). This PR does not touch it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The build now gives each tool the same name every time and processes tools in a fixed order. This makes repeated `mastra build` runs produce identical output.

## Changes

- Generate UUID-shaped tool IDs from each tool’s project-relative path using SHA-256.
- Sort tool glob results before creating the Rollup input map.
- Export `toolIdForEntry`.
- Add tests for deterministic ordering, stable IDs, and UUID-shaped output.
- Add a patch changeset for `@mastra/deployer`.

## Verification

- 105 bundler tests pass.
- Repeated clean builds of a 115-tool application produce identical output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->