### PR TITLE
refactor(playground): remove redundant dataset casts

### DIFF
--- a/packages/playground/src/domains/datasets/components/add-items-to-dataset-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/add-items-to-dataset-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { DatasetItem, DatasetRecord } from '@mastra/client-js';
+import type { DatasetItem } from '@mastra/client-js';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody } from '@mastra/playground-ui/components/Dialog';
 import { Label } from '@mastra/playground-ui/components/Label';
@@ -32,11 +32,9 @@ export function AddItemsToDatasetDialog({
   const { data, isLoading: isDatasetsLoading } = useDatasets();
   const { addItem } = useDatasetMutations();
 
-  // Extract datasets array from response
-  const datasets: DatasetRecord[] = (data as { datasets: DatasetRecord[] } | undefined)?.datasets ?? [];
+  const datasets = data?.datasets ?? [];
 
-  // Filter out the current dataset from the list
-  const availableDatasets = datasets.filter((d: DatasetRecord) => d.id !== currentDatasetId);
+  const availableDatasets = datasets.filter(dataset => dataset.id !== currentDatasetId);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -50,7 +48,6 @@ export function AddItemsToDatasetDialog({
     setProgress(0);
 
     try {
-      // Add items to selected dataset
       for (let i = 0; i < items.length; i++) {
         const item = items[i];
         await addItem.mutateAsync({
@@ -62,10 +59,9 @@ export function AddItemsToDatasetDialog({
         setProgress(i + 1);
       }
 
-      const targetDataset = datasets.find((d: DatasetRecord) => d.id === selectedDatasetId);
+      const targetDataset = datasets.find(dataset => dataset.id === selectedDatasetId);
       toast.success(`Added ${items.length} item${items.length !== 1 ? 's' : ''} to "${targetDataset?.name}"`);
 
-      // Reset form
       setSelectedDatasetId('');
       setIsAdding(false);
       setProgress(0);
@@ -80,7 +76,7 @@ export function AddItemsToDatasetDialog({
   };
 
   const handleCancel = () => {
-    if (isAdding) return; // Prevent cancel during operation
+    if (isAdding) return;
     setSelectedDatasetId('');
     onOpenChange(false);
   };

--- a/packages/playground/src/domains/datasets/components/create-dataset-form.tsx
+++ b/packages/playground/src/domains/datasets/components/create-dataset-form.tsx
@@ -10,7 +10,6 @@ import type { DatasetTargetType } from './target-type-options';
 export interface CreateDatasetFormProps {
   onSuccess: (datasetId: string) => void;
   onCancel: () => void;
-  /** If provided, auto-attaches the dataset to this target on create */
   targetType?: DatasetTargetType;
   targetIds?: string[];
 }
@@ -43,7 +42,7 @@ export function CreateDatasetForm({ onSuccess, onCancel, targetType, targetIds }
     }
 
     try {
-      const result = (await createDataset.mutateAsync({
+      const result = await createDataset.mutateAsync({
         name: name.trim(),
         description: description.trim() || undefined,
         inputSchema,
@@ -51,7 +50,7 @@ export function CreateDatasetForm({ onSuccess, onCancel, targetType, targetIds }
         requestContextSchema,
         targetType,
         targetIds,
-      })) as { id: string };
+      });
 
       toast.success('Dataset created successfully');
 

--- a/packages/playground/src/domains/datasets/components/create-dataset-from-items-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/create-dataset-from-items-dialog.tsx
@@ -40,13 +40,11 @@ export function CreateDatasetFromItemsDialog({
     setProgress(0);
 
     try {
-      // Create the dataset
-      const dataset = (await createDataset.mutateAsync({
+      const dataset = await createDataset.mutateAsync({
         name: name.trim(),
         description: description.trim() || undefined,
-      })) as { id: string };
+      });
 
-      // Copy items to new dataset
       for (let i = 0; i < items.length; i++) {
         const item = items[i];
         await addItem.mutateAsync({
@@ -63,14 +61,12 @@ export function CreateDatasetFromItemsDialog({
 
       toast.success(`Dataset created with ${items.length} items`);
 
-      // Reset form
       setName('');
       setDescription('');
       setIsCreating(false);
       setProgress(0);
       onOpenChange(false);
 
-      // Navigate to new dataset
       onSuccess?.(dataset.id);
     } catch (error) {
       toast.error(`Failed to create dataset: ${error instanceof Error ? error.message : 'Unknown error'}`);
@@ -80,7 +76,7 @@ export function CreateDatasetFromItemsDialog({
   };
 
   const handleCancel = () => {
-    if (isCreating) return; // Prevent cancel during creation
+    if (isCreating) return;
     setName('');
     setDescription('');
     onOpenChange(false);

--- a/packages/playground/src/domains/datasets/components/generate-items-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/generate-items-dialog.tsx
@@ -1,3 +1,4 @@
+import type { GeneratedItem } from '@mastra/client-js';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import {
@@ -23,11 +24,6 @@ import { useGenerationTasks } from '../context/generation-context';
 import { useDatasetMutations } from '../hooks/use-dataset-mutations';
 import { usePlaygroundModel } from '@/domains/agents/context/playground-model-context';
 import { LLMProviders, LLMModels, cleanProviderId } from '@/domains/llm';
-
-interface GeneratedItem {
-  input: unknown;
-  groundTruth?: unknown;
-}
 
 interface AgentContext {
   description?: string;
@@ -58,10 +54,6 @@ function buildDefaultPrompt(agentContext?: AgentContext): string {
   return parts.join(' ');
 }
 
-/**
- * Config-only dialog for generating dataset items.
- * On Generate click, the dialog closes and generation runs in background via GenerationProvider.
- */
 export function GenerateConfigDialog({ datasetId, agentContext, onDismiss }: GenerateConfigDialogProps) {
   const { provider: ctxProvider, model: ctxModel } = usePlaygroundModel();
   const [localProvider, setLocalProvider] = useState(ctxProvider);
@@ -90,7 +82,7 @@ export function GenerateConfigDialog({ datasetId, agentContext, onDismiss }: Gen
       count,
       agentContext,
       generateFn: async params => {
-        const result = (await generateItems.mutateAsync(params)) as { items: GeneratedItem[] };
+        const result = await generateItems.mutateAsync(params);
         return { items: result.items ?? [] };
       },
     });
@@ -184,10 +176,6 @@ export function GenerateConfigDialog({ datasetId, agentContext, onDismiss }: Gen
   );
 }
 
-/**
- * Review dialog for generated items.
- * Receives items directly and allows the user to select and add them to the dataset.
- */
 export function GenerateReviewDialog({
   datasetId,
   items: initialItems,
@@ -381,15 +369,13 @@ export function GenerateReviewDialog({
   );
 }
 
-/** Keep the old export name as an alias for backward compat in agent-playground-datasets.tsx */
 export { GenerateConfigDialog as GenerateItemsDialog };
 
 function formatItemPreview(input: unknown): string {
   if (typeof input === 'string') return input.slice(0, 80);
   if (typeof input === 'object' && input !== null) {
-    const obj = input as Record<string, unknown>;
-    const first = Object.values(obj)[0];
-    if (typeof first === 'string') return first.slice(0, 80);
+    const firstValue = Object.values(input)[0];
+    if (typeof firstValue === 'string') return firstValue.slice(0, 80);
     return JSON.stringify(input).slice(0, 80);
   }
   return String(input).slice(0, 80);


### PR DESCRIPTION
## Description

Remove five redundant `as` casts from the dataset creation, copying, and generation components. The responses are already typed by the client, and `Object.values` accepts the narrowed preview input directly. Reuse the client's `GeneratedItem` type and drop redundant annotations and comments. No runtime behavior changes.

The metadata casts remain: `DatasetItem.metadata` is `unknown`, so removing those needs a separate contract fix.

The mutation run before syncing `main` reported 48 surviving mutations, 292 uncovered mutations, and 56 timeouts. This cleanup does not expand runtime test coverage.

## Related issue(s)

No linked issue; small type cleanup.

## Type of change

- [x] Code refactoring

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (not applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (no new behavior; existing tests run)
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR removes unnecessary TypeScript labels and comments from dataset workflows. It keeps behavior unchanged by using existing types.

## Changes

- Reused `GeneratedItem` from `@mastra/client-js`.
- Removed redundant result casts and type annotations.
- Simplified preview input handling.
- Removed outdated comments.
- Kept metadata casts because `DatasetItem.metadata` uses `unknown`.
- Made no runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->