### PR TITLE
fix(factory): list org custom providers as connected in onboarding

### DIFF
--- a/.changeset/petite-eggs-heal.md
+++ b/.changeset/petite-eggs-heal.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed the Factory onboarding model step so org custom providers appear as connected providers and can be chosen as the Factory default model.

--- a/mastracode/factory-ui/src/hooks/use-custom-providers.ts
+++ b/mastracode/factory-ui/src/hooks/use-custom-providers.ts
@@ -20,13 +20,23 @@ export function useCustomProvidersQuery() {
   });
 }
 
+// A custom provider is also a row in the provider catalogue and its models
+// appear in the model list, so both refetch alongside the custom list.
+function invalidateCustomProviderQueries(queryClient: ReturnType<typeof useQueryClient>) {
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: queryKeys.customProviders() }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.providers() }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.availableModels() }),
+  ]);
+}
+
 export function useSaveCustomProvider() {
   const { client } = useApiConfig();
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (body: SaveCustomProviderBody) =>
       client.post<{ ok: true; provider?: CustomProviderInfo }>('/web/config/custom-providers', body),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.customProviders() }),
+    onSuccess: () => invalidateCustomProviderQueries(queryClient),
   });
 }
 
@@ -40,6 +50,6 @@ export function useRemoveCustomProvider() {
   return useMutation({
     mutationFn: ({ id }: RemoveCustomProviderArgs) =>
       client.del<OkResponse>(`/web/config/custom-providers/${encodeURIComponent(id)}`),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.customProviders() }),
+    onSuccess: () => invalidateCustomProviderQueries(queryClient),
   });
 }

--- a/mastracode/factory-ui/src/ui/domains/settings/components/ProviderAccessSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/ProviderAccessSection.tsx
@@ -116,7 +116,9 @@ export function ProviderAccessSection({ description }: { description?: string })
   const [activeOAuth, setActiveOAuth] = useState<ActiveOAuthSession>();
   const [keyDialogProvider, setKeyDialogProvider] = useState<ProviderInfo>();
 
-  const providers = providersQuery.data ?? [];
+  // Custom providers are edited in their own section; their keys live on the
+  // custom-provider record, not under the provider key routes used here.
+  const providers = (providersQuery.data ?? []).filter(provider => !provider.custom);
   const authEnabled = authQuery.data?.authEnabled === true;
   const canWriteOrgKey = !authEnabled || (orgKeyAdminQuery.data ?? true);
   const scopeOptions: SettingsScope[] = authEnabled ? ['personal', 'org'] : ['personal'];

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/CreateFactoryFlow.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/CreateFactoryFlow.msw.test.tsx
@@ -251,6 +251,42 @@ describe('Create Factory wizard', () => {
     expect(sessionStorage.getItem(STEP_KEY)).toBeNull();
   });
 
