### PR TITLE
feat(core): support the OpenAI Responses API for custom-URL model configs

### DIFF
--- a/.changeset/custom-url-responses-api.md
+++ b/.changeset/custom-url-responses-api.md
@@ -1,0 +1,26 @@
+---
+'@mastra/core': minor
+---
+
+Added an `api` option to custom OpenAI-compatible model configs so a custom `url` can be called through the OpenAI Responses API instead of Chat Completions.
+
+Custom `url` configs always sent requests to `{url}/chat/completions`. Some gateways only serve certain models, or features such as function tools combined with a reasoning effort, through `{url}/responses`. For example, Databricks AI Gateway rejects tool calls with any `reasoning_effort` other than `none` on Chat Completions, which forced tool-using agents to run with reasoning disabled. Set `api: 'responses'` to opt in; the default stays `'chat'`, so existing configs are unchanged.
+
+```ts
+const agent = new Agent({
+  name: 'supervisor',
+  model: {
+    id: 'databricks/system.ai.gpt-5-6-luna',
+    url: 'https://<workspace>.cloud.databricks.com/ai-gateway/openai/v1',
+    apiKey: process.env.GATEWAY_PAT,
+    api: 'responses',
+  },
+  defaultOptions: {
+    providerOptions: {
+      openai: { reasoningEffort: 'high', store: false, include: ['reasoning.encrypted_content'] },
+    },
+  },
+});
+```
+
+Note that the Responses model reads provider options from `providerOptions.openai`, while the Chat Completions model reads `providerOptions['openai-compatible']` or your provider id. Fixes https://github.com/mastra-ai/mastra/issues/22656

