### PR TITLE
feat(factory): deployment preset custom providers with model discovery

### DIFF
--- a/.changeset/bright-impalas-kiss.md
+++ b/.changeset/bright-impalas-kiss.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': minor
+---
+
+Added deployment-level custom providers to the Factory. Pass `customProviders` to `MastraFactory` (or set `MASTRACODE_CUSTOM_PROVIDERS` on the web entry) to list an OpenAI-compatible endpoint for every org as a read-only custom provider, with its models discovered from the endpoint when not listed.

--- a/mastracode/factory-ui/src/ui/domains/settings/components/CustomProvidersSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/CustomProvidersSection.tsx
@@ -182,6 +182,7 @@ export function CustomProvidersSection() {
                       Key saved
                     </Badge>
                   )}
+                  {p.readOnly && <Badge size="sm">Deployment</Badge>}
                 </div>
                 <Txt as="span" variant="ui-xs" className="text-icon3 truncate">
                   {p.url}
@@ -192,14 +193,16 @@ export function CustomProvidersSection() {
                   </Txt>
                 )}
               </div>
-              <div className="flex items-center gap-2">
-                <Button size="sm" disabled={busy} onClick={() => startEdit(p)}>
-                  Edit
-                </Button>
-                <Button variant="outline" size="sm" disabled={busy} onClick={() => void remove(p.id)}>
-                  Remove
-                </Button>
-              </div>
+              {!p.readOnly && (
+                <div className="flex items-center gap-2">
+                  <Button size="sm" disabled={busy} onClick={() => startEdit(p)}>
+                    Edit
+                  </Button>
+                  <Button variant="outline" size="sm" disabled={busy} onClick={() => void remove(p.id)}>
+                    Remove
+                  </Button>
+                </div>
+              )}
             </li>
           ))}
         </ul>

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/CustomProvidersSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/CustomProvidersSection.msw.test.tsx
@@ -54,6 +54,25 @@ describe('CustomProvidersSection', () => {
     });
   });
 
