### PR TITLE
fix(core): extract trajectories for live agent scorers

### DIFF
--- a/.changeset/honest-plants-drop.md
+++ b/.changeset/honest-plants-drop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed live agent trajectory scorers to receive extracted trajectories and save their results.

--- a/packages/core/src/mastra/hook.test.ts
+++ b/packages/core/src/mastra/hook.test.ts
@@ -184,6 +184,139 @@ describe('createOnScorerHook', () => {
     );
   });
 
+  it('should extract a trajectory from live agent output for trajectory scorers', async () => {
+    const output = [
+      {
+        role: 'assistant',
+        content: {
+          toolInvocations: [
+            {
+              state: 'result',
+              toolCallId: 'call-1',
+              toolName: 'weatherTool',
+              args: { city: 'London' },
+              result: { temperature: 18 },
+            },
+          ],
+          parts: [],
+        },
+      },
+    ];
+    const hookData = {
+      runId: 'test-run',
+      scorer: { id: 'trajectory-scorer' },
+      input: [{ role: 'user', content: 'What is the weather?' }],
+      output,
+      source: 'LIVE' as const,
+      entity: { id: 'test-agent' },
+      entityType: 'AGENT' as const,
+    };
+    const mockScorer = {
+      id: 'trajectory-scorer',
+      name: 'Trajectory scorer',
+      type: 'trajectory',
+      run: vi.fn(({ output: trajectory }) => {
+        if (!trajectory.steps) throw new Error('Expected trajectory output');
+        return Promise.resolve({ score: trajectory.steps.length === 1 ? 1 : 0 });
+      }),
+    };
+
+    mockMastra.getAgentById.mockReturnValue({
+      listScorers: vi.fn().mockReturnValue({ trajectory: { scorer: mockScorer } }),
+    });
+
+    await hook(hookData);
+
+    expect(mockScorer.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: {
+          steps: [
+            {
+              stepType: 'tool_call',
+              name: 'weatherTool',
+              toolArgs: { city: 'London' },
+              toolResult: { temperature: 18 },
+              success: true,
+            },
+          ],
+          rawOutput: output,
+        },
+      }),
+    );
+    expect(mockScoresStore.saveScore).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['agent', undefined])('should preserve live agent output for scorer type %s', async type => {
+    const output = [{ role: 'assistant', content: { content: 'Done' } }];
+    const mockScorer = {
+      id: 'message-scorer',
+      name: 'Message scorer',
+      type,
+      run: vi.fn().mockResolvedValue({ score: 1 }),
+    };
+    mockMastra.getScorerById.mockReturnValue(mockScorer);
+
+    await hook({
+      runId: 'test-run',
+      scorer: { id: mockScorer.id },
+      input: [],
+      output,
+      source: 'LIVE',
+      entity: { id: 'test-agent' },
+      entityType: 'AGENT',
+    });
+
+    expect(mockScorer.run.mock.calls[0][0].output).toBe(output);
+  });
+
+  it('should preserve an existing trajectory for live agent scoring', async () => {
+    const output = { steps: [{ stepType: 'tool_call', name: 'weatherTool', success: true }] };
+    const mockScorer = {
+      id: 'trajectory-scorer',
+      name: 'Trajectory scorer',
+      type: 'trajectory',
+      run: vi.fn().mockResolvedValue({ score: 1 }),
+    };
+    mockMastra.getScorerById.mockReturnValue(mockScorer);
+
+    await hook({
+      runId: 'test-run',
+      scorer: { id: mockScorer.id },
+      input: [],
+      output,
+      source: 'LIVE',
+      entity: { id: 'test-agent' },
+      entityType: 'AGENT',
+    });
+
+    expect(mockScorer.run.mock.calls[0][0].output).toBe(output);
+  });
+
+  it('should preserve array output for live workflow trajectory scorers', async () => {
+    const output = [{ value: 'step-result' }];
+    const mockScorer = {
+      id: 'trajectory-scorer',
+      name: 'Trajectory scorer',
+      type: 'trajectory',
+      run: vi.fn().mockResolvedValue({ score: 1 }),
+    };
+    mockMastra.getWorkflowById.mockReturnValue({
+      listScorers: vi.fn().mockReturnValue({ trajectory: { scorer: mockScorer } }),
+    });
+
+    await hook({
+      runId: 'test-run',
+      scorer: { id: mockScorer.id },
+      input: [],
+      output,
+      source: 'LIVE',
+      entity: { id: 'test-workflow' },
+      entityType: 'WORKFLOW',
+    });
+
+    expect(mockScorer.run.mock.calls[0][0].output).toBe(output);
+  });
+
   it('should pass live span correlation context and metadata into scorer.run', async () => {
     const correlationContext = {
       traceId: 'trace-live',

--- a/packages/core/src/mastra/hooks.ts
+++ b/packages/core/src/mastra/hooks.ts
@@ -1,5 +1,5 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '../error';
-import { saveScorePayloadSchema } from '../evals';
+import { extractTrajectory, saveScorePayloadSchema } from '../evals';
 import type { ScoringHookInput } from '../evals/types';
 import { isScorerHookForMastra } from '../hooks/scorer-owner';
 import type { Mastra } from '../mastra';
@@ -55,6 +55,10 @@ export function createOnScorerHook(mastra: Mastra) {
 
       let input = hookData.input;
       let output = hookData.output;
+
+      if (entityType === 'AGENT' && scorerToUse.scorer.type === 'trajectory' && Array.isArray(output)) {
+        output = extractTrajectory(output);
+      }
 
       const { structuredOutput, ...rest } = hookData;
 


### PR DESCRIPTION
## Description

Live agent scoring forwarded response message arrays directly to trajectory scorers even though their output contract requires a `Trajectory`. This extracts live agent trajectories before evaluation so trajectory scorers can run and persist their results.

- Extract `Trajectory` output from live agent response arrays for scorers declared with `type: 'trajectory'`
- Preserve message arrays for normal agent scorers, existing trajectory objects, and workflow outputs
- Add regression coverage for trajectory extraction and the unaffected scorer paths
- Add a patch changeset for `@mastra/core`
- Verify the fix with focused Core tests, Core typecheck, and a real-provider Mastra Studio reproduction

## Related Issue(s)

Fixes #23464

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Live agent scoring now converts response messages into the trajectory format required by trajectory scorers. This allows scores to be calculated and saved without changing other scorer outputs.

## Changes

- Extracts trajectories for agent message arrays when the scorer uses `type: 'trajectory'`.
- Preserves existing trajectories, normal agent outputs, and workflow outputs.
- Adds regression tests for all affected and unaffected paths.
- Adds a patch changeset for `@mastra/core`.

## Verification

- Focused Core tests pass.
- Core typecheck passes.
- Real-provider Mastra Studio reproduction succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->