### PR TITLE
refactor(server): remove redundant type assertions

### DIFF
--- a/.changeset/sharp-lines-clean.md
+++ b/.changeset/sharp-lines-clean.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Removed redundant type assertions without changing runtime behavior or public types.

--- a/packages/server/src/server/handlers/authorship.ts
+++ b/packages/server/src/server/handlers/authorship.ts
@@ -28,7 +28,7 @@ export function getCallerAuthorId(requestContext: RequestContext): string | null
 
   const user = requestContext.get(MASTRA_USER_KEY);
   if (user && typeof user === 'object' && 'id' in user) {
-    const id = (user as { id: unknown }).id;
+    const id = user.id;
     if (typeof id === 'string' && id.length > 0) {
       return id;
     }

--- a/packages/server/src/server/handlers/dynamic-workflows.ts
+++ b/packages/server/src/server/handlers/dynamic-workflows.ts
@@ -176,7 +176,7 @@ export const DELETE_DYNAMIC_WORKFLOW_ROUTE = createRoute({
       if (!store) throw new HTTPException(500, { message: 'workflowDefinitions storage domain is not available' });
 
       await store.delete(dynamicWorkflowId);
-      (mastra as Mastra).removeWorkflow(dynamicWorkflowId);
+      mastra.removeWorkflow(dynamicWorkflowId);
       return { success: true as const, message: `Workflow ${dynamicWorkflowId} deleted` };
     } catch (error) {
       return handleError(error, 'Error deleting dynamic workflow');

--- a/packages/server/src/server/handlers/mcp.ts
+++ b/packages/server/src/server/handlers/mcp.ts
@@ -53,7 +53,7 @@ export const LIST_MCP_SERVERS_ROUTE = createRoute({
       return { servers: [], total_count: 0, next: null };
     }
 
-    const serverList = Object.values(servers) as MastraMCPServerImplementation[];
+    const serverList = Object.values(servers);
     const totalCount = serverList.length;
 
     // Support both page/perPage and limit/offset for backwards compatibility

--- a/packages/server/src/server/handlers/schedules.ts
+++ b/packages/server/src/server/handlers/schedules.ts
@@ -313,7 +313,7 @@ export const LIST_SCHEDULE_TRIGGERS_ROUTE = createRoute({
     if (!schedule?.workflowId) {
       return { triggers };
     }
-    const workflowName = (schedule as WorkflowSchedule).workflowId;
+    const workflowName = schedule.workflowId;
     const hydrated = await Promise.all(
       triggers.map(async trigger => {
         if (trigger.outcome !== 'published' || !trigger.runId) return trigger;

--- a/packages/server/src/server/server-adapter/mcp-auth.ts
+++ b/packages/server/src/server/server-adapter/mcp-auth.ts
@@ -54,7 +54,7 @@ export function buildMcpAuthInfoFromRequestContext(requestContext: RequestContex
   const userRecord = (hasUser ? user : {}) as Record<string, unknown>;
 
   return {
-    token: hasToken ? (token as string) : '',
+    token: hasToken ? token : '',
     clientId: resolveClientId(userRecord),
     scopes: normalizeScopes(userRecord.scopes ?? userRecord.scope ?? userRecord.permissions),
     ...(hasUser ? { extra: { user: userRecord } } : {}),


### PR DESCRIPTION
## Description

Removes 5 redundant type assertions across 5 source files in caller identity, workflow handlers, and MCP helpers. Existing types and guards already provide the asserted types. Runtime behavior and public declarations are unchanged.

This branch typechecks independently. The source edits match the version validated with existing tests and JavaScript/declaration comparisons before the split. Test files, fixtures, and intentional compatibility casts are unchanged.

## Related issue(s)

Split from #23494.

## Type of change

- [x] Code refactoring

## Checklist

- [x] I have linked the related work above
- [x] Documentation changes are not applicable
- [x] Existing tests cover this refactor; test files are unchanged
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR removes unnecessary type checks from server code. The server behaves the same, but the code is simpler and clearer.

## Changes

- Removed redundant type assertions from caller identity, workflow, MCP, schedule, and authentication handlers.
- Added a patch changeset for `@mastra/server`.
- Kept runtime behavior, public types, tests, fixtures, and compatibility casts unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->