### PR TITLE
feat: configure Mastra Code commit attribution

### DIFF
--- a/.changeset/calm-spiders-play.md
+++ b/.changeset/calm-spiders-play.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved commit attribution to identify mastracode terminal sessions.

--- a/.changeset/funny-lamps-rhyme.md
+++ b/.changeset/funny-lamps-rhyme.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Improved coding-agent commit attribution for Factory.
+Factory-generated commits now use the Mastra Platform bot as the commit co-author.

--- a/.changeset/funny-lamps-rhyme.md
+++ b/.changeset/funny-lamps-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Improved coding-agent commit attribution for Factory.

--- a/.changeset/short-hornets-type.md
+++ b/.changeset/short-hornets-type.md
@@ -2,4 +2,5 @@
 '@mastra/code-sdk': patch
 ---
 
-Added configurable commit co-author attribution with per-field defaults.
+Added configurable commit co-author attribution with per-field defaults
+

--- a/.changeset/short-hornets-type.md
+++ b/.changeset/short-hornets-type.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Added configurable commit co-author attribution with per-field defaults.

--- a/docs/src/content/en/reference/code-sdk/mount-agent-controller.mdx
+++ b/docs/src/content/en/reference/code-sdk/mount-agent-controller.mdx
@@ -30,6 +30,24 @@ const { mastra, controller } = await mountAgentControllerOnMastra({
 const session = await controller.createSession({ resourceId: 'user-123' })
 ```
 
+## Commit attribution
+
+Use `coAuthor` to set the `Co-Authored-By` trailer in coding-agent commit guidance:
+
+```typescript title="src/mastra/index.ts"
+const { mastra, controller } = await mountAgentControllerOnMastra({
+  cwd: process.cwd(),
+  coAuthor: {
+    name: 'my-coding-app',
+    email: 'my-coding-app@example.com',
+  },
+})
+```
+
+Both fields are optional. An omitted field uses the SDK default: `mastra-platform[bot]` for the name and `284800079+mastra-platform[bot]@users.noreply.github.com` for the email.
+
+The `mastracode` terminal app sets its name to `mastracode`, and Factory sets its name to `mastra-platform[bot]`. Both use the same default email, so GitHub resolves their trailers to the same bot account while the raw commit message retains the app name.
+
 Pass an existing `mastra` to mount the controller onto a Mastra instance that already hosts other primitives:
 
 ```typescript
@@ -51,6 +69,13 @@ const { controller } = await mountAgentControllerOnMastra({ mastra })
     description: 'Working directory for project detection.',
     isOptional: true,
     defaultValue: 'process.cwd()',
+  },
+  {
+    name: 'coAuthor',
+    type: '{ name?: string; email?: string }',
+    description:
+      'Commit co-author identity included in coding-agent commit guidance. Omitted fields use the SDK defaults.',
+    isOptional: true,
   },
   {
     name: 'mastra',

--- a/docs/src/content/en/reference/coding-agent/build-base-prompt.mdx
+++ b/docs/src/content/en/reference/coding-agent/build-base-prompt.mdx
@@ -89,7 +89,7 @@ const prompt = buildBasePrompt({
   {
     name: 'modelId',
     type: 'string',
-    description: 'Identifier of the active model.',
+    description: 'Identifier of the active model. It is not included in the commit Co-Authored-By line.',
     isOptional: true,
   },
   {

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -238,6 +238,12 @@ describe('MastraFactory constructor', () => {
 });
 
 describe('MastraFactory.prepare', () => {
+  it('uses the platform bot co-author identity', async () => {
+    const config = await prepareFactory({ storage: fakeStorage(), auth: null });
+
+    expect(config.coAuthor).toEqual({ name: 'mastra-platform[bot]' });
+  });
+
   it('warns and falls back to plaintext when auth is enabled without secret encryption', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -737,6 +737,7 @@ export class MastraFactory {
     const prepared = await timedPhase('prepare.controllerMount', () =>
       prepareAgentControllerMount({
         controllerId: CONTROLLER_ID,
+        coAuthor: { name: 'mastra-platform[bot]' },
         workspace: createWorkspaceFactory({
           ...(sandboxConfig ? { sandbox: sandboxConfig } : {}),
           ...(this.#config.sandboxStart ? { sandboxStart: this.#config.sandboxStart } : {}),

--- a/mastracode/sdk/README.md
+++ b/mastracode/sdk/README.md
@@ -21,8 +21,18 @@ import { mountAgentControllerOnMastra } from '@mastra/code-sdk';
 // (thread management, modes, tools, memory) and starts its workers.
 const { mastra, controller } = await mountAgentControllerOnMastra({
   cwd: process.cwd(),
+  coAuthor: {
+    name: 'my-coding-app',
+    email: 'my-coding-app@example.com',
+  },
 });
 ```
+
+### Commit attribution
+
+`coAuthor` controls the `Co-Authored-By` trailer included in coding-agent commit guidance. Both fields are optional: an omitted field uses the SDK's `mastra-platform[bot]` name or `284800079+mastra-platform[bot]@users.noreply.github.com` email default.
+
+The `mastracode` TUI sets only its name to `mastracode`; Factory sets its name to `mastra-platform[bot]`. They intentionally share the default email, so GitHub resolves both trailers to the same bot account while preserving the app name in the raw commit message.
 
 ## Documentation
 

--- a/mastracode/sdk/README.md
+++ b/mastracode/sdk/README.md
@@ -21,18 +21,8 @@ import { mountAgentControllerOnMastra } from '@mastra/code-sdk';
 // (thread management, modes, tools, memory) and starts its workers.
 const { mastra, controller } = await mountAgentControllerOnMastra({
   cwd: process.cwd(),
-  coAuthor: {
-    name: 'my-coding-app',
-    email: 'my-coding-app@example.com',
-  },
 });
 ```
-
-### Commit attribution
-
-`coAuthor` controls the `Co-Authored-By` trailer included in coding-agent commit guidance. Both fields are optional: an omitted field uses the SDK's `mastra-platform[bot]` name or `284800079+mastra-platform[bot]@users.noreply.github.com` email default.
-
-The `mastracode` TUI sets only its name to `mastracode`; Factory sets its name to `mastra-platform[bot]`. They intentionally share the default email, so GitHub resolves both trailers to the same bot account while preserving the app name in the raw commit message.
 
 ## Documentation
 

--- a/mastracode/sdk/src/__tests__/index.test.ts
+++ b/mastracode/sdk/src/__tests__/index.test.ts
@@ -232,8 +232,10 @@ vi.mock('@mastra/core/processors', () => ({
   },
 }));
 
+const getDynamicInstructionsMock = vi.fn();
+
 vi.mock('../agents/instructions.js', () => ({
-  getDynamicInstructions: vi.fn(),
+  getDynamicInstructions: getDynamicInstructionsMock,
 }));
 
 const getDynamicMemoryMock = vi.fn();
@@ -425,6 +427,7 @@ describe('createMastraCode', () => {
     createVectorStoreMock.mockReturnValue({});
     getDynamicMemoryMock.mockReset();
     getDynamicMemoryMock.mockReturnValue(() => undefined);
+    getDynamicInstructionsMock.mockReset();
     controllerSubscribeMock.mockReset();
     controllerGetCurrentThreadIdMock.mockReset();
     controllerGetCurrentThreadIdMock.mockReturnValue(undefined);
@@ -490,6 +493,33 @@ describe('createMastraCode', () => {
     expect(agentControllerConfig?.gateways?.[1]).toBe(mastraCodeGatewayMock);
     expect(agentControllerConfig?.subagents).toEqual([subagent]);
   }, 30_000);
+
+  it('passes configured co-author identity into the agent instruction callback', async () => {
+    const { createMastraCode } = await import('../index.js');
+    await createMastraCode({ coAuthor: { name: 'mastracode' } });
+
+    const agentConfig = agentConstructorMock.mock.calls
+      .map(
+        ([config]) =>
+          config as { instructions?: (ctx: { requestContext: { get(key: string): unknown } }) => Promise<string> },
+      )
+      .find(config => typeof config.instructions === 'function');
+    if (!agentConfig?.instructions) throw new Error('Expected code agent instructions');
+    const requestContext = {
+      get: (key: string) =>
+        key === 'controller'
+          ? {
+              getState: () => ({ projectPath: '/tmp/project', projectName: 'test-project' }),
+              session: { modeId: 'build' },
+            }
+          : undefined,
+    };
+    await agentConfig.instructions({ requestContext });
+
+    expect(getDynamicInstructionsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ requestContext, coAuthor: { name: 'mastracode' } }),
+    );
+  });
 
   it.each([{}, { subagents: undefined }])(
     'registers native defaults when subagents is omitted or undefined (%j)',

--- a/mastracode/sdk/src/acp/index.ts
+++ b/mastracode/sdk/src/acp/index.ts
@@ -9,7 +9,10 @@ import { runAcpServer } from './server.js';
  * Entry point for ACP server mode.
  * Initializes mastracode and runs the ACP protocol over stdio.
  */
-export async function acpMain(options?: { dangerousAutoApprove?: boolean }): Promise<void> {
+export async function acpMain(options?: {
+  dangerousAutoApprove?: boolean;
+  coAuthor?: { name?: string; email?: string };
+}): Promise<void> {
   if (options?.dangerousAutoApprove) {
     setAutoApprove(true);
   }
@@ -25,6 +28,7 @@ export async function acpMain(options?: { dangerousAutoApprove?: boolean }): Pro
 
   try {
     result = await createMastraCode({
+      coAuthor: options?.coAuthor,
       unixSocketPubSub: false,
       disableMcp: false,
       disableHooks: false,

--- a/mastracode/sdk/src/agents/__tests__/instructions.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/instructions.test.ts
@@ -58,6 +58,24 @@ describe('getDynamicInstructions', () => {
     );
   });
 
+  it('uses a configured co-author identity', async () => {
+    const prompt = await getDynamicInstructions({
+      requestContext: {
+        get: vi.fn(key =>
+          key === 'controller'
+            ? {
+                getState: () => ({ projectPath: '/tmp/project', projectName: 'test-project' }),
+                session: { modeId: 'build' },
+              }
+            : undefined,
+        ),
+      },
+      coAuthor: { name: 'mastracode', email: 'mastracode@example.test' },
+    });
+
+    expect(prompt).toContain('Co-Authored-By: mastracode <mastracode@example.test>');
+  });
+
   it('never leaks the host cwd, branch, or instruction files into a session without a project', async () => {
     const { getCurrentGitBranchAsync } = await import('../../utils/project.js');
     const { loadAgentInstructions } = await import('../prompts/agent-instructions.js');

--- a/mastracode/sdk/src/agents/__tests__/prompt-sections.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/prompt-sections.test.ts
@@ -53,6 +53,12 @@ describe('buildFullPromptSections', () => {
     expect(joinPromptSections(buildFullPromptSections(ctx))).toBe(buildFullPrompt(ctx));
   });
 
+  it('rejoins custom co-author output exactly', () => {
+    const ctx = makeCtx({ coAuthorName: 'mastracode', coAuthorEmail: 'custom@example.test' });
+
+    expect(joinPromptSections(buildFullPromptSections(ctx))).toBe(buildFullPrompt(ctx));
+  });
+
   it('rejoins into exactly buildFullPrompt output with agent instructions present', () => {
     writeFileSync(join(projectPath, 'AGENTS.md'), '# Project rules\n\nAlways run the tests.\n');
     const ctx = makeCtx();

--- a/mastracode/sdk/src/agents/__tests__/prompts.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/prompts.test.ts
@@ -233,6 +233,34 @@ describe('buildFullPrompt', () => {
     expect(prompt).not.toContain('Co-Authored-By: mastra-platform[bot] ()');
   });
 
+  it.each([
+    [
+      { name: 'mastracode', email: undefined },
+      'Co-Authored-By: mastracode <284800079+mastra-platform[bot]@users.noreply.github.com>',
+    ],
+    [{ name: undefined, email: 'custom@example.test' }, 'Co-Authored-By: mastra-platform[bot] <custom@example.test>'],
+    [{ name: 'custom', email: 'custom@example.test' }, 'Co-Authored-By: custom <custom@example.test>'],
+  ])('uses configured co-author fields with defaults for omitted fields', (coAuthor, trailer) => {
+    const prompt = buildFullPrompt({
+      projectPath: '/tmp/project',
+      projectName: 'test-project',
+      gitBranch: 'main',
+      platform: 'darwin',
+      date: '2026-03-23',
+      mode: 'build',
+      activePlan: null,
+      modeId: 'build',
+      currentDate: '2026-03-23',
+      workingDir: '/tmp/project',
+      coAuthorName: coAuthor.name,
+      coAuthorEmail: coAuthor.email,
+      state: { permissionRules: { tools: {} } },
+    });
+
+    expect(prompt).toContain(trailer);
+    expect(prompt).not.toContain('(openai/');
+  });
+
   it('includes common binary availability in environment details', () => {
     const prompt = buildFullPrompt({
       projectPath: '/tmp/project',

--- a/mastracode/sdk/src/agents/instructions.ts
+++ b/mastracode/sdk/src/agents/instructions.ts
@@ -8,16 +8,18 @@ import { buildFullPromptSections, joinPromptSections } from './prompts/index.js'
 export async function getDynamicInstructions({
   requestContext,
   hostInstructions,
+  coAuthor,
   hasSubconscious,
   hasSubagents,
 }: {
   requestContext: { get(key: string): unknown };
   hostInstructions?: string;
+  coAuthor?: { name?: string; email?: string };
   hasSubconscious?: boolean | ((state: MastraCodeState | undefined) => boolean);
   hasSubagents?: boolean;
 }): Promise<string> {
   return joinPromptSections(
-    await getDynamicInstructionSections({ requestContext, hostInstructions, hasSubconscious, hasSubagents }),
+    await getDynamicInstructionSections({ requestContext, hostInstructions, coAuthor, hasSubconscious, hasSubagents }),
   );
 }
 
@@ -29,11 +31,13 @@ export async function getDynamicInstructions({
 export async function getDynamicInstructionSections({
   requestContext,
   hostInstructions,
+  coAuthor,
   hasSubconscious,
   hasSubagents,
 }: {
   requestContext: { get(key: string): unknown };
   hostInstructions?: string;
+  coAuthor?: { name?: string; email?: string };
   /**
    * The subconscious knowledge tools are registered on the agent. A function
    * is resolved against the session state, since Factory sessions can refuse
@@ -61,6 +65,8 @@ export async function getDynamicInstructionSections({
     date: new Date().toISOString().split('T')[0]!,
     mode: modeId,
     modelId: agentControllerContext?.session?.modelId || undefined,
+    coAuthorName: coAuthor?.name,
+    coAuthorEmail: coAuthor?.email,
     activePlan: state?.activePlan ?? null,
     modeId: modeId,
     currentDate: new Date().toISOString().split('T')[0]!,

--- a/mastracode/sdk/src/agents/prompts/index.ts
+++ b/mastracode/sdk/src/agents/prompts/index.ts
@@ -124,6 +124,8 @@ export function buildFullPromptSections(ctx: PromptContext): PromptSection[] {
     date: ctx.currentDate,
     mode: ctx.modeId,
     modelId: ctx.modelId,
+    coAuthorName: ctx.coAuthorName,
+    coAuthorEmail: ctx.coAuthorEmail,
     activePlan: ctx.state?.activePlan,
     hasSubagents: ctx.hasSubagents !== false && !deniedTools.has('subagent'),
     toolGuidance,

--- a/mastracode/sdk/src/headless/cli.test.ts
+++ b/mastracode/sdk/src/headless/cli.test.ts
@@ -247,8 +247,12 @@ describe('runMCCli process memory diagnostics lifecycle', () => {
       result: Promise.resolve({ status: 'completed', exitCode: 0 }),
     });
 
-    await expect(runMCCli('do it')).rejects.toThrow('EXIT:0');
+    await expect(runMCCli('do it', { coAuthor: { name: 'mastracode' } })).rejects.toThrow('EXIT:0');
 
+    expect(lifecycleMocks.createMastraCode).toHaveBeenCalledWith({
+      settingsPath: undefined,
+      coAuthor: { name: 'mastracode' },
+    });
     expect(lifecycleMocks.order).toEqual(
       expect.arrayContaining(['diagnostics-start', 'mastracode-create', 'intervals-stop', 'diagnostics-stop']),
     );

--- a/mastracode/sdk/src/headless/cli.ts
+++ b/mastracode/sdk/src/headless/cli.ts
@@ -153,7 +153,10 @@ Examples:
  * Headless CLI entry point: parse arguments, read stdin, initialize MastraCode,
  * run via `runMC`, render output, and exit with the mapped code.
  */
-export async function runMCCli(predrainedInput?: string | null): Promise<never> {
+export async function runMCCli(
+  predrainedInput?: string | null,
+  options?: { coAuthor?: { name?: string; email?: string } },
+): Promise<never> {
   if (process.argv.includes('--help') || process.argv.includes('-h')) {
     printHeadlessUsage();
     process.exit(0);
@@ -199,7 +202,7 @@ export async function runMCCli(predrainedInput?: string | null): Promise<never> 
   // still surfaces as a failure to the caller / CI.
   let exitCode = 1;
   try {
-    boot = await createMastraCode({ settingsPath: args.settings });
+    boot = await createMastraCode({ settingsPath: args.settings, coAuthor: options?.coAuthor });
     const { controller, session, mcpManager, effectiveDefaults } = boot;
 
     if (mcpManager?.hasServers()) {

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -280,6 +280,8 @@ export interface MastraCodeConfig {
   hostInstructions?:
     | string
     | ((ctx: { requestContext: RequestContext }) => string | undefined | Promise<string | undefined>);
+  /** Commit co-author identity included in coding-agent commit guidance. Unspecified fields use core defaults. */
+  coAuthor?: { name?: string; email?: string };
   /** Override id generation for threads/messages. Primarily useful for deterministic tests. */
   idGenerator?: AgentControllerConfig<MastraCodeState>['idGenerator'];
   /** Override interval handlers. Default: gateway-sync */
@@ -850,6 +852,7 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
       return getDynamicInstructions({
         requestContext,
         hostInstructions,
+        coAuthor: config?.coAuthor,
         hasSubconscious,
         hasSubagents: subagents.length > 0,
       });

--- a/mastracode/tui/e2e/fixtures/commit-attribution-prompt.json
+++ b/mastracode/tui/e2e/fixtures/commit-attribution-prompt.json
@@ -13,7 +13,7 @@
             "id": "call_commit_attribution_git_commit",
             "name": "execute_command",
             "arguments": {
-              "command": "printf 'commit attribution e2e\\n' > commit-attribution-e2e.txt && git add commit-attribution-e2e.txt && git commit -m 'test: commit attribution e2e' -m 'Co-Authored-By: mastra-platform[bot] <284800079+mastra-platform[bot]@users.noreply.github.com>'",
+              "command": "printf 'commit attribution e2e\\n' > commit-attribution-e2e.txt && git add commit-attribution-e2e.txt && git commit -m 'test: commit attribution e2e' -m 'Co-Authored-By: mastracode <284800079+mastra-platform[bot]@users.noreply.github.com>'",
               "timeout": 10,
               "cwd": null,
               "tail": 40,

--- a/mastracode/tui/e2e/tui/commit-attribution-prompt.ts
+++ b/mastracode/tui/e2e/tui/commit-attribution-prompt.ts
@@ -2,14 +2,13 @@ import { expect } from './expect.js';
 
 import type { McE2eScenario } from './types.js';
 
-const PLATFORM_BOT_ATTRIBUTION =
-  'Co-Authored-By: mastra-platform[bot] <284800079+mastra-platform[bot]@users.noreply.github.com>';
+const TUI_ATTRIBUTION = 'Co-Authored-By: mastracode <284800079+mastra-platform[bot]@users.noreply.github.com>';
 
 export const commitAttributionPromptScenario: McE2eScenario = {
   name: 'commit-attribution-prompt',
   description:
-    'Verify real TUI prompts include platform bot commit attribution guidance and the authored commit records it.',
-  testName: 'includes platform bot commit attribution prompt guidance and committed history',
+    'Verify real TUI prompts include mastracode commit attribution guidance and the authored commit records it.',
+  testName: 'includes mastracode commit attribution prompt guidance and committed history',
   projectFixture: 'long-branch',
   useOpenAIModel: true,
   aimockFixture: 'commit-attribution-prompt.json',
@@ -25,7 +24,7 @@ export const commitAttributionPromptScenario: McE2eScenario = {
     terminal.submit('!git log -1 --format=%B');
     await runtime.waitForScreenText(/test: commit attribution e2e/i, terminal, 10_000);
     await runtime.waitForScreenText(
-      /Co-Authored-By: mastra-platform\[bot\] <284800079\+mastra-platform\[bot\]@users\.noreply\.github\.com>/i,
+      /Co-Authored-By: mastracode <284800079\+mastra-platform\[bot\]@users\.noreply\.github\.com>/i,
       terminal,
       10_000,
     );
@@ -37,7 +36,7 @@ export const commitAttributionPromptScenario: McE2eScenario = {
       throw new Error(`Expected commit attribution scenario to make 2 AIMock requests, received ${requests.length}`);
     }
     const body = JSON.stringify(requests);
-    expect(body).toContain(PLATFORM_BOT_ATTRIBUTION);
+    expect(body).toContain(TUI_ATTRIBUTION);
     expect(body).toContain('git commit');
   },
 };

--- a/mastracode/tui/src/commit-attribution.ts
+++ b/mastracode/tui/src/commit-attribution.ts
@@ -1,0 +1,1 @@
+export const TUI_CO_AUTHOR = { name: 'mastracode' } as const;

--- a/mastracode/tui/src/main.ts
+++ b/mastracode/tui/src/main.ts
@@ -17,6 +17,7 @@ import {
 import { setupDebugLogging, truncateLogFile } from '@mastra/code-sdk/utils/debug-log';
 import { drainPipedStdin, reopenStdinFromTTY } from '@mastra/code-sdk/utils/stdin-pipe';
 import { releaseAllThreadLocks } from '@mastra/code-sdk/utils/thread-lock';
+import { TUI_CO_AUTHOR } from './commit-attribution.js';
 import {
   createOneShotFatalErrorHandler,
   createShutdownCoordinator,
@@ -80,6 +81,7 @@ async function tuiMain(pipedInput?: string | null) {
 
   const initialState = resolveInitialStateFromEnv();
   const result = await createMastraCode({
+    coAuthor: TUI_CO_AUTHOR,
     unixSocketPubSub: !isTruthyEnv('MASTRACODE_DISABLE_UNIX_SOCKET_PUBSUB'),
     disableMcp: isTruthyEnv('MASTRACODE_DISABLE_MCP'),
     disableHooks: isTruthyEnv('MASTRACODE_DISABLE_HOOKS'),
@@ -351,12 +353,15 @@ async function main() {
   }
 
   if (hasHeadlessFlag(process.argv) || process.argv.includes('--help') || process.argv.includes('-h')) {
-    return runMCCli();
+    return runMCCli(undefined, { coAuthor: TUI_CO_AUTHOR });
   }
 
   if (process.argv.includes('--acp')) {
     const { acpMain } = await import('@mastra/code-sdk/acp/index');
-    return acpMain({ dangerousAutoApprove: process.argv.includes('--dangerous-auto-approve') });
+    return acpMain({
+      dangerousAutoApprove: process.argv.includes('--dangerous-auto-approve'),
+      coAuthor: TUI_CO_AUTHOR,
+    });
   }
 
   // When stdin is piped (e.g. `cat foo | mastracode`), drain the pipe fully
@@ -372,7 +377,7 @@ async function main() {
     const reopenedStdin = reopenStdinFromTTY();
     if (!reopenedStdin) {
       process.stderr.write('No TTY available — falling back to headless mode.\n');
-      return runMCCli(pipedInput);
+      return runMCCli(pipedInput, { coAuthor: TUI_CO_AUTHOR });
     }
   }
 

--- a/mastracode/tui/src/tui/commands/context.ts
+++ b/mastracode/tui/src/tui/commands/context.ts
@@ -2,6 +2,7 @@ import { buildContextAudit } from '@mastra/code-sdk/agents/context-audit';
 import type { ContextAudit, ContextAuditGroup, ContextAuditTool } from '@mastra/code-sdk/agents/context-audit';
 import { getDynamicInstructionSections } from '@mastra/code-sdk/agents/instructions';
 import { formatSkillsCatalog } from '@mastra/core/processors';
+import { TUI_CO_AUTHOR } from '../../commit-attribution.js';
 import type { SlashCommandContext } from './types.js';
 
 /**
@@ -138,6 +139,7 @@ export async function handleContextCommand(ctx: SlashCommandContext): Promise<vo
   try {
     const instructionSections = await getDynamicInstructionSections({
       requestContext: requestContextForSession(ctx),
+      coAuthor: TUI_CO_AUTHOR,
     });
 
     let skillsCatalog: string | undefined;


### PR DESCRIPTION
Adds a supported `coAuthor` option to the Mastra Code SDK so embedders can control coding-agent commit trailers without replacing system instructions.

```ts
createMastraCode({
  coAuthor: { name: 'my-app' },
});
```

The mastracode terminal app now uses its lowercase display name across interactive, headless, and ACP modes. Factory explicitly retains the Mastra Platform bot name, while both continue using the shared bot email.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Mastra Code can now add a clear author name and email to commits made by coding agents. Each app mode uses the correct default identity, and users can configure these values without replacing the system instructions.

## Changes

- Added the optional `coAuthor` setting to the Mastra Code SDK.
- Forwarded `coAuthor` through interactive, headless, ACP, and factory execution paths.
- Added configurable co-author name and email fields to commit guidance.
- Set `mastracode` as the terminal app identity.
- Kept `mastra-platform[bot]` as the Factory identity.
- Kept the shared bot email as the default email.
- Updated commit attribution tests and end-to-end fixtures.
- Documented `coAuthor`, its defaults, and product-specific identities in the API reference.
- Clarified that `modelId` does not affect the commit `Co-Authored-By` trailer.
- Added changesets for `mastracode`, `@mastra/factory`, and `@mastra/code-sdk`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->