### PR TITLE
refactor: remove redundant type assertions across packages

### DIFF
--- a/.changeset/floppy-keys-swim.md
+++ b/.changeset/floppy-keys-swim.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Removed redundant type assertions without changing runtime behavior or public types.

--- a/.changeset/sharp-lines-clean.md
+++ b/.changeset/sharp-lines-clean.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Removed redundant type assertions without changing runtime behavior or public types.

--- a/.changeset/smooth-aliens-poke.md
+++ b/.changeset/smooth-aliens-poke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Removed redundant type assertions without changing runtime behavior or public types.

--- a/.changeset/some-cougars-rest.md
+++ b/.changeset/some-cougars-rest.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Removed redundant type assertions without changing runtime behavior or public types.

--- a/.changeset/tender-walls-dream.md
+++ b/.changeset/tender-walls-dream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Removed redundant type assertions without changing runtime behavior or public types.

--- a/client-sdks/client-js/src/resources/responses.ts
+++ b/client-sdks/client-js/src/resources/responses.ts
@@ -52,7 +52,7 @@ function hydrateStreamEvent(event: ResponsesStreamEvent | ResponsePayload): Resp
   }
 
   if (typeof event === 'object' && event !== null && 'output' in event) {
-    return attachOutputText(event as ResponsePayload);
+    return attachOutputText(event);
   }
 
   if (
@@ -63,7 +63,7 @@ function hydrateStreamEvent(event: ResponsesStreamEvent | ResponsePayload): Resp
   ) {
     return {
       ...event,
-      item: hydrateOutputItem(event.item as ResponseOutputItem),
+      item: hydrateOutputItem(event.item),
     } as ResponsesStreamEvent;
   }
 

--- a/client-sdks/client-js/src/utils/verify-agent-card-signature.ts
+++ b/client-sdks/client-js/src/utils/verify-agent-card-signature.ts
@@ -85,7 +85,7 @@ async function importVerificationKey(
     return importSPKI(key, algorithm);
   }
 
