### PR TITLE
refactor(core): remove redundant casts in storage and channels

### DIFF
--- a/.changeset/great-parents-care.md
+++ b/.changeset/great-parents-care.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Removed redundant type assertions in storage and channels without changing runtime behavior or public types.

--- a/packages/core/src/channels/chat-driver-static.ts
+++ b/packages/core/src/channels/chat-driver-static.ts
@@ -331,7 +331,7 @@ export async function runStaticDriver({
         displayName: enr.displayName,
         argsSummary: enr.argsSummary,
         startedAt: Date.now(),
-        runId: (chunk as { runId?: string }).runId,
+        runId: chunk.runId,
         toolName: enr.toolName,
         args: (enr.args ?? {}) as Record<string, unknown>,
       });

--- a/packages/core/src/channels/state-adapter.ts
+++ b/packages/core/src/channels/state-adapter.ts
@@ -65,7 +65,7 @@ export class MastraStateAdapter implements StateAdapter {
       metadata: {
         ...thread.metadata,
         channel_subscribed: 'true',
-        ...this.ownerStamp(thread.metadata as Record<string, unknown> | undefined),
+        ...this.ownerStamp(thread.metadata),
       },
     });
   }
@@ -76,9 +76,9 @@ export class MastraStateAdapter implements StateAdapter {
     await this.memoryStore.patchThread({
       id: thread.id,
       metadata: {
-        ...((thread.metadata ?? {}) as Record<string, unknown>),
+        ...(thread.metadata ?? {}),
         channel_subscribed: 'false',
-        ...this.ownerStamp(thread.metadata as Record<string, unknown> | undefined),
+        ...this.ownerStamp(thread.metadata),
       },
     });
   }
@@ -287,7 +287,7 @@ export class MastraStateAdapter implements StateAdapter {
     });
     return (
       candidates.find(candidate => {
-        const metadata = (candidate.metadata ?? {}) as Record<string, unknown>;
+        const metadata = candidate.metadata ?? {};
         return !('channel_ownerId' in metadata);
       }) ?? null
     );

