### PR TITLE
refactor(core): remove redundant casts in workflow execution

### DIFF
--- a/.changeset/empty-kiwis-invite.md
+++ b/.changeset/empty-kiwis-invite.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Removed redundant type assertions in workflow execution without changing runtime behavior or public types.

--- a/packages/core/src/background-tasks/workflow.ts
+++ b/packages/core/src/background-tasks/workflow.ts
@@ -3,7 +3,6 @@ import { InternalSpans } from '../observability';
 import type { SuspendOptions } from '../workflows';
 import { createStep, createWorkflow } from '../workflows';
 import type { BackgroundTaskManager } from './manager';
-import type { BackgroundTaskStatus } from './types';
 import { BACKGROUND_TASK_WORKFLOW_ID } from './workflow-id';
 
 export { BACKGROUND_TASK_WORKFLOW_ID } from './workflow-id';
@@ -180,7 +179,7 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
         return { taskId, outcome: 'success' as const, result };
       } catch (error: any) {
         const currentTask = await storage.getTask(taskId);
-        if (!currentTask || (currentTask.status as BackgroundTaskStatus) === 'cancelled') {
+        if (!currentTask || currentTask.status === 'cancelled') {
           manager.deregisterTaskContext(taskId);
           return { taskId, outcome: 'cancelled' as const };
         }
@@ -260,7 +259,7 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
       }
 
       if (outcome === 'success') {
-        if ((task.status as BackgroundTaskStatus) === 'cancelled') {
+        if (task.status === 'cancelled') {
           manager.deregisterTaskContext(taskId);
           return { taskId, done: true };
         }

--- a/packages/core/src/loop/shared/compose-step-input.ts
+++ b/packages/core/src/loop/shared/compose-step-input.ts
@@ -55,6 +55,6 @@ export function composeStepInput(
     // Restore type-narrowed defaults for the canonical fields if the
     // processor returned undefined for any of them.
     messageId: processInputStepResult.messageId ?? current.messageId,
-    model: (processInputStepResult.model ?? current.model) as MastraLanguageModel,
+    model: processInputStepResult.model ?? current.model,
   };
 }

--- a/packages/core/src/loop/timeout.ts
+++ b/packages/core/src/loop/timeout.ts
@@ -129,7 +129,7 @@ export function guardStreamWithAbort<T>(
       new TransformStream<T, T>({
         flush: () => onSettled(),
       }) as any,
-    ) as ReadableStream<T>;
+    );
   }
 
   const reader = stream.getReader();

--- a/packages/core/src/loop/workflows/agentic-execution/index.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/index.ts
@@ -132,10 +132,10 @@ export function createAgenticExecutionWorkflow<Tools extends ToolSet = ToolSet, 
         // called this step. A pure-safe batch parallelizes even while an
         // approval/suspend tool stays registered; a batch that calls one still
         // serializes; run-wide requireToolApproval still forces sequential.
