### PR TITLE
fix(express): cancel registered streams on client disconnect

### DIFF
--- a/.changeset/puny-dingos-learn.md
+++ b/.changeset/puny-dingos-learn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/express': patch
+---
+
+Fixed registered route streams continuing after the client disconnects.

--- a/server-adapters/express/src/__tests__/express-adapter.test.ts
+++ b/server-adapters/express/src/__tests__/express-adapter.test.ts
@@ -875,7 +875,7 @@ describe('Express Server Adapter', () => {
       expect(receivedAbortSignal).toBeInstanceOf(AbortSignal);
     });
 
-    it('aborts registered route signals when the response closes early', async () => {
+    it('cancels registered route streams and aborts their signals when the response closes early', async () => {
       const app = express();
       app.use(express.json());
 
@@ -885,6 +885,7 @@ describe('Express Server Adapter', () => {
       });
 
       const signalAbort = vi.fn();
+      const streamCancel = vi.fn();
       const testRoute: ServerRoute<any, any, any> = {
         method: 'GET',
         path: '/test/stream-close',
@@ -893,12 +894,10 @@ describe('Express Server Adapter', () => {
           params.abortSignal?.addEventListener('abort', signalAbort);
           return {
             fullStream: new ReadableStream({
-              async start(controller) {
+              start(controller) {
                 controller.enqueue({ type: 'text-delta', textDelta: 'one' });
-                await sleep(10);
-                controller.enqueue({ type: 'text-delta', textDelta: 'two' });
-                controller.close();
               },
+              cancel: streamCancel,
             }),
           };
         },
@@ -922,8 +921,10 @@ describe('Express Server Adapter', () => {
       await reader.read();
       await reader.cancel();
       await waitFor(() => signalAbort.mock.calls.length > 0);
+      await waitFor(() => streamCancel.mock.calls.length > 0);
 
       expect(signalAbort).toHaveBeenCalledTimes(1);
+      expect(streamCancel).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -164,6 +164,14 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
 
     const readableStream = result instanceof ReadableStream ? result : result.fullStream;
     const reader = readableStream.getReader();
+    const abortSignal = res.locals.abortSignal;
+    const cancelStream = () => {
+      void reader.cancel(abortSignal.reason).catch(error => {
+        this.mastra.getLogger()?.error('Failed to cancel stream', { path: route.path, error });
+      });
+    };
+    abortSignal.addEventListener('abort', cancelStream, { once: true });
+    if (abortSignal.aborted) cancelStream();
 
     try {
       while (true) {
@@ -201,6 +209,8 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
         error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
       });
     } finally {
+      abortSignal.removeEventListener('abort', cancelStream);
+      reader.releaseLock();
       res.end();
     }
   }


### PR DESCRIPTION
## Description

**─────── TLDR ───────**
> When a client drops mid-stream, the Express adapter now cancels the source reader instead of waiting on it forever.

Express was the only adapter without this. Hono has cancelled the reader on abort since the adapters landed in #10263, and Koa, Fastify and Elysia do the same. The route already received an abort signal on disconnect, but the adapter's own read loop kept waiting for the next chunk, so a handler that ignores its signal never let the response end.

a registered stream route whose client disconnects mid-stream
&nbsp;&nbsp;├─ **was** — signal aborts, read loop parked on the next chunk, response never ends
&nbsp;&nbsp;└─ **now** — reader cancelled with the abort reason, loop exits, response ends

The test replaces the timed two-chunk stream with one that never closes on its own and asserts the source's `cancel` ran exactly once. It fails against the adapter on `main`.

### Watch

> [!WARNING]
> On an agent route the cancel now reaches the core output stream, <mark>the same path Hono has sent it down since #10263</mark>. Nothing new for a `mastra dev` user, new for an Express deployment.

Split from #23500, where it rode along with a cast cleanup. The approval there covers the casts only.

## Related issue(s)

Split from #23500.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] Documentation changes are not applicable
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

---

> ██████████████████ **tests** `+6 −5`
> ████████████████ **source** `+10`
> ████████ **changeset** `+5`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a client disconnects, the Express adapter now stops waiting for more stream data. This lets the response finish instead of remaining open.

## Changes

- Cancel the stream reader when the request aborts.
- Pass the abort reason to the reader’s `cancel` function.
- Handle already-aborted signals and clean up the abort listener and reader lock.
- Update tests to verify signal propagation and exactly one source cancellation.
- Add a patch changeset for `@mastra/express`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->