### PR TITLE
fix(core): bound snapshot batches during suspended-run discovery

### DIFF
--- a/.changeset/bold-states-press.md
+++ b/.changeset/bold-states-press.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved suspended run discovery to retain fewer workflow snapshots while processing large sets of suspended runs.

--- a/packages/core/src/agent/__tests__/suspended-run-discovery.test.ts
+++ b/packages/core/src/agent/__tests__/suspended-run-discovery.test.ts
@@ -339,6 +339,83 @@ describe('suspended-run discovery', () => {
       expect((await agent.listSuspendedRuns({ resourceId: 'resource-1', perPage: 2 })).runs).toHaveLength(3);
     }, 30000);
 
+    it('scans bounded storage pages while filtering and counting across workflow names', async () => {
+      const storage = new InMemoryStore();
+      const { agent } = createSuspendedSetup({ storage });
+      const { runId } = await suspendRun(agent, 'thread-1', 'resource-1');
+      const workflowsStore = (await storage.getStore('workflows'))!;
+      const seedRun = await workflowsStore.getWorkflowRunById({ runId, workflowName: 'agentic-loop' });
+      expect(seedRun).not.toBeNull();
+      const seedSnapshot = seedRun!.snapshot as WorkflowRunState;
+      type StoredRun = Awaited<ReturnType<typeof workflowsStore.listWorkflowRuns>>['runs'][number];
+
+      const createRun = (runId: string, snapshot: WorkflowRunState | string, workflowName = 'agentic-loop') =>
+        ({
+          runId,
+          workflowName,
+          resourceId: 'resource-1',
+          snapshot,
+          createdAt: new Date(0),
+          updatedAt: new Date(0),
+        }) satisfies StoredRun;
+      const snapshotForAgent = (agentId: string) => {
+        const snapshot = structuredClone(seedSnapshot);
+        for (const key in snapshot.context) {
+          const step = snapshot.context[key];
+          if (step?.status === 'suspended' && step.suspendPayload) {
+            step.suspendPayload.__agentId = agentId;
+          }
+        }
+        return snapshot;
+      };
+      const unrelatedRuns = Array.from({ length: 100 }, (_, index) =>
+        createRun(`other-${index}`, snapshotForAgent('other-agent')),
+      );
+      const runningSnapshot = structuredClone(seedSnapshot);
+      runningSnapshot.status = 'running';
+      const regularRuns = [
+        ...unrelatedRuns,
+        createRun('regular-first', structuredClone(seedSnapshot)),
+        createRun('regular-second', JSON.stringify(seedSnapshot)),
+        createRun('malformed', '{'),
+        createRun('not-suspended', runningSnapshot),
+        ...Array.from({ length: 96 }, (_, index) => createRun(`other-late-${index}`, snapshotForAgent('other-agent'))),
+        createRun('regular-third', structuredClone(seedSnapshot)),
+      ];
+      const durableRuns = [createRun('durable-first', structuredClone(seedSnapshot), DurableStepIds.AGENTIC_LOOP)];
+      const runsByWorkflow = new Map([
+        ['agentic-loop', regularRuns],
+        [DurableStepIds.AGENTIC_LOOP, durableRuns],
+      ]);
+      const listSpy = vi.spyOn(workflowsStore, 'listWorkflowRuns').mockImplementation(async args => {
+        const workflowRuns = runsByWorkflow.get(args?.workflowName!) ?? [];
+        const currentPage = args?.page ?? 0;
+        const currentPerPage = args?.perPage ?? workflowRuns.length;
+        if (typeof currentPerPage !== 'number') throw new Error('expected numeric storage page size');
+
+        return {
+          runs: workflowRuns.slice(currentPage * currentPerPage, (currentPage + 1) * currentPerPage),
+          total: workflowRuns.length,
+        };
+      });
+
+      const firstPage = await agent.listSuspendedRuns({ resourceId: 'resource-1', perPage: 1, page: 0 });
+      expect(firstPage).toMatchObject({ total: 4, runs: [{ runId: 'regular-first' }] });
+      expect(listSpy.mock.calls.map(([args]) => [args.workflowName, args.page, args.perPage])).toEqual([
+        ['agentic-loop', 0, 100],
+        ['agentic-loop', 1, 100],
+        ['agentic-loop', 2, 100],
+        [DurableStepIds.AGENTIC_LOOP, 0, 100],
+      ]);
+      expect(listSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'suspended', resourceId: 'resource-1', perPage: 100 }),
+      );
+
+      listSpy.mockClear();
+      const secondPage = await agent.listSuspendedRuns({ resourceId: 'resource-1', perPage: 2, page: 1 });
+      expect(secondPage).toMatchObject({ total: 4, runs: [{ runId: 'regular-third' }, { runId: 'durable-first' }] });
+    }, 30000);
+
     it('only returns runs owned by the listing agent', async () => {
       const storage = new InMemoryStore();
       const agentA = new Agent({

--- a/packages/core/src/agent/__tests__/suspended-run-discovery.test.ts
+++ b/packages/core/src/agent/__tests__/suspended-run-discovery.test.ts
@@ -385,7 +385,32 @@ describe('suspended-run discovery', () => {
         ...Array.from({ length: 96 }, (_, index) => createRun(`other-late-${index}`, snapshotForAgent('other-agent'))),
         createRun('regular-third', structuredClone(seedSnapshot)),
       ];
-      const durableRuns = [createRun('durable-first', structuredClone(seedSnapshot), DurableStepIds.AGENTIC_LOOP)];
+      const durableSnapshot = structuredClone(seedSnapshot);
+      for (const step of Object.values(durableSnapshot.context)) {
+        if (step?.status === 'suspended' && step.suspendPayload) {
+          delete step.suspendPayload.__agentId;
+          delete step.suspendPayload.__streamState;
+        }
+      }
+      durableSnapshot.context.input = {
+        agentId: agent.id,
+        messageListState: { memoryInfo: { threadId: 'thread-1', resourceId: 'resource-1' } },
+      };
+      const durableRuns = [createRun('durable-first', durableSnapshot, DurableStepIds.AGENTIC_LOOP)];
+      const summaryReads = new Set<string>();
+      for (const run of [...regularRuns, ...durableRuns]) {
+        if (typeof run.snapshot === 'string') continue;
+        for (const step of Object.values(run.snapshot.context)) {
+          if (step?.status !== 'suspended' || !step.suspendPayload) continue;
+          const metadata = step.suspendPayload.__workflow_meta;
+          Object.defineProperty(step.suspendPayload, '__workflow_meta', {
+            get() {
+              summaryReads.add(run.runId);
+              return metadata;
+            },
+          });
+        }
+      }
       const runsByWorkflow = new Map([
         ['agentic-loop', regularRuns],
         [DurableStepIds.AGENTIC_LOOP, durableRuns],
@@ -404,6 +429,7 @@ describe('suspended-run discovery', () => {
 
       const firstPage = await agent.listSuspendedRuns({ resourceId: 'resource-1', perPage: 1, page: 0 });
       expect(firstPage).toMatchObject({ total: 4, runs: [{ runId: 'regular-first' }] });
+      expect([...summaryReads]).toEqual(['regular-first']);
       expect(listSpy.mock.calls.map(([args]) => [args?.workflowName, args?.page, args?.perPage])).toEqual([
         ['agentic-loop', 0, 100],
         ['agentic-loop', 1, 100],
@@ -415,8 +441,18 @@ describe('suspended-run discovery', () => {
       );
 
       listSpy.mockClear();
-      const secondPage = await agent.listSuspendedRuns({ resourceId: 'resource-1', perPage: 2, page: 1 });
-      expect(secondPage).toMatchObject({ total: 4, runs: [{ runId: 'regular-third' }, { runId: 'durable-first' }] });
+      summaryReads.clear();
+      const secondPage = await agent.listSuspendedRuns({
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        perPage: 2,
+        page: 1,
+      });
+      expect(secondPage).toMatchObject({
+        total: 4,
+        runs: [{ runId: 'regular-third' }, { runId: 'durable-first', threadId: 'thread-1', resourceId: 'resource-1' }],
+      });
+      expect([...summaryReads]).toEqual(['regular-third', 'durable-first']);
 
       runsByWorkflow.set(
         'agentic-loop',

--- a/packages/core/src/agent/__tests__/suspended-run-discovery.test.ts
+++ b/packages/core/src/agent/__tests__/suspended-run-discovery.test.ts
@@ -349,15 +349,18 @@ describe('suspended-run discovery', () => {
       const seedSnapshot = seedRun!.snapshot as WorkflowRunState;
       type StoredRun = Awaited<ReturnType<typeof workflowsStore.listWorkflowRuns>>['runs'][number];
 
-      const createRun = (runId: string, snapshot: WorkflowRunState | string, workflowName = 'agentic-loop') =>
-        ({
+      let timestamp = 0;
+      const createRun = (runId: string, snapshot: WorkflowRunState | string, workflowName = 'agentic-loop') => {
+        const createdAt = new Date(timestamp++);
+        return {
           runId,
           workflowName,
           resourceId: 'resource-1',
           snapshot,
-          createdAt: new Date(0),
-          updatedAt: new Date(0),
-        }) satisfies StoredRun;
+          createdAt,
+          updatedAt: createdAt,
+        } satisfies StoredRun;
+      };
       const snapshotForAgent = (agentId: string) => {
         const snapshot = structuredClone(seedSnapshot);
         for (const key in snapshot.context) {
@@ -401,7 +404,7 @@ describe('suspended-run discovery', () => {
 
       const firstPage = await agent.listSuspendedRuns({ resourceId: 'resource-1', perPage: 1, page: 0 });
       expect(firstPage).toMatchObject({ total: 4, runs: [{ runId: 'regular-first' }] });
-      expect(listSpy.mock.calls.map(([args]) => [args.workflowName, args.page, args.perPage])).toEqual([
+      expect(listSpy.mock.calls.map(([args]) => [args?.workflowName, args?.page, args?.perPage])).toEqual([
         ['agentic-loop', 0, 100],
         ['agentic-loop', 1, 100],
         ['agentic-loop', 2, 100],
@@ -414,6 +417,21 @@ describe('suspended-run discovery', () => {
       listSpy.mockClear();
       const secondPage = await agent.listSuspendedRuns({ resourceId: 'resource-1', perPage: 2, page: 1 });
       expect(secondPage).toMatchObject({ total: 4, runs: [{ runId: 'regular-third' }, { runId: 'durable-first' }] });
+
+      runsByWorkflow.set(
+        'agentic-loop',
+        Array.from({ length: 100 }, (_, index) => createRun(`exact-multiple-${index}`, structuredClone(seedSnapshot))),
+      );
+      runsByWorkflow.set(DurableStepIds.AGENTIC_LOOP, []);
+      listSpy.mockClear();
+
+      const outOfRangePage = await agent.listSuspendedRuns({ resourceId: 'resource-1', perPage: 10, page: 10 });
+      expect(outOfRangePage).toEqual({ runs: [], total: 100 });
+      expect(listSpy.mock.calls.map(([args]) => [args?.workflowName, args?.page, args?.perPage])).toEqual([
+        ['agentic-loop', 0, 100],
+        ['agentic-loop', 1, 100],
+        [DurableStepIds.AGENTIC_LOOP, 0, 100],
+      ]);
     }, 30000);
 
     it('only returns runs owned by the listing agent', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -8219,6 +8219,10 @@ export class Agent<
    * agent's id, and runs whose snapshots carry a different id are skipped. Filter by
    * `threadId`/`resourceId` to scope results to a conversation.
    *
+   * Storage pagination is offset-based, so concurrent changes or rows with tied sort
+   * values can make a multi-page discovery reflect the storage adapter's ordering
+   * rather than a transactional snapshot.
+   *
    * @example
    * ```typescript
    * const { runs } = await agent.listSuspendedRuns({ threadId, resourceId });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -8265,69 +8265,77 @@ export class Agent<
     }
 
     // resourceId is a storage column, so push it down to narrow the query;
-    // threadId lives inside the snapshot state, so fetch matching rows and
-    // filter/paginate here to keep `total` accurate. The in-process resource
-    // check below stays as the correctness backstop: adapters silently skip
-    // the filter when the column is missing, and rows persisted before the
+    // threadId lives inside the snapshot state, so filter here. The in-process
+    // resource check below stays as the correctness backstop: adapters silently
+    // skip the filter when the column is missing, and rows persisted before the
     // column was populated carry the resource only in the snapshot. Durable
     // agents persist their agentic loop under a separate workflow name, so
     // query both — otherwise suspended durable runs are never discoverable.
-    const runs: Awaited<ReturnType<typeof workflowsStore.listWorkflowRuns>>['runs'] = [];
-    for (const workflowName of ['agentic-loop', DurableStepIds.AGENTIC_LOOP]) {
-      const { runs: workflowRuns } = await workflowsStore.listWorkflowRuns({
-        workflowName,
-        status: 'suspended',
-        resourceId,
-        fromDate,
-        toDate,
-      });
-      runs.push(...workflowRuns);
-    }
-
+    const storagePageSize = 100;
+    const isPaginated = perPage !== undefined && page !== undefined;
+    const firstRequestedMatch = isPaginated ? page * perPage : 0;
+    const pastLastRequestedMatch = isPaginated ? firstRequestedMatch + perPage : Number.POSITIVE_INFINITY;
     const matchedRuns: AgentRun[] = [];
-    for (const run of runs) {
-      let snapshot = run.snapshot;
-      if (typeof snapshot === 'string') {
-        try {
-          snapshot = JSON.parse(snapshot) as WorkflowRunState;
-        } catch {
-          continue;
+    let total = 0;
+
+    for (const workflowName of ['agentic-loop', DurableStepIds.AGENTIC_LOOP]) {
+      for (let storagePage = 0; ; storagePage++) {
+        const { runs: workflowRuns } = await workflowsStore.listWorkflowRuns({
+          workflowName,
+          status: 'suspended',
+          resourceId,
+          fromDate,
+          toDate,
+          perPage: storagePageSize,
+          page: storagePage,
+        });
+
+        for (const run of workflowRuns) {
+          let snapshot = run.snapshot;
+          if (typeof snapshot === 'string') {
+            try {
+              snapshot = JSON.parse(snapshot) as WorkflowRunState;
+            } catch {
+              continue;
+            }
+          }
+          if (snapshot?.status !== 'suspended') continue;
+
+          // Snapshots persist the owning agent's id, so runs started by other
+          // agents sharing the same agentic-loop snapshot storage are skipped.
+          // Default-deny: a snapshot whose owning agent id is missing or does not
+          // match is not surfaced, so runs cannot leak across agents.
+          const runAgentId = this.#getSnapshotAgentId(snapshot);
+          if (runAgentId !== this.id) continue;
+
+          // thread/resource info travels in the suspended stream state; the run row's
+          // resourceId column is used as the primary source when present.
+          const memoryInfo = this.#getSnapshotMemoryInfo(snapshot);
+          const runThreadId = memoryInfo?.threadId;
+          const runResourceId = run.resourceId ?? memoryInfo?.resourceId;
+          if (threadId && runThreadId !== threadId) continue;
+          if (resourceId && runResourceId !== resourceId) continue;
+
+          // Storage pagination bounds candidate snapshots. Filtered output
+          // pagination still needs to scan every batch to return an exact total.
+          const matchingIndex = total++;
+          if (matchingIndex < firstRequestedMatch || matchingIndex >= pastLastRequestedMatch) continue;
+
+          matchedRuns.push({
+            runId: run.runId,
+            status: 'suspended',
+            threadId: runThreadId,
+            resourceId: runResourceId,
+            suspendedAt: run.updatedAt,
+            toolCalls: this.#getSuspendedToolCalls(snapshot),
+          });
         }
+
+        if (workflowRuns.length < storagePageSize) break;
       }
-      if (snapshot?.status !== 'suspended') continue;
-
-      // Snapshots persist the owning agent's id, so runs started by other
-      // agents sharing the same agentic-loop snapshot storage are skipped.
-      // Default-deny: a snapshot whose owning agent id is missing or does not
-      // match is not surfaced, so runs cannot leak across agents.
-      const runAgentId = this.#getSnapshotAgentId(snapshot);
-      if (runAgentId !== this.id) continue;
-
-      // thread/resource info travels in the suspended stream state; the run row's
-      // resourceId column is used as the primary source when present.
-      const memoryInfo = this.#getSnapshotMemoryInfo(snapshot);
-      const runThreadId = memoryInfo?.threadId;
-      const runResourceId = run.resourceId ?? memoryInfo?.resourceId;
-      if (threadId && runThreadId !== threadId) continue;
-      if (resourceId && runResourceId !== resourceId) continue;
-
-      matchedRuns.push({
-        runId: run.runId,
-        status: 'suspended',
-        threadId: runThreadId,
-        resourceId: runResourceId,
-        suspendedAt: run.updatedAt,
-        toolCalls: this.#getSuspendedToolCalls(snapshot),
-      });
     }
 
-    const total = matchedRuns.length;
-    const paginatedRuns =
-      perPage !== undefined && page !== undefined
-        ? matchedRuns.slice(page * perPage, (page + 1) * perPage)
-        : matchedRuns;
-
-    return { runs: paginatedRuns, total };
+    return { runs: matchedRuns, total };
   }
 
   abortThreadStream(options: AgentSubscribeToThreadOptions): boolean {


### PR DESCRIPTION
`listSuspendedRuns()` currently loads all candidate workflow snapshots before filtering, which can create a large buffer when many runs are suspended. This scans regular and durable workflow snapshots in sequential 100-row storage batches instead, retaining only the requested summaries while continuing to count matches.

The public API stays the same:

```ts
// Before: loads all candidate snapshots, filters, then slices.
// After: filters storage batches and retains the requested page.
const { runs, total } = await agent.listSuspendedRuns({
  resourceId,
  perPage: 10,
  page: 0,
});
```

Ownership and thread/resource filtering are preserved. This bounds core's candidate batches, not every adapter's internal allocations; offset pagination can still duplicate or omit rows under concurrent changes or tied sort values.

Verified with 31 focused discovery/approval tests, the core typecheck, and a built-core LibSQL demo: the baseline fetched 250 rows at once, while this branch fetched at most 100 with identical results. The demo does not measure peak-memory reduction.