-        const stepActiveTools = _internal?.stepActiveTools as string[] | undefined;
+        const stepActiveTools = _internal?.stepActiveTools;
         toolCallForeachOptions.concurrency = resolveToolCallConcurrency({
           requireToolApproval: rest.requireToolApproval,
-          tools: ((_internal?.stepTools as Tools | undefined) ?? rest.tools) as Tools | undefined,
+          tools: (_internal?.stepTools as Tools | undefined) ?? rest.tools,
           activeTools: stepActiveTools,
           configuredConcurrency: configuredToolCallConcurrency,
           strategy: toolCallConcurrencyStrategy,

--- a/packages/core/src/loop/workflows/agentic-execution/is-task-complete-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/is-task-complete-step.ts
@@ -71,7 +71,7 @@ export function createIsTaskCompleteStep<Tools extends ToolSet = ToolSet, OUTPUT
         if (typeof firstUserMessage.content === 'string') {
           originalTask = firstUserMessage.content;
         } else if (firstUserMessage.content?.parts?.[0]?.type === 'text') {
-          originalTask = (firstUserMessage.content.parts[0] as { type: 'text'; text: string }).text;
+          originalTask = firstUserMessage.content.parts[0].text;
         }
       }
 

--- a/packages/core/src/worker/workers/scheduler-worker.ts
+++ b/packages/core/src/worker/workers/scheduler-worker.ts
@@ -1,4 +1,3 @@
-import type { IMastraLogger } from '../../logger';
 import { resolveAgentById } from '../../mastra/resolve-agent';
 import type { ScheduleTarget } from '../../storage/domains/schedules/base';
 import { computeScheduleDefinitionHash } from '../../workflows/scheduler/definition-hash';
@@ -106,7 +105,7 @@ export class SchedulerWorker extends MastraWorker {
       pubsub: deps.pubsub,
       config: { ...this.#config, isTargetReady, isTargetCurrent, canExecuteLocally },
     });
-    this.#scheduler.__setLogger(deps.logger as IMastraLogger);
+    this.#scheduler.__setLogger(deps.logger);
 
     // Register declarative schedules from workflow configs before starting
     // the tick loop. This syncs code-declared schedules to the DB.

--- a/packages/core/src/workflows/dynamic/json-schema-to-zod.ts
+++ b/packages/core/src/workflows/dynamic/json-schema-to-zod.ts
@@ -118,7 +118,7 @@ function walk(schema: JsonSchema, opts: JsonSchemaToZodOptions): z.ZodTypeAny {
     } else {
       // Mixed/non-string enums (e.g. [1, 2, 3] or ['a', 1]): preserve the
       // original member types via literal union instead of coercing to string.
-      const literals: z.ZodTypeAny[] = values.map(v => z.literal(v as string | number | boolean | null));
+      const literals: z.ZodTypeAny[] = values.map(v => z.literal(v));
       out = literals.length === 1 ? literals[0]! : z.union(literals as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]);
     }
   } else if (Array.isArray(schema.type)) {

--- a/packages/core/src/workflows/execution-engine.ts
+++ b/packages/core/src/workflows/execution-engine.ts
@@ -192,7 +192,7 @@ export abstract class ExecutionEngine extends MastraBase {
       try {
         await Promise.resolve(
           onError({
-            status: result.status as 'failed' | 'tripwire',
+            status: result.status,
             error: result.error,
             steps: result.steps,
             tripwire: result.tripwire,

--- a/packages/core/src/workflows/step-entry.ts
+++ b/packages/core/src/workflows/step-entry.ts
@@ -50,7 +50,7 @@ export function getEntryRetries(entry: SingleStepEntry, fallback?: number): numb
  * declarative variants have none.
  */
 export function getEntryComponent(entry: SingleStepEntry): string | undefined {
-  return entry.type === 'step' ? (entry.step as { component?: string }).component : undefined;
+  return entry.type === 'step' ? entry.step.component : undefined;
 }
 
 /**

--- a/packages/core/src/workflows/step-factories.ts
+++ b/packages/core/src/workflows/step-factories.ts
@@ -48,7 +48,7 @@ export function createStepFromAgent<TStepId extends string, TStepOutput>(
   // Determine output schema based on structuredOutput option
   const outputSchema = toStandardSchema(
     (options?.structuredOutput?.schema ?? z.object({ text: z.string() })) as PublicSchema<TStepOutput>,
-  ) as StandardSchemaWithJSON<TStepOutput>;
+  );
   const { retries, scorers, metadata } =
     options ??
     ({} as AgentStepOptions<TStepOutput> & {


### PR DESCRIPTION
## Description

Removes 12 redundant type assertions across 10 source files in workflow execution and loop helpers. Existing types and guards already provide the asserted types. Runtime behavior and public declarations are unchanged.

This branch typechecks independently. The source edits match the version validated with existing tests and JavaScript/declaration comparisons before the split. Test files, fixtures, and intentional compatibility casts are unchanged.

## Related issue(s)

Split from #23494.

## Type of change

- [x] Code refactoring

## Checklist

- [x] I have linked the related work above
- [x] Documentation changes are not applicable
- [x] Existing tests cover this refactor; test files are unchanged
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR removes unnecessary type assertions from workflow and loop code. The code already knows these types, so the change makes it simpler without changing behavior or public types.

## Changes

- Removed 12 redundant type assertions across 10 source files.
- Kept runtime behavior and exported declarations unchanged.
- Added a patch changeset for `@mastra/core`.
- Left tests, fixtures, and intentional compatibility casts unchanged.

## Validation

- The branch typechecks independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->