### PR TITLE
fix(server): scope active controller runs to native request identity

### DIFF
--- a/.changeset/brave-ads-sniff.md
+++ b/.changeset/brave-ads-sniff.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed active controller run listings exposing other resources when a server-owned identity or thread scope is present.

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -1,7 +1,7 @@
 import { Agent } from '@mastra/core/agent';
 import { AgentController } from '@mastra/core/agent-controller';
 import { Mastra } from '@mastra/core/mastra';
-import { RequestContext } from '@mastra/core/request-context';
+import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY, RequestContext } from '@mastra/core/request-context';
 import { InMemoryStore } from '@mastra/core/storage';
 import { Workspace } from '@mastra/core/workspace';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -1035,6 +1035,41 @@ describe('agent-controller routes', () => {
         } as any);
 
         expect(res).toEqual({ runs: [{ runId: 'run-1', resourceId: 'workspace-a', threadId: 'thread-a' }] });
+        expect(createSession).not.toHaveBeenCalled();
+      } finally {
+        spy.mockRestore();
+        createSession.mockRestore();
+      }
+    });
+
+    it.each([
+      { resourceId: 'workspace-a', threadId: undefined, expected: ['run-a1', 'run-a2'] },
+      { resourceId: 'workspace-b', threadId: undefined, expected: ['run-b'] },
+      { resourceId: 'missing', threadId: undefined, expected: [] },
+      { resourceId: 'workspace-a', threadId: 'thread-a1', expected: ['run-a1'] },
+      { resourceId: 'workspace-a', threadId: 'thread-b', expected: [] },
+      { resourceId: undefined, threadId: 'thread-a1', expected: ['run-a1'] },
+    ])('scopes active runs to native identity ($resourceId, $threadId)', async ({ resourceId, threadId, expected }) => {
+      const controller = mastra.getAgentController('code')!;
+      const createSession = vi.spyOn(controller, 'createSession');
+      const runs = [
+        { runId: 'run-a1', resourceId: 'workspace-a', threadId: 'thread-a1' },
+        { runId: 'run-a2', resourceId: 'workspace-a', threadId: 'thread-a2' },
+        { runId: 'run-b', resourceId: 'workspace-b', threadId: 'thread-b' },
+        { runId: 'ownerless', threadId: 'shared-thread' },
+      ];
+      const spy = vi.spyOn(Agent.prototype, 'listActiveThreadRuns').mockReturnValue(runs);
+      const requestContext = new RequestContext();
+      if (resourceId) requestContext.set(MASTRA_RESOURCE_ID_KEY, resourceId);
+      if (threadId) requestContext.set(MASTRA_THREAD_ID_KEY, threadId);
+      requestContext.set('resourceId', 'workspace-b');
+      try {
+        const res = await LIST_AGENT_CONTROLLER_ACTIVE_RUNS_ROUTE.handler({
+          mastra,
+          controllerId: 'code',
+          requestContext,
+        } as any);
+        expect(res).toEqual({ runs: runs.filter(run => expected.includes(run.runId)) });
         expect(createSession).not.toHaveBeenCalled();
       } finally {
         spy.mockRestore();

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -20,6 +20,7 @@ import { z } from 'zod/v4';
 import { HTTPException } from '../http-exception';
 import { createRoute } from '../server-adapter/routes/route-builder';
 import { handleError } from './error';
+import { getEffectiveResourceId, getEffectiveThreadId } from './utils';
 
 /**
  * AgentController session routes.
@@ -915,14 +916,20 @@ export const LIST_AGENT_CONTROLLER_ACTIVE_RUNS_ROUTE = createRoute({
   responseSchema: listActiveRunsResponseSchema,
   summary: 'List active controller runs',
   description:
-    'Lists the runs in flight on the controller across all resources, without creating or touching a session.',
+    'Lists runs in flight within the server-owned resource and thread scope, without creating or touching a session.',
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:read',
-  handler: async ({ mastra, controllerId }) => {
+  handler: async ({ mastra, controllerId, requestContext }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      return { runs: controller.listActiveThreadRuns() };
+      const resourceId = getEffectiveResourceId(requestContext, undefined);
+      const threadId = getEffectiveThreadId(requestContext, undefined);
+      return {
+        runs: controller
+          .listActiveThreadRuns()
+          .filter(run => (!resourceId || run.resourceId === resourceId) && (!threadId || run.threadId === threadId)),
+      };
     } catch (error) {
       return handleError(error, 'error listing active controller runs');
     }


### PR DESCRIPTION
The active-runs handler returns controller runs without applying the authenticated resource and thread restrictions already present in RequestContext. This filters the existing native run list through getEffectiveResourceId and getEffectiveThreadId. An unconstrained trusted caller keeps the existing administration behavior; query input cannot override reserved identity, and ownerless runs are excluded under resource scope.

All 56 focused handler tests, the normal 18-task build, lint and commit hooks pass on this upstream branch. The controlled contribution also passes an HTTP check with a positively active owner run: the owner sees that same run, another account sees none, a conflicting query has no effect and anonymous access is rejected.

Kept draft because current upstream main has unrelated generated-permission drift: regeneration adds observability:delete. The generator/check passes after regeneration, but the unchanged baseline fails. That unrelated generated-file change is retained only in local evidence and is excluded from this repair. No Session, storage or lifecycle replacement is introduced.