### PR TITLE
feat(cli): map Langfuse traces to Mastra spans

### DIFF
--- a/packages/cli/src/commands/traces/import/providers/langfuse/adapter.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/adapter.test.ts
@@ -105,6 +105,39 @@ describe('mapLangfuseSourceTrace', () => {
     expect(record.trace.spans[1]?.tags).toBeUndefined();
   });
 
+  it('orders siblings by their actual time and uses the observation ID to break ties', () => {
+    const record = mapLangfuseSourceTrace(
+      sourceTrace([
+        observation({
+          id: 'later',
+          parentObservationId: 'root',
+          startTime: '2026-08-20T05:00:02.000-05:00',
+          endTime: '2026-08-20T05:00:03.000-05:00',
+        }),
+        observation({
+          id: 'same-time-b',
+          parentObservationId: 'root',
+          startTime: '2026-08-20T10:00:01.000Z',
+          endTime: '2026-08-20T10:00:02.000Z',
+        }),
+        observation(),
+        observation({
+          id: 'same-time-a',
+          parentObservationId: 'root',
+          startTime: '2026-08-20T11:00:01.000+01:00',
+          endTime: '2026-08-20T11:00:02.000+01:00',
+        }),
+      ]),
+      { importId: 'import-1', ...mappedWindow },
+    );
+
+    expect(record.kind).toBe('trace');
+    if (record.kind !== 'trace') return;
+    expect(record.trace.spans.map(span => span.spanId)).toEqual(
+      ['root', 'same-time-a', 'same-time-b', 'later'].map(id => createLangfuseSpanImportId('project-1', id)),
+    );
+  });
+
   it('falls back to valid usage details when direct usage values are malformed', () => {
     const record = mapLangfuseSourceTrace(
       sourceTrace([

--- a/packages/cli/src/commands/traces/import/providers/langfuse/adapter.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/adapter.test.ts
@@ -15,6 +15,11 @@ const window = {
   snapshotAt: '2026-09-01T12:00:00.000Z',
 };
 
+const mappedWindow = {
+  cutoffMs: Date.parse(window.cutoffAt),
+  snapshotMs: Date.parse(window.snapshotAt),
+};
+
 function observation(overrides: Partial<LangfuseObservation> = {}): LangfuseObservation {
   return {
     id: 'root',
@@ -60,7 +65,7 @@ describe('mapLangfuseSourceTrace', () => {
 
     const record = mapLangfuseSourceTrace(sourceTrace([child, observation({ tags: ['trace-tag'] })]), {
       importId: 'import-1',
-      ...window,
+      ...mappedWindow,
     });
 
     expect(record.kind).toBe('trace');
@@ -110,7 +115,7 @@ describe('mapLangfuseSourceTrace', () => {
           usageDetails: { input: 7, output: 3 },
         }),
       ]),
-      { importId: 'import-1', ...window },
+      { importId: 'import-1', ...mappedWindow },
     );
 
     expect(record.kind).toBe('trace');
@@ -134,7 +139,7 @@ describe('mapLangfuseSourceTrace', () => {
   ])('maps Langfuse type %s to Mastra span type %s', (langfuseType, spanType) => {
     const record = mapLangfuseSourceTrace(sourceTrace([observation({ type: langfuseType })]), {
       importId: 'import-1',
-      ...window,
+      ...mappedWindow,
     });
 
     expect(record.kind).toBe('trace');
@@ -153,11 +158,11 @@ describe('mapLangfuseSourceTrace', () => {
           metadata: { 'scope.name': '@mastra/langfuse', spanType: 'workflow_run' },
         }),
       ]),
-      { importId: 'import-1', ...window },
+      { importId: 'import-1', ...mappedWindow },
     );
     const ignored = mapLangfuseSourceTrace(sourceTrace([observation({ metadata: { spanType: 'workflow_run' } })]), {
       importId: 'import-1',
-      ...window,
+      ...mappedWindow,
     });
 
     expect(restored.kind).toBe('trace');
@@ -178,7 +183,7 @@ describe('mapLangfuseSourceTrace', () => {
           endTime: '2026-08-20T10:00:05.000Z',
         }),
       ]),
-      { importId: 'import-1', ...window },
+      { importId: 'import-1', ...mappedWindow },
     );
 
     expect(record.kind).toBe('trace');
@@ -218,7 +223,7 @@ describe('mapLangfuseSourceTrace', () => {
     ['completed_after_snapshot', [observation({ endTime: '2026-09-02T00:00:00.000Z' })]],
     ['root_outside_window', [observation({ startTime: '2026-08-01T23:59:59.000Z' })]],
   ])('skips invalid traces with reason %s', (reason, observations) => {
-    const record = mapLangfuseSourceTrace(sourceTrace(observations), { importId: 'import-1', ...window });
+    const record = mapLangfuseSourceTrace(sourceTrace(observations), { importId: 'import-1', ...mappedWindow });
 
     expect(record).toMatchObject({
       kind: 'skipped',
@@ -233,7 +238,7 @@ describe('mapLangfuseSourceTrace', () => {
   it('detaches an imported logical root while keeping the source parent in metadata', () => {
     const record = mapLangfuseSourceTrace(
       sourceTrace([observation({ parentObservationId: 'external-parent', isRootObservation: true })]),
-      { importId: 'import-1', ...window },
+      { importId: 'import-1', ...mappedWindow },
     );
 
     expect(record.kind).toBe('trace');
@@ -252,7 +257,7 @@ describe('mapLangfuseSourceTrace', () => {
   it('uses start time as event end time and preserves provider warning state as metadata', () => {
     const record = mapLangfuseSourceTrace(
       sourceTrace([observation({ type: 'EVENT', endTime: null, level: 'WARNING', statusMessage: 'fallback used' })]),
-      { importId: 'import-1', ...window },
+      { importId: 'import-1', ...mappedWindow },
     );
 
     expect(record.kind).toBe('trace');
@@ -262,6 +267,21 @@ describe('mapLangfuseSourceTrace', () => {
       endedAt: '2026-08-20T10:00:00.000Z',
       error: null,
       metadata: { langfuse: { level: 'WARNING', statusMessage: 'fallback used' } },
+    });
+  });
+
+  it('ignores an event end time because events use their start time as an instantaneous duration', () => {
+    const record = mapLangfuseSourceTrace(sourceTrace([observation({ type: 'EVENT', endTime: 'not-a-timestamp' })]), {
+      importId: 'import-1',
+      ...mappedWindow,
+    });
+
+    expect(record.kind).toBe('trace');
+    if (record.kind !== 'trace') return;
+    expect(record.trace.spans[0]).toMatchObject({
+      startedAt: '2026-08-20T10:00:00.000Z',
+      endedAt: '2026-08-20T10:00:00.000Z',
+      isEvent: true,
     });
   });
 
@@ -277,7 +297,7 @@ describe('mapLangfuseSourceTrace', () => {
           endTime: null,
         }),
       ]),
-      { importId: 'import-1', ...window },
+      { importId: 'import-1', ...mappedWindow },
     );
 
     expect(record).toMatchObject({
@@ -293,7 +313,7 @@ describe('mapLangfuseSourceTrace', () => {
   it('turns Langfuse error observations into Mastra span errors', () => {
     const record = mapLangfuseSourceTrace(
       sourceTrace([observation({ type: 'GENERATION', level: 'ERROR', statusMessage: 'provider failed' })]),
-      { importId: 'import-1', ...window },
+      { importId: 'import-1', ...mappedWindow },
     );
 
     expect(record.kind).toBe('trace');
@@ -398,5 +418,29 @@ describe('LangfuseTraceImportProvider', () => {
 
     expect(fetch).toHaveBeenCalledTimes(3);
     expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('validates the import window once at the provider boundary before making a request', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>();
+    const provider = new LangfuseTraceImportProvider(clientOptions, { fetch });
+
+    await expect(
+      collect(
+        provider.read({
+          importId: 'import-1',
+          source: {
+            provider: 'langfuse',
+            baseUrl: 'https://cloud.langfuse.com',
+            projectId: 'project-1',
+            mapperVersion: 'langfuse-api-v2@1',
+            idAlgorithmVersion: 'langfuse-sha256-v1',
+          },
+          cutoffAt: '2026-09-02T00:00:00.000Z',
+          snapshotAt: '2026-09-01T00:00:00.000Z',
+          onRetry: vi.fn(),
+        }),
+      ),
+    ).rejects.toThrow('cutoffAt before snapshotAt');
+    expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/traces/import/providers/langfuse/adapter.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/adapter.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { LangfuseTraceImportProvider, mapLangfuseSourceTrace } from './adapter.js';
+import { createLangfuseSpanImportId, createLangfuseTraceImportId } from './ids.js';
+import type { LangfuseObservation } from './types.js';
+
+const clientOptions = {
+  baseUrl: 'https://cloud.langfuse.com',
+  publicKey: 'pk-lf-test',
+  secretKey: 'sk-lf-test',
+};
+
+const window = {
+  cutoffAt: '2026-08-02T00:00:00.000Z',
+  snapshotAt: '2026-09-01T12:00:00.000Z',
+};
+
+function observation(overrides: Partial<LangfuseObservation> = {}): LangfuseObservation {
+  return {
+    id: 'root',
+    traceId: 'trace-1',
+    startTime: '2026-08-20T10:00:00.000Z',
+    endTime: '2026-08-20T10:00:02.000Z',
+    projectId: 'project-1',
+    parentObservationId: null,
+    type: 'SPAN',
+    name: 'root',
+    ...overrides,
+  };
+}
+
+function sourceTrace(observations: LangfuseObservation[]) {
+  return { traceId: 'trace-1', observations };
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const value of iterable) values.push(value);
+  return values;
+}
+
+describe('mapLangfuseSourceTrace', () => {
+  it('validates, orders, and maps a complete Langfuse tree into Mastra spans', () => {
+    const child = observation({
+      id: 'child',
+      parentObservationId: 'root',
+      type: 'GENERATION',
+      name: 'answer-generation',
+      startTime: '2026-08-20T10:00:01.000Z',
+      endTime: '2026-08-20T10:00:02.000Z',
+      input: '{"question":"hello"}',
+      output: { answer: 'hi' },
+      model: 'gpt-4o-mini',
+      inputUsage: 10,
+      outputUsage: 4,
+      modelParameters: { temperature: 0.2, top_p: 0.9, ignored: true },
+      metadata: { customer: 'acme' },
+      tags: ['child-tag'],
+    });
+
+    const record = mapLangfuseSourceTrace(sourceTrace([child, observation({ tags: ['trace-tag'] })]), {
+      importId: 'import-1',
+      ...window,
+    });
+
+    expect(record.kind).toBe('trace');
+    if (record.kind !== 'trace') return;
+    expect(record.trace.sourceTraceId).toBe('trace-1');
+    expect(record.trace.spans.map(span => span.spanId)).toEqual([
+      createLangfuseSpanImportId('project-1', 'root'),
+      createLangfuseSpanImportId('project-1', 'child'),
+    ]);
+    expect(record.trace.spans[0]).toMatchObject({
+      traceId: createLangfuseTraceImportId('project-1', 'trace-1'),
+      parentSpanId: null,
+      spanType: 'generic',
+      tags: ['trace-tag'],
+    });
+    expect(record.trace.spans[1]).toMatchObject({
+      parentSpanId: createLangfuseSpanImportId('project-1', 'root'),
+      spanType: 'model_generation',
+      input: { question: 'hello' },
+      output: { answer: 'hi' },
+      attributes: {
+        model: 'gpt-4o-mini',
+        usage: { inputTokens: 10, outputTokens: 4 },
+        parameters: { temperature: 0.2, topP: 0.9 },
+      },
+      metadata: {
+        source: 'langfuse',
+        importSource: 'langfuse-api-v2',
+        importBatchId: 'import-1',
+        langfuseTraceId: 'trace-1',
+        langfuseObservationId: 'child',
+        langfuseProjectId: 'project-1',
+        langfuseType: 'GENERATION',
+        langfuseMetadata: { customer: 'acme' },
+      },
+    });
+    expect(record.trace.spans[1]?.tags).toBeUndefined();
+  });
+
+  it.each([
+    ['GENERATION', 'model_generation'],
+    ['AGENT', 'agent_run'],
+    ['TOOL', 'tool_call'],
+    ['EVALUATOR', 'scorer_run'],
+    ['EMBEDDING', 'rag_embedding'],
+    ['EVENT', 'generic'],
+    ['CHAIN', 'generic'],
+    ['RETRIEVER', 'generic'],
+    ['GUARDRAIL', 'generic'],
+    ['FUTURE_KIND', 'generic'],
+  ])('maps Langfuse type %s to Mastra span type %s', (langfuseType, spanType) => {
+    const record = mapLangfuseSourceTrace(sourceTrace([observation({ type: langfuseType })]), {
+      importId: 'import-1',
+      ...window,
+    });
+
+    expect(record.kind).toBe('trace');
+    if (record.kind !== 'trace') return;
+    expect(record.trace.spans[0]?.spanType).toBe(spanType);
+    expect(record.trace.spans[0]?.metadata.langfuseType).toBe(langfuseType);
+    expect(record.warnings).toEqual(
+      langfuseType === 'FUTURE_KIND' ? ['Unknown Langfuse observation type: FUTURE_KIND'] : undefined,
+    );
+  });
+
+  it('restores Mastra span types only from recognized Mastra Langfuse exporter metadata', () => {
+    const restored = mapLangfuseSourceTrace(
+      sourceTrace([
+        observation({
+          metadata: { 'scope.name': '@mastra/langfuse', spanType: 'workflow_run' },
+        }),
+      ]),
+      { importId: 'import-1', ...window },
+    );
+    const ignored = mapLangfuseSourceTrace(sourceTrace([observation({ metadata: { spanType: 'workflow_run' } })]), {
+      importId: 'import-1',
+      ...window,
+    });
+
+    expect(restored.kind).toBe('trace');
+    expect(ignored.kind).toBe('trace');
+    if (restored.kind !== 'trace' || ignored.kind !== 'trace') return;
+    expect(restored.trace.spans[0]?.spanType).toBe('workflow_run');
+    expect(ignored.trace.spans[0]?.spanType).toBe('generic');
+  });
+
+  it('derives Langfuse virtual root end time from the latest child', () => {
+    const record = mapLangfuseSourceTrace(
+      sourceTrace([
+        observation({ id: 't-trace-1', endTime: null }),
+        observation({
+          id: 'child',
+          parentObservationId: 't-trace-1',
+          startTime: '2026-08-20T10:00:01.000Z',
+          endTime: '2026-08-20T10:00:05.000Z',
+        }),
+      ]),
+      { importId: 'import-1', ...window },
+    );
+
+    expect(record.kind).toBe('trace');
+    if (record.kind !== 'trace') return;
+    expect(record.trace.spans[0]).toMatchObject({
+      spanId: createLangfuseSpanImportId('project-1', 't-trace-1'),
+      endedAt: '2026-08-20T10:00:05.000Z',
+      metadata: {
+        langfuse: {
+          derivedEndTime: true,
+          derivedEndTimeSourceObservationId: 'child',
+        },
+      },
+    });
+  });
+
+  it.each([
+    ['empty_trace', []],
+    ['mixed_project_ids', [observation(), observation({ id: 'other-project-root', projectId: 'project-2' })]],
+    ['duplicate_observation_id', [observation(), observation()]],
+    [
+      'missing_root',
+      [observation({ parentObservationId: 'child' }), observation({ id: 'child', parentObservationId: 'root' })],
+    ],
+    ['multiple_roots', [observation(), observation({ id: 'other-root' })]],
+    ['missing_parent', [observation(), observation({ id: 'child', parentObservationId: 'missing' })]],
+    [
+      'cycle',
+      [
+        observation(),
+        observation({ id: 'child', parentObservationId: 'grandchild' }),
+        observation({ id: 'grandchild', parentObservationId: 'child' }),
+      ],
+    ],
+    ['invalid_timestamp', [observation({ endTime: '2026-08-20T09:59:59.000Z' })]],
+    ['incomplete_duration', [observation({ endTime: null })]],
+    ['completed_after_snapshot', [observation({ endTime: '2026-09-02T00:00:00.000Z' })]],
+    ['root_outside_window', [observation({ startTime: '2026-08-01T23:59:59.000Z' })]],
+  ])('skips invalid traces with reason %s', (reason, observations) => {
+    const record = mapLangfuseSourceTrace(sourceTrace(observations), { importId: 'import-1', ...window });
+
+    expect(record).toMatchObject({
+      kind: 'skipped',
+      skipped: {
+        sourceTraceId: 'trace-1',
+        reason,
+        spanCount: observations.length,
+      },
+    });
+  });
+
+  it('detaches an imported logical root while keeping the source parent in metadata', () => {
+    const record = mapLangfuseSourceTrace(
+      sourceTrace([observation({ parentObservationId: 'external-parent', isRootObservation: true })]),
+      { importId: 'import-1', ...window },
+    );
+
+    expect(record.kind).toBe('trace');
+    if (record.kind !== 'trace') return;
+    expect(record.trace.spans[0]).toMatchObject({
+      parentSpanId: null,
+      metadata: {
+        langfuse: {
+          isRootObservation: true,
+          parentObservationId: 'external-parent',
+        },
+      },
+    });
+  });
+
+  it('uses start time as event end time and preserves provider warning state as metadata', () => {
+    const record = mapLangfuseSourceTrace(
+      sourceTrace([observation({ type: 'EVENT', endTime: null, level: 'WARNING', statusMessage: 'fallback used' })]),
+      { importId: 'import-1', ...window },
+    );
+
+    expect(record.kind).toBe('trace');
+    if (record.kind !== 'trace') return;
+    expect(record.trace.spans[0]).toMatchObject({
+      isEvent: true,
+      endedAt: '2026-08-20T10:00:00.000Z',
+      error: null,
+      metadata: { langfuse: { level: 'WARNING', statusMessage: 'fallback used' } },
+    });
+  });
+
+  it('turns Langfuse error observations into Mastra span errors', () => {
+    const record = mapLangfuseSourceTrace(
+      sourceTrace([observation({ type: 'GENERATION', level: 'ERROR', statusMessage: 'provider failed' })]),
+      { importId: 'import-1', ...window },
+    );
+
+    expect(record.kind).toBe('trace');
+    if (record.kind !== 'trace') return;
+    expect(record.trace.spans[0]?.error).toEqual({
+      message: 'provider failed',
+      name: 'LangfuseObservationError',
+      details: { level: 'ERROR', sourceType: 'GENERATION' },
+    });
+  });
+});
+
+describe('LangfuseTraceImportProvider', () => {
+  it('identifies the Langfuse source with mapper and ID strategy versions', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
+      Response.json({
+        data: [{ id: 'project-1', name: 'Demo' }],
+        meta: { cursor: null },
+      }),
+    );
+    const provider = new LangfuseTraceImportProvider(clientOptions, { fetch });
+
+    await expect(provider.identify()).resolves.toEqual({
+      provider: 'langfuse',
+      baseUrl: 'https://cloud.langfuse.com',
+      projectId: 'project-1',
+      mapperVersion: 'langfuse-api-v2@1',
+      idAlgorithmVersion: 'langfuse-sha256-v1',
+    });
+  });
+
+  it('reads discoveries and yields neutral trace import records', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async input => {
+      const url = new URL(String(input));
+      if (url.searchParams.get('fields') === 'core') {
+        return Response.json({
+          data: [observation(), observation({ id: 'orphan', traceId: null })],
+          meta: { cursor: null },
+        });
+      }
+
+      return Response.json({
+        data: [observation()],
+        meta: { cursor: null },
+      });
+    });
+    const provider = new LangfuseTraceImportProvider(clientOptions, { fetch });
+
+    const records = await collect(
+      provider.read({
+        importId: 'import-1',
+        source: {
+          provider: 'langfuse',
+          baseUrl: 'https://cloud.langfuse.com',
+          projectId: 'project-1',
+          mapperVersion: 'langfuse-api-v2@1',
+          idAlgorithmVersion: 'langfuse-sha256-v1',
+        },
+        onRetry: vi.fn(),
+        ...window,
+      }),
+    );
+
+    expect(records.map(record => record.kind)).toEqual(['trace', 'skipped']);
+    expect(records[0]).toMatchObject({ kind: 'trace', trace: { sourceTraceId: 'trace-1' } });
+    expect(records[1]).toMatchObject({
+      kind: 'skipped',
+      skipped: {
+        sourceTraceId: null,
+        reason: 'missing_trace_id',
+        sourceSpanIds: ['orphan'],
+      },
+    });
+  });
+});

--- a/packages/cli/src/commands/traces/import/providers/langfuse/adapter.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/adapter.test.ts
@@ -100,6 +100,26 @@ describe('mapLangfuseSourceTrace', () => {
     expect(record.trace.spans[1]?.tags).toBeUndefined();
   });
 
+  it('falls back to valid usage details when direct usage values are malformed', () => {
+    const record = mapLangfuseSourceTrace(
+      sourceTrace([
+        observation({
+          type: 'GENERATION',
+          inputUsage: 'invalid' as unknown as number,
+          outputUsage: Number.POSITIVE_INFINITY,
+          usageDetails: { input: 7, output: 3 },
+        }),
+      ]),
+      { importId: 'import-1', ...window },
+    );
+
+    expect(record.kind).toBe('trace');
+    if (record.kind !== 'trace') return;
+    expect(record.trace.spans[0]?.attributes).toMatchObject({
+      usage: { inputTokens: 7, outputTokens: 3 },
+    });
+  });
+
   it.each([
     ['GENERATION', 'model_generation'],
     ['AGENT', 'agent_run'],

--- a/packages/cli/src/commands/traces/import/providers/langfuse/adapter.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/adapter.test.ts
@@ -63,6 +63,7 @@ describe('mapLangfuseSourceTrace', () => {
       totalUsage: 14,
       inputCost: 0.001,
       modelParameters: { temperature: 0.2, top_p: 0.9, ignored: true },
+      usageDetails: { input: 10, output: 4, input_cache_creation: 3, reasoning_tokens: 2, customUnits: 1 },
       metadata: { customer: 'acme' },
       tags: ['child-tag'],
       createdAt: '2026-08-20T10:00:00.000Z',
@@ -94,7 +95,12 @@ describe('mapLangfuseSourceTrace', () => {
       output: { answer: 'hi' },
       attributes: {
         model: 'gpt-4o-mini',
-        usage: { inputTokens: 10, outputTokens: 4 },
+        usage: {
+          inputTokens: 10,
+          outputTokens: 4,
+          inputDetails: { cacheWrite: 3 },
+          outputDetails: { reasoning: 2 },
+        },
         parameters: { temperature: 0.2, topP: 0.9 },
       },
       metadata: {
@@ -109,6 +115,8 @@ describe('mapLangfuseSourceTrace', () => {
         langfuse: {
           providedModelName: 'openai/gpt-4o-mini',
           internalModelId: 'internal-model-1',
+          modelParameters: { ignored: true },
+          usageDetails: { customUnits: 1 },
           totalUsage: 14,
           inputCost: 0.001,
         },
@@ -119,6 +127,8 @@ describe('mapLangfuseSourceTrace', () => {
       parentObservationId: 'root',
       providedModelName: 'openai/gpt-4o-mini',
       internalModelId: 'internal-model-1',
+      modelParameters: { ignored: true },
+      usageDetails: { customUnits: 1 },
       totalUsage: 14,
       inputCost: 0.001,
     });

--- a/packages/cli/src/commands/traces/import/providers/langfuse/adapter.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/adapter.test.ts
@@ -245,6 +245,31 @@ describe('mapLangfuseSourceTrace', () => {
     });
   });
 
+  it('skips the complete trace when an event occurs after the snapshot', () => {
+    const record = mapLangfuseSourceTrace(
+      sourceTrace([
+        observation(),
+        observation({
+          id: 'late-event',
+          parentObservationId: 'root',
+          type: 'EVENT',
+          startTime: '2026-09-01T12:05:00.000Z',
+          endTime: null,
+        }),
+      ]),
+      { importId: 'import-1', ...window },
+    );
+
+    expect(record).toMatchObject({
+      kind: 'skipped',
+      skipped: {
+        sourceTraceId: 'trace-1',
+        reason: 'completed_after_snapshot',
+        detail: 'late-event',
+      },
+    });
+  });
+
   it('turns Langfuse error observations into Mastra span errors', () => {
     const record = mapLangfuseSourceTrace(
       sourceTrace([observation({ type: 'GENERATION', level: 'ERROR', statusMessage: 'provider failed' })]),
@@ -322,5 +347,36 @@ describe('LangfuseTraceImportProvider', () => {
         sourceSpanIds: ['orphan'],
       },
     });
+  });
+
+  it('reports Langfuse API retries through the shared read context', async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+      .mockResolvedValueOnce(Response.json({ data: [observation()], meta: { cursor: null } }))
+      .mockResolvedValueOnce(Response.json({ data: [observation()], meta: { cursor: null } }));
+    const onRetry = vi.fn();
+    const provider = new LangfuseTraceImportProvider(clientOptions, {
+      fetch,
+      sleep: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await collect(
+      provider.read({
+        importId: 'import-1',
+        source: {
+          provider: 'langfuse',
+          baseUrl: 'https://cloud.langfuse.com',
+          projectId: 'project-1',
+          mapperVersion: 'langfuse-api-v2@1',
+          idAlgorithmVersion: 'langfuse-sha256-v1',
+        },
+        onRetry,
+        ...window,
+      }),
+    );
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledOnce();
   });
 });

--- a/packages/cli/src/commands/traces/import/providers/langfuse/adapter.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/adapter.test.ts
@@ -56,11 +56,17 @@ describe('mapLangfuseSourceTrace', () => {
       input: '{"question":"hello"}',
       output: { answer: 'hi' },
       model: 'gpt-4o-mini',
+      providedModelName: 'openai/gpt-4o-mini',
+      internalModelId: 'internal-model-1',
       inputUsage: 10,
       outputUsage: 4,
+      totalUsage: 14,
+      inputCost: 0.001,
       modelParameters: { temperature: 0.2, top_p: 0.9, ignored: true },
       metadata: { customer: 'acme' },
       tags: ['child-tag'],
+      createdAt: '2026-08-20T10:00:00.000Z',
+      bookmarked: true,
     });
 
     const record = mapLangfuseSourceTrace(sourceTrace([child, observation({ tags: ['trace-tag'] })]), {
@@ -100,9 +106,22 @@ describe('mapLangfuseSourceTrace', () => {
         langfuseProjectId: 'project-1',
         langfuseType: 'GENERATION',
         langfuseMetadata: { customer: 'acme' },
+        langfuse: {
+          providedModelName: 'openai/gpt-4o-mini',
+          internalModelId: 'internal-model-1',
+          totalUsage: 14,
+          inputCost: 0.001,
+        },
       },
     });
     expect(record.trace.spans[1]?.tags).toBeUndefined();
+    expect(record.trace.spans[1]?.metadata.langfuse).toEqual({
+      parentObservationId: 'root',
+      providedModelName: 'openai/gpt-4o-mini',
+      internalModelId: 'internal-model-1',
+      totalUsage: 14,
+      inputCost: 0.001,
+    });
   });
 
   it('orders siblings by their actual time and uses the observation ID to break ties', () => {
@@ -155,6 +174,49 @@ describe('mapLangfuseSourceTrace', () => {
     if (record.kind !== 'trace') return;
     expect(record.trace.spans[0]?.attributes).toMatchObject({
       usage: { inputTokens: 7, outputTokens: 3 },
+    });
+  });
+
+  it('does not duplicate a provided model name used as the canonical fallback', () => {
+    const record = mapLangfuseSourceTrace(
+      sourceTrace([observation({ type: 'GENERATION', model: null, providedModelName: 'fallback-model' })]),
+      { importId: 'import-1', ...mappedWindow },
+    );
+
+    expect(record.kind).toBe('trace');
+    if (record.kind !== 'trace') return;
+    expect(record.trace.spans[0]?.attributes).toMatchObject({ model: 'fallback-model' });
+    expect(record.trace.spans[0]?.metadata.langfuse).not.toHaveProperty('providedModelName');
+  });
+
+  it('keeps model and usage fields in metadata when the span type has no canonical destination', () => {
+    const record = mapLangfuseSourceTrace(
+      sourceTrace([
+        observation({
+          model: 'custom-model',
+          modelParameters: { custom: true },
+          usageDetails: { customUnits: 12 },
+          inputUsage: 7,
+          outputUsage: 5,
+          totalCost: 0.01,
+          completionStartTime: '2026-08-20T10:00:01.000Z',
+        }),
+      ]),
+      { importId: 'import-1', ...mappedWindow },
+    );
+
+    expect(record.kind).toBe('trace');
+    if (record.kind !== 'trace') return;
+    expect(record.trace.spans[0]?.metadata).toMatchObject({
+      langfuse: {
+        model: 'custom-model',
+        modelParameters: { custom: true },
+        usageDetails: { customUnits: 12 },
+        inputUsage: 7,
+        outputUsage: 5,
+        totalCost: 0.01,
+        completionStartTime: '2026-08-20T10:00:01.000Z',
+      },
     });
   });
 

--- a/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
@@ -325,7 +325,7 @@ function mapObservationToSpan(
     endedAt: isEvent ? observation.startTime : observation.endTime!,
     isEvent,
     attributes: buildAttributes(observation, spanType),
-    metadata: buildMetadata(observation, trace, importId),
+    metadata: buildMetadata(observation, trace, importId, spanType),
     tags: index === 0 && observation.tags ? observation.tags : undefined,
     input: parseIo(observation.input),
     output: parseIo(observation.output),
@@ -536,7 +536,18 @@ function buildMetadata(
   observation: TimestampedObservation,
   trace: OrderedLangfuseTrace,
   importId: string,
+  spanType: TraceImportSpan['spanType'],
 ): Record<string, unknown> {
+  const hasModelAttributes =
+    spanType === 'rag_embedding' ||
+    spanType === 'model_generation' ||
+    spanType === 'model_step' ||
+    spanType === 'model_inference';
+  const hasGenerationAttributes =
+    spanType === 'model_generation' || spanType === 'model_step' || spanType === 'model_inference';
+
+  // Keep source-only context, but avoid a second copy of values represented by
+  // this span type's canonical Mastra attributes.
   return definedRecord({
     source: 'langfuse',
     importSource: 'langfuse-api-v2',
@@ -555,27 +566,26 @@ function buildMetadata(
       level: observation.level ?? undefined,
       statusMessage: observation.statusMessage ?? undefined,
       version: observation.version ?? undefined,
-      environment: observation.environment ?? undefined,
-      createdAt: observation.createdAt ?? undefined,
-      updatedAt: observation.updatedAt ?? undefined,
       release: observation.release ?? undefined,
       traceName: observation.traceName ?? undefined,
-      bookmarked: observation.bookmarked ?? undefined,
-      public: observation.public ?? undefined,
-      model: observation.model ?? undefined,
-      providedModelName: observation.providedModelName ?? undefined,
+      model: hasModelAttributes ? undefined : (observation.model ?? undefined),
+      providedModelName:
+        observation.providedModelName &&
+        (!hasModelAttributes || (observation.model != null && observation.providedModelName !== observation.model))
+          ? observation.providedModelName
+          : undefined,
       internalModelId: observation.internalModelId ?? undefined,
       modelId: observation.modelId ?? undefined,
-      modelParameters: observation.modelParameters ?? undefined,
-      usageDetails: observation.usageDetails ?? undefined,
-      inputUsage: observation.inputUsage ?? undefined,
-      outputUsage: observation.outputUsage ?? undefined,
+      modelParameters: hasGenerationAttributes ? undefined : (observation.modelParameters ?? undefined),
+      usageDetails: hasModelAttributes ? undefined : (observation.usageDetails ?? undefined),
+      inputUsage: hasModelAttributes ? undefined : (observation.inputUsage ?? undefined),
+      outputUsage: hasModelAttributes ? undefined : (observation.outputUsage ?? undefined),
       totalUsage: observation.totalUsage ?? undefined,
       costDetails: observation.costDetails ?? undefined,
       inputCost: observation.inputCost ?? undefined,
       outputCost: observation.outputCost ?? undefined,
-      totalCost: observation.totalCost ?? undefined,
-      completionStartTime: observation.completionStartTime ?? undefined,
+      totalCost: hasGenerationAttributes ? undefined : (observation.totalCost ?? undefined),
+      completionStartTime: hasGenerationAttributes ? undefined : (observation.completionStartTime ?? undefined),
       inputPrice: observation.inputPrice ?? undefined,
       outputPrice: observation.outputPrice ?? undefined,
       totalPrice: observation.totalPrice ?? undefined,
@@ -586,7 +596,6 @@ function buildMetadata(
       promptVersion: observation.promptVersion ?? undefined,
       latency: observation.latency ?? undefined,
       timeToFirstToken: observation.timeToFirstToken ?? undefined,
-      tags: observation.tags ?? undefined,
       derivedEndTime: observation.mastraImportDerivedEndTime ?? undefined,
       derivedEndTimeSourceObservationId: observation.mastraImportDerivedEndTimeSourceObservationId ?? undefined,
     }),

--- a/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
@@ -1,0 +1,579 @@
+import type { TraceImportProvider, TraceImportReadContext } from '../../provider.js';
+import type {
+  SkippedTrace,
+  TraceImportRecord,
+  TraceImportSourceIdentity,
+  TraceImportSpan,
+  TraceImportTrace,
+} from '../../types.js';
+import type { LangfuseClientDependencies, LangfuseClientOptions } from './client.js';
+import { createLangfuseSpanImportId, createLangfuseTraceImportId } from './ids.js';
+import { LangfuseObservationsReader, type LangfuseReadWindow, type LangfuseTraceReadOptions } from './reader.js';
+import type { LangfuseObservation, LangfuseSourceTrace } from './types.js';
+
+const MAPPER_VERSION = 'langfuse-api-v2@1';
+const ID_ALGORITHM_VERSION = 'langfuse-sha256-v1';
+
+const LANGFUSE_TYPE_MAP: Record<string, TraceImportSpan['spanType']> = {
+  AGENT: 'agent_run',
+  CHAIN: 'generic',
+  EMBEDDING: 'rag_embedding',
+  EVALUATOR: 'scorer_run',
+  EVENT: 'generic',
+  GENERATION: 'model_generation',
+  GUARDRAIL: 'generic',
+  RETRIEVER: 'generic',
+  SPAN: 'generic',
+  TOOL: 'tool_call',
+};
+
+const MASTRA_SPAN_TYPES = new Set<TraceImportSpan['spanType']>([
+  'agent_run',
+  'scorer_run',
+  'scorer_step',
+  'generic',
+  'model_generation',
+  'model_step',
+  'model_inference',
+  'model_chunk',
+  'mcp_tool_call',
+  'processor_run',
+  'tool_call',
+  'client_tool_call',
+  'provider_tool_call',
+  'workflow_run',
+  'workflow_step',
+  'workflow_conditional',
+  'workflow_conditional_eval',
+  'workflow_parallel',
+  'workflow_loop',
+  'workflow_sleep',
+  'workflow_wait_event',
+  'memory_operation',
+  'workspace_action',
+  'rag_ingestion',
+  'rag_embedding',
+  'rag_vector_operation',
+  'rag_action',
+  'graph_action',
+  'mapping',
+  'skill_resolution',
+  'skill_action',
+  'agent_signal',
+]);
+
+type TimestampedObservation = LangfuseObservation & {
+  mastraImportDerivedEndTime?: true;
+  mastraImportDerivedEndTimeSourceObservationId?: string;
+};
+
+interface OrderedLangfuseTrace {
+  sourceTraceId: string;
+  projectId: string;
+  observations: TimestampedObservation[];
+}
+
+export interface MapLangfuseTraceOptions {
+  importId: string;
+  cutoffAt: string;
+  snapshotAt: string;
+}
+
+export class LangfuseTraceImportProvider implements TraceImportProvider {
+  private readonly reader: LangfuseObservationsReader;
+
+  constructor(options: LangfuseClientOptions, dependencies: LangfuseClientDependencies = {}) {
+    this.reader = new LangfuseObservationsReader(options, dependencies);
+  }
+
+  async identify(signal?: AbortSignal): Promise<TraceImportSourceIdentity> {
+    const project = await this.reader.identify(signal);
+    return {
+      provider: 'langfuse',
+      baseUrl: this.reader.baseUrl,
+      projectId: project.id,
+      mapperVersion: MAPPER_VERSION,
+      idAlgorithmVersion: ID_ALGORITHM_VERSION,
+    };
+  }
+
+  async *read(context: TraceImportReadContext): AsyncIterable<TraceImportRecord> {
+    const window: LangfuseReadWindow = {
+      cutoffAt: context.cutoffAt,
+      snapshotAt: context.snapshotAt,
+      projectId: context.source.projectId,
+      signal: context.signal,
+    };
+
+    for await (const discovery of this.reader.discoverTraces(window)) {
+      if (discovery.kind === 'missing-trace-id') {
+        yield {
+          kind: 'skipped',
+          skipped: {
+            sourceTraceId: null,
+            spanCount: 1,
+            reason: 'missing_trace_id',
+            detail: discovery.observationId,
+            sourceSpanIds: [discovery.observationId],
+          },
+        };
+        continue;
+      }
+
+      const options: LangfuseTraceReadOptions = {
+        traceId: discovery.traceId,
+        projectId: context.source.projectId,
+        signal: context.signal,
+      };
+      const sourceTrace = await this.reader.readTrace(options);
+      yield mapLangfuseSourceTrace(sourceTrace, {
+        importId: context.importId,
+        cutoffAt: context.cutoffAt,
+        snapshotAt: context.snapshotAt,
+      });
+    }
+  }
+}
+
+export function mapLangfuseSourceTrace(
+  sourceTrace: LangfuseSourceTrace,
+  options: MapLangfuseTraceOptions,
+): TraceImportRecord {
+  const ordered = validateAndOrderTrace(sourceTrace, options);
+  if ('skipped' in ordered) return { kind: 'skipped', skipped: ordered.skipped };
+
+  const unknownTypes = new Set<string>();
+  const trace: TraceImportTrace = {
+    sourceTraceId: ordered.trace.sourceTraceId,
+    spans: ordered.trace.observations.map((observation, index) => {
+      const mappedType = restoredMastraSpanType(observation) ?? LANGFUSE_TYPE_MAP[observation.type];
+      if (mappedType === undefined) unknownTypes.add(observation.type);
+      return mapObservationToSpan(observation, ordered.trace, options.importId, mappedType ?? 'generic', index);
+    }),
+  };
+
+  const warnings = [...unknownTypes].sort().map(type => `Unknown Langfuse observation type: ${type}`);
+  return warnings.length > 0 ? { kind: 'trace', trace, warnings } : { kind: 'trace', trace };
+}
+
+function validateAndOrderTrace(
+  sourceTrace: LangfuseSourceTrace,
+  options: MapLangfuseTraceOptions,
+): { trace: OrderedLangfuseTrace } | { skipped: SkippedTrace } {
+  const observations = sourceTrace.observations;
+  if (observations.length === 0) {
+    return { skipped: createSkippedTrace(sourceTrace.traceId, observations, 'empty_trace') };
+  }
+
+  const cutoffMs = parseRequiredTimestamp(options.cutoffAt);
+  const snapshotMs = parseRequiredTimestamp(options.snapshotAt);
+  if (cutoffMs === null || snapshotMs === null || cutoffMs >= snapshotMs) {
+    throw new Error('Langfuse import window must contain valid timestamps with cutoffAt before snapshotAt.');
+  }
+
+  const projectIds = new Set(observations.map(observation => observation.projectId));
+  if (projectIds.size !== 1) {
+    return { skipped: createSkippedTrace(sourceTrace.traceId, observations, 'mixed_project_ids') };
+  }
+
+  const byId = new Map<string, LangfuseObservation>();
+  for (const observation of observations) {
+    if (byId.has(observation.id)) {
+      return {
+        skipped: createSkippedTrace(sourceTrace.traceId, observations, 'duplicate_observation_id', observation.id),
+      };
+    }
+    byId.set(observation.id, observation);
+  }
+
+  const roots = observations.filter(
+    observation =>
+      !observation.parentObservationId ||
+      (observation.isRootObservation === true && !byId.has(observation.parentObservationId)),
+  );
+  if (roots.length === 0) return { skipped: createSkippedTrace(sourceTrace.traceId, observations, 'missing_root') };
+  if (roots.length > 1) return { skipped: createSkippedTrace(sourceTrace.traceId, observations, 'multiple_roots') };
+
+  const normalizedObservations = deriveVirtualRootEndTime(sourceTrace.traceId, observations, roots[0]!);
+  const normalizedById = new Map(normalizedObservations.map(observation => [observation.id, observation]));
+  const root = normalizedById.get(roots[0]!.id)!;
+
+  for (const observation of normalizedObservations) {
+    if (
+      observation !== root &&
+      observation.parentObservationId &&
+      !normalizedById.has(observation.parentObservationId)
+    ) {
+      return {
+        skipped: createSkippedTrace(
+          sourceTrace.traceId,
+          normalizedObservations,
+          'missing_parent',
+          observation.parentObservationId,
+        ),
+      };
+    }
+
+    const startMs = parseSourceTimestamp(observation.startTime);
+    if (startMs === null) {
+      return {
+        skipped: createSkippedTrace(sourceTrace.traceId, normalizedObservations, 'invalid_timestamp', observation.id),
+      };
+    }
+
+    if (observation.type === 'EVENT') {
+      if (observation.endTime && parseSourceTimestamp(observation.endTime) === null) {
+        return {
+          skipped: createSkippedTrace(sourceTrace.traceId, normalizedObservations, 'invalid_timestamp', observation.id),
+        };
+      }
+      continue;
+    }
+
+    const endMs = parseSourceTimestamp(observation.endTime);
+    if (endMs === null) {
+      return {
+        skipped: createSkippedTrace(sourceTrace.traceId, normalizedObservations, 'incomplete_duration', observation.id),
+      };
+    }
+    if (endMs < startMs) {
+      return {
+        skipped: createSkippedTrace(sourceTrace.traceId, normalizedObservations, 'invalid_timestamp', observation.id),
+      };
+    }
+    if (endMs > snapshotMs) {
+      return {
+        skipped: createSkippedTrace(
+          sourceTrace.traceId,
+          normalizedObservations,
+          'completed_after_snapshot',
+          observation.id,
+        ),
+      };
+    }
+  }
+
+  const rootStartMs = parseSourceTimestamp(root.startTime)!;
+  if (rootStartMs < cutoffMs || rootStartMs >= snapshotMs) {
+    return { skipped: createSkippedTrace(sourceTrace.traceId, normalizedObservations, 'root_outside_window') };
+  }
+
+  const children = new Map<string, TimestampedObservation[]>();
+  for (const observation of normalizedObservations) {
+    if (observation === root || !observation.parentObservationId) continue;
+    const siblings = children.get(observation.parentObservationId) ?? [];
+    siblings.push(observation);
+    children.set(observation.parentObservationId, siblings);
+  }
+
+  for (const siblings of children.values()) {
+    siblings.sort((a, b) => a.startTime.localeCompare(b.startTime) || a.id.localeCompare(b.id));
+  }
+
+  const ordered: TimestampedObservation[] = [];
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+
+  const visit = (observation: TimestampedObservation): boolean => {
+    if (visiting.has(observation.id)) return false;
+    if (visited.has(observation.id)) return true;
+    visiting.add(observation.id);
+    ordered.push(observation);
+    for (const child of children.get(observation.id) ?? []) {
+      if (!visit(child)) return false;
+    }
+    visiting.delete(observation.id);
+    visited.add(observation.id);
+    return true;
+  };
+
+  if (!visit(root) || visited.size !== normalizedObservations.length) {
+    return { skipped: createSkippedTrace(sourceTrace.traceId, normalizedObservations, 'cycle') };
+  }
+
+  return {
+    trace: {
+      sourceTraceId: sourceTrace.traceId,
+      projectId: projectIds.values().next().value!,
+      observations: ordered,
+    },
+  };
+}
+
+function mapObservationToSpan(
+  observation: TimestampedObservation,
+  trace: OrderedLangfuseTrace,
+  importId: string,
+  spanType: TraceImportSpan['spanType'],
+  index: number,
+): TraceImportSpan {
+  const isEvent = observation.type === 'EVENT';
+  return {
+    traceId: createLangfuseTraceImportId(trace.projectId, trace.sourceTraceId),
+    spanId: createLangfuseSpanImportId(trace.projectId, observation.id),
+    parentSpanId:
+      index > 0 && observation.parentObservationId
+        ? createLangfuseSpanImportId(trace.projectId, observation.parentObservationId)
+        : null,
+    name: observation.name?.trim() || `langfuse:${observation.type.toLowerCase()}`,
+    spanType,
+    startedAt: observation.startTime,
+    endedAt: isEvent ? observation.startTime : observation.endTime!,
+    isEvent,
+    attributes: buildAttributes(observation, spanType),
+    metadata: buildMetadata(observation, trace, importId),
+    tags: index === 0 && observation.tags ? observation.tags : undefined,
+    input: parseIo(observation.input),
+    output: parseIo(observation.output),
+    error:
+      observation.level === 'ERROR'
+        ? {
+            message: observation.statusMessage || 'Langfuse observation reported an error',
+            name: 'LangfuseObservationError',
+            details: { level: observation.level, sourceType: observation.type },
+          }
+        : null,
+  };
+}
+
+function createSkippedTrace(
+  sourceTraceId: string | null,
+  observations: LangfuseObservation[],
+  reason: string,
+  detail?: string,
+): SkippedTrace {
+  const traceName = observations.find(observation => observation.traceName)?.traceName ?? undefined;
+  return {
+    sourceTraceId,
+    spanCount: observations.length,
+    reason,
+    detail,
+    traceName,
+    sourceSpanIds: observations.map(observation => observation.id).sort(),
+  };
+}
+
+function deriveVirtualRootEndTime(
+  sourceTraceId: string,
+  observations: LangfuseObservation[],
+  root: LangfuseObservation,
+): TimestampedObservation[] {
+  if (root.endTime || root.id !== `t-${sourceTraceId}`) return observations;
+
+  const latest = observations
+    .filter(observation => observation.id !== root.id)
+    .map(observation => ({
+      observation,
+      endMs: parseSourceTimestamp(
+        observation.endTime ?? (observation.type === 'EVENT' ? observation.startTime : undefined),
+      ),
+    }))
+    .filter((item): item is { observation: LangfuseObservation; endMs: number } => item.endMs !== null)
+    .sort((left, right) => right.endMs - left.endMs || left.observation.id.localeCompare(right.observation.id))[0];
+
+  if (!latest) return observations;
+
+  return observations.map(observation =>
+    observation.id === root.id
+      ? {
+          ...observation,
+          endTime: new Date(latest.endMs).toISOString(),
+          mastraImportDerivedEndTime: true,
+          mastraImportDerivedEndTimeSourceObservationId: latest.observation.id,
+        }
+      : observation,
+  );
+}
+
+function parseRequiredTimestamp(value: string): number | null {
+  return parseSourceTimestamp(value);
+}
+
+function parseSourceTimestamp(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseIo(value: unknown): unknown {
+  if (value == null) return undefined;
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
+}
+
+function definedRecord(record: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined));
+}
+
+function numericValue(record: Record<string, unknown> | null | undefined, ...keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = record?.[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+  }
+  return undefined;
+}
+
+function wrapSourceMetadata(value: unknown): Record<string, unknown> | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'object' && !Array.isArray(value)) return value as Record<string, unknown>;
+  return { value };
+}
+
+function restoredMastraSpanType(observation: LangfuseObservation): TraceImportSpan['spanType'] | undefined {
+  const metadata = wrapSourceMetadata(observation.metadata);
+  if (!metadata) return undefined;
+
+  const fromMastraExporter =
+    metadata['scope.name'] === '@mastra/langfuse' ||
+    metadata['resourceAttributes.telemetry.sdk.name'] === '@mastra/langfuse';
+  if (!fromMastraExporter) return undefined;
+
+  const spanType = metadata.spanType;
+  return typeof spanType === 'string' && MASTRA_SPAN_TYPES.has(spanType as TraceImportSpan['spanType'])
+    ? (spanType as TraceImportSpan['spanType'])
+    : undefined;
+}
+
+function buildAttributes(
+  observation: LangfuseObservation,
+  spanType: TraceImportSpan['spanType'],
+): Record<string, unknown> | undefined {
+  const model = observation.model ?? observation.providedModelName ?? undefined;
+  const usage = mapUsage(observation);
+
+  if (spanType === 'rag_embedding') {
+    const attributes = definedRecord({ model, usage });
+    return Object.keys(attributes).length > 0 ? attributes : undefined;
+  }
+
+  if (spanType !== 'model_generation' && spanType !== 'model_step' && spanType !== 'model_inference') {
+    return undefined;
+  }
+
+  const completionStartMs = observation.completionStartTime ? Date.parse(observation.completionStartTime) : Number.NaN;
+  const attributes = definedRecord({
+    model,
+    usage,
+    parameters: mapModelParameters(observation.modelParameters),
+    costContext:
+      typeof observation.totalCost === 'number' && Number.isFinite(observation.totalCost)
+        ? { estimatedCost: observation.totalCost, costUnit: 'USD' }
+        : undefined,
+    completionStartTime: Number.isFinite(completionStartMs) ? new Date(completionStartMs).toISOString() : undefined,
+  });
+  return Object.keys(attributes).length > 0 ? attributes : undefined;
+}
+
+function mapUsage(observation: LangfuseObservation): Record<string, unknown> | undefined {
+  const inputTokens =
+    observation.inputUsage ?? numericValue(observation.usageDetails, 'input', 'inputTokens', 'input_tokens');
+  const outputTokens =
+    observation.outputUsage ?? numericValue(observation.usageDetails, 'output', 'outputTokens', 'output_tokens');
+  const inputDetails = definedRecord({
+    cacheRead: numericValue(
+      observation.usageDetails,
+      'inputCachedTokens',
+      'input_cached_tokens',
+      'cacheReadInputTokens',
+    ),
+    cacheWrite: numericValue(observation.usageDetails, 'cacheCreationInputTokens', 'cache_creation_input_tokens'),
+    audio: numericValue(observation.usageDetails, 'inputAudioTokens', 'input_audio_tokens'),
+  });
+  const outputDetails = definedRecord({
+    reasoning: numericValue(observation.usageDetails, 'outputReasoningTokens', 'output_reasoning_tokens'),
+    audio: numericValue(observation.usageDetails, 'outputAudioTokens', 'output_audio_tokens'),
+  });
+  const usage = definedRecord({
+    inputTokens,
+    outputTokens,
+    inputDetails: Object.keys(inputDetails).length > 0 ? inputDetails : undefined,
+    outputDetails: Object.keys(outputDetails).length > 0 ? outputDetails : undefined,
+  });
+  return Object.keys(usage).length > 0 ? usage : undefined;
+}
+
+function mapModelParameters(parameters: unknown): Record<string, unknown> | undefined {
+  if (!parameters || typeof parameters !== 'object' || Array.isArray(parameters)) return undefined;
+  const source = parameters as Record<string, unknown>;
+  const stopSequences = source.stopSequences ?? source.stop_sequences ?? source.stop;
+  const mapped = definedRecord({
+    maxOutputTokens: numericValue(source, 'maxOutputTokens', 'max_output_tokens', 'max_tokens'),
+    temperature: numericValue(source, 'temperature'),
+    topP: numericValue(source, 'topP', 'top_p'),
+    topK: numericValue(source, 'topK', 'top_k'),
+    presencePenalty: numericValue(source, 'presencePenalty', 'presence_penalty'),
+    frequencyPenalty: numericValue(source, 'frequencyPenalty', 'frequency_penalty'),
+    seed: numericValue(source, 'seed'),
+    maxRetries: numericValue(source, 'maxRetries', 'max_retries'),
+    stopSequences:
+      Array.isArray(stopSequences) && stopSequences.every(value => typeof value === 'string')
+        ? stopSequences
+        : undefined,
+  });
+  return Object.keys(mapped).length > 0 ? mapped : undefined;
+}
+
+function buildMetadata(
+  observation: TimestampedObservation,
+  trace: OrderedLangfuseTrace,
+  importId: string,
+): Record<string, unknown> {
+  return definedRecord({
+    source: 'langfuse',
+    importSource: 'langfuse-api-v2',
+    importBatchId: importId,
+    langfuseTraceId: trace.sourceTraceId,
+    langfuseObservationId: observation.id,
+    langfuseProjectId: trace.projectId,
+    environment: observation.environment ?? undefined,
+    userId: observation.userId ?? undefined,
+    sessionId: observation.sessionId ?? undefined,
+    langfuseType: observation.type,
+    langfuseMetadata: wrapSourceMetadata(observation.metadata),
+    langfuse: definedRecord({
+      isRootObservation: observation.isRootObservation ?? undefined,
+      parentObservationId: observation.parentObservationId ?? undefined,
+      level: observation.level ?? undefined,
+      statusMessage: observation.statusMessage ?? undefined,
+      version: observation.version ?? undefined,
+      environment: observation.environment ?? undefined,
+      createdAt: observation.createdAt ?? undefined,
+      updatedAt: observation.updatedAt ?? undefined,
+      release: observation.release ?? undefined,
+      traceName: observation.traceName ?? undefined,
+      bookmarked: observation.bookmarked ?? undefined,
+      public: observation.public ?? undefined,
+      model: observation.model ?? undefined,
+      providedModelName: observation.providedModelName ?? undefined,
+      internalModelId: observation.internalModelId ?? undefined,
+      modelId: observation.modelId ?? undefined,
+      modelParameters: observation.modelParameters ?? undefined,
+      usageDetails: observation.usageDetails ?? undefined,
+      inputUsage: observation.inputUsage ?? undefined,
+      outputUsage: observation.outputUsage ?? undefined,
+      totalUsage: observation.totalUsage ?? undefined,
+      costDetails: observation.costDetails ?? undefined,
+      inputCost: observation.inputCost ?? undefined,
+      outputCost: observation.outputCost ?? undefined,
+      totalCost: observation.totalCost ?? undefined,
+      completionStartTime: observation.completionStartTime ?? undefined,
+      inputPrice: observation.inputPrice ?? undefined,
+      outputPrice: observation.outputPrice ?? undefined,
+      totalPrice: observation.totalPrice ?? undefined,
+      usagePricingTierId: observation.usagePricingTierId ?? undefined,
+      usagePricingTierName: observation.usagePricingTierName ?? undefined,
+      promptId: observation.promptId ?? undefined,
+      promptName: observation.promptName ?? undefined,
+      promptVersion: observation.promptVersion ?? undefined,
+      latency: observation.latency ?? undefined,
+      timeToFirstToken: observation.timeToFirstToken ?? undefined,
+      tags: observation.tags ?? undefined,
+      derivedEndTime: observation.mastraImportDerivedEndTime ?? undefined,
+      derivedEndTimeSourceObservationId: observation.mastraImportDerivedEndTimeSourceObservationId ?? undefined,
+    }),
+  });
+}

--- a/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
@@ -26,6 +26,48 @@ const LANGFUSE_TYPE_MAP: Record<string, TraceImportSpan['spanType']> = {
   TOOL: 'tool_call',
 };
 
+const INPUT_TOKEN_KEYS = ['input', 'inputTokens', 'input_tokens'] as const;
+const OUTPUT_TOKEN_KEYS = ['output', 'outputTokens', 'output_tokens'] as const;
+const CACHE_READ_TOKEN_KEYS = ['inputCachedTokens', 'input_cached_tokens', 'cacheReadInputTokens'] as const;
+const CACHE_WRITE_TOKEN_KEYS = [
+  'cacheCreationInputTokens',
+  'cache_creation_input_tokens',
+  'input_cache_creation',
+] as const;
+const INPUT_AUDIO_TOKEN_KEYS = ['inputAudioTokens', 'input_audio_tokens'] as const;
+const REASONING_TOKEN_KEYS = ['outputReasoningTokens', 'output_reasoning_tokens', 'reasoning_tokens'] as const;
+const OUTPUT_AUDIO_TOKEN_KEYS = ['outputAudioTokens', 'output_audio_tokens'] as const;
+
+const MAX_OUTPUT_TOKEN_PARAMETER_KEYS = ['maxOutputTokens', 'max_output_tokens', 'max_tokens'] as const;
+const TOP_P_PARAMETER_KEYS = ['topP', 'top_p'] as const;
+const TOP_K_PARAMETER_KEYS = ['topK', 'top_k'] as const;
+const PRESENCE_PENALTY_PARAMETER_KEYS = ['presencePenalty', 'presence_penalty'] as const;
+const FREQUENCY_PENALTY_PARAMETER_KEYS = ['frequencyPenalty', 'frequency_penalty'] as const;
+const MAX_RETRY_PARAMETER_KEYS = ['maxRetries', 'max_retries'] as const;
+const STOP_SEQUENCE_PARAMETER_KEYS = ['stopSequences', 'stop_sequences', 'stop'] as const;
+
+const MAPPED_USAGE_DETAIL_KEYS = new Set<string>([
+  ...INPUT_TOKEN_KEYS,
+  ...OUTPUT_TOKEN_KEYS,
+  ...CACHE_READ_TOKEN_KEYS,
+  ...CACHE_WRITE_TOKEN_KEYS,
+  ...INPUT_AUDIO_TOKEN_KEYS,
+  ...REASONING_TOKEN_KEYS,
+  ...OUTPUT_AUDIO_TOKEN_KEYS,
+]);
+
+const MAPPED_MODEL_PARAMETER_KEYS = new Set<string>([
+  ...MAX_OUTPUT_TOKEN_PARAMETER_KEYS,
+  'temperature',
+  ...TOP_P_PARAMETER_KEYS,
+  ...TOP_K_PARAMETER_KEYS,
+  ...PRESENCE_PENALTY_PARAMETER_KEYS,
+  ...FREQUENCY_PENALTY_PARAMETER_KEYS,
+  'seed',
+  ...MAX_RETRY_PARAMETER_KEYS,
+  ...STOP_SEQUENCE_PARAMETER_KEYS,
+]);
+
 const MASTRA_SPAN_TYPES = new Set<TraceImportSpan['spanType']>([
   'agent_run',
   'scorer_run',
@@ -483,24 +525,17 @@ function buildAttributes(
 
 function mapUsage(observation: LangfuseObservation): Record<string, unknown> | undefined {
   const inputTokens =
-    finiteNumber(observation.inputUsage) ??
-    numericValue(observation.usageDetails, 'input', 'inputTokens', 'input_tokens');
+    finiteNumber(observation.inputUsage) ?? numericValue(observation.usageDetails, ...INPUT_TOKEN_KEYS);
   const outputTokens =
-    finiteNumber(observation.outputUsage) ??
-    numericValue(observation.usageDetails, 'output', 'outputTokens', 'output_tokens');
+    finiteNumber(observation.outputUsage) ?? numericValue(observation.usageDetails, ...OUTPUT_TOKEN_KEYS);
   const inputDetails = definedRecord({
-    cacheRead: numericValue(
-      observation.usageDetails,
-      'inputCachedTokens',
-      'input_cached_tokens',
-      'cacheReadInputTokens',
-    ),
-    cacheWrite: numericValue(observation.usageDetails, 'cacheCreationInputTokens', 'cache_creation_input_tokens'),
-    audio: numericValue(observation.usageDetails, 'inputAudioTokens', 'input_audio_tokens'),
+    cacheRead: numericValue(observation.usageDetails, ...CACHE_READ_TOKEN_KEYS),
+    cacheWrite: numericValue(observation.usageDetails, ...CACHE_WRITE_TOKEN_KEYS),
+    audio: numericValue(observation.usageDetails, ...INPUT_AUDIO_TOKEN_KEYS),
   });
   const outputDetails = definedRecord({
-    reasoning: numericValue(observation.usageDetails, 'outputReasoningTokens', 'output_reasoning_tokens'),
-    audio: numericValue(observation.usageDetails, 'outputAudioTokens', 'output_audio_tokens'),
+    reasoning: numericValue(observation.usageDetails, ...REASONING_TOKEN_KEYS),
+    audio: numericValue(observation.usageDetails, ...OUTPUT_AUDIO_TOKEN_KEYS),
   });
   const usage = definedRecord({
     inputTokens,
@@ -514,22 +549,32 @@ function mapUsage(observation: LangfuseObservation): Record<string, unknown> | u
 function mapModelParameters(parameters: unknown): Record<string, unknown> | undefined {
   if (!parameters || typeof parameters !== 'object' || Array.isArray(parameters)) return undefined;
   const source = parameters as Record<string, unknown>;
-  const stopSequences = source.stopSequences ?? source.stop_sequences ?? source.stop;
+  const stopSequences = STOP_SEQUENCE_PARAMETER_KEYS.map(key => source[key]).find(value => value != null);
   const mapped = definedRecord({
-    maxOutputTokens: numericValue(source, 'maxOutputTokens', 'max_output_tokens', 'max_tokens'),
+    maxOutputTokens: numericValue(source, ...MAX_OUTPUT_TOKEN_PARAMETER_KEYS),
     temperature: numericValue(source, 'temperature'),
-    topP: numericValue(source, 'topP', 'top_p'),
-    topK: numericValue(source, 'topK', 'top_k'),
-    presencePenalty: numericValue(source, 'presencePenalty', 'presence_penalty'),
-    frequencyPenalty: numericValue(source, 'frequencyPenalty', 'frequency_penalty'),
+    topP: numericValue(source, ...TOP_P_PARAMETER_KEYS),
+    topK: numericValue(source, ...TOP_K_PARAMETER_KEYS),
+    presencePenalty: numericValue(source, ...PRESENCE_PENALTY_PARAMETER_KEYS),
+    frequencyPenalty: numericValue(source, ...FREQUENCY_PENALTY_PARAMETER_KEYS),
     seed: numericValue(source, 'seed'),
-    maxRetries: numericValue(source, 'maxRetries', 'max_retries'),
+    maxRetries: numericValue(source, ...MAX_RETRY_PARAMETER_KEYS),
     stopSequences:
       Array.isArray(stopSequences) && stopSequences.every(value => typeof value === 'string')
         ? stopSequences
         : undefined,
   });
   return Object.keys(mapped).length > 0 ? mapped : undefined;
+}
+
+function preserveUnmappedFields(value: unknown, mappedKeys: ReadonlySet<string>): unknown {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'object' || Array.isArray(value)) return value;
+
+  const remaining = Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).filter(([key]) => !mappedKeys.has(key)),
+  );
+  return Object.keys(remaining).length > 0 ? remaining : undefined;
 }
 
 function buildMetadata(
@@ -576,8 +621,12 @@ function buildMetadata(
           : undefined,
       internalModelId: observation.internalModelId ?? undefined,
       modelId: observation.modelId ?? undefined,
-      modelParameters: hasGenerationAttributes ? undefined : (observation.modelParameters ?? undefined),
-      usageDetails: hasModelAttributes ? undefined : (observation.usageDetails ?? undefined),
+      modelParameters: hasGenerationAttributes
+        ? preserveUnmappedFields(observation.modelParameters, MAPPED_MODEL_PARAMETER_KEYS)
+        : (observation.modelParameters ?? undefined),
+      usageDetails: hasModelAttributes
+        ? preserveUnmappedFields(observation.usageDetails, MAPPED_USAGE_DETAIL_KEYS)
+        : (observation.usageDetails ?? undefined),
       inputUsage: hasModelAttributes ? undefined : (observation.inputUsage ?? undefined),
       outputUsage: hasModelAttributes ? undefined : (observation.outputUsage ?? undefined),
       totalUsage: observation.totalUsage ?? undefined,

--- a/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
@@ -193,6 +193,7 @@ function validateAndOrderTrace(
 
   const normalizedObservations = deriveVirtualRootEndTime(sourceTrace.traceId, observations, roots[0]!);
   const normalizedById = new Map(normalizedObservations.map(observation => [observation.id, observation]));
+  const startTimesById = new Map<string, number>();
   const root = normalizedById.get(roots[0]!.id)!;
 
   for (const observation of normalizedObservations) {
@@ -217,6 +218,7 @@ function validateAndOrderTrace(
         skipped: createSkippedTrace(sourceTrace.traceId, normalizedObservations, 'invalid_timestamp', observation.id),
       };
     }
+    startTimesById.set(observation.id, startMs);
 
     if (observation.type === 'EVENT') {
       if (startMs > options.snapshotMs) {
@@ -269,7 +271,7 @@ function validateAndOrderTrace(
   }
 
   for (const siblings of children.values()) {
-    siblings.sort((a, b) => a.startTime.localeCompare(b.startTime) || a.id.localeCompare(b.id));
+    siblings.sort((a, b) => startTimesById.get(a.id)! - startTimesById.get(b.id)! || a.id.localeCompare(b.id));
   }
 
   const ordered: TimestampedObservation[] = [];

--- a/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
@@ -7,12 +7,11 @@ import type {
   TraceImportTrace,
 } from '../../types.js';
 import type { LangfuseClientDependencies, LangfuseClientOptions } from './client.js';
-import { createLangfuseSpanImportId, createLangfuseTraceImportId } from './ids.js';
+import { createLangfuseSpanImportId, createLangfuseTraceImportId, LANGFUSE_ID_ALGORITHM_VERSION } from './ids.js';
 import { LangfuseObservationsReader, type LangfuseReadWindow, type LangfuseTraceReadOptions } from './reader.js';
 import type { LangfuseObservation, LangfuseSourceTrace } from './types.js';
 
 const MAPPER_VERSION = 'langfuse-api-v2@1';
-const ID_ALGORITHM_VERSION = 'langfuse-sha256-v1';
 
 const LANGFUSE_TYPE_MAP: Record<string, TraceImportSpan['spanType']> = {
   AGENT: 'agent_run',
@@ -93,7 +92,7 @@ export class LangfuseTraceImportProvider implements TraceImportProvider {
       baseUrl: this.reader.baseUrl,
       projectId: project.id,
       mapperVersion: MAPPER_VERSION,
-      idAlgorithmVersion: ID_ALGORITHM_VERSION,
+      idAlgorithmVersion: LANGFUSE_ID_ALGORITHM_VERSION,
     };
   }
 

--- a/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
@@ -74,8 +74,8 @@ interface OrderedLangfuseTrace {
 
 export interface MapLangfuseTraceOptions {
   importId: string;
-  cutoffAt: string;
-  snapshotAt: string;
+  cutoffMs: number;
+  snapshotMs: number;
 }
 
 export class LangfuseTraceImportProvider implements TraceImportProvider {
@@ -97,6 +97,9 @@ export class LangfuseTraceImportProvider implements TraceImportProvider {
   }
 
   async *read(context: TraceImportReadContext): AsyncIterable<TraceImportRecord> {
+    const importWindow = parseImportWindow(context.cutoffAt, context.snapshotAt);
+    if (context.source.projectId.trim().length === 0) throw new Error('Langfuse project ID is required.');
+
     const window: LangfuseReadWindow = {
       cutoffAt: context.cutoffAt,
       snapshotAt: context.snapshotAt,
@@ -129,8 +132,7 @@ export class LangfuseTraceImportProvider implements TraceImportProvider {
       const sourceTrace = await this.reader.readTrace(options);
       yield mapLangfuseSourceTrace(sourceTrace, {
         importId: context.importId,
-        cutoffAt: context.cutoffAt,
-        snapshotAt: context.snapshotAt,
+        ...importWindow,
       });
     }
   }
@@ -164,12 +166,6 @@ function validateAndOrderTrace(
   const observations = sourceTrace.observations;
   if (observations.length === 0) {
     return { skipped: createSkippedTrace(sourceTrace.traceId, observations, 'empty_trace') };
-  }
-
-  const cutoffMs = parseRequiredTimestamp(options.cutoffAt);
-  const snapshotMs = parseRequiredTimestamp(options.snapshotAt);
-  if (cutoffMs === null || snapshotMs === null || cutoffMs >= snapshotMs) {
-    throw new Error('Langfuse import window must contain valid timestamps with cutoffAt before snapshotAt.');
   }
 
   const projectIds = new Set(observations.map(observation => observation.projectId));
@@ -223,12 +219,7 @@ function validateAndOrderTrace(
     }
 
     if (observation.type === 'EVENT') {
-      if (observation.endTime && parseSourceTimestamp(observation.endTime) === null) {
-        return {
-          skipped: createSkippedTrace(sourceTrace.traceId, normalizedObservations, 'invalid_timestamp', observation.id),
-        };
-      }
-      if (startMs > snapshotMs) {
+      if (startMs > options.snapshotMs) {
         return {
           skipped: createSkippedTrace(
             sourceTrace.traceId,
@@ -252,7 +243,7 @@ function validateAndOrderTrace(
         skipped: createSkippedTrace(sourceTrace.traceId, normalizedObservations, 'invalid_timestamp', observation.id),
       };
     }
-    if (endMs > snapshotMs) {
+    if (endMs > options.snapshotMs) {
       return {
         skipped: createSkippedTrace(
           sourceTrace.traceId,
@@ -265,7 +256,7 @@ function validateAndOrderTrace(
   }
 
   const rootStartMs = parseSourceTimestamp(root.startTime)!;
-  if (rootStartMs < cutoffMs || rootStartMs >= snapshotMs) {
+  if (rootStartMs < options.cutoffMs || rootStartMs >= options.snapshotMs) {
     return { skipped: createSkippedTrace(sourceTrace.traceId, normalizedObservations, 'root_outside_window') };
   }
 
@@ -396,8 +387,13 @@ function deriveVirtualRootEndTime(
   );
 }
 
-function parseRequiredTimestamp(value: string): number | null {
-  return parseSourceTimestamp(value);
+function parseImportWindow(cutoffAt: string, snapshotAt: string): { cutoffMs: number; snapshotMs: number } {
+  const cutoffMs = parseSourceTimestamp(cutoffAt);
+  const snapshotMs = parseSourceTimestamp(snapshotAt);
+  if (cutoffMs === null || snapshotMs === null || cutoffMs >= snapshotMs) {
+    throw new Error('Langfuse import window must contain valid timestamps with cutoffAt before snapshotAt.');
+  }
+  return { cutoffMs, snapshotMs };
 }
 
 function parseSourceTimestamp(value: string | null | undefined): number | null {

--- a/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
@@ -103,6 +103,7 @@ export class LangfuseTraceImportProvider implements TraceImportProvider {
       snapshotAt: context.snapshotAt,
       projectId: context.source.projectId,
       signal: context.signal,
+      onRetry: context.onRetry,
     };
 
     for await (const discovery of this.reader.discoverTraces(window)) {
@@ -124,6 +125,7 @@ export class LangfuseTraceImportProvider implements TraceImportProvider {
         traceId: discovery.traceId,
         projectId: context.source.projectId,
         signal: context.signal,
+        onRetry: context.onRetry,
       };
       const sourceTrace = await this.reader.readTrace(options);
       yield mapLangfuseSourceTrace(sourceTrace, {
@@ -225,6 +227,16 @@ function validateAndOrderTrace(
       if (observation.endTime && parseSourceTimestamp(observation.endTime) === null) {
         return {
           skipped: createSkippedTrace(sourceTrace.traceId, normalizedObservations, 'invalid_timestamp', observation.id),
+        };
+      }
+      if (startMs > snapshotMs) {
+        return {
+          skipped: createSkippedTrace(
+            sourceTrace.traceId,
+            normalizedObservations,
+            'completed_after_snapshot',
+            observation.id,
+          ),
         };
       }
       continue;

--- a/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/adapter.ts
@@ -421,10 +421,14 @@ function definedRecord(record: Record<string, unknown>): Record<string, unknown>
   return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined));
 }
 
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
 function numericValue(record: Record<string, unknown> | null | undefined, ...keys: string[]): number | undefined {
   for (const key of keys) {
-    const value = record?.[key];
-    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    const value = finiteNumber(record?.[key]);
+    if (value !== undefined) return value;
   }
   return undefined;
 }
@@ -482,9 +486,11 @@ function buildAttributes(
 
 function mapUsage(observation: LangfuseObservation): Record<string, unknown> | undefined {
   const inputTokens =
-    observation.inputUsage ?? numericValue(observation.usageDetails, 'input', 'inputTokens', 'input_tokens');
+    finiteNumber(observation.inputUsage) ??
+    numericValue(observation.usageDetails, 'input', 'inputTokens', 'input_tokens');
   const outputTokens =
-    observation.outputUsage ?? numericValue(observation.usageDetails, 'output', 'outputTokens', 'output_tokens');
+    finiteNumber(observation.outputUsage) ??
+    numericValue(observation.usageDetails, 'output', 'outputTokens', 'output_tokens');
   const inputDetails = definedRecord({
     cacheRead: numericValue(
       observation.usageDetails,

--- a/packages/cli/src/commands/traces/import/providers/langfuse/client.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/client.test.ts
@@ -54,12 +54,15 @@ describe('LangfuseClient', () => {
     const fetch = vi
       .fn<typeof globalThis.fetch>()
       .mockResolvedValueOnce(new Response(failedBody))
-      .mockResolvedValueOnce(Response.json({ data: [{ id: 'project-1', name: 'Customer project' }] }));
+      .mockResolvedValueOnce(Response.json({ data: [observation], meta: { cursor: null } }));
     const sleep = vi.fn().mockResolvedValue(undefined);
     const onRetry = vi.fn();
-    const client = new LangfuseClient(options, { fetch, sleep, maxAttempts: 2, onRetry });
+    const client = new LangfuseClient(options, { fetch, sleep, maxAttempts: 2 });
 
-    await expect(client.identifyProject()).resolves.toEqual({ id: 'project-1', name: 'Customer project' });
+    await expect(client.getObservationsPage({ fields: 'core', limit: 1000 }, onRetry)).resolves.toEqual({
+      data: [observation],
+      cursor: null,
+    });
     expect(fetch).toHaveBeenCalledTimes(2);
     expect(sleep).toHaveBeenCalledOnce();
     expect(onRetry).toHaveBeenCalledOnce();
@@ -104,9 +107,9 @@ describe('LangfuseClient', () => {
       .mockResolvedValueOnce(Response.json({ data: [], meta: { cursor: null } }));
     const sleep = vi.fn().mockResolvedValue(undefined);
     const onRetry = vi.fn();
-    const client = new LangfuseClient(options, { fetch, sleep, onRetry });
+    const client = new LangfuseClient(options, { fetch, sleep });
 
-    await client.getObservationsPage({ fields: 'core', limit: 1000 });
+    await client.getObservationsPage({ fields: 'core', limit: 1000 }, onRetry);
 
     expect(fetch).toHaveBeenCalledTimes(2);
     expect(rateLimit.cancel).toHaveBeenCalledOnce();

--- a/packages/cli/src/commands/traces/import/providers/langfuse/client.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/client.test.ts
@@ -45,6 +45,26 @@ describe('LangfuseClient', () => {
     );
   });
 
+  it('retries when a successful response body fails while streaming', async () => {
+    const failedBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new TypeError('stream interrupted'));
+      },
+    });
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(new Response(failedBody))
+      .mockResolvedValueOnce(Response.json({ data: [{ id: 'project-1', name: 'Customer project' }] }));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const onRetry = vi.fn();
+    const client = new LangfuseClient(options, { fetch, sleep, maxAttempts: 2, onRetry });
+
+    await expect(client.identifyProject()).resolves.toEqual({ id: 'project-1', name: 'Customer project' });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
   it('builds a bounded Observations API v2 request', async () => {
     const fetch = vi
       .fn<typeof globalThis.fetch>()

--- a/packages/cli/src/commands/traces/import/providers/langfuse/client.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/client.ts
@@ -148,7 +148,21 @@ export class LangfuseClient {
       }
 
       if (response.ok) {
-        return parseJson(await readResponseText(response));
+        try {
+          return parseJson(await readResponseText(response));
+        } catch (error) {
+          if (error instanceof LangfuseReaderError) throw error;
+          if (signal?.aborted) throw signal.reason ?? error;
+          lastError = error;
+          if (attempt + 1 < this.maxAttempts) {
+            await this.waitBeforeRetry(backoffMilliseconds(attempt), signal, onRetry);
+            continue;
+          }
+          throw new LangfuseReaderError('Could not read the Langfuse response after the retry limit was exhausted.', {
+            retryable: true,
+            cause: error,
+          });
+        }
       }
 
       if (response.status === 401 || response.status === 403) {

--- a/packages/cli/src/commands/traces/import/providers/langfuse/client.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/client.ts
@@ -18,7 +18,6 @@ export interface LangfuseClientDependencies {
   sleep?: Sleep;
   maxAttempts?: number;
   requestTimeoutMs?: number;
-  onRetry?: () => void;
 }
 
 export interface LangfuseObservationQuery {
@@ -59,7 +58,6 @@ export class LangfuseClient {
   private readonly sleep: Sleep;
   private readonly maxAttempts: number;
   private readonly requestTimeoutMs: number;
-  private readonly onRetry?: () => void;
 
   constructor(options: LangfuseClientOptions, dependencies: LangfuseClientDependencies = {}) {
     const publicKey = requireCredential(options.publicKey, 'Langfuse public key');
@@ -71,7 +69,6 @@ export class LangfuseClient {
     this.sleep = dependencies.sleep ?? sleep;
     this.maxAttempts = dependencies.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
     this.requestTimeoutMs = dependencies.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
-    this.onRetry = dependencies.onRetry;
 
     if (!Number.isInteger(this.maxAttempts) || this.maxAttempts < 1) {
       throw new Error('Langfuse max attempts must be a positive integer.');
@@ -114,9 +111,7 @@ export class LangfuseClient {
   }
 
   private async requestJson(url: URL, signal?: AbortSignal, onRetry?: () => void): Promise<unknown> {
-    let lastError: unknown;
-
-    for (let attempt = 0; attempt < this.maxAttempts; attempt++) {
+    for (let attempt = 0; ; attempt++) {
       signal?.throwIfAborted();
 
       let response: Response;
@@ -129,7 +124,6 @@ export class LangfuseClient {
         });
       } catch (error) {
         if (signal?.aborted) throw signal.reason ?? error;
-        lastError = error;
         if (attempt + 1 < this.maxAttempts) {
           await this.waitBeforeRetry(backoffMilliseconds(attempt), signal, onRetry);
           continue;
@@ -153,7 +147,6 @@ export class LangfuseClient {
         } catch (error) {
           if (error instanceof LangfuseReaderError) throw error;
           if (signal?.aborted) throw signal.reason ?? error;
-          lastError = error;
           if (attempt + 1 < this.maxAttempts) {
             await this.waitBeforeRetry(backoffMilliseconds(attempt), signal, onRetry);
             continue;
@@ -199,13 +192,10 @@ export class LangfuseClient {
         status: response.status,
       });
     }
-
-    throw new LangfuseReaderError('Langfuse request failed.', { retryable: true, cause: lastError });
   }
 
   private async waitBeforeRetry(milliseconds: number, signal?: AbortSignal, onRetry?: () => void): Promise<void> {
-    this.onRetry?.();
-    if (onRetry !== this.onRetry) onRetry?.();
+    onRetry?.();
     await this.sleep(milliseconds, signal);
   }
 }

--- a/packages/cli/src/commands/traces/import/providers/langfuse/client.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/client.ts
@@ -86,7 +86,7 @@ export class LangfuseClient {
     return parseProject(value);
   }
 
-  async getObservationsPage(query: LangfuseObservationQuery): Promise<LangfuseObservationsPage> {
+  async getObservationsPage(query: LangfuseObservationQuery, onRetry?: () => void): Promise<LangfuseObservationsPage> {
     if (!Number.isInteger(query.limit) || query.limit < 1 || query.limit > 1000) {
       throw new Error('Langfuse observation page size must be between 1 and 1000.');
     }
@@ -101,7 +101,7 @@ export class LangfuseClient {
     setQuery(url, 'expandMetadata', query.expandMetadata);
 
     try {
-      return parseObservationsPage(await this.requestJson(url, query.signal));
+      return parseObservationsPage(await this.requestJson(url, query.signal, onRetry));
     } catch (error) {
       if (error instanceof LangfuseReaderError && error.status === 404) {
         throw new LangfuseReaderError(
@@ -113,7 +113,7 @@ export class LangfuseClient {
     }
   }
 
-  private async requestJson(url: URL, signal?: AbortSignal): Promise<unknown> {
+  private async requestJson(url: URL, signal?: AbortSignal, onRetry?: () => void): Promise<unknown> {
     let lastError: unknown;
 
     for (let attempt = 0; attempt < this.maxAttempts; attempt++) {
@@ -131,7 +131,7 @@ export class LangfuseClient {
         if (signal?.aborted) throw signal.reason ?? error;
         lastError = error;
         if (attempt + 1 < this.maxAttempts) {
-          await this.waitBeforeRetry(backoffMilliseconds(attempt), signal);
+          await this.waitBeforeRetry(backoffMilliseconds(attempt), signal, onRetry);
           continue;
         }
         throw new LangfuseReaderError('Could not reach Langfuse after the retry limit was exhausted.', {
@@ -170,7 +170,7 @@ export class LangfuseClient {
               ? parseRetryAfter(response.headers.get('retry-after'), backoffMilliseconds(attempt))
               : backoffMilliseconds(attempt);
           await discardResponseBody(response);
-          await this.waitBeforeRetry(delay, signal);
+          await this.waitBeforeRetry(delay, signal, onRetry);
           continue;
         }
         await discardResponseBody(response);
@@ -189,8 +189,9 @@ export class LangfuseClient {
     throw new LangfuseReaderError('Langfuse request failed.', { retryable: true, cause: lastError });
   }
 
-  private async waitBeforeRetry(milliseconds: number, signal?: AbortSignal): Promise<void> {
+  private async waitBeforeRetry(milliseconds: number, signal?: AbortSignal, onRetry?: () => void): Promise<void> {
     this.onRetry?.();
+    if (onRetry !== this.onRetry) onRetry?.();
     await this.sleep(milliseconds, signal);
   }
 }

--- a/packages/cli/src/commands/traces/import/providers/langfuse/ids.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/ids.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { createLangfuseSpanImportId, createLangfuseTraceImportId } from './ids.js';
+
+describe('Langfuse import IDs', () => {
+  it('keeps the versioned deterministic ID strategy stable', () => {
+    expect(createLangfuseTraceImportId('project-1', 'trace-1')).toBe('e24f0e8ae0ea8423ad3b20aa25821bff');
+    expect(createLangfuseSpanImportId('project-1', 'root')).toBe('8abe9fdc27cd4e38');
+  });
+});

--- a/packages/cli/src/commands/traces/import/providers/langfuse/ids.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/ids.ts
@@ -2,6 +2,8 @@ import { createHash } from 'node:crypto';
 
 const PROVIDER_ID = 'langfuse';
 
+export const LANGFUSE_ID_ALGORITHM_VERSION = 'langfuse-sha256-v1';
+
 function stableHexId(parts: string[], length: 16 | 32): string {
   return createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, length);
 }

--- a/packages/cli/src/commands/traces/import/providers/langfuse/ids.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/ids.ts
@@ -1,0 +1,15 @@
+import { createHash } from 'node:crypto';
+
+const PROVIDER_ID = 'langfuse';
+
+function stableHexId(parts: string[], length: 16 | 32): string {
+  return createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, length);
+}
+
+export function createLangfuseTraceImportId(projectId: string, traceId: string): string {
+  return stableHexId([PROVIDER_ID, projectId, 'trace', traceId], 32);
+}
+
+export function createLangfuseSpanImportId(projectId: string, observationId: string): string {
+  return stableHexId([PROVIDER_ID, projectId, 'observation', observationId], 16);
+}

--- a/packages/cli/src/commands/traces/import/providers/langfuse/reader.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/reader.test.ts
@@ -113,12 +113,9 @@ describe('LangfuseObservationsReader', () => {
       .mockResolvedValueOnce(Response.json({ data: [child], meta: { cursor: 'final-page' } }))
       .mockResolvedValueOnce(Response.json({ data: [grandchild], meta: { cursor: null } }));
     const onRetry = vi.fn();
-    const operationOnRetry = vi.fn();
-    const reader = new LangfuseObservationsReader(clientOptions, { fetch, onRetry });
+    const reader = new LangfuseObservationsReader(clientOptions, { fetch });
 
-    await expect(
-      reader.readTrace({ traceId: 'trace-1', projectId: 'project-1', onRetry: operationOnRetry }),
-    ).resolves.toEqual({
+    await expect(reader.readTrace({ traceId: 'trace-1', projectId: 'project-1', onRetry })).resolves.toEqual({
       traceId: 'trace-1',
       observations: [root, child, grandchild],
     });
@@ -127,7 +124,6 @@ describe('LangfuseObservationsReader', () => {
     expect(urls.map(url => url.searchParams.get('limit'))).toEqual(['1000', '1000', '500', '500']);
     expect(urls.map(url => url.searchParams.get('cursor'))).toEqual([null, 'next-page', 'next-page', 'final-page']);
     expect(onRetry).toHaveBeenCalledOnce();
-    expect(operationOnRetry).toHaveBeenCalledOnce();
   });
 
   it('fails when one observation exceeds the response limit', async () => {
@@ -185,22 +181,6 @@ describe('LangfuseObservationsReader', () => {
     await expect(wrongTrace.readTrace({ traceId: 'trace-1', projectId: 'project-1' })).rejects.toThrow(
       'different trace',
     );
-  });
-
-  it('validates the discovery window before making a request', async () => {
-    const fetch = vi.fn<typeof globalThis.fetch>();
-    const reader = new LangfuseObservationsReader(clientOptions, { fetch });
-
-    await expect(
-      collect(
-        reader.discoverTraces({
-          projectId: 'project-1',
-          cutoffAt: '2026-09-02T00:00:00.000Z',
-          snapshotAt: '2026-09-01T00:00:00.000Z',
-        }),
-      ),
-    ).rejects.toThrow('cutoffAt before snapshotAt');
-    expect(fetch).not.toHaveBeenCalled();
   });
 
   it('stops before the next page when aborted', async () => {

--- a/packages/cli/src/commands/traces/import/providers/langfuse/reader.test.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/reader.test.ts
@@ -113,9 +113,12 @@ describe('LangfuseObservationsReader', () => {
       .mockResolvedValueOnce(Response.json({ data: [child], meta: { cursor: 'final-page' } }))
       .mockResolvedValueOnce(Response.json({ data: [grandchild], meta: { cursor: null } }));
     const onRetry = vi.fn();
+    const operationOnRetry = vi.fn();
     const reader = new LangfuseObservationsReader(clientOptions, { fetch, onRetry });
 
-    await expect(reader.readTrace({ traceId: 'trace-1', projectId: 'project-1' })).resolves.toEqual({
+    await expect(
+      reader.readTrace({ traceId: 'trace-1', projectId: 'project-1', onRetry: operationOnRetry }),
+    ).resolves.toEqual({
       traceId: 'trace-1',
       observations: [root, child, grandchild],
     });
@@ -124,6 +127,7 @@ describe('LangfuseObservationsReader', () => {
     expect(urls.map(url => url.searchParams.get('limit'))).toEqual(['1000', '1000', '500', '500']);
     expect(urls.map(url => url.searchParams.get('cursor'))).toEqual([null, 'next-page', 'next-page', 'final-page']);
     expect(onRetry).toHaveBeenCalledOnce();
+    expect(operationOnRetry).toHaveBeenCalledOnce();
   });
 
   it('fails when one observation exceeds the response limit', async () => {

--- a/packages/cli/src/commands/traces/import/providers/langfuse/reader.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/reader.ts
@@ -38,11 +38,9 @@ export interface LangfuseTraceReadOptions {
  */
 export class LangfuseObservationsReader {
   private readonly client: LangfuseClient;
-  private readonly onRetry?: () => void;
 
   constructor(options: LangfuseClientOptions, dependencies: LangfuseClientDependencies = {}) {
     this.client = new LangfuseClient(options, dependencies);
-    this.onRetry = dependencies.onRetry;
   }
 
   get baseUrl(): string {
@@ -59,7 +57,6 @@ export class LangfuseObservationsReader {
    * it can report them instead of silently dropping them.
    */
   async *discoverTraces(window: LangfuseReadWindow): AsyncGenerator<LangfuseTraceDiscovery> {
-    assertWindow(window);
     const seenTraceIds = new Set<string>();
 
     for await (const page of this.pages({
@@ -133,8 +130,7 @@ export class LangfuseObservationsReader {
           // The cursor identifies the last returned observation independently
           // of the requested limit, so the page can safely be retried smaller.
           limit = Math.max(1, Math.floor(limit / 2));
-          this.onRetry?.();
-          if (onRetry !== this.onRetry) onRetry?.();
+          onRetry?.();
         }
       }
       yield page.data;
@@ -148,15 +144,6 @@ export class LangfuseObservationsReader {
       }
     } while (cursor !== undefined);
   }
-}
-
-function assertWindow(window: LangfuseReadWindow): void {
-  const cutoff = Date.parse(window.cutoffAt);
-  const snapshot = Date.parse(window.snapshotAt);
-  if (!Number.isFinite(cutoff) || !Number.isFinite(snapshot) || cutoff >= snapshot) {
-    throw new Error('Langfuse import window must contain valid timestamps with cutoffAt before snapshotAt.');
-  }
-  if (window.projectId.trim().length === 0) throw new Error('Langfuse project ID is required.');
 }
 
 function assertProject(observation: LangfuseObservation, projectId: string): void {

--- a/packages/cli/src/commands/traces/import/providers/langfuse/reader.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/reader.ts
@@ -34,7 +34,7 @@ export interface LangfuseTraceReadOptions {
 
 /**
  * Reads raw Langfuse observations. Tree validation and conversion into Mastra
- * spans belong to the Langfuse adapter implemented by the next ticket.
+ * spans belong to the Langfuse provider adapter.
  */
 export class LangfuseObservationsReader {
   private readonly client: LangfuseClient;

--- a/packages/cli/src/commands/traces/import/providers/langfuse/reader.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/reader.ts
@@ -22,12 +22,14 @@ export interface LangfuseReadWindow {
   snapshotAt: string;
   projectId: string;
   signal?: AbortSignal;
+  onRetry?: () => void;
 }
 
 export interface LangfuseTraceReadOptions {
   traceId: string;
   projectId: string;
   signal?: AbortSignal;
+  onRetry?: () => void;
 }
 
 /**
@@ -66,6 +68,7 @@ export class LangfuseObservationsReader {
       fromStartTime: window.cutoffAt,
       toStartTime: window.snapshotAt,
       signal: window.signal,
+      onRetry: window.onRetry,
     })) {
       for (const observation of page) {
         assertProject(observation, window.projectId);
@@ -95,6 +98,7 @@ export class LangfuseObservationsReader {
       limit: PAGE_SIZE,
       traceId: options.traceId,
       signal: options.signal,
+      onRetry: options.onRetry,
     })) {
       for (const observation of page) {
         assertProject(observation, options.projectId);
@@ -108,17 +112,20 @@ export class LangfuseObservationsReader {
     return { traceId: options.traceId, observations };
   }
 
-  private async *pages(query: Omit<LangfuseObservationQuery, 'cursor'>): AsyncGenerator<LangfuseObservation[]> {
+  private async *pages(
+    query: Omit<LangfuseObservationQuery, 'cursor'> & { onRetry?: () => void },
+  ): AsyncGenerator<LangfuseObservation[]> {
+    const { onRetry, ...observationQuery } = query;
     const seenCursors = new Set<string>();
-    let limit = query.limit;
+    let limit = observationQuery.limit;
     let cursor: string | undefined;
 
     do {
-      query.signal?.throwIfAborted();
+      observationQuery.signal?.throwIfAborted();
       let page: LangfuseObservationsPage;
       while (true) {
         try {
-          page = await this.client.getObservationsPage({ ...query, cursor, limit });
+          page = await this.client.getObservationsPage({ ...observationQuery, cursor, limit }, onRetry);
           break;
         } catch (error) {
           if (!(error instanceof LangfuseResponseTooLargeError) || limit === 1) throw error;
@@ -127,6 +134,7 @@ export class LangfuseObservationsReader {
           // of the requested limit, so the page can safely be retried smaller.
           limit = Math.max(1, Math.floor(limit / 2));
           this.onRetry?.();
+          if (onRetry !== this.onRetry) onRetry?.();
         }
       }
       yield page.data;

--- a/packages/cli/src/commands/traces/import/providers/langfuse/types.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/types.ts
@@ -50,6 +50,9 @@ export interface LangfuseObservation {
   modelId?: string | null;
   modelParameters?: unknown;
   usageDetails?: Record<string, number> | null;
+  inputUsage?: number | null;
+  outputUsage?: number | null;
+  totalUsage?: number | null;
   costDetails?: Record<string, number> | null;
   inputCost?: number | null;
   outputCost?: number | null;

--- a/packages/cli/src/commands/traces/import/providers/langfuse/types.ts
+++ b/packages/cli/src/commands/traces/import/providers/langfuse/types.ts
@@ -51,7 +51,13 @@ export interface LangfuseObservation {
   modelParameters?: unknown;
   usageDetails?: Record<string, number> | null;
   costDetails?: Record<string, number> | null;
+  inputCost?: number | null;
+  outputCost?: number | null;
   totalCost?: number | null;
+  inputPrice?: string | null;
+  outputPrice?: string | null;
+  totalPrice?: string | null;
+  usagePricingTierId?: string | null;
   usagePricingTierName?: string | null;
   promptId?: string | null;
   promptName?: string | null;


### PR DESCRIPTION
Adds the OBS-312 Langfuse mapping layer on top of the merged Observations API v2 reader.

## What changed

- Validates complete Langfuse trace trees, including roots, parents, cycles, duplicate IDs, project consistency, and timestamps.
- Converts valid observations into provider-neutral Mastra spans while preserving source metadata.
- Maps Langfuse observation types, events, errors, model attributes, usage, and costs.
- Restores valid Mastra exporter span types only when recognized provenance is present.
- Derives legacy virtual-root end times from completed children.
- Generates versioned deterministic trace and span IDs, pinned by golden tests.
- Reports invalid traces with explicit skip reasons.
- Reports provider retries through the shared import context and retries interrupted successful response bodies.

## Validation

- Focused Langfuse tests: 73 passed with 91.93% line and 87.38% branch coverage.
- CLI tests: 1,281 passed; create-mastra tests: 12 passed.
- CLI typecheck, lint, and build passed.
- Read-only hosted validation: 30 traces and 114 spans mapped, 4 invalid source traces explicitly skipped, 0 warnings, and 1 provider retry. No Platform upload was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR lets Mastra import Langfuse traces from the Observations API v2. It checks trace data, converts valid records into Mastra spans, and explains why invalid records are skipped.

## Changes

- Added the Langfuse trace import adapter.
- Added observation discovery, pagination, and trace reads.
- Added deterministic, versioned trace and span IDs.
- Validated missing roots, missing parents, duplicate IDs, cycles, invalid timestamps, incomplete durations, mixed projects, and snapshot violations.
- Sorted observations by validated timestamps with deterministic ID tie-breakers.
- Added virtual-root timing.
- Mapped types, events, errors, input/output, metadata, usage, costs, model parameters, and warnings.
- Reduced duplicate normalized metadata while preserving provenance and unmapped fields.
- Restored Mastra exporter span types when source metadata is available.
- Added retries for network failures, oversized responses, and interrupted response bodies.
- Added retry backoff and import-context retry reporting.
- Added focused adapter, reader, client, and ID-generation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->