+  it('lists an org custom provider as connected and saves one of its models', async () => {
+    const calls: string[] = [];
+    seedDraft('project-management');
+    const { patchedBodies } = stubModelStepEndpoints(calls);
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/linear/status`, () =>
+        HttpResponse.json({ enabled: true, connected: false, reason: 'not_connected' }),
+      ),
+      http.get(`${TEST_BASE_URL}/web/config/providers`, () =>
+        HttpResponse.json({
+          providers: [
+            { provider: 'anthropic', source: 'none', oauth: { supported: true, modes: ['paste-code'] } },
+            { provider: 'acme', source: 'stored-org', orgKey: true, orgCredential: 'api_key', custom: true },
+          ],
+        }),
+      ),
+      http.get(`${TEST_BASE_URL}/web/config/models`, () =>
+        HttpResponse.json({ models: [{ id: 'acme/fast-1', provider: 'acme', modelName: 'fast-1', hasApiKey: true }] }),
+      ),
+    );
+    const user = userEvent.setup();
+
+    const { client } = renderFlow();
+
+    await user.click(await screen.findByRole('button', { name: 'Skip' }));
+
+    const acme = await screen.findByRole('option', { name: /acme/i });
+    expect(acme).toHaveTextContent('Connected');
+    await user.click(acme);
+    await user.click(await screen.findByRole('option', { name: /acme\/fast-1/ }));
+
+    await waitForMutationsIdle(client);
+    expect(patchedBodies).toEqual([{ defaultModelId: 'acme/fast-1' }]);
+    expect(screen.getByTestId('pathname')).toHaveTextContent('/factories/fp-1');
+  });
+
   it('skips the intake write when the repository already feeds issue intake', async () => {
     const calls: string[] = [];
     seedDraft('model-provider');

--- a/mastracode/factory/src/routes/config.test.ts
+++ b/mastracode/factory/src/routes/config.test.ts
@@ -251,6 +251,20 @@ describe('buildProviderAccess', () => {
     expect(access.cerebras).toBe('apikey');
     expect(access.xai).toBe('apikey');
   });
+
+  it('grants custom providers by their stored key, never by the catalog', async () => {
+    const access = await buildProviderAccess({
+      controller: makeAgentController([]),
+      tenantCredentials: [],
+      customProviders: [
+        { providerId: 'acme', apiKey: 'sk-acme' },
+        { providerId: 'keyless', apiKey: undefined },
+      ],
+    });
+
+    expect(access.acme).toBe('apikey');
+    expect(access.keyless).toBe(false);
+  });
 });
 
 // ── Scoped API key routes (tenant mode) ─────────────────────────────────
@@ -512,6 +526,53 @@ describe('GET /web/config/models', () => {
     expect(await res.json()).toEqual({
       models: [{ id: 'acme/fast-1', provider: 'acme', modelName: 'fast-1', hasApiKey: true }],
     });
+  });
+});
+
+describe('GET /web/config/providers with custom providers', () => {
+  async function buildApp(orgId: string) {
+    const seed = await createFactoryStorageForTests();
+    await seed.customProviders.upsert({
+      orgId: 'org1',
+      userId: 'user-a',
+      input: { providerId: 'acme', name: 'Acme', url: 'https://llm.acme.dev/v1', apiKey: 'sk', models: ['fast-1'] },
+    });
+    await seed.customProviders.upsert({
+      orgId: 'org1',
+      userId: 'user-a',
+      input: { providerId: 'keyless', name: 'Keyless', url: 'https://keyless.dev/v1', models: ['m-1'] },
+    });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('factoryAuthUser' as never, { workosId: 'user-a', organizationId: orgId } as never);
+      await next();
+    });
+    mountApiRoutes(
+      app as any,
+      new ConfigRoutes({
+        auth: fakeRouteAuth(),
+        controller: makeAgentController([{ provider: 'anthropic', hasApiKey: false }]),
+        modelCredentials: seed.credentials,
+        customProviders: seed.customProviders,
+      }).routes(),
+    );
+    return app;
+  }
+
+  it('lists keyed custom providers of the caller org as connected org keys', async () => {
+    const res = await buildApp('org1').then(app => app.request('/web/config/providers'));
+    expect(res.status).toBe(200);
+    const { providers } = await res.json();
+    expect(providers).toEqual([
+      expect.objectContaining({ provider: 'anthropic', source: 'none' }),
+      { provider: 'acme', source: 'stored-org', orgKey: true, orgCredential: 'api_key', custom: true },
+    ]);
+  });
+
+  it('keeps custom providers invisible across organizations', async () => {
+    const res = await buildApp('org2').then(app => app.request('/web/config/providers'));
+    const { providers } = await res.json();
+    expect(providers.map((p: { provider: string }) => p.provider)).toEqual(['anthropic']);
   });
 });
 
@@ -952,6 +1013,7 @@ describe('OM routes with a tenant', () => {
         auth: fakeRouteAuth({ enabled: opts.authEnabled !== false }),
         controller,
         modelCredentials: seed.credentials,
+        customProviders: seed.customProviders,
         ...(opts.withStorage === false ? {} : { memorySettings: seed.memorySettings, factoryProjects: seed.projects }),
       }).routes(),
     );
@@ -1018,6 +1080,38 @@ describe('OM routes with a tenant', () => {
     });
     // The personal row must remain untouched.
     await expect(seed.memorySettings.get({ orgId: 'org1', userId: 'user-a' })).resolves.toBeNull();
+  });
+
+  it('seeds OM defaults from a custom provider model of the caller org', async () => {
+    await seed.customProviders.upsert({
+      orgId: 'org1',
+      userId: 'user-a',
+      input: { providerId: 'acme', name: 'Acme', url: 'https://llm.acme.dev/v1', apiKey: 'sk', models: ['fast-1'] },
+    });
+    const res = await postJson(buildApp(makeOmSession()), '/web/config/om/provider-defaults', {
+      providerId: 'acme',
+      factoryModelId: 'acme/fast-1',
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).config).toMatchObject({
+      observerModelId: 'acme/fast-1',
+      reflectorModelId: 'acme/fast-1',
+    });
+  });
+
+  it('rejects OM defaults for a custom provider of another org', async () => {
+    await seed.customProviders.upsert({
+      orgId: 'org2',
+      userId: 'user-b',
+      input: { providerId: 'acme', name: 'Acme', url: 'https://llm.acme.dev/v1', apiKey: 'sk', models: ['fast-1'] },
+    });
+    const res = await postJson(buildApp(makeOmSession()), '/web/config/om/provider-defaults', {
+      providerId: 'acme',
+      factoryModelId: 'acme/fast-1',
+    });
+
+    expect(res.status).toBe(400);
   });
 
   it('rejects factory-scoped OM access for a factory outside the caller org', async () => {

--- a/mastracode/factory/src/routes/config.ts
+++ b/mastracode/factory/src/routes/config.ts
@@ -102,6 +102,8 @@ export interface ProviderInfo {
   orgCredential?: 'oauth' | 'api_key';
   /** Web OAuth sign-in capability, when the provider supports it. */
   oauth?: { supported: true; modes: LoginSessionKind[] };
+  /** Org custom provider, managed under custom providers rather than provider keys. */
+  custom?: true;
 }
 
 /** Minimal session surface a pack activation touches. */
@@ -233,6 +235,45 @@ export interface CustomProviderInfo {
   models: string[];
 }
 
+/**
+ * The caller's org custom providers, or `[]` when custom-provider storage is
+ * unavailable or the caller has no tenant. Callers fail soft: the built-in
+ * catalogue still serves.
+ */
+async function listCallerCustomProviders({
+  c,
+  auth,
+  customProviders,
+}: {
+  c: Context;
+  auth: RouteAuth;
+  customProviders?: CustomProvidersStorage;
+}): Promise<CustomProviderRecord[]> {
+  if (!customProviders) return [];
+  try {
+    const ctx = await resolveCustomProvidersContext({ c, auth, customProviders });
+    return 'response' in ctx ? [] : await ctx.storage.list({ orgId: ctx.orgId });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Custom providers that carry a key, shaped like catalogue entries so provider
+ * pickers list them as connected. Keyless records cannot run models and are
+ * left out.
+ */
+export function customProviderInfos(records: CustomProviderRecord[], tenantMode: boolean): ProviderInfo[] {
+  return records
+    .filter(record => record.apiKey)
+    .map(record => ({
+      provider: record.providerId,
+      source: tenantMode ? 'stored-org' : 'stored',
+      ...(tenantMode ? { orgKey: true, orgCredential: 'api_key' as const } : {}),
+      custom: true,
+    }));
+}
+
 /** Redact a stored custom-provider row for the client (key presence only). */
 function toCustomProviderInfo(record: CustomProviderRecord): CustomProviderInfo {
   return {
@@ -329,10 +370,13 @@ export async function buildProviderAccess({
   controller,
   authStorage,
   tenantCredentials,
+  customProviders,
 }: {
   controller: ModelCatalog;
   authStorage?: AuthStorage;
   tenantCredentials?: CredentialRecord[];
+  /** Custom providers are not in the gateway catalogue; a stored key is their access. */
+  customProviders?: Pick<CustomProviderRecord, 'providerId' | 'apiKey'>[];
 }): Promise<ProviderAccess> {
   const models = await controller.listAvailableModels();
   const hasModelKey = (provider: string) => models.some(m => m.provider === provider && m.hasApiKey);
@@ -368,6 +412,11 @@ export async function buildProviderAccess({
       access[m.provider] = accessLevel(m.provider);
       seen.add(m.provider);
     }
+  }
+  for (const custom of customProviders ?? []) {
+    if (seen.has(custom.providerId)) continue;
+    access[custom.providerId] = custom.apiKey ? 'apikey' : false;
+    seen.add(custom.providerId);
   }
   return access;
 }
@@ -732,12 +781,20 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
             // keys, so the settings UI can gate the "Everyone in org" option.
             const tenant = auth.tenant(loose(c));
             const orgKeyAdmin = tenant ? await auth.isOrganizationAdmin(loose(c), tenantOrgId(tenant)) : undefined;
+            const providers = await listProviders({
+              controller,
+              authStorage: tenantCredentials ? undefined : authStorage,
+              tenantCredentials,
+            });
+            // Custom providers live in the DB, not the gateway catalogue, so the
+            // pickers only see them when appended here.
+            const known = new Set(providers.map(p => p.provider));
+            const custom = customProviderInfos(
+              await listCallerCustomProviders({ c: loose(c), auth, customProviders: options.customProviders }),
+              tenantCredentials !== undefined,
+            ).filter(p => !known.has(p.provider));
             return c.json({
-              providers: await listProviders({
-                controller,
-                authStorage: tenantCredentials ? undefined : authStorage,
-                tenantCredentials,
-              }),
+              providers: [...providers, ...custom],
               ...(orgKeyAdmin !== undefined ? { orgKeyAdmin } : {}),
             });
           } catch (error) {
@@ -940,26 +997,18 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
             // tenant mode / sentinel `local` org in no-auth mode). The boot-time
             // gateway catalog only carries the local list, so tenant callers get
             // theirs here. Dedupe against ids already present.
-            if (options.customProviders) {
-              try {
-                const ctx = await resolveCustomProvidersContext({
-                  c: loose(c),
-                  auth,
-                  customProviders: options.customProviders,
-                });
-                if (!('response' in ctx)) {
-                  const known = new Set(catalog.map(m => m.id));
-                  for (const record of await ctx.storage.list({ orgId: ctx.orgId })) {
-                    for (const model of record.models) {
-                      const id = `${record.providerId}/${model}`;
-                      if (known.has(id)) continue;
-                      known.add(id);
-                      catalog.push({ id, provider: record.providerId, modelName: model, hasApiKey: true });
-                    }
-                  }
-                }
-              } catch {
-                // Fail soft: the catalog still serves the built-in models.
+            const known = new Set(catalog.map(m => m.id));
+            const customRecords = await listCallerCustomProviders({
+              c: loose(c),
+              auth,
+              customProviders: options.customProviders,
+            });
+            for (const record of customRecords) {
+              for (const model of record.models) {
+                const id = `${record.providerId}/${model}`;
+                if (known.has(id)) continue;
+                known.add(id);
+                catalog.push({ id, provider: record.providerId, modelName: model, hasApiKey: true });
               }
             }
             return c.json({
@@ -1306,6 +1355,11 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
               controller,
               authStorage: tenantCredentials ? undefined : authStorage,
               tenantCredentials,
+              customProviders: await listCallerCustomProviders({
+                c: loose(c),
+                auth,
+                customProviders: options.customProviders,
+              }),
             });
             if (!access[providerId]) return c.json({ error: `Provider "${providerId}" is not configured` }, 400);
 


### PR DESCRIPTION
Custom providers are stored in the DB rather than the gateway catalogue, so `GET /web/config/providers` never listed them. In the Factory onboarding model step that meant an org that only had a custom OpenAI-compatible provider saw no connected provider, and picking one by hand failed because `POST /web/config/om/provider-defaults` checks `buildProviderAccess`, which had no entry for it.

Before, a tenant with a custom provider `acme` (key stored, one model) got:

```json
{ "providers": [{ "provider": "anthropic", "source": "none" }] }
```

After:

```json
{
  "providers": [
    { "provider": "anthropic", "source": "none" },
    { "provider": "acme", "source": "stored-org", "orgKey": true, "orgCredential": "api_key", "custom": true }
  ]
}
```

`buildProviderAccess` now takes the caller's custom providers and grants `apikey` when a key is stored, so provider defaults for `acme/fast-1` seed the OM models instead of returning 400. The models route reuses the same lookup. On the UI side the `custom` flag keeps these rows out of the provider access section, since their key lives on the custom-provider record and is edited there, and saving or removing a custom provider now refetches the provider and model lists.

Tests cover the providers route, `buildProviderAccess`, provider defaults for a custom provider (including cross-org rejection), and the onboarding flow picking a custom provider model.