+  describe('when a provider is configured on the deployment', () => {
+    it('shows it as read-only without edit or remove actions', async () => {
+      server.use(
+        http.get(LIST_URL, () =>
+          listResponse([myLlm, { ...myLlm, id: 'team-proxy', name: 'Team Proxy', hasApiKey: false, readOnly: true }]),
+        ),
+      );
+
+      renderWithProviders(<CustomProvidersSection />);
+
+      const row = (await screen.findByText('Team Proxy')).closest('li')!;
+      expect(within(row).getByText('Deployment')).toBeInTheDocument();
+      expect(within(row).queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+      expect(within(row).queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
+      const own = screen.getByText('my-llm').closest('li')!;
+      expect(within(own).getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+    });
+  });
+
   describe('when the list is empty', () => {
     it('renders no provider rows and keeps the add affordance', async () => {
       server.use(http.get(LIST_URL, () => listResponse([])));

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -97,6 +97,8 @@ import { FactoryFeedReader } from './storage/domains/comments/feed-context.js';
 import type { WorkItemFeedPublisher } from './storage/domains/comments/feed-sync.js';
 import { ModelCredentialsStorage } from './storage/domains/credentials/base.js';
 import { CustomProvidersStorage } from './storage/domains/custom-providers/base.js';
+import { CustomProviderPresets } from './storage/domains/custom-providers/presets.js';
+import type { CustomProviderPreset } from './storage/domains/custom-providers/presets.js';
 import { FilesystemStorage } from './storage/domains/filesystem/base.js';
 import { IntakeStorage } from './storage/domains/intake/base.js';
 import { IntegrationStorage } from './storage/domains/integrations/base.js';
@@ -197,6 +199,13 @@ export interface MastraFactoryConfig {
    * plaintext compatibility with a boot-time warning.
    */
   secretEncryption?: FactorySecretEncryption;
+  /**
+   * OpenAI-compatible providers configured on the deployment (an internal
+   * LLM proxy, for example). They are listed for every org as read-only
+   * custom providers; a preset without `models` discovers them from
+   * `GET {url}/models`.
+   */
+  customProviders?: CustomProviderPreset[];
   /**
    * Registered capability providers. The factory registers the pieces each
    * `FactoryIntegration` instance provides — HTTP routes, storage domains,
@@ -430,6 +439,9 @@ export class MastraFactory {
     const modelPacksStorage = storage.registerDomain(new ModelPacksStorage());
     const memorySettingsStorage = storage.registerDomain(new MemorySettingsStorage());
     const customProvidersStorage = storage.registerDomain(new CustomProvidersStorage(secretEncryption));
+    if (this.#config.customProviders?.length) {
+      customProvidersStorage.usePresets(new CustomProviderPresets(this.#config.customProviders));
+    }
     const queueHealthStorage = storage.registerDomain(new QueueHealthStorage());
     // Generic integration storage (connections/subscriptions/settings) — the
     // default persistence surface for integrations without a bespoke domain.

--- a/mastracode/factory/src/index.ts
+++ b/mastracode/factory/src/index.ts
@@ -20,6 +20,7 @@ export type {
 } from './boards/index.js';
 export { MastraFactory } from './factory.js';
 export type { MastraArgs, MastraFactoryConfig, MastraFactorySandboxConfig, FactorySandboxStart } from './factory.js';
+export type { CustomProviderPreset } from './storage/domains/custom-providers/presets.js';
 export type { FactorySandboxContext, SessionSetupGate, SessionSetupRun } from './sandbox/session-sandbox.js';
 export { ChannelIdentityStorage } from './storage/domains/channel-identity/base.js';
 export type {

--- a/mastracode/factory/src/routes/config.test.ts
+++ b/mastracode/factory/src/routes/config.test.ts
@@ -8,6 +8,7 @@ import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { __clearSessionSandboxesForTests, getSessionSandbox } from '../sandbox/session-sandbox.js';
+import { CustomProviderPresets } from '../storage/domains/custom-providers/presets.js';
 import { factoryMemorySettingsUserId } from '../storage/domains/memory-settings/base.js';
 import type { SourceControlSession } from '../storage/domains/source-control/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
@@ -1331,6 +1332,33 @@ describe('custom provider routes', () => {
 
   it('rejects unauthenticated access when web auth is enabled', async () => {
     expect((await buildApp(null).request('/web/config/custom-providers')).status).toBe(401);
+  });
+
+  it('lists deployment presets as read-only and refuses to change them', async () => {
+    seed.customProviders.usePresets(
+      new CustomProviderPresets([{ name: 'Team Proxy', url: 'https://proxy.example.com/v1', models: ['fast'] }]),
+    );
+    const app = buildApp(userA);
+
+    const { providers } = await (await app.request('/web/config/custom-providers')).json();
+    expect(providers).toEqual([
+      {
+        id: 'team-proxy',
+        name: 'Team Proxy',
+        url: 'https://proxy.example.com/v1',
+        hasApiKey: false,
+        models: ['fast'],
+        readOnly: true,
+      },
+    ]);
+
+    const overwrite = await postProvider(app, { ...providerBody, name: 'Team Proxy' });
+    expect(overwrite.status).toBe(409);
+    const renameOnto = await postProvider(app, { ...providerBody, previousId: 'team-proxy' });
+    expect(renameOnto.status).toBe(409);
+    const removed = await app.request('/web/config/custom-providers/team-proxy', { method: 'DELETE' });
+    expect(removed.status).toBe(409);
+    expect(onCustomProvidersChanged).not.toHaveBeenCalled();
   });
 
   it('persists providers in the org-scoped domain with keys redacted', async () => {

--- a/mastracode/factory/src/routes/config.ts
+++ b/mastracode/factory/src/routes/config.ts
@@ -231,6 +231,8 @@ export interface CustomProviderInfo {
   url: string;
   hasApiKey: boolean;
   models: string[];
+  /** Configured on the deployment; cannot be edited or removed by an org. */
+  readOnly?: true;
 }
 
 /** Redact a stored custom-provider row for the client (key presence only). */
@@ -241,8 +243,11 @@ function toCustomProviderInfo(record: CustomProviderRecord): CustomProviderInfo 
     url: record.url,
     hasApiKey: Boolean(record.apiKey),
     models: record.models,
+    ...(record.preset ? { readOnly: true as const } : {}),
   };
 }
+
+const PRESET_CONFLICT = 'This provider is configured on the deployment and cannot be changed here';
 
 /** The resolved custom-providers storage scope for a request. */
 interface CustomProvidersContext {
@@ -868,12 +873,16 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
             body && typeof body === 'object' && typeof (body as Record<string, unknown>).previousId === 'string'
               ? ((body as Record<string, unknown>).previousId as string)
               : undefined;
+          const providerId = getCustomProviderId(parsed.name);
+          if (ctx.storage.isPreset(providerId) || (previousId !== undefined && ctx.storage.isPreset(previousId))) {
+            return c.json({ error: PRESET_CONFLICT }, 409);
+          }
           try {
             const record = await ctx.storage.upsert({
               orgId: ctx.orgId,
               userId: ctx.userId,
               input: {
-                providerId: getCustomProviderId(parsed.name),
+                providerId,
                 name: parsed.name,
                 url: parsed.url,
                 apiKey: parsed.apiKey,
@@ -900,6 +909,7 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
           });
           if ('response' in ctx) return ctx.response;
           const id = c.req.param('id');
+          if (ctx.storage.isPreset(id)) return c.json({ error: PRESET_CONFLICT }, 409);
           try {
             await ctx.storage.delete({ orgId: ctx.orgId, providerId: id });
             onCustomProvidersChanged({ orgId: ctx.orgId });

--- a/mastracode/factory/src/storage/domains/custom-providers/base.test.ts
+++ b/mastracode/factory/src/storage/domains/custom-providers/base.test.ts
@@ -9,6 +9,7 @@ import { createFactorySecretEncryption } from '../../../secret-encryption.js';
 import type { FactorySecretEncryption } from '../../../secret-encryption.js';
 import { createFactoryStorageForTests } from '../../test-utils.js';
 import { CustomProvidersStorage } from './base.js';
+import { CustomProviderPresets } from './presets.js';
 
 /**
  * File-backed store so a "pre-encryption deployment" can write rows, close,
@@ -207,6 +208,34 @@ describe('CustomProvidersStorage', () => {
 
     expect(created.providerId).toBe('new-name');
     expect(await seed.customProviders.list({ orgId: 'org-1' })).toHaveLength(1);
+  });
+
+  it('appends deployment presets to every org and lets a preset shadow an org row with its id', async () => {
+    const seed = await createFactoryStorageForTests();
+    await seed.customProviders.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      input: { providerId: 'proxy', name: 'Proxy', url: 'https://old.example.com/v1', models: ['old'] },
+    });
+    await seed.customProviders.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      input: { providerId: 'mine', name: 'Mine', url: 'https://mine.example.com/v1', models: ['m'] },
+    });
+    seed.customProviders.usePresets(
+      new CustomProviderPresets([{ name: 'Proxy', url: 'https://proxy.example.com/v1', models: ['fast'] }]),
+    );
+
+    const org1 = await seed.customProviders.list({ orgId: 'org-1' });
+    const org2 = await seed.customProviders.list({ orgId: 'org-2' });
+
+    expect(org1.map(r => [r.providerId, r.url, r.preset])).toEqual([
+      ['mine', 'https://mine.example.com/v1', undefined],
+      ['proxy', 'https://proxy.example.com/v1', true],
+    ]);
+    expect(org2.map(r => [r.providerId, r.orgId, r.preset])).toEqual([['proxy', 'org-2', true]]);
+    expect(seed.customProviders.isPreset('proxy')).toBe(true);
+    expect(seed.customProviders.isPreset('mine')).toBe(false);
   });
 
   it('deletes only within the org', async () => {

--- a/mastracode/factory/src/storage/domains/custom-providers/base.ts
+++ b/mastracode/factory/src/storage/domains/custom-providers/base.ts
@@ -2,6 +2,7 @@ import { FactoryStorageDomain, UniqueViolationError } from '@mastra/core/storage
 import type { CollectionSchema, FactoryStorageOps } from '@mastra/core/storage';
 import { createPlaintextFactorySecretEncryption } from '../../../secret-encryption.js';
 import type { FactorySecretEncryption } from '../../../secret-encryption.js';
+import type { CustomProviderPresets } from './presets.js';
 
 /**
  * A user-defined OpenAI-compatible provider. The DB-backed counterpart of the
@@ -21,6 +22,8 @@ export interface CustomProviderRecord {
   models: string[];
   createdAt: Date;
   updatedAt: Date;
+  /** Configured on the deployment (`CustomProviderPresets`): listed for every org, read-only. */
+  preset?: true;
 }
 
 export interface UpsertCustomProviderInput {
@@ -62,8 +65,19 @@ interface CustomProviderDbRow extends Record<string, unknown> {
 }
 
 export class CustomProvidersStorage extends FactoryStorageDomain {
+  #presets?: CustomProviderPresets;
+
   constructor(private readonly encryption: FactorySecretEncryption = createPlaintextFactorySecretEncryption()) {
     super('custom-providers');
+  }
+
+  /** Deployment presets appended to every org's list. A preset shadows an org row with the same id. */
+  usePresets(presets: CustomProviderPresets): void {
+    this.#presets = presets;
+  }
+
+  isPreset(providerId: string): boolean {
+    return this.#presets?.has(providerId) ?? false;
   }
 
   async init(): Promise<void> {
@@ -233,7 +247,10 @@ export class CustomProvidersStorage extends FactoryStorageDomain {
       { org_id: orgId },
       { orderBy: [['name', 'asc']] },
     );
-    return Promise.all(rows.map(row => this.#toRecord(row)));
+    const own = await Promise.all(rows.map(row => this.#toRecord(row)));
+    if (!this.#presets) return own;
+    const presets = await this.#presets.records(orgId);
+    return [...own.filter(record => !this.isPreset(record.providerId)), ...presets];
   }
 
   async delete({ orgId, providerId }: { orgId: string; providerId: string }): Promise<boolean> {

--- a/mastracode/factory/src/storage/domains/custom-providers/presets.test.ts
+++ b/mastracode/factory/src/storage/domains/custom-providers/presets.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CustomProviderPresets } from './presets.js';
+
+function fakeFetch(models: string[], status = 200) {
+  return vi.fn(async () => new Response(JSON.stringify({ data: models.map(id => ({ id })) }), { status }));
+}
+
+describe('CustomProviderPresets', () => {
+  it('lists a preset with static models for the requested org without touching the network', async () => {
+    const fetchImpl = fakeFetch(['unused']);
+    const presets = new CustomProviderPresets(
+      [{ name: 'Team Proxy', url: 'https://llm.example.com/v1', apiKey: 'sk', models: ['fast'] }],
+      fetchImpl,
+    );
+
+    const records = await presets.records('org-1');
+
+    expect(records).toEqual([
+      expect.objectContaining({
+        orgId: 'org-1',
+        providerId: 'team-proxy',
+        name: 'Team Proxy',
+        url: 'https://llm.example.com/v1',
+        apiKey: 'sk',
+        models: ['fast'],
+        preset: true,
+      }),
+    ]);
+    expect(presets.has('team-proxy')).toBe(true);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('discovers models from the provider once and serves them from cache', async () => {
+    const fetchImpl = fakeFetch(['smart', 'fast']);
+    const presets = new CustomProviderPresets(
+      [{ name: 'Proxy', url: 'https://llm.example.com/v1/', apiKey: 'sk' }],
+      fetchImpl,
+    );
+
+    const [first] = await presets.records('org-1');
+    const [second] = await presets.records('org-2');
+
+    expect(first?.models).toEqual(['fast', 'smart']);
+    expect(second?.models).toEqual(['fast', 'smart']);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://llm.example.com/v1/models',
+      expect.objectContaining({ headers: { Authorization: 'Bearer sk' } }),
+    );
+  });
+
+  it('serves an empty list when discovery fails and retries on the next read', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('nope', { status: 500 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: [{ id: 'fast' }] }), { status: 200 }));
+    const presets = new CustomProviderPresets([{ name: 'Proxy', url: 'https://llm.example.com/v1' }], fetchImpl);
+
+    expect((await presets.records('org-1'))[0]?.models).toEqual([]);
+    expect((await presets.records('org-1'))[0]?.models).toEqual(['fast']);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+});

--- a/mastracode/factory/src/storage/domains/custom-providers/presets.ts
+++ b/mastracode/factory/src/storage/domains/custom-providers/presets.ts
@@ -1,0 +1,104 @@
+import { getCustomProviderId } from '@mastra/code-sdk/onboarding/settings';
+
+import type { CustomProviderRecord } from './base.js';
+
+/**
+ * An OpenAI-compatible provider configured on the deployment rather than by an
+ * org. Presets are listed for every org, read-only, alongside the org's own
+ * custom providers.
+ */
+export interface CustomProviderPreset {
+  /** Display name. The provider id is its slug (`getCustomProviderId`). */
+  name: string;
+  /** OpenAI-compatible base URL, e.g. `https://llm.example.com/v1`. */
+  url: string;
+  apiKey?: string;
+  /**
+   * Model ids. Omitted → discovered from `GET {url}/models` and refreshed
+   * periodically, so a proxy that fronts many models needs no static list.
+   */
+  models?: string[];
+}
+
+/** How long a discovered model list is served before it is refetched. */
+const DISCOVERY_TTL_MS = 5 * 60_000;
+const DISCOVERY_TIMEOUT_MS = 10_000;
+
+interface PresetState {
+  preset: CustomProviderPreset;
+  providerId: string;
+  models: string[];
+  fetchedAt: number;
+  discovering?: Promise<void>;
+}
+
+/**
+ * Deployment presets and their model lists. Presets with a static `models`
+ * list never hit the network; the rest are discovered from the provider's
+ * `/models` endpoint, cached per preset, and kept at the last good list when
+ * a refresh fails.
+ */
+export class CustomProviderPresets {
+  readonly #states: PresetState[];
+  readonly #createdAt = new Date();
+  readonly #fetch: typeof fetch;
+
+  constructor(presets: CustomProviderPreset[], fetchImpl: typeof fetch = fetch) {
+    this.#fetch = fetchImpl;
+    this.#states = presets.map(preset => ({
+      preset,
+      providerId: getCustomProviderId(preset.name),
+      models: preset.models ?? [],
+      fetchedAt: preset.models ? Number.POSITIVE_INFINITY : 0,
+    }));
+  }
+
+  has(providerId: string): boolean {
+    return this.#states.some(state => state.providerId === providerId);
+  }
+
+  /** Preset rows shaped like the org's own records, models discovered when due. */
+  async records(orgId: string): Promise<CustomProviderRecord[]> {
+    await Promise.all(this.#states.map(state => this.#ensureModels(state)));
+    return this.#states.map(state => ({
+      id: `preset:${state.providerId}`,
+      orgId,
+      createdBy: 'preset',
+      providerId: state.providerId,
+      name: state.preset.name,
+      url: state.preset.url,
+      apiKey: state.preset.apiKey ?? null,
+      models: state.models,
+      createdAt: this.#createdAt,
+      updatedAt: this.#createdAt,
+      preset: true,
+    }));
+  }
+
+  async #ensureModels(state: PresetState, now = Date.now()): Promise<void> {
+    if (now - state.fetchedAt < DISCOVERY_TTL_MS) return;
+    state.discovering ??= this.#discover(state).finally(() => {
+      state.discovering = undefined;
+    });
+    await state.discovering;
+  }
+
+  async #discover(state: PresetState): Promise<void> {
+    try {
+      const res = await this.#fetch(`${state.preset.url.replace(/\/+$/, '')}/models`, {
+        headers: state.preset.apiKey ? { Authorization: `Bearer ${state.preset.apiKey}` } : {},
+        signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = (await res.json()) as { data?: { id?: unknown }[] };
+      const models = (body.data ?? []).map(m => m.id).filter((id): id is string => typeof id === 'string');
+      state.models = models.sort();
+      state.fetchedAt = Date.now();
+    } catch (error) {
+      // Keep serving the last good list; retry on the next read.
+      console.warn(
+        `[factory] Could not list models for custom provider "${state.preset.name}": ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -30,6 +30,7 @@ import { getDatabasePath } from '@mastra/code-sdk/utils/project';
 import { DEFAULT_RETENTION } from '@mastra/code-sdk/utils/storage-maintenance';
 import { MastraAuthWorkos } from '@mastra/auth-workos';
 import { createFactorySecretEncryption, MastraFactory } from '@mastra/factory';
+import type { CustomProviderPreset } from '@mastra/factory';
 import { GithubIntegration } from '@mastra/factory/integrations/github/integration';
 import { parseAuthorizedBotsEnv } from '@mastra/factory/integrations/github/webhook';
 import { LinearIntegration } from '@mastra/factory/integrations/linear/integration';
@@ -47,6 +48,18 @@ function positiveInt(raw: string | undefined): number | undefined {
   const parsed = Number(raw);
   if (!Number.isSafeInteger(parsed) || parsed <= 0) return undefined;
   return parsed;
+}
+
+function parseCustomProvidersEnv(raw: string | undefined): CustomProviderPreset[] | undefined {
+  if (!raw?.trim()) return undefined;
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed)) throw new Error('MASTRACODE_CUSTOM_PROVIDERS must be a JSON array.');
+  for (const entry of parsed) {
+    if (!entry || typeof entry !== 'object' || typeof entry.name !== 'string' || typeof entry.url !== 'string') {
+      throw new Error('MASTRACODE_CUSTOM_PROVIDERS entries need a string "name" and "url".');
+    }
+  }
+  return parsed as CustomProviderPreset[];
 }
 
 function decodeCredentialEncryptionKey(name: string, encodedKey: string): Buffer {
@@ -287,6 +300,10 @@ export const factory = new MastraFactory({
   auth,
   secretEncryption,
   integrations,
+  // OpenAI-compatible providers every org gets, e.g. an internal LLM proxy:
+  // a JSON array of { name, url, apiKey?, models? }. Models are discovered
+  // from the provider when omitted.
+  customProviders: parseCustomProvidersEnv(process.env.MASTRACODE_CUSTOM_PROVIDERS),
   configVersion: factoryConfigVersion,
   sandbox: ctx => {
     const useLocalSandbox = process.env.FACTORY_SANDBOX_PROVIDER?.trim() === 'local';


### PR DESCRIPTION
Custom providers are entered per org today. A deployment that fronts its models with one OpenAI-compatible proxy has to have every org add the same endpoint and key by hand, and keep the model list in step with the proxy. This lets the deployment configure those providers once.

```ts
new MastraFactory({
  storage,
  customProviders: [{ name: 'Team Proxy', url: 'https://llm.example.com/v1', apiKey: process.env.TEAM_PROXY_KEY }],
});
```

or, on the web entry, `MASTRACODE_CUSTOM_PROVIDERS='[{"name":"Team Proxy","url":"https://llm.example.com/v1","apiKey":"..."}]'`.

Presets are appended to every org's custom provider list as read-only rows (`CustomProviderInfo.readOnly`), so they flow through the existing custom-provider source, the model catalogue and the settings UI unchanged. A preset with no `models` discovers them from `GET {url}/models`, cached for five minutes per preset, and keeps the last good list when a refresh fails. The custom provider routes answer 409 when an org tries to overwrite, rename onto, or delete a preset id, and the settings section hides Edit and Remove for those rows.

Tests cover discovery and caching, the storage merge (a preset shadows an org row with the same id), the route guards, and the read-only rendering.