--- a/packages/core/src/channels/stream-helpers.ts
+++ b/packages/core/src/channels/stream-helpers.ts
@@ -286,7 +286,7 @@ export async function postFileAttachment(args: {
   logger?.debug?.('[CHANNEL] Received file chunk', {
     mimeType,
     dataType: typeof data,
-    size: typeof data === 'string' ? data.length : (data as Uint8Array)?.byteLength,
+    size: typeof data === 'string' ? data.length : data?.byteLength,
   });
   const ext = mimeType.split('/')[1]?.split(';')[0] || 'bin';
   const filename = payloadFilename ?? `generated.${ext}`;

--- a/packages/core/src/storage/domains/datasets/serialization.ts
+++ b/packages/core/src/storage/domains/datasets/serialization.ts
@@ -44,7 +44,7 @@ function findSerializationIssue(
       // Date, Map, Set, class instances, custom toJSON() objects, etc. change
       // shape during JSON persistence, so identical retries would no longer
       // deep-equal the persisted payload. Require explicit conversion instead.
-      const constructorName = (value as object).constructor?.name || 'unknown class';
+      const constructorName = value.constructor?.name || 'unknown class';
       return { path, reason: `non-plain object (${constructorName}) at ${path} would change during JSON persistence` };
     }
   }

--- a/packages/core/src/storage/domains/mcp-clients/inmemory.ts
+++ b/packages/core/src/storage/domains/mcp-clients/inmemory.ts
@@ -96,7 +96,7 @@ export class InMemoryMCPClientsStorage extends MCPClientsStorage {
       ...existingConfig,
       ...(authorId !== undefined && { authorId }),
       ...(activeVersionId !== undefined && { activeVersionId }),
-      ...(status !== undefined && { status: status as StorageMCPClientType['status'] }),
+      ...(status !== undefined && { status }),
       ...(metadata !== undefined && {
         metadata: { ...existingConfig.metadata, ...metadata },
       }),

--- a/packages/core/src/storage/domains/mcp-servers/inmemory.ts
+++ b/packages/core/src/storage/domains/mcp-servers/inmemory.ts
@@ -96,7 +96,7 @@ export class InMemoryMCPServersStorage extends MCPServersStorage {
       ...existingConfig,
       ...(authorId !== undefined && { authorId }),
       ...(activeVersionId !== undefined && { activeVersionId }),
-      ...(status !== undefined && { status: status as StorageMCPServerType['status'] }),
+      ...(status !== undefined && { status }),
       ...(metadata !== undefined && {
         metadata: { ...existingConfig.metadata, ...metadata },
       }),

--- a/packages/core/src/storage/domains/prompt-blocks/inmemory.ts
+++ b/packages/core/src/storage/domains/prompt-blocks/inmemory.ts
@@ -96,7 +96,7 @@ export class InMemoryPromptBlocksStorage extends PromptBlocksStorage {
       ...existingBlock,
       ...(authorId !== undefined && { authorId }),
       ...(activeVersionId !== undefined && { activeVersionId }),
-      ...(status !== undefined && { status: status as StoragePromptBlockType['status'] }),
+      ...(status !== undefined && { status }),
       ...(metadata !== undefined && {
         metadata: { ...existingBlock.metadata, ...metadata },
       }),

--- a/packages/core/src/storage/domains/scorer-definitions/inmemory.ts
+++ b/packages/core/src/storage/domains/scorer-definitions/inmemory.ts
@@ -105,7 +105,7 @@ export class InMemoryScorerDefinitionsStorage extends ScorerDefinitionsStorage {
       ...existingScorer,
       ...(authorId !== undefined && { authorId }),
       ...(activeVersionId !== undefined && { activeVersionId }),
-      ...(status !== undefined && { status: status as StorageScorerDefinitionType['status'] }),
+      ...(status !== undefined && { status }),
       ...(metadata !== undefined && {
         metadata: { ...existingScorer.metadata, ...metadata },
       }),

--- a/packages/core/src/storage/domains/skills/filesystem.ts
+++ b/packages/core/src/storage/domains/skills/filesystem.ts
@@ -111,7 +111,7 @@ export class FilesystemSkillsStorage extends SkillsStorage {
       ...(authorId !== undefined && { authorId }),
       ...(visibility !== undefined && { visibility }),
       ...(activeVersionId !== undefined && { activeVersionId }),
-      ...(status !== undefined && { status: status as StorageSkillType['status'] }),
+      ...(status !== undefined && { status }),
       updatedAt: new Date(),
     };
 
@@ -145,10 +145,7 @@ export class FilesystemSkillsStorage extends SkillsStorage {
       const changedFields = configFieldNames.filter(
         field =>
           field in configFields &&
-          !skillSnapshotFieldValuesEqual(
-            configFields[field as keyof typeof configFields],
-            latestConfig[field as keyof typeof latestConfig],
-          ),
+          !skillSnapshotFieldValuesEqual(configFields[field], latestConfig[field as keyof typeof latestConfig]),
       );
 
       if (changedFields.length > 0) {

--- a/packages/core/src/storage/domains/workspaces/inmemory.ts
+++ b/packages/core/src/storage/domains/workspaces/inmemory.ts
@@ -119,7 +119,7 @@ export class InMemoryWorkspacesStorage extends WorkspacesStorage {
       ...existingConfig,
       ...(authorId !== undefined && { authorId }),
       ...(activeVersionId !== undefined && { activeVersionId }),
-      ...(status !== undefined && { status: status as StorageWorkspaceType['status'] }),
+      ...(status !== undefined && { status }),
       ...(metadata !== undefined && {
         metadata: { ...existingConfig.metadata, ...metadata },
       }),
@@ -160,8 +160,7 @@ export class InMemoryWorkspacesStorage extends WorkspacesStorage {
       const changedFields = configFieldNames.filter(
         field =>
           field in configFields &&
-          JSON.stringify(configFields[field as keyof typeof configFields]) !==
-            JSON.stringify(latestConfig[field as keyof typeof latestConfig]),
+          JSON.stringify(configFields[field]) !== JSON.stringify(latestConfig[field as keyof typeof latestConfig]),
       );
 
       // Only create a new version if something actually changed

--- a/packages/core/src/workspace/skills/publish.ts
+++ b/packages/core/src/workspace/skills/publish.ts
@@ -183,7 +183,7 @@ function buildSkillFileNodes(files: WalkedFile[]): StorageSkillFileNode[] {
 
     const fileName = segments[segments.length - 1]!;
     const content = file.isBinary
-      ? (Buffer.isBuffer(file.content) ? file.content : Buffer.from(file.content as string)).toString('base64')
+      ? (Buffer.isBuffer(file.content) ? file.content : Buffer.from(file.content)).toString('base64')
       : (file.content as string);
     cursor.push({ name: fileName, type: 'file', content });
   }
@@ -273,7 +273,7 @@ export async function collectSkillForPublish(source: SkillSource, skillPath: str
 
     if (file.isBinary) {
       // Binary file: store as base64-encoded string
-      const buf = Buffer.isBuffer(file.content) ? file.content : Buffer.from(file.content as string);
+      const buf = Buffer.isBuffer(file.content) ? file.content : Buffer.from(file.content);
       const size = buf.length;
       const base64Content = buf.toString('base64');
 


### PR DESCRIPTION
## Description

Removes 17 redundant type assertions across 11 source files in storage adapters, channels, and skill publishing. Existing types and guards already provide the asserted types. Runtime behavior and public declarations are unchanged.

This branch typechecks independently. The source edits match the version validated with existing tests and JavaScript/declaration comparisons before the split. Test files, fixtures, and intentional compatibility casts are unchanged.

## Related issue(s)

Split from #23494.

## Type of change

- [x] Code refactoring

## Checklist

- [x] I have linked the related work above
- [x] Documentation changes are not applicable
- [x] Existing tests cover this refactor; test files are unchanged
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR removes unnecessary type labels from internal code. The code keeps the same behavior and public types.

## Changes

- Removed 17 redundant type assertions across 11 core files.
- Simplified storage adapter, channel, dataset, and skill publishing code.
- Added a patch changeset for `@mastra/core`.
- Kept tests, fixtures, compatibility casts, runtime behavior, and public declarations unchanged.
- Validated typechecking, existing tests, and JavaScript/declaration output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->