-  return importJWK(key as JWK, algorithm);
+  return importJWK(key, algorithm);
 }
 
 export async function verifyAgentCardSignatureIfPresent(

--- a/packages/core/src/agent-builder/ee/normalize-candidate.ts
+++ b/packages/core/src/agent-builder/ee/normalize-candidate.ts
@@ -102,7 +102,7 @@ function fromObject(value: Record<string, unknown>, origin: ModelCandidateOrigin
 
   // AI SDK language model instance: `{ provider, modelId, ... doGenerate }`
   if (typeof providerField === 'string' && typeof modelIdField === 'string') {
-    const isSdkInstance = typeof (value as { doGenerate?: unknown }).doGenerate === 'function';
+    const isSdkInstance = typeof value.doGenerate === 'function';
     return [
       {
         provider: providerField,
@@ -155,8 +155,8 @@ export function toModelCandidates(input: ModelCandidateInput): ModelCandidate[] 
     const candidates: ModelCandidate[] = [];
     input.forEach((variant, index) => {
       if (!isPlainObject(variant)) return;
-      const value = (variant as { value?: unknown }).value ?? variant;
-      const hasRules = isPlainObject(variant) && 'rules' in variant && (variant as { rules?: unknown }).rules != null;
+      const value = variant.value ?? variant;
+      const hasRules = isPlainObject(variant) && 'rules' in variant && variant.rules != null;
       const origin: ModelCandidateOrigin = hasRules ? 'conditional-variant' : 'conditional-default';
       const label = hasRules ? `variant[${index}]` : `variant[${index}] (default)`;
       if (typeof value === 'string') {

--- a/packages/core/src/agent/durable/utils/serialize-state.ts
+++ b/packages/core/src/agent/durable/utils/serialize-state.ts
@@ -182,9 +182,9 @@ export function serializeModelSettings(
   const source = settings as Record<string, unknown>;
   const out: SerializableModelSettings = {};
   const pickNumber = (key: keyof SerializableModelSettings) => {
-    const value = source[key as string];
+    const value = source[key];
     if (typeof value === 'number' && Number.isFinite(value)) {
-      (out as Record<string, unknown>)[key as string] = value;
+      (out as Record<string, unknown>)[key] = value;
     }
   };
 
@@ -198,7 +198,7 @@ export function serializeModelSettings(
   pickNumber('maxRetries');
 
   if (Array.isArray(source.stopSequences) && source.stopSequences.every(v => typeof v === 'string')) {
-    out.stopSequences = source.stopSequences as string[];
+    out.stopSequences = source.stopSequences;
   }
 
   // Headers are never serialized into the workflow input. They are stored

--- a/packages/core/src/agent/durable/workflows/shared/execute-scorers.ts
+++ b/packages/core/src/agent/durable/workflows/shared/execute-scorers.ts
@@ -4,11 +4,7 @@ import type { Mastra } from '../../../../mastra';
 import { createObservabilityContext } from '../../../../observability';
 import { RequestContext } from '../../../../request-context';
 import { MessageList } from '../../../message-list';
-import type {
-  DurableAgenticExecutionOutput,
-  DurableAgenticWorkflowInput,
-  SerializableScorersConfig,
-} from '../../types';
+import type { DurableAgenticExecutionOutput, DurableAgenticWorkflowInput } from '../../types';
 
 export interface ExecuteDurableAgentScorersParams {
   /** Workflow init data, carrying the serialized scorer config and run identity. */
@@ -39,7 +35,7 @@ export function executeDurableAgentScorers({
   requestContext,
   tracingContext,
 }: ExecuteDurableAgentScorersParams): void {
-  const scorers = initData.scorers as SerializableScorersConfig | undefined;
+  const scorers = initData.scorers;
   if (!scorers || Object.keys(scorers).length === 0) {
     return;
   }

--- a/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
@@ -119,7 +119,7 @@ export function createDurableLLMMappingStep() {
         | undefined;
       if (llmOutput.stepSpanData) {
         try {
-          const observability = (mastra as Mastra | undefined)?.observability?.getSelectedInstance({ requestContext });
+          const observability = mastra?.observability?.getSelectedInstance({ requestContext });
           stepSpan = observability?.rebuildSpan(llmOutput.stepSpanData as ExportedSpan<SpanType.MODEL_STEP>);
         } catch {
           // Span bookkeeping must never break the merge step.
@@ -152,9 +152,7 @@ export function createDurableLLMMappingStep() {
           // Start from the existing providerMetadata so it's preserved even when
           // toModelOutput is absent or fails — otherwise provider-executed tools
           // or tools without a mapper lose their metadata.
-          let providerMetadata: Record<string, unknown> | undefined = toolResult.providerMetadata as
-            | Record<string, unknown>
-            | undefined;
+          let providerMetadata: Record<string, unknown> | undefined = toolResult.providerMetadata;
           if (
             !toolResult.error &&
             toolResult.result != null &&
@@ -198,7 +196,7 @@ export function createDurableLLMMappingStep() {
               } catch (err) {
                 mappingSpan?.error({ error: err as Error, endSpan: true });
                 // toModelOutput errors are non-fatal — the tool result is still usable
-                (mastra as Mastra | undefined)
+                mastra
                   ?.getLogger?.()
                   ?.warn?.(`[DurableAgent] toModelOutput failed for tool "${toolResult.toolName}": ${err}`);
               }
@@ -322,9 +320,7 @@ export function createDurableLLMMappingStep() {
           });
         } catch (error) {
           // Span bookkeeping must never break the merge step.
-          (mastra as Mastra | undefined)
-            ?.getLogger?.()
-            ?.warn?.(`[DurableAgent] Failed to close model_step span: ${error}`);
+          mastra?.getLogger?.()?.warn?.(`[DurableAgent] Failed to close model_step span: ${error}`);
         }
       }
 
@@ -374,9 +370,7 @@ export function createDurableLLMMappingStep() {
           };
           await emitChunkEvent(pubsub, _runId, enrichedChunk);
         } catch (error) {
-          (mastra as Mastra | undefined)
-            ?.getLogger?.()
-            ?.warn?.(`[DurableAgent] Failed to emit deferred step-finish: ${error}`);
+          mastra?.getLogger?.()?.warn?.(`[DurableAgent] Failed to emit deferred step-finish: ${error}`);
         }
       }
 

--- a/packages/core/src/agent/durable/workflows/steps/scorer-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/scorer-execution.ts
@@ -122,7 +122,7 @@ export function createDurableScorerStep() {
 
         try {
           // Resolve the scorer from Mastra
-          const scorer = (mastra as Mastra)?.getScorer?.(scorerName) as MastraScorer | undefined;
+          const scorer = mastra?.getScorer?.(scorerName) as MastraScorer | undefined;
 
           if (!scorer) {
             logger?.warn?.(`Scorer ${scorerName} not found in Mastra, skipping`, { runId, scorerKey });

--- a/packages/core/src/agent/message-list/conversion/input-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/input-converter.ts
@@ -1,14 +1,8 @@
-import type { CoreMessage as CoreMessageV4, UIMessage as UIMessageV4 } from '@internal/ai-sdk-v4';
+import type { CoreMessage as CoreMessageV4 } from '@internal/ai-sdk-v4';
 
 import { AIV4Adapter, AIV5Adapter, AIV6Adapter } from '../adapters';
 import { TypeDetector } from '../detection/TypeDetector';
-import type {
-  MastraDBMessage,
-  MastraMessageV1,
-  MessageSource,
-  MemoryInfo,
-  UIMessageWithMetadata,
-} from '../state/types';
+import type { MastraDBMessage, MastraMessageV1, MessageSource, MemoryInfo } from '../state/types';
 import type { MessageInput } from '../types';
 import { stampMessageParts } from '../utils/stamp-part';
 
@@ -70,10 +64,7 @@ export function inputToMastraDBMessage(
     return stampMessageParts(AIV4Adapter.fromCoreMessage(message, context, messageSource), messageSource);
   }
   if (TypeDetector.isAIV4UIMessage(message)) {
-    return stampMessageParts(
-      AIV4Adapter.fromUIMessage(message as UIMessageV4 | UIMessageWithMetadata, context, messageSource),
-      messageSource,
-    );
+    return stampMessageParts(AIV4Adapter.fromUIMessage(message, context, messageSource), messageSource);
   }
 
   // Use custom ID generator if message doesn't have an ID, otherwise keep the original

--- a/packages/core/src/agent/message-list/detection/TypeDetector.ts
+++ b/packages/core/src/agent/message-list/detection/TypeDetector.ts
@@ -123,9 +123,7 @@ export class TypeDetector {
       !TypeDetector.isMastraMessage(msg) &&
       !('parts' in msg) &&
       'content' in msg &&
-      TypeDetector.hasAIV6CoreMessageCharacteristics(
-        msg as CoreMessageV4 | AIV5Type.ModelMessage | AIV6Type.ModelMessage | AIV7Type.ModelMessage | AIV4Message,
-      )
+      TypeDetector.hasAIV6CoreMessageCharacteristics(msg)
     );
   }
 

--- a/packages/core/src/agent/workflows/prepare-stream/client-tool-output-hooks.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/client-tool-output-hooks.ts
@@ -52,7 +52,7 @@ function unwrapToolOutput(value: unknown): { skip: true } | { skip: false; outpu
     'value' in value &&
     Object.keys(value).length === 2;
   if (isV5Wrapper && (value.type === 'error-text' || value.type === 'error-json')) return { skip: true };
-  return { skip: false, output: isV5Wrapper ? (value as Record<string, unknown>).value : value };
+  return { skip: false, output: isV5Wrapper ? value.value : value };
 }
 
 function getToolResult(part: unknown): ToolResult | undefined {
@@ -181,7 +181,7 @@ export async function applyClientToolModelOutput({
       if (
         mastraMetadata &&
         typeof mastraMetadata === 'object' &&
-        ('modelOutput' in mastraMetadata || (mastraMetadata as Record<string, unknown>).modelOutputComputed)
+        ('modelOutput' in mastraMetadata || mastraMetadata.modelOutputComputed)
       ) {
         continue;
       }

--- a/packages/core/src/background-tasks/workflow.ts
+++ b/packages/core/src/background-tasks/workflow.ts
@@ -3,7 +3,6 @@ import { InternalSpans } from '../observability';
 import type { SuspendOptions } from '../workflows';
 import { createStep, createWorkflow } from '../workflows';
 import type { BackgroundTaskManager } from './manager';
-import type { BackgroundTaskStatus } from './types';
 import { BACKGROUND_TASK_WORKFLOW_ID } from './workflow-id';
 
 export { BACKGROUND_TASK_WORKFLOW_ID } from './workflow-id';
@@ -180,7 +179,7 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
         return { taskId, outcome: 'success' as const, result };
       } catch (error: any) {
         const currentTask = await storage.getTask(taskId);
-        if (!currentTask || (currentTask.status as BackgroundTaskStatus) === 'cancelled') {
+        if (!currentTask || currentTask.status === 'cancelled') {
           manager.deregisterTaskContext(taskId);
           return { taskId, outcome: 'cancelled' as const };
         }
@@ -260,7 +259,7 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
       }
 
       if (outcome === 'success') {
-        if ((task.status as BackgroundTaskStatus) === 'cancelled') {
+        if (task.status === 'cancelled') {
           manager.deregisterTaskContext(taskId);
           return { taskId, done: true };
         }

--- a/packages/core/src/browser/processor.ts
+++ b/packages/core/src/browser/processor.ts
@@ -244,7 +244,7 @@ function getMostRecentBrowserClickResultUrlFromMessages(
 
     const content = message.content;
     if (!content || typeof content !== 'object' || Array.isArray(content)) continue;
-    const parts = (content as { parts?: unknown }).parts;
+    const parts = content.parts;
     if (!Array.isArray(parts)) continue;
 
     for (const part of [...parts].reverse()) {
@@ -263,7 +263,7 @@ function getMostRecentBrowserClickResultUrlFromMessages(
 function isBrowserStateSignalMessage(message: ComputeStateSignalArgs['messages'][number]): boolean {
   const content = message.content;
   if (!content || typeof content !== 'object' || Array.isArray(content)) return false;
-  const signal = (content as { metadata?: { signal?: unknown } }).metadata?.signal;
+  const signal = content.metadata?.signal;
   if (!signal || typeof signal !== 'object' || Array.isArray(signal)) return false;
   const metadata = (signal as { metadata?: unknown }).metadata;
   if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return false;

--- a/packages/core/src/channels/chat-driver-static.ts
+++ b/packages/core/src/channels/chat-driver-static.ts
@@ -331,7 +331,7 @@ export async function runStaticDriver({
         displayName: enr.displayName,
         argsSummary: enr.argsSummary,
         startedAt: Date.now(),
-        runId: (chunk as { runId?: string }).runId,
+        runId: chunk.runId,
         toolName: enr.toolName,
         args: (enr.args ?? {}) as Record<string, unknown>,
       });

--- a/packages/core/src/channels/state-adapter.ts
+++ b/packages/core/src/channels/state-adapter.ts
@@ -65,7 +65,7 @@ export class MastraStateAdapter implements StateAdapter {
       metadata: {
         ...thread.metadata,
         channel_subscribed: 'true',
-        ...this.ownerStamp(thread.metadata as Record<string, unknown> | undefined),
+        ...this.ownerStamp(thread.metadata),
       },
     });
   }
@@ -76,9 +76,9 @@ export class MastraStateAdapter implements StateAdapter {
     await this.memoryStore.patchThread({
       id: thread.id,
       metadata: {
-        ...((thread.metadata ?? {}) as Record<string, unknown>),
+        ...(thread.metadata ?? {}),
         channel_subscribed: 'false',
-        ...this.ownerStamp(thread.metadata as Record<string, unknown> | undefined),
+        ...this.ownerStamp(thread.metadata),
       },
     });
   }
@@ -287,7 +287,7 @@ export class MastraStateAdapter implements StateAdapter {
     });
     return (
       candidates.find(candidate => {
-        const metadata = (candidate.metadata ?? {}) as Record<string, unknown>;
+        const metadata = candidate.metadata ?? {};
         return !('channel_ownerId' in metadata);
       }) ?? null
     );

--- a/packages/core/src/channels/stream-helpers.ts
+++ b/packages/core/src/channels/stream-helpers.ts
@@ -286,7 +286,7 @@ export async function postFileAttachment(args: {
   logger?.debug?.('[CHANNEL] Received file chunk', {
     mimeType,
     dataType: typeof data,
-    size: typeof data === 'string' ? data.length : (data as Uint8Array)?.byteLength,
+    size: typeof data === 'string' ? data.length : data?.byteLength,
   });
   const ext = mimeType.split('/')[1]?.split(';')[0] || 'bin';
   const filename = payloadFilename ?? `generated.${ext}`;

--- a/packages/core/src/coding-agent/index.ts
+++ b/packages/core/src/coding-agent/index.ts
@@ -34,7 +34,7 @@ const ECONNRESET_MESSAGE_PATTERN = /econnreset|socket hang up/i;
 function isECONNRESETError(error: unknown): boolean {
   if (!error) return false;
 
-  const code = typeof error === 'object' && 'code' in error ? (error as { code?: unknown }).code : undefined;
+  const code = typeof error === 'object' && 'code' in error ? error.code : undefined;
   if (typeof code === 'string' && code.toUpperCase() === 'ECONNRESET') return true;
 
   const message = error instanceof Error ? error.message : undefined;

--- a/packages/core/src/evals/scoreTraces/utils.ts
+++ b/packages/core/src/evals/scoreTraces/utils.ts
@@ -149,12 +149,12 @@ function extractInputMessages(agentSpan: SpanRecord): MastraDBMessage[] {
   }
 
   if (Array.isArray(input)) {
-    const messages = input.filter(isSpanMessage) as SpanMessage[];
+    const messages = input.filter(isSpanMessage);
     return messages.map(msg => createMastraDBMessage(msg, agentSpan.startedAt));
   }
 
   if (hasMessagesArray(input)) {
-    const messages = input.messages.filter(isSpanMessage) as SpanMessage[];
+    const messages = input.messages.filter(isSpanMessage);
     return messages.map(msg => createMastraDBMessage(msg, agentSpan.startedAt));
   }
   return [];
@@ -255,7 +255,7 @@ function prepareTraceForTransformation(trace: TraceRecord) {
   const spanTree = buildSpanTree(trace.spans);
 
   // Find the root agent run span
-  const rootAgentSpan = spanTree.rootSpans.find(span => span.spanType === 'agent_run') as SpanRecord | undefined;
+  const rootAgentSpan = spanTree.rootSpans.find(span => span.spanType === 'agent_run');
 
   if (!rootAgentSpan) {
     throw new Error('No root agent_run span found in trace');

--- a/packages/core/src/events/codec/codec.ts
+++ b/packages/core/src/events/codec/codec.ts
@@ -174,7 +174,7 @@ export function decode(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(decode);
 
   if (CODEC_TAG in value && isEnvelope(value)) {
-    const env = value as Envelope;
+    const env = value;
     switch (env[CODEC_TAG]) {
       case 'Undefined':
         return undefined;

--- a/packages/core/src/events/codec/error.ts
+++ b/packages/core/src/events/codec/error.ts
@@ -39,7 +39,7 @@ export function serializeError(err: Error, depth = 0): SerializedError {
 export function rehydrateError(s: SerializedError): Error {
   const cause =
     s.cause !== undefined
-      ? s.cause && typeof s.cause === 'object' && 'message' in (s.cause as object) && 'name' in (s.cause as object)
+      ? s.cause && typeof s.cause === 'object' && 'message' in s.cause && 'name' in s.cause
         ? rehydrateError(s.cause as SerializedError)
         : s.cause
       : undefined;

--- a/packages/core/src/events/event-emitter/ack-handle-buffer.ts
+++ b/packages/core/src/events/event-emitter/ack-handle-buffer.ts
@@ -114,10 +114,7 @@ export class AckHandleBuffer {
           if (this.disposed) break;
           const entry = byEvent.get(ev);
           try {
-            // The declared EventCallback return type is `void`, but real
-            // implementations frequently return a Promise. Await both kinds
-            // so per-event isolation actually waits for the cb to settle.
-            await (this.cb(ev, entry?.ack, entry?.nack) as void | Promise<void>);
+            await this.cb(ev, entry?.ack, entry?.nack);
           } catch (err) {
             this.onError?.(err, { phase: 'cb' });
           }

--- a/packages/core/src/license/index.ts
+++ b/packages/core/src/license/index.ts
@@ -92,9 +92,7 @@ export class LicenseClient {
       const timer = setTimeout(() => controller.abort(), this.REQUEST_TIMEOUT_MS);
       timer.unref?.();
       try {
-        const signal = options.signal
-          ? AbortSignal.any([options.signal as AbortSignal, controller.signal])
-          : controller.signal;
+        const signal = options.signal ? AbortSignal.any([options.signal, controller.signal]) : controller.signal;
         const response = await fetch(url, { ...options, signal });
         if (response.status === 429 || response.status >= 500) {
           if (i === retries - 1) return response;

--- a/packages/core/src/llm/model/embedding-router.ts
+++ b/packages/core/src/llm/model/embedding-router.ts
@@ -283,7 +283,7 @@ export class ModelRouterEmbeddingModel<VALUE extends string = string> implements
     const result = await this.providerModel.doEmbed({ ...args, headers });
     // Ensure warnings is always an array — AI SDK v6's embedMany spreads
     // result.warnings and crashes if it's undefined.
-    const warnings = (result as { warnings?: unknown[] }).warnings ?? [];
+    const warnings = result.warnings ?? [];
     return { ...result, warnings } as Awaited<ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>>;
   }
 }

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -220,7 +220,7 @@ export class MastraLLMVNext extends MastraBase {
         messageList,
         models: this.#models,
         logger: this.logger,
-        tools: tools as Tools,
+        tools,
         stopWhen: stopWhenToUse,
         toolChoice,
         modelSettings,

--- a/packages/core/src/llm/model/registry-generator.ts
+++ b/packages/core/src/llm/model/registry-generator.ts
@@ -32,28 +32,19 @@ interface GatewayWithStructuredOutputCapabilities {
 function hasAttachmentCapabilities(
   gateway: MastraModelGatewayInterface,
 ): gateway is MastraModelGatewayInterface & GatewayWithAttachmentCapabilities {
-  return (
-    'getAttachmentCapabilities' in gateway &&
-    typeof (gateway as { getAttachmentCapabilities?: unknown }).getAttachmentCapabilities === 'function'
-  );
+  return 'getAttachmentCapabilities' in gateway && typeof gateway.getAttachmentCapabilities === 'function';
 }
 
 function hasTemperatureCapabilities(
   gateway: MastraModelGatewayInterface,
 ): gateway is MastraModelGatewayInterface & GatewayWithTemperatureCapabilities {
-  return (
-    'getTemperatureCapabilities' in gateway &&
-    typeof (gateway as { getTemperatureCapabilities?: unknown }).getTemperatureCapabilities === 'function'
-  );
+  return 'getTemperatureCapabilities' in gateway && typeof gateway.getTemperatureCapabilities === 'function';
 }
 
 function hasStructuredOutputCapabilities(
   gateway: MastraModelGatewayInterface,
 ): gateway is MastraModelGatewayInterface & GatewayWithStructuredOutputCapabilities {
-  return (
-    'getStructuredOutputCapabilities' in gateway &&
-    typeof (gateway as { getStructuredOutputCapabilities?: unknown }).getStructuredOutputCapabilities === 'function'
-  );
+  return 'getStructuredOutputCapabilities' in gateway && typeof gateway.getStructuredOutputCapabilities === 'function';
 }
 
 /**

--- a/packages/core/src/llm/model/resolve-model.ts
+++ b/packages/core/src/llm/model/resolve-model.ts
@@ -1,7 +1,6 @@
 import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 import type { LanguageModelV3 } from '@ai-sdk/provider-v6';
 import type { LanguageModelV4 } from '@ai-sdk/provider-v7';
-import type { LanguageModelV1 } from '@internal/ai-sdk-v4';
 import type { Mastra } from '../../mastra';
 import { RequestContext } from '../../request-context';
 import { AISDKV4LegacyLanguageModel } from './aisdk/v4/model';
@@ -119,7 +118,7 @@ export async function resolveModelConfig(
     if (modelConfig.specificationVersion === 'v1') {
       // Wrap legacy v1 models so the underlying SDK client (and any
       // enumerable config) does not leak into observability spans.
-      return new AISDKV4LegacyLanguageModel(modelConfig as LanguageModelV1);
+      return new AISDKV4LegacyLanguageModel(modelConfig);
     }
     // Unknown specificationVersion from a third-party provider (e.g. ollama-ai-provider-v2).
     // If the model has doStream/doGenerate methods, wrap it as a modern model

--- a/packages/core/src/loop/shared/compose-step-input.ts
+++ b/packages/core/src/loop/shared/compose-step-input.ts
@@ -55,6 +55,6 @@ export function composeStepInput(
     // Restore type-narrowed defaults for the canonical fields if the
     // processor returned undefined for any of them.
     messageId: processInputStepResult.messageId ?? current.messageId,
-    model: (processInputStepResult.model ?? current.model) as MastraLanguageModel,
+    model: processInputStepResult.model ?? current.model,
   };
 }

--- a/packages/core/src/loop/timeout.ts
+++ b/packages/core/src/loop/timeout.ts
@@ -129,7 +129,7 @@ export function guardStreamWithAbort<T>(
       new TransformStream<T, T>({
         flush: () => onSettled(),
       }) as any,
-    ) as ReadableStream<T>;
+    );
   }
 
   const reader = stream.getReader();

--- a/packages/core/src/loop/workflows/agentic-execution/index.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/index.ts
@@ -132,10 +132,10 @@ export function createAgenticExecutionWorkflow<Tools extends ToolSet = ToolSet, 
         // called this step. A pure-safe batch parallelizes even while an
         // approval/suspend tool stays registered; a batch that calls one still
         // serializes; run-wide requireToolApproval still forces sequential.
-        const stepActiveTools = _internal?.stepActiveTools as string[] | undefined;
+        const stepActiveTools = _internal?.stepActiveTools;
         toolCallForeachOptions.concurrency = resolveToolCallConcurrency({
           requireToolApproval: rest.requireToolApproval,
-          tools: ((_internal?.stepTools as Tools | undefined) ?? rest.tools) as Tools | undefined,
+          tools: (_internal?.stepTools as Tools | undefined) ?? rest.tools,
           activeTools: stepActiveTools,
           configuredConcurrency: configuredToolCallConcurrency,
           strategy: toolCallConcurrencyStrategy,

--- a/packages/core/src/loop/workflows/agentic-execution/is-task-complete-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/is-task-complete-step.ts
@@ -71,7 +71,7 @@ export function createIsTaskCompleteStep<Tools extends ToolSet = ToolSet, OUTPUT
         if (typeof firstUserMessage.content === 'string') {
           originalTask = firstUserMessage.content;
         } else if (firstUserMessage.content?.parts?.[0]?.type === 'text') {
-          originalTask = (firstUserMessage.content.parts[0] as { type: 'text'; text: string }).text;
+          originalTask = firstUserMessage.content.parts[0].text;
         }
       }
 

--- a/packages/core/src/processors/is-processor-workflow.ts
+++ b/packages/core/src/processors/is-processor-workflow.ts
@@ -13,11 +13,11 @@ export function isProcessorWorkflow(obj: unknown): obj is ProcessorWorkflow {
     obj !== null &&
     typeof obj === 'object' &&
     'id' in obj &&
-    typeof (obj as Record<string, unknown>).id === 'string' &&
+    typeof obj.id === 'string' &&
     'inputSchema' in obj &&
     'outputSchema' in obj &&
     'execute' in obj &&
-    typeof (obj as Record<string, unknown>).execute === 'function' &&
+    typeof obj.execute === 'function' &&
     !('processInput' in obj) &&
     !('processInputStep' in obj) &&
     !('processOutputStream' in obj) &&

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -376,13 +376,8 @@ The input text may be in any format (sentences, bullet points, paragraphs, etc.)
   }
 
   private getErrorMessage(error: unknown): string {
-    if (
-      error &&
-      typeof error === 'object' &&
-      'message' in error &&
-      typeof (error as { message?: unknown }).message === 'string'
-    ) {
-      return (error as { message: string }).message;
+    if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string') {
+      return error.message;
     }
 
     if (error instanceof Error) {

--- a/packages/core/src/processors/processors/tool-call-filter.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.ts
@@ -197,7 +197,7 @@ export class ToolCallFilter implements Processor {
         if (part.type !== 'tool-result') continue;
         if (!excludedToolCallIds.has(part.toolCallId)) continue;
 
-        const text = this.modelOutputToText((part as ToolResultPart).output);
+        const text = this.modelOutputToText(part.output);
         if (text) {
           texts.set(part.toolCallId, `${part.toolName} result:\n${text}`);
         }

--- a/packages/core/src/processors/stream-error-retry-processor.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.ts
@@ -136,7 +136,7 @@ export function isRetryableOpenAIResponsesStreamError(error: unknown): boolean {
 export function isBadRequestError(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
 
-  if ('statusCode' in error && (error as { statusCode?: unknown }).statusCode === 400) return true;
+  if ('statusCode' in error && error.statusCode === 400) return true;
 
   return false;
 }

--- a/packages/core/src/storage/domains/datasets/serialization.ts
+++ b/packages/core/src/storage/domains/datasets/serialization.ts
@@ -44,7 +44,7 @@ function findSerializationIssue(
       // Date, Map, Set, class instances, custom toJSON() objects, etc. change
       // shape during JSON persistence, so identical retries would no longer
       // deep-equal the persisted payload. Require explicit conversion instead.
-      const constructorName = (value as object).constructor?.name || 'unknown class';
+      const constructorName = value.constructor?.name || 'unknown class';
       return { path, reason: `non-plain object (${constructorName}) at ${path} would change during JSON persistence` };
     }
   }

--- a/packages/core/src/storage/domains/mcp-clients/inmemory.ts
+++ b/packages/core/src/storage/domains/mcp-clients/inmemory.ts
@@ -96,7 +96,7 @@ export class InMemoryMCPClientsStorage extends MCPClientsStorage {
       ...existingConfig,
       ...(authorId !== undefined && { authorId }),
       ...(activeVersionId !== undefined && { activeVersionId }),
-      ...(status !== undefined && { status: status as StorageMCPClientType['status'] }),
+      ...(status !== undefined && { status }),
       ...(metadata !== undefined && {
         metadata: { ...existingConfig.metadata, ...metadata },
       }),

--- a/packages/core/src/storage/domains/mcp-servers/inmemory.ts
+++ b/packages/core/src/storage/domains/mcp-servers/inmemory.ts
@@ -96,7 +96,7 @@ export class InMemoryMCPServersStorage extends MCPServersStorage {
       ...existingConfig,
       ...(authorId !== undefined && { authorId }),
       ...(activeVersionId !== undefined && { activeVersionId }),
-      ...(status !== undefined && { status: status as StorageMCPServerType['status'] }),
+      ...(status !== undefined && { status }),
       ...(metadata !== undefined && {
         metadata: { ...existingConfig.metadata, ...metadata },
       }),

--- a/packages/core/src/storage/domains/prompt-blocks/inmemory.ts
+++ b/packages/core/src/storage/domains/prompt-blocks/inmemory.ts
@@ -96,7 +96,7 @@ export class InMemoryPromptBlocksStorage extends PromptBlocksStorage {
       ...existingBlock,
       ...(authorId !== undefined && { authorId }),
       ...(activeVersionId !== undefined && { activeVersionId }),
-      ...(status !== undefined && { status: status as StoragePromptBlockType['status'] }),
+      ...(status !== undefined && { status }),
       ...(metadata !== undefined && {
         metadata: { ...existingBlock.metadata, ...metadata },
       }),

--- a/packages/core/src/storage/domains/scorer-definitions/inmemory.ts
+++ b/packages/core/src/storage/domains/scorer-definitions/inmemory.ts
@@ -105,7 +105,7 @@ export class InMemoryScorerDefinitionsStorage extends ScorerDefinitionsStorage {
       ...existingScorer,
       ...(authorId !== undefined && { authorId }),
       ...(activeVersionId !== undefined && { activeVersionId }),
-      ...(status !== undefined && { status: status as StorageScorerDefinitionType['status'] }),
+      ...(status !== undefined && { status }),
       ...(metadata !== undefined && {
         metadata: { ...existingScorer.metadata, ...metadata },
       }),

--- a/packages/core/src/storage/domains/skills/filesystem.ts
+++ b/packages/core/src/storage/domains/skills/filesystem.ts
@@ -111,7 +111,7 @@ export class FilesystemSkillsStorage extends SkillsStorage {
       ...(authorId !== undefined && { authorId }),
       ...(visibility !== undefined && { visibility }),
       ...(activeVersionId !== undefined && { activeVersionId }),
-      ...(status !== undefined && { status: status as StorageSkillType['status'] }),
+      ...(status !== undefined && { status }),
       updatedAt: new Date(),
     };
 
@@ -145,10 +145,7 @@ export class FilesystemSkillsStorage extends SkillsStorage {
       const changedFields = configFieldNames.filter(
         field =>
           field in configFields &&
-          !skillSnapshotFieldValuesEqual(
-            configFields[field as keyof typeof configFields],
-            latestConfig[field as keyof typeof latestConfig],
-          ),
+          !skillSnapshotFieldValuesEqual(configFields[field], latestConfig[field as keyof typeof latestConfig]),
       );
 
       if (changedFields.length > 0) {

--- a/packages/core/src/storage/domains/workspaces/inmemory.ts
+++ b/packages/core/src/storage/domains/workspaces/inmemory.ts
@@ -119,7 +119,7 @@ export class InMemoryWorkspacesStorage extends WorkspacesStorage {
       ...existingConfig,
       ...(authorId !== undefined && { authorId }),
       ...(activeVersionId !== undefined && { activeVersionId }),
-      ...(status !== undefined && { status: status as StorageWorkspaceType['status'] }),
+      ...(status !== undefined && { status }),
       ...(metadata !== undefined && {
         metadata: { ...existingConfig.metadata, ...metadata },
       }),
@@ -160,8 +160,7 @@ export class InMemoryWorkspacesStorage extends WorkspacesStorage {
       const changedFields = configFieldNames.filter(
         field =>
           field in configFields &&
-          JSON.stringify(configFields[field as keyof typeof configFields]) !==
-            JSON.stringify(latestConfig[field as keyof typeof latestConfig]),
+          JSON.stringify(configFields[field]) !== JSON.stringify(latestConfig[field as keyof typeof latestConfig]),
       );
 
       // Only create a new version if something actually changed

--- a/packages/core/src/stream/aisdk/v5/input.ts
+++ b/packages/core/src/stream/aisdk/v5/input.ts
@@ -51,7 +51,7 @@ export class AISDKV5InputStream extends MastraModelInput {
       const rawChunk = chunk as StreamPart;
 
       // Clear ID map on new step so each step gets fresh UUIDs
-      if ((rawChunk as { type: string }).type === 'stream-start') {
+      if (rawChunk.type === 'stream-start') {
         idMap.clear();
       }
 

--- a/packages/core/src/stream/base/step-message-mirrors.ts
+++ b/packages/core/src/stream/base/step-message-mirrors.ts
@@ -119,7 +119,7 @@ export function unpackStepMessageMirrors<T extends StepLike>(steps: T[], message
           // of the whole run — is what makes this faithful: conversions merge
           // adjacent assistant messages, so later messages can change how
           // earlier ones render.
-          return (uiMessages ??= convertMessages(getDbMessages()).to('AIV5.UI') as AIV5Type.UIMessage[]);
+          return (uiMessages ??= convertMessages(getDbMessages()).to('AIV5.UI'));
         },
       },
       messages: {

--- a/packages/core/src/telemetry/usage-telemetry.ts
+++ b/packages/core/src/telemetry/usage-telemetry.ts
@@ -2,7 +2,7 @@ import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { Mastra } from '../mastra';
-import type { GetMetricBreakdownResponse, ObservabilityStorage } from '../storage/domains';
+import type { GetMetricBreakdownResponse } from '../storage/domains';
 import { getServerTelemetryContext } from './context';
 import { captureTelemetryEvent, isTelemetryEnabled } from './posthog';
 
@@ -97,7 +97,7 @@ export async function syncUsageTelemetry(mastra: Mastra, options: SyncUsageTelem
       return;
     }
 
-    const observability = mastra.getStorage()?.stores?.observability as ObservabilityStorage | undefined;
+    const observability = mastra.getStorage()?.stores?.observability;
     if (!observability || typeof observability.getMetricBreakdown !== 'function') {
       return;
     }

--- a/packages/core/src/tools/code-mode/stub-generator.ts
+++ b/packages/core/src/tools/code-mode/stub-generator.ts
@@ -16,7 +16,6 @@
 import type { JSONSchema7, JSONSchema7Definition, JSONSchema7TypeName } from 'json-schema';
 import type { ToolsInput } from '../../agent/types';
 import { isStandardSchemaWithJSON, standardSchemaToJSONSchema } from '../../schema';
-import type { StandardSchemaWithJSON } from '../../schema';
 import type { CodeModeConfig } from './types';
 
 /** A valid TypeScript identifier? (used to decide quoting of object keys). */
@@ -132,7 +131,7 @@ function literal(value: unknown): string {
 function schemaToTs(schema: unknown, io: 'input' | 'output'): string {
   if (!isStandardSchemaWithJSON(schema)) return 'unknown';
   try {
-    const json = standardSchemaToJSONSchema(schema as StandardSchemaWithJSON, { io });
+    const json = standardSchemaToJSONSchema(schema, { io });
     return jsonSchemaToTsString(json as JSONSchema7);
   } catch {
     return 'unknown';

--- a/packages/core/src/utils/zod-utils.ts
+++ b/packages/core/src/utils/zod-utils.ts
@@ -60,7 +60,7 @@ export function getZodTypeName(schema: ZodTypeAny): string | undefined {
  */
 export function isZodArray(value: unknown): value is ZodArrayAny {
   if (!isZodType(value)) return false;
-  return getZodTypeName(value as ZodTypeAny) === 'ZodArray';
+  return getZodTypeName(value) === 'ZodArray';
 }
 
 /**
@@ -70,7 +70,7 @@ export function isZodArray(value: unknown): value is ZodArrayAny {
  */
 export function isZodObject(value: unknown): value is ZodObjectAny {
   if (!isZodType(value)) return false;
-  return getZodTypeName(value as ZodTypeAny) === 'ZodObject';
+  return getZodTypeName(value) === 'ZodObject';
 }
 
 /**

--- a/packages/core/src/worker/workers/scheduler-worker.ts
+++ b/packages/core/src/worker/workers/scheduler-worker.ts
@@ -1,4 +1,3 @@
-import type { IMastraLogger } from '../../logger';
 import { resolveAgentById } from '../../mastra/resolve-agent';
 import type { ScheduleTarget } from '../../storage/domains/schedules/base';
 import { computeScheduleDefinitionHash } from '../../workflows/scheduler/definition-hash';
@@ -106,7 +105,7 @@ export class SchedulerWorker extends MastraWorker {
       pubsub: deps.pubsub,
       config: { ...this.#config, isTargetReady, isTargetCurrent, canExecuteLocally },
     });
-    this.#scheduler.__setLogger(deps.logger as IMastraLogger);
+    this.#scheduler.__setLogger(deps.logger);
 
     // Register declarative schedules from workflow configs before starting
     // the tick loop. This syncs code-declared schedules to the DB.

--- a/packages/core/src/workflows/dynamic/json-schema-to-zod.ts
+++ b/packages/core/src/workflows/dynamic/json-schema-to-zod.ts
@@ -118,7 +118,7 @@ function walk(schema: JsonSchema, opts: JsonSchemaToZodOptions): z.ZodTypeAny {
     } else {
       // Mixed/non-string enums (e.g. [1, 2, 3] or ['a', 1]): preserve the
       // original member types via literal union instead of coercing to string.
-      const literals: z.ZodTypeAny[] = values.map(v => z.literal(v as string | number | boolean | null));
+      const literals: z.ZodTypeAny[] = values.map(v => z.literal(v));
       out = literals.length === 1 ? literals[0]! : z.union(literals as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]);
     }
   } else if (Array.isArray(schema.type)) {

--- a/packages/core/src/workflows/execution-engine.ts
+++ b/packages/core/src/workflows/execution-engine.ts
@@ -192,7 +192,7 @@ export abstract class ExecutionEngine extends MastraBase {
       try {
         await Promise.resolve(
           onError({
-            status: result.status as 'failed' | 'tripwire',
+            status: result.status,
             error: result.error,
             steps: result.steps,
             tripwire: result.tripwire,

--- a/packages/core/src/workflows/step-entry.ts
+++ b/packages/core/src/workflows/step-entry.ts
@@ -50,7 +50,7 @@ export function getEntryRetries(entry: SingleStepEntry, fallback?: number): numb
  * declarative variants have none.
  */
 export function getEntryComponent(entry: SingleStepEntry): string | undefined {
-  return entry.type === 'step' ? (entry.step as { component?: string }).component : undefined;
+  return entry.type === 'step' ? entry.step.component : undefined;
 }
 
 /**

--- a/packages/core/src/workflows/step-factories.ts
+++ b/packages/core/src/workflows/step-factories.ts
@@ -48,7 +48,7 @@ export function createStepFromAgent<TStepId extends string, TStepOutput>(
   // Determine output schema based on structuredOutput option
   const outputSchema = toStandardSchema(
     (options?.structuredOutput?.schema ?? z.object({ text: z.string() })) as PublicSchema<TStepOutput>,
-  ) as StandardSchemaWithJSON<TStepOutput>;
+  );
   const { retries, scorers, metadata } =
     options ??
     ({} as AgentStepOptions<TStepOutput> & {

--- a/packages/core/src/workspace/skills/publish.ts
+++ b/packages/core/src/workspace/skills/publish.ts
@@ -183,7 +183,7 @@ function buildSkillFileNodes(files: WalkedFile[]): StorageSkillFileNode[] {
 
     const fileName = segments[segments.length - 1]!;
     const content = file.isBinary
-      ? (Buffer.isBuffer(file.content) ? file.content : Buffer.from(file.content as string)).toString('base64')
+      ? (Buffer.isBuffer(file.content) ? file.content : Buffer.from(file.content)).toString('base64')
       : (file.content as string);
     cursor.push({ name: fileName, type: 'file', content });
   }
@@ -273,7 +273,7 @@ export async function collectSkillForPublish(source: SkillSource, skillPath: str
 
     if (file.isBinary) {
       // Binary file: store as base64-encoded string
-      const buf = Buffer.isBuffer(file.content) ? file.content : Buffer.from(file.content as string);
+      const buf = Buffer.isBuffer(file.content) ? file.content : Buffer.from(file.content);
       const size = buf.length;
       const base64Content = buf.toString('base64');
 

--- a/packages/memory/src/processors/observational-memory/extraction-runner.ts
+++ b/packages/memory/src/processors/observational-memory/extraction-runner.ts
@@ -129,7 +129,7 @@ ${extractorInstructions}${priorLines.length > 0 ? `\n\n## Prior Extracted Values
   }
 
   for (const extractor of structuredExtractors) {
-    const value = (object as Record<string, unknown>)[extractor.slug];
+    const value = object[extractor.slug];
     if (value === undefined || value === null || value === '') {
       continue;
     }

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-protocol.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-protocol.ts
@@ -91,7 +91,7 @@ function parseMetadata(value: unknown): RemindMessageMetadata | undefined {
 }
 
 export function getRemindMessageMetadata(message: MastraDBMessage): RemindMessageMetadata | undefined {
-  const metadata = message.content.metadata as Record<string, unknown> | undefined;
+  const metadata = message.content.metadata;
   return parseMetadata(metadata?.[REMIND_MESSAGE_METADATA_KEY]);
 }
 

--- a/packages/schema-compat/src/standard-schema/standard-schema.ts
+++ b/packages/schema-compat/src/standard-schema/standard-schema.ts
@@ -165,7 +165,7 @@ export function toStandardSchema<T = unknown>(schema: PublicSchema<T>): Standard
 
   // Check for AI SDK Schema objects (Vercel's jsonSchema wrapper)
   if (isVercelSchema(schema)) {
-    return toStandardSchemaAiSdk(schema as Schema<T>);
+    return toStandardSchemaAiSdk(schema);
   }
 
   // At this point, assume it's a plain JSON Schema object

--- a/packages/schema-compat/src/utils.ts
+++ b/packages/schema-compat/src/utils.ts
@@ -39,7 +39,7 @@ type ZodType = ZodTypeV3 | ZodTypeV4;
  */
 // mirrors https://github.com/vercel/ai/blob/main/packages/ui-utils/src/zod-schema.ts#L21 but with a custom target
 export function convertZodSchemaToAISDKSchema(zodSchema: ZodSchema, target: Targets = 'jsonSchema7'): Schema<any> {
-  const jsonSchemaToUse = zodToJsonSchema(zodSchema, target) as JSONSchema7;
+  const jsonSchemaToUse = zodToJsonSchema(zodSchema, target);
 
   return jsonSchema(jsonSchemaToUse, {
     validate: value => {

--- a/packages/schema-compat/src/zod-to-json.ts
+++ b/packages/schema-compat/src/zod-to-json.ts
@@ -113,7 +113,7 @@ function fixAnyOfNullable(schema: JSONSchema7): JSONSchema7 {
       // Normalize sibling fields (like properties/items) before returning
       const { anyOf, ...rest } = result;
       const fixedRest = fixAnyOfNullable(rest as JSONSchema7);
-      const fixedOther = fixAnyOfNullable(otherSchema as JSONSchema7);
+      const fixedOther = fixAnyOfNullable(otherSchema);
       return {
         ...fixedRest,
         ...fixedOther,
@@ -195,12 +195,12 @@ export function ensureAllPropertiesRequired(schema: JSONSchema7): JSONSchema7 {
     if (Array.isArray(result.items)) {
       result.items = result.items.map(item => ensureAllPropertiesRequired(item as JSONSchema7));
     } else if (typeof result.items === 'object') {
-      result.items = ensureAllPropertiesRequired(result.items as JSONSchema7);
+      result.items = ensureAllPropertiesRequired(result.items);
     }
   }
 
   if (result.additionalProperties && typeof result.additionalProperties === 'object') {
-    result.additionalProperties = ensureAllPropertiesRequired(result.additionalProperties as JSONSchema7);
+    result.additionalProperties = ensureAllPropertiesRequired(result.additionalProperties);
   }
 
   if (result.anyOf && Array.isArray(result.anyOf)) {
@@ -249,7 +249,7 @@ function ensureAdditionalPropertiesFalse(schema: JSONSchema7): JSONSchema7 {
     if (Array.isArray(result.items)) {
       result.items = result.items.map(item => ensureAdditionalPropertiesFalse(item as JSONSchema7));
     } else if (typeof result.items === 'object') {
-      result.items = ensureAdditionalPropertiesFalse(result.items as JSONSchema7);
+      result.items = ensureAdditionalPropertiesFalse(result.items);
     }
   }
 

--- a/packages/server/src/server/handlers/authorship.ts
+++ b/packages/server/src/server/handlers/authorship.ts
@@ -28,7 +28,7 @@ export function getCallerAuthorId(requestContext: RequestContext): string | null
 
   const user = requestContext.get(MASTRA_USER_KEY);
   if (user && typeof user === 'object' && 'id' in user) {
-    const id = (user as { id: unknown }).id;
+    const id = user.id;
     if (typeof id === 'string' && id.length > 0) {
       return id;
     }

--- a/packages/server/src/server/handlers/dynamic-workflows.ts
+++ b/packages/server/src/server/handlers/dynamic-workflows.ts
@@ -176,7 +176,7 @@ export const DELETE_DYNAMIC_WORKFLOW_ROUTE = createRoute({
       if (!store) throw new HTTPException(500, { message: 'workflowDefinitions storage domain is not available' });
 
       await store.delete(dynamicWorkflowId);
-      (mastra as Mastra).removeWorkflow(dynamicWorkflowId);
+      mastra.removeWorkflow(dynamicWorkflowId);
       return { success: true as const, message: `Workflow ${dynamicWorkflowId} deleted` };
     } catch (error) {
       return handleError(error, 'Error deleting dynamic workflow');

--- a/packages/server/src/server/handlers/mcp.ts
+++ b/packages/server/src/server/handlers/mcp.ts
@@ -53,7 +53,7 @@ export const LIST_MCP_SERVERS_ROUTE = createRoute({
       return { servers: [], total_count: 0, next: null };
     }
 
-    const serverList = Object.values(servers) as MastraMCPServerImplementation[];
+    const serverList = Object.values(servers);
     const totalCount = serverList.length;
 
     // Support both page/perPage and limit/offset for backwards compatibility

--- a/packages/server/src/server/handlers/schedules.ts
+++ b/packages/server/src/server/handlers/schedules.ts
@@ -313,7 +313,7 @@ export const LIST_SCHEDULE_TRIGGERS_ROUTE = createRoute({
     if (!schedule?.workflowId) {
       return { triggers };
     }
-    const workflowName = (schedule as WorkflowSchedule).workflowId;
+    const workflowName = schedule.workflowId;
     const hydrated = await Promise.all(
       triggers.map(async trigger => {
         if (trigger.outcome !== 'published' || !trigger.runId) return trigger;

--- a/packages/server/src/server/server-adapter/mcp-auth.ts
+++ b/packages/server/src/server/server-adapter/mcp-auth.ts
@@ -54,7 +54,7 @@ export function buildMcpAuthInfoFromRequestContext(requestContext: RequestContex
   const userRecord = (hasUser ? user : {}) as Record<string, unknown>;
 
   return {
-    token: hasToken ? (token as string) : '',
+    token: hasToken ? token : '',
     clientId: resolveClientId(userRecord),
     scopes: normalizeScopes(userRecord.scopes ?? userRecord.scope ?? userRecord.permissions),
     ...(hasUser ? { extra: { user: userRecord } } : {}),


### PR DESCRIPTION
## Description

This cleanup has been split into smaller, independent PRs targeting `main`.

| Scope | Replacement PR | Source files |
| --- | --- | --- |
| Client JS | #23497 | 2 |
| Server | #23498 | 5 |
| Memory | #23499 | 2 |
| Schema compatibility | #23500 | 3 |
| Core agents and models | #23501 | 14 |
| Core workflows | #23502 | 10 |
| Core storage and channels | #23503 | 11 |
| Core processors and utilities | #23504 | 14 |

The replacements preserve all 91 cast removals across the same 61 source files, with no overlap. No production edits were added during the split. Tests, fixtures, examples, and intentional compatibility casts remain unchanged.

Before the split, all five package typechecks, lint, and formatting passed; 2,013 tests passed and 9 were skipped. JavaScript syntax trees were equivalent after normalizing parentheses and property shorthand, and declaration output was unchanged. Every replacement branch also passes its own package typecheck.

## Related issue(s)

The existing Playground cleanup remains separate in #23492.

## Type of change

- [x] Code refactoring

## Checklist

- [x] I have linked the replacement PRs above
- [x] Documentation changes are not applicable
- [x] Existing tests cover this refactor; test files are unchanged
