### PR TITLE
refactor(core): remove redundant casts in agents and models

### DIFF
--- a/.changeset/smooth-aliens-poke.md
+++ b/.changeset/smooth-aliens-poke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Removed redundant type assertions without changing runtime behavior or public types.

--- a/packages/core/src/agent-builder/ee/normalize-candidate.ts
+++ b/packages/core/src/agent-builder/ee/normalize-candidate.ts
@@ -102,7 +102,7 @@ function fromObject(value: Record<string, unknown>, origin: ModelCandidateOrigin
 
   // AI SDK language model instance: `{ provider, modelId, ... doGenerate }`
   if (typeof providerField === 'string' && typeof modelIdField === 'string') {
-    const isSdkInstance = typeof (value as { doGenerate?: unknown }).doGenerate === 'function';
+    const isSdkInstance = typeof value.doGenerate === 'function';
     return [
       {
         provider: providerField,
@@ -155,8 +155,8 @@ export function toModelCandidates(input: ModelCandidateInput): ModelCandidate[] 
     const candidates: ModelCandidate[] = [];
     input.forEach((variant, index) => {
       if (!isPlainObject(variant)) return;
-      const value = (variant as { value?: unknown }).value ?? variant;
-      const hasRules = isPlainObject(variant) && 'rules' in variant && (variant as { rules?: unknown }).rules != null;
+      const value = variant.value ?? variant;
+      const hasRules = isPlainObject(variant) && 'rules' in variant && variant.rules != null;
       const origin: ModelCandidateOrigin = hasRules ? 'conditional-variant' : 'conditional-default';
       const label = hasRules ? `variant[${index}]` : `variant[${index}] (default)`;
       if (typeof value === 'string') {

--- a/packages/core/src/agent/durable/utils/serialize-state.ts
+++ b/packages/core/src/agent/durable/utils/serialize-state.ts
@@ -182,9 +182,9 @@ export function serializeModelSettings(
   const source = settings as Record<string, unknown>;
   const out: SerializableModelSettings = {};
   const pickNumber = (key: keyof SerializableModelSettings) => {
-    const value = source[key as string];
+    const value = source[key];
     if (typeof value === 'number' && Number.isFinite(value)) {
-      (out as Record<string, unknown>)[key as string] = value;
+      (out as Record<string, unknown>)[key] = value;
     }
   };
 
@@ -198,7 +198,7 @@ export function serializeModelSettings(
   pickNumber('maxRetries');
 
   if (Array.isArray(source.stopSequences) && source.stopSequences.every(v => typeof v === 'string')) {
-    out.stopSequences = source.stopSequences as string[];
+    out.stopSequences = source.stopSequences;
   }
 
   // Headers are never serialized into the workflow input. They are stored

--- a/packages/core/src/agent/durable/workflows/shared/execute-scorers.ts
+++ b/packages/core/src/agent/durable/workflows/shared/execute-scorers.ts
@@ -4,11 +4,7 @@ import type { Mastra } from '../../../../mastra';
 import { createObservabilityContext } from '../../../../observability';
 import { RequestContext } from '../../../../request-context';
 import { MessageList } from '../../../message-list';
-import type {
-  DurableAgenticExecutionOutput,
-  DurableAgenticWorkflowInput,
-  SerializableScorersConfig,
-} from '../../types';
+import type { DurableAgenticExecutionOutput, DurableAgenticWorkflowInput } from '../../types';
 
 export interface ExecuteDurableAgentScorersParams {
   /** Workflow init data, carrying the serialized scorer config and run identity. */
@@ -39,7 +35,7 @@ export function executeDurableAgentScorers({
   requestContext,
   tracingContext,
 }: ExecuteDurableAgentScorersParams): void {
-  const scorers = initData.scorers as SerializableScorersConfig | undefined;
+  const scorers = initData.scorers;
   if (!scorers || Object.keys(scorers).length === 0) {
     return;
   }

--- a/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
@@ -119,7 +119,7 @@ export function createDurableLLMMappingStep() {
         | undefined;
       if (llmOutput.stepSpanData) {
         try {
-          const observability = (mastra as Mastra | undefined)?.observability?.getSelectedInstance({ requestContext });
+          const observability = mastra?.observability?.getSelectedInstance({ requestContext });
           stepSpan = observability?.rebuildSpan(llmOutput.stepSpanData as ExportedSpan<SpanType.MODEL_STEP>);
         } catch {
           // Span bookkeeping must never break the merge step.
@@ -152,9 +152,7 @@ export function createDurableLLMMappingStep() {
           // Start from the existing providerMetadata so it's preserved even when
           // toModelOutput is absent or fails — otherwise provider-executed tools
           // or tools without a mapper lose their metadata.
-          let providerMetadata: Record<string, unknown> | undefined = toolResult.providerMetadata as
-            | Record<string, unknown>
-            | undefined;
+          let providerMetadata: Record<string, unknown> | undefined = toolResult.providerMetadata;
           if (
             !toolResult.error &&
             toolResult.result != null &&
@@ -198,7 +196,7 @@ export function createDurableLLMMappingStep() {
               } catch (err) {
                 mappingSpan?.error({ error: err as Error, endSpan: true });
                 // toModelOutput errors are non-fatal — the tool result is still usable
-                (mastra as Mastra | undefined)
+                mastra
                   ?.getLogger?.()
                   ?.warn?.(`[DurableAgent] toModelOutput failed for tool "${toolResult.toolName}": ${err}`);
               }
@@ -322,9 +320,7 @@ export function createDurableLLMMappingStep() {
           });
         } catch (error) {
           // Span bookkeeping must never break the merge step.
-          (mastra as Mastra | undefined)
-            ?.getLogger?.()
-            ?.warn?.(`[DurableAgent] Failed to close model_step span: ${error}`);
+          mastra?.getLogger?.()?.warn?.(`[DurableAgent] Failed to close model_step span: ${error}`);
         }
       }
 
@@ -374,9 +370,7 @@ export function createDurableLLMMappingStep() {
           };
           await emitChunkEvent(pubsub, _runId, enrichedChunk);
         } catch (error) {
-          (mastra as Mastra | undefined)
-            ?.getLogger?.()
-            ?.warn?.(`[DurableAgent] Failed to emit deferred step-finish: ${error}`);
+          mastra?.getLogger?.()?.warn?.(`[DurableAgent] Failed to emit deferred step-finish: ${error}`);
         }
       }
 

--- a/packages/core/src/agent/durable/workflows/steps/scorer-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/scorer-execution.ts
@@ -122,7 +122,7 @@ export function createDurableScorerStep() {
 
         try {
           // Resolve the scorer from Mastra
-          const scorer = (mastra as Mastra)?.getScorer?.(scorerName) as MastraScorer | undefined;
+          const scorer = mastra?.getScorer?.(scorerName) as MastraScorer | undefined;
 
           if (!scorer) {
             logger?.warn?.(`Scorer ${scorerName} not found in Mastra, skipping`, { runId, scorerKey });

--- a/packages/core/src/agent/message-list/conversion/input-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/input-converter.ts
@@ -1,14 +1,8 @@
-import type { CoreMessage as CoreMessageV4, UIMessage as UIMessageV4 } from '@internal/ai-sdk-v4';
+import type { CoreMessage as CoreMessageV4 } from '@internal/ai-sdk-v4';
 
 import { AIV4Adapter, AIV5Adapter, AIV6Adapter } from '../adapters';
 import { TypeDetector } from '../detection/TypeDetector';
-import type {
-  MastraDBMessage,
-  MastraMessageV1,
-  MessageSource,
-  MemoryInfo,
-  UIMessageWithMetadata,
-} from '../state/types';
+import type { MastraDBMessage, MastraMessageV1, MessageSource, MemoryInfo } from '../state/types';
 import type { MessageInput } from '../types';
 import { stampMessageParts } from '../utils/stamp-part';
 
@@ -70,10 +64,7 @@ export function inputToMastraDBMessage(
     return stampMessageParts(AIV4Adapter.fromCoreMessage(message, context, messageSource), messageSource);
   }
   if (TypeDetector.isAIV4UIMessage(message)) {
-    return stampMessageParts(
-      AIV4Adapter.fromUIMessage(message as UIMessageV4 | UIMessageWithMetadata, context, messageSource),
-      messageSource,
-    );
+    return stampMessageParts(AIV4Adapter.fromUIMessage(message, context, messageSource), messageSource);
   }
 
   // Use custom ID generator if message doesn't have an ID, otherwise keep the original

--- a/packages/core/src/agent/message-list/detection/TypeDetector.ts
+++ b/packages/core/src/agent/message-list/detection/TypeDetector.ts
@@ -123,9 +123,7 @@ export class TypeDetector {
       !TypeDetector.isMastraMessage(msg) &&
       !('parts' in msg) &&
       'content' in msg &&
-      TypeDetector.hasAIV6CoreMessageCharacteristics(
-        msg as CoreMessageV4 | AIV5Type.ModelMessage | AIV6Type.ModelMessage | AIV7Type.ModelMessage | AIV4Message,
-      )
+      TypeDetector.hasAIV6CoreMessageCharacteristics(msg)
     );
   }
 

--- a/packages/core/src/agent/workflows/prepare-stream/client-tool-output-hooks.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/client-tool-output-hooks.ts
@@ -52,7 +52,7 @@ function unwrapToolOutput(value: unknown): { skip: true } | { skip: false; outpu
     'value' in value &&
     Object.keys(value).length === 2;
   if (isV5Wrapper && (value.type === 'error-text' || value.type === 'error-json')) return { skip: true };
-  return { skip: false, output: isV5Wrapper ? (value as Record<string, unknown>).value : value };
+  return { skip: false, output: isV5Wrapper ? value.value : value };
 }
 
 function getToolResult(part: unknown): ToolResult | undefined {
@@ -181,7 +181,7 @@ export async function applyClientToolModelOutput({
       if (
         mastraMetadata &&
         typeof mastraMetadata === 'object' &&
-        ('modelOutput' in mastraMetadata || (mastraMetadata as Record<string, unknown>).modelOutputComputed)
+        ('modelOutput' in mastraMetadata || mastraMetadata.modelOutputComputed)
       ) {
         continue;
       }

--- a/packages/core/src/coding-agent/index.ts
+++ b/packages/core/src/coding-agent/index.ts
@@ -34,7 +34,7 @@ const ECONNRESET_MESSAGE_PATTERN = /econnreset|socket hang up/i;
 function isECONNRESETError(error: unknown): boolean {
   if (!error) return false;
 
-  const code = typeof error === 'object' && 'code' in error ? (error as { code?: unknown }).code : undefined;
+  const code = typeof error === 'object' && 'code' in error ? error.code : undefined;
   if (typeof code === 'string' && code.toUpperCase() === 'ECONNRESET') return true;
 
   const message = error instanceof Error ? error.message : undefined;

--- a/packages/core/src/evals/scoreTraces/utils.ts
+++ b/packages/core/src/evals/scoreTraces/utils.ts
@@ -149,12 +149,12 @@ function extractInputMessages(agentSpan: SpanRecord): MastraDBMessage[] {
   }
 
   if (Array.isArray(input)) {
-    const messages = input.filter(isSpanMessage) as SpanMessage[];
+    const messages = input.filter(isSpanMessage);
     return messages.map(msg => createMastraDBMessage(msg, agentSpan.startedAt));
   }
 
   if (hasMessagesArray(input)) {
-    const messages = input.messages.filter(isSpanMessage) as SpanMessage[];
+    const messages = input.messages.filter(isSpanMessage);
     return messages.map(msg => createMastraDBMessage(msg, agentSpan.startedAt));
   }
   return [];
@@ -255,7 +255,7 @@ function prepareTraceForTransformation(trace: TraceRecord) {
   const spanTree = buildSpanTree(trace.spans);
 
   // Find the root agent run span
-  const rootAgentSpan = spanTree.rootSpans.find(span => span.spanType === 'agent_run') as SpanRecord | undefined;
+  const rootAgentSpan = spanTree.rootSpans.find(span => span.spanType === 'agent_run');
 
   if (!rootAgentSpan) {
     throw new Error('No root agent_run span found in trace');

--- a/packages/core/src/llm/model/embedding-router.ts
+++ b/packages/core/src/llm/model/embedding-router.ts
@@ -283,7 +283,7 @@ export class ModelRouterEmbeddingModel<VALUE extends string = string> implements
     const result = await this.providerModel.doEmbed({ ...args, headers });
     // Ensure warnings is always an array — AI SDK v6's embedMany spreads
     // result.warnings and crashes if it's undefined.
-    const warnings = (result as { warnings?: unknown[] }).warnings ?? [];
+    const warnings = result.warnings ?? [];
     return { ...result, warnings } as Awaited<ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>>;
   }
 }

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -220,7 +220,7 @@ export class MastraLLMVNext extends MastraBase {
         messageList,
         models: this.#models,
         logger: this.logger,
-        tools: tools as Tools,
+        tools,
         stopWhen: stopWhenToUse,
         toolChoice,
         modelSettings,

--- a/packages/core/src/llm/model/registry-generator.ts
+++ b/packages/core/src/llm/model/registry-generator.ts
@@ -32,28 +32,19 @@ interface GatewayWithStructuredOutputCapabilities {
 function hasAttachmentCapabilities(
   gateway: MastraModelGatewayInterface,
 ): gateway is MastraModelGatewayInterface & GatewayWithAttachmentCapabilities {
-  return (
-    'getAttachmentCapabilities' in gateway &&
-    typeof (gateway as { getAttachmentCapabilities?: unknown }).getAttachmentCapabilities === 'function'
-  );
+  return 'getAttachmentCapabilities' in gateway && typeof gateway.getAttachmentCapabilities === 'function';
 }
 
 function hasTemperatureCapabilities(
   gateway: MastraModelGatewayInterface,
 ): gateway is MastraModelGatewayInterface & GatewayWithTemperatureCapabilities {
-  return (
-    'getTemperatureCapabilities' in gateway &&
-    typeof (gateway as { getTemperatureCapabilities?: unknown }).getTemperatureCapabilities === 'function'
-  );
+  return 'getTemperatureCapabilities' in gateway && typeof gateway.getTemperatureCapabilities === 'function';
 }
 
 function hasStructuredOutputCapabilities(
   gateway: MastraModelGatewayInterface,
 ): gateway is MastraModelGatewayInterface & GatewayWithStructuredOutputCapabilities {
-  return (
-    'getStructuredOutputCapabilities' in gateway &&
-    typeof (gateway as { getStructuredOutputCapabilities?: unknown }).getStructuredOutputCapabilities === 'function'
-  );
+  return 'getStructuredOutputCapabilities' in gateway && typeof gateway.getStructuredOutputCapabilities === 'function';
 }
 
 /**

--- a/packages/core/src/llm/model/resolve-model.ts
+++ b/packages/core/src/llm/model/resolve-model.ts
@@ -1,7 +1,6 @@
 import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 import type { LanguageModelV3 } from '@ai-sdk/provider-v6';
 import type { LanguageModelV4 } from '@ai-sdk/provider-v7';
-import type { LanguageModelV1 } from '@internal/ai-sdk-v4';
 import type { Mastra } from '../../mastra';
 import { RequestContext } from '../../request-context';
 import { AISDKV4LegacyLanguageModel } from './aisdk/v4/model';
@@ -119,7 +118,7 @@ export async function resolveModelConfig(
     if (modelConfig.specificationVersion === 'v1') {
       // Wrap legacy v1 models so the underlying SDK client (and any
       // enumerable config) does not leak into observability spans.
-      return new AISDKV4LegacyLanguageModel(modelConfig as LanguageModelV1);
+      return new AISDKV4LegacyLanguageModel(modelConfig);
     }
     // Unknown specificationVersion from a third-party provider (e.g. ollama-ai-provider-v2).
     // If the model has doStream/doGenerate methods, wrap it as a modern model


### PR DESCRIPTION
## Description

Removes 27 redundant type assertions across 14 source files in agent execution, message conversion, and model handling. Existing types and guards already provide the asserted types. Runtime behavior and public declarations are unchanged.

This branch typechecks independently. The source edits match the version validated with existing tests and JavaScript/declaration comparisons before the split. Test files, fixtures, and intentional compatibility casts are unchanged.

## Related issue(s)

Split from #23494.

## Type of change

- [x] Code refactoring

## Checklist

- [x] I have linked the related work above
- [x] Documentation changes are not applicable
- [x] Existing tests cover this refactor; test files are unchanged
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR removes type casts that TypeScript can already verify. It keeps runtime behavior and public types unchanged while making the code simpler.

## Changes

- Removed 27 redundant type assertions across 14 `@mastra/core` source files.
- Simplified type handling in agent execution, message conversion, workflow processing, evaluations, and model handling.
- Removed unused type imports.
- Added a patch changeset for `@mastra/core`.
- Left tests, fixtures, and intentional compatibility casts unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->