--- a/docs/src/content/en/models/index.mdx
+++ b/docs/src/content/en/models/index.mdx
@@ -394,6 +394,37 @@ const agent = new Agent({
 })
 ```
 
+### Use the OpenAI Responses API
+
+By default, a custom `url` is called through the OpenAI Chat Completions protocol (`{url}/chat/completions`). Some gateways only serve certain models, or certain features such as function tools combined with a reasoning effort, through the OpenAI Responses API. Set `api: "responses"` to call `{url}/responses` instead:
+
+```typescript title="src/mastra/agents/my-agent.ts"
+import { Agent } from "@mastra/core/agent";
+
+const agent = new Agent({
+  id: "my-agent",
+  name: "My Agent",
+  instructions: "You are a helpful assistant",
+  model: {
+    id: "my-gateway/gpt-5",
+    url: "https://my-gateway.example.com/openai/v1",
+    apiKey: process.env.MY_GATEWAY_API_KEY,
+    api: "responses"
+  },
+  defaultOptions: {
+    providerOptions: {
+      openai: {
+        reasoningEffort: "high",
+        store: false,
+        include: ["reasoning.encrypted_content"]
+      }
+    }
+  }
+})
+```
+
+The two protocols read different provider option keys. The Responses model reads `providerOptions.openai`, while the default Chat Completions model reads `providerOptions["openai-compatible"]` or the key matching your provider id. If your gateway does not persist responses, set `store: false` so the full conversation is replayed on every request, and include `reasoning.encrypted_content` to carry reasoning across tool calls.
+
 ## Use AI SDK with Mastra
 
 Mastra supports AI SDK provider modules, should you need to use them directly.

--- a/packages/core/scripts/generate-model-docs.ts
+++ b/packages/core/scripts/generate-model-docs.ts
@@ -1076,6 +1076,37 @@ const agent = new Agent({
 })
 \`\`\`
 
+### Use the OpenAI Responses API
+
+By default, a custom \`url\` is called through the OpenAI Chat Completions protocol (\`{url}/chat/completions\`). Some gateways only serve certain models, or certain features such as function tools combined with a reasoning effort, through the OpenAI Responses API. Set \`api: "responses"\` to call \`{url}/responses\` instead:
+
+\`\`\`typescript title="src/mastra/agents/my-agent.ts"
+import { Agent } from "@mastra/core/agent";
+
+const agent = new Agent({
+  id: "my-agent",
+  name: "My Agent",
+  instructions: "You are a helpful assistant",
+  model: {
+    id: "my-gateway/gpt-5",
+    url: "https://my-gateway.example.com/openai/v1",
+    apiKey: process.env.MY_GATEWAY_API_KEY,
+    api: "responses"
+  },
+  defaultOptions: {
+    providerOptions: {
+      openai: {
+        reasoningEffort: "high",
+        store: false,
+        include: ["reasoning.encrypted_content"]
+      }
+    }
+  }
+})
+\`\`\`
+
+The two protocols read different provider option keys. The Responses model reads \`providerOptions.openai\`, while the default Chat Completions model reads \`providerOptions["openai-compatible"]\` or the key matching your provider id. If your gateway does not persist responses, set \`store: false\` so the full conversation is replayed on every request, and include \`reasoning.encrypted_content\` to carry reasoning across tool calls.
+
 ## Use AI SDK with Mastra
 
 Mastra supports AI SDK provider modules, should you need to use them directly.

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -76,7 +76,12 @@ export type {
   StreamObjectResult,
   StreamTextResult,
 } from './model/base.types';
-export type { TripwireProperties, MastraModelConfig, OpenAICompatibleConfig } from './model/shared.types';
+export type {
+  TripwireProperties,
+  MastraModelConfig,
+  OpenAICompatibleApi,
+  OpenAICompatibleConfig,
+} from './model/shared.types';
 export { ModelRouterLanguageModel, defaultGateways } from './model/router';
 export {
   GatewayRegistry,

--- a/packages/core/src/llm/model/router-custom-provider-responses.test.ts
+++ b/packages/core/src/llm/model/router-custom-provider-responses.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Agent } from '../../agent/index.js';
+import { createMockModel } from '../../test-utils/llm-mock.js';
+import { ModelRouterLanguageModel } from './router.js';
+
+// Mock both factories BEFORE importing them so the router picks up the mocks.
+vi.mock('@ai-sdk/openai-compatible-v6', async () => {
+  return {
+    createOpenAICompatible: vi.fn(),
+  };
+});
+
+vi.mock('@ai-sdk/openai-v6', async () => {
+  return {
+    createOpenAI: vi.fn(),
+  };
+});
+
+const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible-v6');
+const { createOpenAI } = await import('@ai-sdk/openai-v6');
+
+const GATEWAY_URL = 'http://fake-gateway.local:9999/openai/v1';
+
+function makeAgent(model: ConstructorParameters<typeof Agent>[0]['model']) {
+  return new Agent({
+    id: 'test-agent',
+    name: 'test-agent',
+    instructions: 'You are a helpful assistant.',
+    model,
+  });
+}
+
+describe('ModelRouter - Custom URL `api` selection', () => {
+  beforeEach(() => {
+    vi.mocked(createOpenAICompatible).mockReturnValue({
+      chatModel: vi.fn((_modelId: string) => createMockModel({ mockText: 'Hello from chat completions!' })),
+    } as any);
+
+    vi.mocked(createOpenAI).mockReturnValue({
+      responses: vi.fn((_modelId: string) => createMockModel({ mockText: 'Hello from responses!' })),
+      chat: vi.fn(),
+    } as any);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('default (no `api`)', () => {
+    it('keeps using the OpenAI-compatible chat model', async () => {
+      const agent = makeAgent({
+        id: 'my-gateway/my-model',
+        url: GATEWAY_URL,
+        apiKey: 'test-key',
+      });
+
+      const result = await agent.generate('test', { maxSteps: 1 });
+
+      expect(result.text).toBe('Hello from chat completions!');
+      expect(createOpenAICompatible).toHaveBeenCalledTimes(1);
+      expect(createOpenAI).not.toHaveBeenCalled();
+    });
+
+    it('treats `api: "chat"` the same as the default', async () => {
+      const agent = makeAgent({
+        id: 'my-gateway/my-model',
+        url: GATEWAY_URL,
+        apiKey: 'test-key',
+        api: 'chat',
+      });
+
+      await agent.generate('test', { maxSteps: 1 });
+
+      expect(createOpenAICompatible).toHaveBeenCalledTimes(1);
+      const compatible = vi.mocked(createOpenAICompatible).mock.results[0]!.value;
+      expect(compatible.chatModel).toHaveBeenCalledWith('my-model');
+      expect(createOpenAI).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('`api: "responses"`', () => {
+    it('builds an OpenAI Responses model against the custom URL (id form)', async () => {
+      const agent = makeAgent({
+        id: 'my-gateway/my-model',
+        url: GATEWAY_URL,
+        apiKey: 'test-key',
+        api: 'responses',
+      });
+
+      const result = await agent.generate('test', { maxSteps: 1 });
+
+      expect(result.text).toBe('Hello from responses!');
+      expect(createOpenAI).toHaveBeenCalledTimes(1);
+      expect(createOpenAI).toHaveBeenCalledWith({
+        apiKey: 'test-key',
+        baseURL: GATEWAY_URL,
+        headers: undefined,
+      });
+      const openai = vi.mocked(createOpenAI).mock.results[0]!.value;
+      expect(openai.responses).toHaveBeenCalledWith('my-model');
+      expect(openai.chat).not.toHaveBeenCalled();
+      expect(createOpenAICompatible).not.toHaveBeenCalled();
+    });
+
+    it('builds an OpenAI Responses model against the custom URL (providerId/modelId form)', async () => {
+      const agent = makeAgent({
+        providerId: 'my-gateway',
+        modelId: 'my-model',
+        url: GATEWAY_URL,
+        apiKey: 'test-key',
+        api: 'responses',
+      });
+
+      await agent.generate('test', { maxSteps: 1 });
+
+      expect(createOpenAI).toHaveBeenCalledTimes(1);
+      const openai = vi.mocked(createOpenAI).mock.results[0]!.value;
+      expect(openai.responses).toHaveBeenCalledWith('my-model');
+      expect(createOpenAICompatible).not.toHaveBeenCalled();
+    });
+
+    it('forwards custom headers to the Responses provider', async () => {
+      const agent = makeAgent({
+        id: 'my-gateway/my-model',
+        url: GATEWAY_URL,
+        apiKey: 'test-key',
+        headers: { 'x-tenant': 'acme' },
+        api: 'responses',
+      });
+
+      await agent.generate('test', { maxSteps: 1 });
+
+      expect(createOpenAI).toHaveBeenCalledWith({
+        apiKey: 'test-key',
+        baseURL: GATEWAY_URL,
+        headers: { 'x-tenant': 'acme' },
+      });
+    });
+
+    it('works when streaming', async () => {
+      const agent = makeAgent({
+        id: 'my-gateway/my-model',
+        url: GATEWAY_URL,
+        apiKey: 'test-key',
+        api: 'responses',
+      });
+
+      const stream = await agent.stream('test', { maxSteps: 1 });
+      let text = '';
+      for await (const chunk of stream.textStream) {
+        text += chunk;
+      }
+
+      expect(text).toBe('Hello from responses!');
+      expect(createOpenAI).toHaveBeenCalledTimes(1);
+      expect(createOpenAICompatible).not.toHaveBeenCalled();
+    });
+
+    it('reuses the cached Responses model across calls on the same router instance', async () => {
+      const model = new ModelRouterLanguageModel({
+        id: 'my-gateway/my-model',
+        url: GATEWAY_URL,
+        apiKey: 'test-key',
+        api: 'responses',
+      });
+      const prompt = [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'hi' }] }];
+
+      await model.doGenerate({ prompt } as any);
+      await model.doGenerate({ prompt } as any);
+
+      expect(createOpenAI).toHaveBeenCalledTimes(1);
+      const openai = vi.mocked(createOpenAI).mock.results[0]!.value;
+      expect(openai.responses).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not share a cached instance between chat and responses for the same endpoint', async () => {
+      const chatAgent = makeAgent({
+        id: 'my-gateway/my-model',
+        url: GATEWAY_URL,
+        apiKey: 'test-key',
+      });
+      const responsesAgent = makeAgent({
+        id: 'my-gateway/my-model',
+        url: GATEWAY_URL,
+        apiKey: 'test-key',
+        api: 'responses',
+      });
+
+      const chatResult = await chatAgent.generate('test', { maxSteps: 1 });
+      const responsesResult = await responsesAgent.generate('test', { maxSteps: 1 });
+
+      expect(chatResult.text).toBe('Hello from chat completions!');
+      expect(responsesResult.text).toBe('Hello from responses!');
+      expect(createOpenAICompatible).toHaveBeenCalledTimes(1);
+      expect(createOpenAI).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('`api` without a custom URL', () => {
+    it('is ignored and routes through the gateway as before', async () => {
+      const previous = process.env.OPENAI_API_KEY;
+      process.env.OPENAI_API_KEY = 'test-openai-key';
+      try {
+        // Without `url` the registry path is used; the mocked `createOpenAI` still satisfies it.
+        const agent = makeAgent({
+          id: 'openai/gpt-4o',
+          api: 'responses',
+        });
+
+        const result = await agent.generate('test', { maxSteps: 1 });
+
+        expect(result.text).toBe('Hello from responses!');
+        expect(createOpenAICompatible).not.toHaveBeenCalled();
+      } finally {
+        if (previous === undefined) delete process.env.OPENAI_API_KEY;
+        else process.env.OPENAI_API_KEY = previous;
+      }
+    });
+  });
+});

--- a/packages/core/src/llm/model/router.ts
+++ b/packages/core/src/llm/model/router.ts
@@ -25,7 +25,7 @@ import type { OpenAIWebSocketFetch } from './openai-websocket-fetch.js';
 import type { OpenAITransport, ProviderOptions, ResponsesWebSocketOptions } from './provider-options.js';
 import type { ModelRouterModelId } from './provider-registry.js';
 import { modelSupportsTemperature } from './provider-registry.js';
-import type { MastraLanguageModelV2, OpenAICompatibleConfig } from './shared.types';
+import type { MastraLanguageModelV2, OpenAICompatibleApi, OpenAICompatibleConfig } from './shared.types';
 
 export { defaultGateways, gateways } from './gateways/defaults.js';
 
@@ -140,6 +140,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
       url?: string;
       apiKey?: string;
       headers?: Record<string, string>;
+      api?: OpenAICompatibleApi;
     };
 
     if (typeof config === 'string') {
@@ -151,6 +152,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
         url: config.url,
         apiKey: config.apiKey,
         headers: config.headers,
+        api: config.api,
       };
     } else {
       // config has 'id' field
@@ -159,6 +161,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
         url: config.url,
         apiKey: config.apiKey,
         headers: config.headers,
+        api: config.api,
       };
     }
 
@@ -168,6 +171,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
       url?: string;
       apiKey?: string;
       headers?: Record<string, string>;
+      api?: OpenAICompatibleApi;
     } = {
       ...normalizedConfig,
       routerId: normalizedConfig.id,
@@ -509,6 +513,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
           modelId,
           providerId,
           this.config.url || '',
+          this.config.api ?? 'chat',
           apiKey,
           stableHeaderKey(headers),
           resolvedTransport,
@@ -522,15 +527,24 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
       return cache.modelInstances.get(key)!;
     }
 
-    // If custom URL is provided, use it directly with openai-compatible
+    // If custom URL is provided, use it directly. Default to the OpenAI-compatible
+    // Chat Completions model; opt into the OpenAI Responses model with `api: 'responses'`
+    // (`@ai-sdk/openai-compatible` has no Responses factory, so reuse `@ai-sdk/openai`).
     if (this.config.url) {
-      const modelInstance = createOpenAICompatible({
-        name: providerId,
-        apiKey,
-        baseURL: this.config.url,
-        headers,
-        supportsStructuredOutputs: true,
-      }).chatModel(modelId);
+      const modelInstance =
+        this.config.api === 'responses'
+          ? createOpenAI({
+              apiKey,
+              baseURL: this.config.url,
+              headers,
+            }).responses(modelId)
+          : createOpenAICompatible({
+              name: providerId,
+              apiKey,
+              baseURL: this.config.url,
+              headers,
+              supportsStructuredOutputs: true,
+            }).chatModel(modelId);
       cache.modelInstances.set(key, modelInstance);
       this.setStreamTransportHandle({ resolvedTransport, responsesWebSocket });
       return modelInstance;

--- a/packages/core/src/llm/model/shared.types.ts
+++ b/packages/core/src/llm/model/shared.types.ts
@@ -33,12 +33,27 @@ export type ScoringProperties = {
   scoringData?: ScoringData;
 };
 
+/**
+ * Which OpenAI wire protocol a custom `url` endpoint speaks.
+ *
+ * - `'chat'` (default): `POST {url}/chat/completions` via `@ai-sdk/openai-compatible`.
+ * - `'responses'`: `POST {url}/responses` via the OpenAI Responses model from `@ai-sdk/openai`.
+ *   Use this for gateways that only expose some models or features (for example function
+ *   tools combined with `reasoning_effort`) through the Responses API.
+ *
+ * Only applies when `url` is set. Provider options differ between the two protocols: the
+ * chat model reads `providerOptions['openai-compatible']` / `providerOptions[providerId]`,
+ * the Responses model reads `providerOptions.openai`.
+ */
+export type OpenAICompatibleApi = 'chat' | 'responses';
+
 export type OpenAICompatibleConfig =
   | {
       id: `${string}/${string}`; // Model ID like "openai/gpt-4o" or "custom-provider/my-model"
       url?: string; // Optional custom URL endpoint
       apiKey?: string; // Optional API key (falls back to env vars)
       headers?: Record<string, string>; // Additional headers
+      api?: OpenAICompatibleApi; // Wire protocol for custom URL endpoints (defaults to 'chat')
     }
   | {
       providerId: string; // Provider ID like "openai" or "custom-provider"
@@ -46,6 +61,7 @@ export type OpenAICompatibleConfig =
       url?: string; // Optional custom URL endpoint
       apiKey?: string; // Optional API key (falls back to env vars)
       headers?: Record<string, string>; // Additional headers
+      api?: OpenAICompatibleApi; // Wire protocol for custom URL endpoints (defaults to 'chat')
     };
 
 type DoStreamResultPromiseV2 = PromiseLike<Awaited<ReturnType<LanguageModelV2['doStream']>>>;


### PR DESCRIPTION
## Description

`OpenAICompatibleConfig` with a custom `url` always resolves to `createOpenAICompatible(...).chatModel()`, so there is no way to reach an OpenAI-compatible gateway's `/v1/responses` endpoint through the config object. Some gateways only serve certain models or features there. Databricks AI Gateway, for example, rejects function tools combined with any `reasoning_effort` other than `none` on `/chat/completions`, which forces every tool-using agent on that endpoint to run with reasoning disabled.

This adds an optional `api: 'chat' | 'responses'` field to both `OpenAICompatibleConfig` shapes. It defaults to `'chat'`, so existing configs behave exactly as before. When set to `'responses'`, the custom-URL branch builds `createOpenAI({ baseURL, apiKey, headers }).responses(modelId)` from `@ai-sdk/openai` (which core already vendors for the built-in `openai` provider), since `@ai-sdk/openai-compatible` has no Responses factory. The value is threaded through constructor normalization and the model cache key so chat and Responses instances for the same endpoint can never collide.

```ts
const agent = new Agent({
  name: 'supervisor',
  model: {
    id: 'databricks/system.ai.gpt-5-6-luna',
    url: 'https://<workspace>.cloud.databricks.com/ai-gateway/openai/v1',
    apiKey: process.env.GATEWAY_PAT,
    api: 'responses',
  },
  defaultOptions: {
    providerOptions: {
      openai: { reasoningEffort: 'high', store: false, include: ['reasoning.encrypted_content'] },
    },
  },
  tools: { weather },
});
```

The naming follows #19665, which adds the same `api: 'chat' | 'responses'` option to Mastra Code custom providers, so both surfaces stay aligned. The docs note that the two protocols read different provider option namespaces (`providerOptions.openai` for Responses, `providerOptions['openai-compatible']` / the provider id for chat) and recommend `store: false` plus `reasoning.encrypted_content` for gateways that do not persist responses. Both the generator template in `packages/core/scripts/generate-model-docs.ts` and the generated `docs/src/content/en/models/index.mdx` were updated.

Validation: `packages/core` typecheck passes, oxlint/eslint/oxfmt are clean, and the new `router-custom-provider-responses.test.ts` (9 tests) plus the existing router/resolve-model suites pass (65 tests total). I have not been able to add an end-to-end test against Databricks in CI since it needs gateway credentials; the behavior matches the `createOpenAI(...).responses()` workaround described in the issue, which I run in production today.

## Related issue(s)

Fixes #22656

Related: #19665 (Mastra Code custom providers, same root cause in a different call site)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Custom OpenAI-compatible models can now use either Chat Completions or the Responses API. Existing models still use Chat Completions by default.

## Changes

- Added `api?: 'chat' | 'responses'` to `OpenAICompatibleConfig`.
- Routed custom URLs with `api: 'responses'` through `@ai-sdk/openai` Responses models.
- Preserved existing Chat Completions behavior by default.
- Included the selected API in the model cache key.
- Re-exported `OpenAICompatibleApi`.
- Added documentation for API selection and provider option namespaces.
- Added a changeset for the minor `@mastra/core` release.
- Added tests for API selection, headers, streaming, caching, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->