### PR TITLE
refactor(playground): remove redundant workflow and scorer casts

### DIFF
--- a/packages/playground/src/domains/agents/components/agent-cms-pages/scorers-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/scorers-page.tsx
@@ -31,8 +31,8 @@ export function ScorersPage() {
     if (!scorers) return [];
     return Object.entries(scorers).map(([id, scorer]) => ({
       value: id,
-      label: (scorer as { scorer?: { config?: { name?: string } } }).scorer?.config?.name || id,
-      description: (scorer as { scorer?: { config?: { description?: string } } }).scorer?.config?.description || '',
+      label: scorer.scorer?.config?.name || id,
+      description: scorer.scorer?.config?.description || '',
     }));
   }, [scorers]);
 

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/workflows-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/workflows-page.tsx
@@ -27,8 +27,8 @@ export function WorkflowsPage() {
     if (!workflows) return [];
     return Object.entries(workflows).map(([id, workflow]) => ({
       value: id,
-      label: (workflow as { name?: string }).name || id,
-      description: (workflow as { description?: string }).description || '',
+      label: workflow.name || id,
+      description: workflow.description || '',
     }));
   }, [workflows]);
 

--- a/packages/playground/src/domains/agents/components/agent-edit-page/sections/scorers-section.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/sections/scorers-section.tsx
@@ -32,8 +32,8 @@ export function ScorersSection({ control, error, readOnly = false }: ScorersSect
     if (!scorers) return [];
     return Object.entries(scorers).map(([id, scorer]) => ({
       value: id,
-      label: (scorer as { scorer?: { config?: { name?: string } } }).scorer?.config?.name || id,
-      description: (scorer as { scorer?: { config?: { description?: string } } }).scorer?.config?.description || '',
+      label: scorer.scorer?.config?.name || id,
+      description: scorer.scorer?.config?.description || '',
     }));
   }, [scorers]);
 

--- a/packages/playground/src/domains/agents/components/agent-edit-page/sections/workflows-section.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/sections/workflows-section.tsx
@@ -27,8 +27,8 @@ export function WorkflowsSection({ control, error, readOnly = false }: Workflows
     if (!workflows) return [];
     return Object.entries(workflows).map(([id, workflow]) => ({
       value: id,
-      label: (workflow as { name?: string }).name || id,
-      description: (workflow as { description?: string }).description || '',
+      label: workflow.name || id,
+      description: workflow.description || '',
     }));
   }, [workflows]);
 


### PR DESCRIPTION
## Description

Remove eight redundant `as` casts from the workflow and scorer pickers in the agent CMS pages and edit sections. The client response types already define their names and descriptions, so the components can use them directly.

Four files, eight line replacements. Displayed values, fallbacks, and emitted JavaScript are unchanged.

Full mutation coverage was not verified. The run was stopped after 6 of 512 mutants (all 6 survived), with an estimate of nearly two hours remaining.

## Related issue(s)

Follow-up to #23487.

## Type of change

- [x] Code refactoring

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (not applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (type-only cleanup; existing tests run)
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The code already knew the workflow and scorer names and descriptions. This change removes extra type labels and uses those values directly without changing what users see.

## Changes

- Removed eight redundant `as` casts from workflow and scorer pickers.
- Updated CMS pages and agent edit sections to access client response fields directly.
- Preserved displayed values, fallbacks, and emitted JavaScript.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->