### PR TITLE
refactor(memory): remove redundant type assertions

### DIFF
--- a/.changeset/tender-walls-dream.md
+++ b/.changeset/tender-walls-dream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Removed redundant type assertions without changing runtime behavior or public types.

--- a/packages/memory/src/processors/observational-memory/extraction-runner.ts
+++ b/packages/memory/src/processors/observational-memory/extraction-runner.ts
@@ -129,7 +129,7 @@ ${extractorInstructions}${priorLines.length > 0 ? `\n\n## Prior Extracted Values
   }
 
   for (const extractor of structuredExtractors) {
-    const value = (object as Record<string, unknown>)[extractor.slug];
+    const value = object[extractor.slug];
     if (value === undefined || value === null || value === '') {
       continue;
     }

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-protocol.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-protocol.ts
@@ -91,7 +91,7 @@ function parseMetadata(value: unknown): RemindMessageMetadata | undefined {
 }
 
 export function getRemindMessageMetadata(message: MastraDBMessage): RemindMessageMetadata | undefined {
-  const metadata = message.content.metadata as Record<string, unknown> | undefined;
+  const metadata = message.content.metadata;
   return parseMetadata(metadata?.[REMIND_MESSAGE_METADATA_KEY]);
 }
 


### PR DESCRIPTION
## Description

Removes 2 redundant type assertions across 2 source files in structured extraction and reminder metadata. Existing types and guards already provide the asserted types. Runtime behavior and public declarations are unchanged.

This branch typechecks independently. The source edits match the version validated with existing tests and JavaScript/declaration comparisons before the split. Test files, fixtures, and intentional compatibility casts are unchanged.

## Related issue(s)

Split from #23494.

## Type of change

- [x] Code refactoring

## Checklist

- [x] I have linked the related work above
- [x] Documentation changes are not applicable
- [x] Existing tests cover this refactor; test files are unchanged
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR removes two unnecessary type conversions from memory code. The code already knows the correct types, so behavior stays the same while the code becomes simpler.

## Changes

- Removed a redundant type assertion in `extractStructuredValues`.
- Removed a redundant type assertion in `getRemindMessageMetadata`.
- Added a patch changeset for `@mastra/memory`.
- Preserved runtime behavior, public types, tests, fixtures, and compatibility casts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->