### PR TITLE
refactor(client-js): remove redundant type assertions

### DIFF
--- a/.changeset/floppy-keys-swim.md
+++ b/.changeset/floppy-keys-swim.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Removed redundant type assertions without changing runtime behavior or public types.

--- a/client-sdks/client-js/src/resources/responses.ts
+++ b/client-sdks/client-js/src/resources/responses.ts
@@ -52,7 +52,7 @@ function hydrateStreamEvent(event: ResponsesStreamEvent | ResponsePayload): Resp
   }
 
   if (typeof event === 'object' && event !== null && 'output' in event) {
-    return attachOutputText(event as ResponsePayload);
+    return attachOutputText(event);
   }
 
   if (
@@ -63,7 +63,7 @@ function hydrateStreamEvent(event: ResponsesStreamEvent | ResponsePayload): Resp
   ) {
     return {
       ...event,
-      item: hydrateOutputItem(event.item as ResponseOutputItem),
+      item: hydrateOutputItem(event.item),
     } as ResponsesStreamEvent;
   }
 

--- a/client-sdks/client-js/src/utils/verify-agent-card-signature.ts
+++ b/client-sdks/client-js/src/utils/verify-agent-card-signature.ts
@@ -85,7 +85,7 @@ async function importVerificationKey(
     return importSPKI(key, algorithm);
   }
 
-  return importJWK(key as JWK, algorithm);
+  return importJWK(key, algorithm);
 }
 
 export async function verifyAgentCardSignatureIfPresent(


### PR DESCRIPTION
## Description

Removes 3 redundant type assertions across 2 source files in response event handling and agent-card signature verification. Existing types and guards already provide the asserted types. Runtime behavior and public declarations are unchanged.

This branch typechecks independently. The source edits match the version validated with existing tests and JavaScript/declaration comparisons before the split. Test files, fixtures, and intentional compatibility casts are unchanged.

## Related issue(s)

Split from #23494.

## Type of change

- [x] Code refactoring

## Checklist

- [x] I have linked the related work above
- [x] Documentation changes are not applicable
- [x] Existing tests cover this refactor; test files are unchanged
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The client already knew the correct data types, so this PR removes three unnecessary type overrides. The code behaves the same, but it is simpler and easier to maintain.

## Changes

- Removed two redundant type assertions in response event handling.
- Removed one redundant type assertion during agent-card signature verification.
- Added a patch changeset for `@mastra/client-js`.
- Kept runtime behavior, public types, tests, fixtures, and compatibility casts unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->