### PR TITLE
fix(core): preserve tool failures and identity in trajectories

### DIFF
--- a/.changeset/slimy-bats-walk.md
+++ b/.changeset/slimy-bats-walk.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent trajectories dropping thrown tool calls and using display labels as tool names. Trajectories now keep failed calls with success:false and prefer canonical tool identity from entityId/entityName. (#23462)

--- a/packages/core/src/evals/types.test.ts
+++ b/packages/core/src/evals/types.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { SpanType } from '../observability';
 import type { SpanRecord } from '../storage';
 import { extractTrajectory, extractTrajectoryFromTrace, saveScorePayloadSchema } from './types';
+import type { ScorerRunOutputForAgent } from './types';
 
 function createSpan(overrides: Partial<SpanRecord> & { spanId: string; spanType: SpanRecord['spanType'] }): SpanRecord {
   return {
@@ -26,6 +27,25 @@ function createSpan(overrides: Partial<SpanRecord> & { spanId: string; spanType:
 }
 
 describe('extractTrajectoryFromTrace', () => {
+  it.each([SpanType.TOOL_CALL, SpanType.MCP_TOOL_CALL, SpanType.PROVIDER_TOOL_CALL])(
+    'uses canonical tool identity instead of the trace display label (%s)',
+    spanType => {
+      const result = extractTrajectoryFromTrace([
+        createSpan({
+          spanId: 'tool',
+          spanType,
+          name: "tool: 'save_result'",
+          entityId: 'save_result',
+          entityName: 'Save result',
+          input: { attempt: 1 },
+          attributes: { success: false },
+        }),
+      ]);
+      expect(result.steps).toHaveLength(1);
+      expect(result.steps[0]).toMatchObject({ name: 'save_result', success: false, toolArgs: { attempt: 1 } });
+    },
+  );
+
   it('returns empty trajectory for empty spans', () => {
     const result = extractTrajectoryFromTrace([]);
     expect(result.steps).toEqual([]);
@@ -780,6 +800,122 @@ describe('saveScorePayloadSchema', () => {
 });
 
 describe('extractTrajectory', () => {
+  it.each(['parts-only', 'mixed'] as const)('retains native thrown calls as failed steps (%s)', shape => {
+    const good = { state: 'result' as const, toolCallId: 'good', toolName: 'read', args: {}, result: { ok: true } };
+    const bad = {
+      state: 'output-error' as const,
+      toolCallId: 'bad',
+      toolName: 'save',
+      args: { value: 1 },
+      errorText: 'Save failed',
+    };
+    const output: ScorerRunOutputForAgent = [
+      {
+        id: 'message',
+        role: 'assistant',
+        createdAt: new Date(0),
+        content: {
+          format: 2,
+          parts: (shape === 'mixed' ? [good, bad] : [bad]).map(toolInvocation => ({
+            type: 'tool-invocation',
+            toolInvocation,
+          })),
+          ...(shape === 'mixed' ? { toolInvocations: [good] } : {}),
+        },
+      },
+    ];
+    const result = extractTrajectory(output);
+    expect(result.steps).toHaveLength(shape === 'mixed' ? 2 : 1);
+    expect(result.steps.at(-1)).toMatchObject({
+      stepType: 'tool_call',
+      name: 'save',
+      toolArgs: { value: 1 },
+      success: false,
+    });
+    expect(result.rawOutput).toBe(output);
+  });
+
+  it('retains the native error marker on result-state invocations', () => {
+    const output: ScorerRunOutputForAgent = [
+      {
+        id: 'marked',
+        role: 'assistant',
+        createdAt: new Date(0),
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'bad',
+                toolName: 'save',
+                args: {},
+                result: 'Save failed',
+                isError: true,
+              },
+            },
+          ],
+        },
+      },
+    ];
+    expect(extractTrajectory(output).steps).toEqual([
+      { stepType: 'tool_call', name: 'save', toolArgs: {}, toolResult: { value: 'Save failed' }, success: false },
+    ]);
+  });
+
+  it.each([
+    { legacy: ['read', 'save'], parts: ['save'], expected: ['read', 'save'] },
+    { legacy: ['read', 'check', 'save'], parts: ['read', 'save'], expected: ['read', 'check', 'save'] },
+    { legacy: ['save'], parts: ['read', 'save'], expected: ['read', 'save'] },
+  ])('preserves both compatible call sequences when merging $legacy and $parts', ({ legacy, parts, expected }) => {
+    const invocation = (name: string) => ({
+      state: 'result' as const,
+      toolCallId: name,
+      toolName: name,
+      args: {},
+      result: {},
+    });
+    const output: ScorerRunOutputForAgent = [
+      {
+        id: 'ordered',
+        role: 'assistant',
+        createdAt: new Date(0),
+        content: {
+          format: 2,
+          toolInvocations: legacy.map(invocation),
+          parts: parts.map(name => ({ type: 'tool-invocation', toolInvocation: invocation(name) })),
+        },
+      },
+    ];
+    expect(extractTrajectory(output).steps.map(step => step.name)).toEqual(expected);
+  });
+
+  it('prefers the completed native part over its stale legacy call mirror', () => {
+    const invocation = {
+      state: 'result' as const,
+      toolCallId: 'save',
+      toolName: 'save',
+      args: {},
+      result: { saved: true },
+    };
+    const output: ScorerRunOutputForAgent = [
+      {
+        id: 'mirror',
+        role: 'assistant',
+        createdAt: new Date(0),
+        content: {
+          format: 2,
+          toolInvocations: [{ ...invocation, state: 'call' }],
+          parts: [{ type: 'tool-invocation', toolInvocation: invocation }],
+        },
+      },
+    ];
+    expect(extractTrajectory(output).steps).toEqual([
+      { stepType: 'tool_call', name: 'save', toolArgs: {}, toolResult: { saved: true }, success: true },
+    ]);
+  });
+
   // --- legacy toolInvocations path ---
 
   it('extracts tool calls from content.toolInvocations when present', () => {
@@ -896,7 +1032,7 @@ describe('extractTrajectory', () => {
 
   // --- precedence ---
 
-  it('prefers content.toolInvocations over content.parts when both are present', () => {
+  it('preserves distinct calls from content.toolInvocations and content.parts', () => {
     const output = [
       {
         role: 'assistant',
@@ -921,9 +1057,13 @@ describe('extractTrajectory', () => {
 
     const result = extractTrajectory(output);
 
-    expect(result.steps).toHaveLength(1);
-    expect(result.steps[0]).toMatchObject({ name: 'topLevelTool', success: false });
-    expect(result.steps[0].name).not.toBe('partsTool');
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'topLevelTool', success: false }),
+        expect.objectContaining({ name: 'partsTool', success: true }),
+      ]),
+    );
   });
 
   // --- edge cases ---

--- a/packages/core/src/evals/types.ts
+++ b/packages/core/src/evals/types.ts
@@ -649,19 +649,43 @@ export function extractTrajectory(output: ScorerRunOutputForAgent): Trajectory {
   const steps: ToolCallStep[] = [];
 
   for (const message of output) {
-    // Prefer the legacy toolInvocations array when present; fall back to
-    // V2 content.parts for messages that only store tool calls there.
+    // Native parts retain thrown calls that the legacy array may omit.
+    // Merge by call ID while retaining compatible order from both forms.
     const legacy = message?.content?.toolInvocations;
-    const fromParts = legacy
-      ? undefined
-      : message?.content?.parts
-          ?.filter((p): p is Extract<typeof p, { type: 'tool-invocation' }> => p.type === 'tool-invocation')
-          .map(p => p.toolInvocation);
-    const toolInvocations = legacy ?? fromParts;
+    const fromParts =
+      message?.content?.parts
+        ?.filter((p): p is Extract<typeof p, { type: 'tool-invocation' }> => p.type === 'tool-invocation')
+        .map(p => p.toolInvocation)
+        .filter(Boolean) ?? [];
+    const partCallIds = new Set(fromParts.map(invocation => invocation.toolCallId).filter(Boolean));
+    const legacyInvocations = legacy ?? [];
+    const legacyPositions = new Map(legacyInvocations.map((invocation, index) => [invocation?.toolCallId, index]));
+    const toolInvocations: typeof fromParts = [];
+    let legacyIndex = 0;
+    for (const invocation of fromParts) {
+      const sharedIndex = invocation.toolCallId ? legacyPositions.get(invocation.toolCallId) : undefined;
+      if (sharedIndex !== undefined && sharedIndex >= legacyIndex) {
+        // Retain legacy-only calls before their next shared anchor.
+        for (; legacyIndex < sharedIndex; legacyIndex++) {
+          const previous = legacyInvocations[legacyIndex];
+          if (previous && !partCallIds.has(previous.toolCallId)) toolInvocations.push(previous);
+        }
+        legacyIndex++;
+      }
+      toolInvocations.push(invocation);
+    }
+    for (; legacyIndex < legacyInvocations.length; legacyIndex++) {
+      const invocation = legacyInvocations[legacyIndex];
+      if (invocation && !partCallIds.has(invocation.toolCallId)) toolInvocations.push(invocation);
+    }
     if (!toolInvocations?.length) continue;
 
     for (const invocation of toolInvocations) {
-      if (invocation && invocation.toolName && (invocation.state === 'result' || invocation.state === 'call')) {
+      if (
+        invocation &&
+        invocation.toolName &&
+        (invocation.state === 'result' || invocation.state === 'call' || invocation.state === 'output-error')
+      ) {
         const toolArgs =
           invocation.args != null && typeof invocation.args === 'object' && !Array.isArray(invocation.args)
             ? (invocation.args as Record<string, unknown>)
@@ -682,7 +706,7 @@ export function extractTrajectory(output: ScorerRunOutputForAgent): Trajectory {
           name: invocation.toolName,
           toolArgs,
           toolResult,
-          success: invocation.state === 'result',
+          success: invocation.state === 'result' && invocation.isError !== true,
         });
       }
     }
@@ -833,6 +857,7 @@ function spanToTrajectorySteps(node: SpanTreeNode): TrajectoryStep[] {
         {
           ...base,
           stepType: 'tool_call' as const,
+          name: span.entityId ?? span.entityName ?? span.name,
           toolArgs,
           toolResult,
           success: typeof attrs.success === 'boolean' ? attrs.success : undefined,
@@ -847,6 +872,7 @@ function spanToTrajectorySteps(node: SpanTreeNode): TrajectoryStep[] {
         {
           ...base,
           stepType: 'mcp_tool_call' as const,
+          name: span.entityId ?? span.entityName ?? span.name,
           toolArgs,
           toolResult,
           mcpServer: typeof attrs.mcpServer === 'string' ? attrs.mcpServer : undefined,
@@ -862,6 +888,7 @@ function spanToTrajectorySteps(node: SpanTreeNode): TrajectoryStep[] {
         {
           ...base,
           stepType: 'provider_tool_call' as const,
+          name: span.entityId ?? span.entityName ?? span.name,
           toolArgs,
           toolResult,
           success: typeof attrs.success === 'boolean' ? attrs.success : undefined,


### PR DESCRIPTION
## Description

Native agent trajectory extraction had two bugs:

1. **Message-based `extractTrajectory`** dropped thrown tool calls stored as `state: 'output-error'`, and could miss calls present only in `content.parts` when a legacy `toolInvocations` array also existed.
2. **Trace-based `extractTrajectoryFromTrace`** used the display `span.name` (e.g. `tool: 'save_result'`) as the step name instead of the canonical tool identity from `entityId` / `entityName`.

This change:
- Retains thrown/error tool invocations (`output-error`) as trajectory steps with `success: false`
- Honors explicit `isError` on result-state invocations
- Merges overlapping legacy + parts forms without losing compatible parts-only calls
- Resolves tool/MCP/provider tool span names from `entityId`, then `entityName`, then `span.name`

Fixes #23462

## Test plan

- [x] Added/updated unit tests in `packages/core/src/evals/types.test.ts` for thrown calls, merge order, `isError`, and canonical trace tool names
- [x] `pnpm exec vitest run src/evals/types.test.ts` from `packages/core` — 45 passed
- [ ] Confirm native `runEvals` message vs trace trajectories agree on failed tool identity when tracing is enabled

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR keeps failed tool actions in agent histories instead of losing them. It also ensures traced and untraced histories use the same tool names.

## Changes

- Preserve `output-error` tool calls with `success: false`.
- Honor explicit `isError` values.
- Merge `toolInvocations` and `content.parts` without dropping calls or duplicating call IDs.
- Resolve trace tool names from `entityId`, then `entityName`, then `span.name`.
- Add regression tests for message and trace extraction.
- Add a patch changeset for `@mastra/core`.

## Validation

- 45 tests pass in `packages/core/src/evals/types.test.ts`.
- Additional traced `runEvals` agreement validation remains pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->