### PR TITLE
fix(evals): reject incomplete trajectory budget measurements

### DIFF
--- a/.changeset/eighty-pianos-pay.md
+++ b/.changeset/eighty-pianos-pay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/evals': patch
+---
+
+Fixed trajectory budget scorers that treated missing token or duration measurements as zero success, and counted nested model-generation usage toward token totals. Configured token budgets now require complete model measurements; duration budgets require a valid total or complete top-level durations. Incomplete evidence rejects via the existing scorer preprocessing error path instead of certifying a perfect score. (#23468)

--- a/packages/evals/src/scorers/code/trajectory/index.test.ts
+++ b/packages/evals/src/scorers/code/trajectory/index.test.ts
@@ -3,6 +3,62 @@ import { describe, expect, test } from 'vitest';
 import { createTestMessage, createTrajectoryTestRun } from '../../utils';
 import { createTrajectoryAccuracyScorerCode, createTrajectoryScorerCode } from './index';
 
+describe('trajectory budget measurement failures', () => {
+  test.each(['defaults', 'item', 'nested'] as const)(
+    'rejects incomplete budget evidence from %s without a score',
+    async source => {
+      for (const budget of [{ maxTotalTokens: 10 }, { maxTotalDurationMs: 10 }]) {
+        const trajectory: Trajectory = { steps: [{ stepType: 'model_generation', name: 'model' }] };
+        const defaults: TrajectoryExpectation =
+          source === 'defaults' ? budget : source === 'nested' ? { steps: [{ name: 'agent', children: budget }] } : {};
+        const scorer = createTrajectoryScorerCode({ defaults });
+        const run = createTrajectoryTestRun({
+          trajectory:
+            source === 'nested'
+              ? { steps: [{ stepType: 'agent_run', name: 'agent', children: trajectory.steps }] }
+              : trajectory,
+        });
+        if (source === 'item') run.expectedTrajectory = budget;
+        const error = await scorer.run(run).then(
+          () => undefined,
+          error => error,
+        );
+        expect(error).toMatchObject({ failedStep: 'preprocess', completedSteps: [] });
+        expect(error).not.toHaveProperty('result.score');
+      }
+    },
+  );
+
+  test('honors an item override that removes the token budget', async () => {
+    const scorer = createTrajectoryScorerCode({ defaults: { maxTotalTokens: 10 } });
+    const run = createTrajectoryTestRun({ trajectory: { steps: [{ stepType: 'tool_call', name: 'search' }] } });
+    run.expectedTrajectory = { maxTotalTokens: undefined, maxSteps: 1 };
+    expect((await scorer.run(run)).score).toBe(1);
+  });
+
+  test('uses a matched parent duration for nested duration budgets', async () => {
+    const scorer = createTrajectoryScorerCode({
+      defaults: { steps: [{ name: 'agent', children: { maxTotalDurationMs: 10 } }] },
+    });
+    const result = await scorer.run(
+      createTrajectoryTestRun({
+        trajectory: {
+          steps: [
+            {
+              stepType: 'agent_run',
+              name: 'agent',
+              durationMs: 5,
+              children: [{ stepType: 'tool_call', name: 'search' }],
+            },
+          ],
+        },
+      }),
+    );
+    expect(result.score).toBe(1);
+    expect(result.preprocessStepResult?.nested?.[0]?.efficiency?.totalDurationMs).toBe(5);
+  });
+});
+
 describe('createTrajectoryAccuracyScorerCode', () => {
   /**
    * Helper to build a Trajectory from step names.

--- a/packages/evals/src/scorers/utils.test.ts
+++ b/packages/evals/src/scorers/utils.test.ts
@@ -1585,6 +1585,173 @@ describe('Scorer Utils', () => {
   });
 
   describe('checkTrajectoryEfficiency', () => {
+    it.each([undefined, NaN, Infinity, -1])('rejects missing or invalid token counts: %s', count => {
+      for (const field of ['promptTokens', 'completionTokens'] as const) {
+        const trajectory: Trajectory = {
+          steps: [
+            { stepType: 'model_generation', name: 'model', promptTokens: 0, completionTokens: 0, [field]: count },
+          ],
+        };
+        expect(() => checkTrajectoryEfficiency(trajectory, { maxTotalTokens: 10 })).toThrow(/token/i);
+      }
+    });
+
+    it.each([{ steps: [] }, { steps: [{ stepType: 'tool_call' as const, name: 'search' }] }])(
+      'rejects a token budget without model-generation evidence',
+      ({ steps }) => {
+        expect(() => checkTrajectoryEfficiency({ steps }, { maxTotalTokens: 10 })).toThrow(/token/i);
+      },
+    );
+
+    it.each([undefined, NaN, Infinity, -1])('rejects missing or invalid duration: %s', duration => {
+      const steps: Trajectory['steps'] = [{ stepType: 'tool_call', name: 'search', durationMs: duration }];
+      expect(() => checkTrajectoryEfficiency({ steps }, { maxTotalDurationMs: 10 })).toThrow(/duration/i);
+      if (duration !== undefined) {
+        expect(() =>
+          checkTrajectoryEfficiency(
+            { steps: [{ ...steps[0]!, durationMs: 0 }], totalDurationMs: duration },
+            { maxTotalDurationMs: 10 },
+          ),
+        ).toThrow(/duration/i);
+      }
+    });
+
+    it('rejects empty or partially measured duration fallback', () => {
+      for (const steps of [
+        [],
+        [
+          { stepType: 'tool_call' as const, name: 'a', durationMs: 0 },
+          { stepType: 'tool_call' as const, name: 'b' },
+        ],
+      ]) {
+        expect(() => checkTrajectoryEfficiency({ steps }, { maxTotalDurationMs: 10 })).toThrow(/duration/i);
+      }
+    });
+
+    it('preserves measured zeros and checks positive usage against a zero budget', () => {
+      const trajectory: Trajectory = {
+        steps: [{ stepType: 'model_generation', name: 'model', promptTokens: 0, completionTokens: 0 }],
+        totalDurationMs: 0,
+      };
+      expect(checkTrajectoryEfficiency(trajectory, { maxTotalTokens: 0, maxTotalDurationMs: 0 }).score).toBe(1);
+      expect(checkTrajectoryEfficiency({ steps: [], totalDurationMs: 0 }, { maxTotalDurationMs: 0 }).score).toBe(1);
+      expect(
+        checkTrajectoryEfficiency(
+          {
+            steps: [{ stepType: 'model_generation', name: 'model', promptTokens: 1, completionTokens: 0 }],
+            totalDurationMs: 1,
+          },
+          { maxTotalTokens: 0, maxTotalDurationMs: 0, noRedundantCalls: false },
+        ).score,
+      ).toBe(0);
+    });
+
+    it('counts nested model generations once and rejects incomplete nested counts', () => {
+      const nested: Trajectory['steps'][number] = {
+        stepType: 'model_generation',
+        name: 'inner',
+        promptTokens: 20,
+        completionTokens: 30,
+      };
+      const trajectory: Trajectory = {
+        steps: [
+          {
+            stepType: 'model_generation',
+            name: 'outer',
+            promptTokens: 2,
+            completionTokens: 3,
+            children: [
+              {
+                stepType: 'tool_call',
+                name: 'delegate',
+                children: [{ stepType: 'agent_run', name: 'agent', children: [nested] }],
+              },
+            ],
+          },
+        ],
+      };
+      expect(checkTrajectoryEfficiency(trajectory, { maxTotalTokens: 10 })).toMatchObject({
+        totalTokens: 55,
+        overTokenBudget: true,
+      });
+      nested.completionTokens = undefined;
+      expect(() => checkTrajectoryEfficiency(trajectory, { maxTotalTokens: 10 })).toThrow(/token/i);
+    });
+
+    it('uses top-level duration without adding nested durations', () => {
+      const trajectory: Trajectory = {
+        steps: [
+          {
+            stepType: 'agent_run',
+            name: 'agent',
+            durationMs: 10,
+            children: [{ stepType: 'tool_call', name: 'search', durationMs: 8 }],
+          },
+          { stepType: 'tool_call', name: 'finish', durationMs: 2 },
+        ],
+      };
+      expect(checkTrajectoryEfficiency(trajectory, { maxTotalDurationMs: 12 }).totalDurationMs).toBe(12);
+      expect(
+        checkTrajectoryEfficiency({ ...trajectory, totalDurationMs: 5 }, { maxTotalDurationMs: 5 }).totalDurationMs,
+      ).toBe(5);
+    });
+
+    it('does not require measurements for unrelated checks', () => {
+      const unknown: Trajectory = { steps: [{ stepType: 'model_generation', name: 'model' }] };
+      expect(checkTrajectoryEfficiency(unknown, { maxSteps: 1 }).score).toBe(1);
+      expect(checkTrajectoryEfficiency(unknown).score).toBe(1);
+      expect(checkTrajectoryEfficiency({ ...unknown, totalDurationMs: 0 }, { maxTotalDurationMs: 0 }).score).toBe(1);
+      expect(
+        checkTrajectoryEfficiency(
+          { steps: [{ stepType: 'model_generation', name: 'model', promptTokens: 0, completionTokens: 0 }] },
+          { maxTotalTokens: 0 },
+        ).score,
+      ).toBe(1);
+    });
+
+    it.each([NaN, Infinity, -1])('rejects invalid configured limits: %s', limit => {
+      for (const field of ['maxSteps', 'maxTotalTokens', 'maxTotalDurationMs'] as const) {
+        expect(() =>
+          checkTrajectoryEfficiency(
+            {
+              steps: [{ stepType: 'model_generation', name: 'model', promptTokens: 0, completionTokens: 0 }],
+              totalDurationMs: 0,
+            },
+            { [field]: limit },
+          ),
+        ).toThrow(/budget/i);
+      }
+    });
+
+    it('rejects non-finite measurement totals', () => {
+      expect(() =>
+        checkTrajectoryEfficiency(
+          {
+            steps: [
+              {
+                stepType: 'model_generation',
+                name: 'model',
+                promptTokens: Number.MAX_VALUE,
+                completionTokens: Number.MAX_VALUE,
+              },
+            ],
+          },
+          { maxTotalTokens: 10 },
+        ),
+      ).toThrow(/token/i);
+      expect(() =>
+        checkTrajectoryEfficiency(
+          {
+            steps: [
+              { stepType: 'tool_call', name: 'a', durationMs: Number.MAX_VALUE },
+              { stepType: 'tool_call', name: 'b', durationMs: Number.MAX_VALUE },
+            ],
+          },
+          { maxTotalDurationMs: 10 },
+        ),
+      ).toThrow(/duration/i);
+    });
+
     it('should return score 1.0 when all budgets are met and no redundancy', () => {
       const trajectory: Trajectory = {
         steps: [

--- a/packages/evals/src/scorers/utils.ts
+++ b/packages/evals/src/scorers/utils.ts
@@ -1302,6 +1302,7 @@ export type TrajectoryEfficiencyResult = {
 
 /**
  * Evaluate trajectory efficiency against budgets and redundancy checks.
+ * Throws when a configured budget is invalid or its required measurements are incomplete or invalid.
  */
 export function checkTrajectoryEfficiency(
   trajectory: Trajectory,
@@ -1314,19 +1315,54 @@ export function checkTrajectoryEfficiency(
 ): TrajectoryEfficiencyResult {
   const { maxSteps, maxTotalTokens, maxTotalDurationMs, noRedundantCalls = true } = options;
 
-  const totalSteps = trajectory.steps.length;
-
-  // Calculate total tokens from model_generation steps
-  let totalTokens = 0;
-  for (const step of trajectory.steps) {
-    if (step.stepType === 'model_generation') {
-      totalTokens += (step.promptTokens ?? 0) + (step.completionTokens ?? 0);
+  const isMeasurement = (value: number | undefined): value is number =>
+    typeof value === 'number' && Number.isFinite(value) && value >= 0;
+  for (const [name, limit] of Object.entries({ maxSteps, maxTotalTokens, maxTotalDurationMs })) {
+    if (limit !== undefined && !isMeasurement(limit)) {
+      throw new Error(`Invalid ${name} budget: expected a finite nonnegative number`);
     }
   }
 
-  // Calculate total duration
+  const totalSteps = trajectory.steps.length;
+
+  // Count each model generation, including nested agents, without counting container aggregates.
+  let totalTokens = 0;
+  let modelGenerations = 0;
+  const remaining = [...trajectory.steps];
+  while (remaining.length > 0) {
+    const step = remaining.pop()!;
+    if (step.stepType === 'model_generation') {
+      modelGenerations++;
+      if (
+        maxTotalTokens !== undefined &&
+        (!isMeasurement(step.promptTokens) || !isMeasurement(step.completionTokens))
+      ) {
+        throw new Error(
+          `Cannot evaluate token budget: model generation "${step.name}" has missing or invalid token counts`,
+        );
+      }
+      totalTokens += (step.promptTokens ?? 0) + (step.completionTokens ?? 0);
+    }
+    if (step.children) {
+      for (const child of step.children) remaining.push(child);
+    }
+  }
+  if (maxTotalTokens !== undefined && (modelGenerations === 0 || !isMeasurement(totalTokens))) {
+    throw new Error('Cannot evaluate token budget: missing model-generation measurements or invalid total tokens');
+  }
+
+  // A parent duration already covers its children; never add both.
   const totalDurationMs =
     trajectory.totalDurationMs ?? trajectory.steps.reduce((sum, s) => sum + (s.durationMs ?? 0), 0);
+  if (maxTotalDurationMs !== undefined) {
+    const hasDuration =
+      trajectory.totalDurationMs !== undefined
+        ? isMeasurement(trajectory.totalDurationMs)
+        : trajectory.steps.length > 0 && trajectory.steps.every(step => isMeasurement(step.durationMs));
+    if (!hasDuration || !isMeasurement(totalDurationMs)) {
+      throw new Error('Cannot evaluate duration budget: missing or invalid duration measurements');
+    }
+  }
 
   // Detect redundant calls (same tool name + same args in consecutive calls)
   const redundantCalls: Array<{ name: string; index: number }> = [];


### PR DESCRIPTION
## Description

`checkTrajectoryEfficiency` (and the unified trajectory scorer that uses it) could report score `1` / “all budgets met” when required token or duration measurements were missing, and it ignored nested `model_generation` token usage.

This change:
- Rejects invalid budget limits and incomplete/invalid measurements when a token or duration budget is configured
- Treats explicit measured zeros as valid (still under budget when appropriate)
- Walks nested children to sum `model_generation` token usage
- Prefers explicit `totalDurationMs` when present; otherwise requires complete top-level step durations (does not double-count parent+child)
- Leaves unrelated checks (e.g. step count / redundancy-only) unaffected
- Surfaces incomplete evidence through the existing preprocess `ScorerRunError` path (no numerical score)

**Compatibility note:** trajectories without model-generation evidence (including message-derived live trajectories that omit model measurements) cannot establish token-budget completeness. Configured token/time budget scorers now fail explicitly instead of certifying them.

Fixes #23468

## Test plan

- [x] `pnpm exec vitest run src/scorers/utils.test.ts src/scorers/code/trajectory/index.test.ts` in `packages/evals` (174 passed)
- [x] `pnpm run build:lib` in `packages/evals`
- [ ] Confirm live/message-derived trajectories with a configured token budget fail preprocess instead of scoring 1
- [ ] Confirm nested agent model usage counts toward `maxTotalTokens`
- [ ] Confirm redundancy/step-only efficiency configs still work without token/duration fields

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI/chore


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The scorer now rejects a budget check when token or time data is missing or invalid. It still accepts measured zero values and counts token use from nested model steps.

## Changes

- Validate configured token and duration limits.
- Reject incomplete or invalid measurements through `ScorerRunError`.
- Include nested `model_generation` token usage.
- Use `totalDurationMs` when available.
- Otherwise require complete top-level durations without double-counting nested durations.
- Keep unrelated checks independent of token and duration data.
- Add regression tests and a patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->