### PR TITLE
test(playground-ui): match IntegrationDialog row names without separators

### DIFF
--- a/packages/playground-ui/src/ds/components/IntegrationDialog/integration-dialog.test.tsx
+++ b/packages/playground-ui/src/ds/components/IntegrationDialog/integration-dialog.test.tsx
@@ -78,7 +78,7 @@ describe('IntegrationDialog badge and meta', () => {
   describe('when an item has a badge', () => {
     it('renders it next to the name', () => {
       renderDialog();
-      const button = screen.getByRole('button', { name: 'Sanity MCP OAuth' });
+      const button = screen.getByRole('button', { name: /^Sanity\s*MCP\s*OAuth$/ });
       expect(button.children[2]?.textContent).toBe('MCP');
     });
 
@@ -92,7 +92,7 @@ describe('IntegrationDialog badge and meta', () => {
   describe('when an item has meta text', () => {
     it('renders it muted on the right of the row', () => {
       renderDialog();
-      const button = screen.getByRole('button', { name: 'Notion OAuth' });
+      const button = screen.getByRole('button', { name: /^Notion\s*OAuth$/ });
       expect(button.lastElementChild?.textContent).toBe('OAuth');
       expect(button.lastElementChild?.className).toContain('ml-auto');
     });


### PR DESCRIPTION
## Description

**─────── TLDR ───────**
> The two IntegrationDialog row lookups now match the accessible name with or without separators, so unit shard 1 stops failing on every pull request.

CI runs the unit shards from the repo root with `--project 'unit:*'`. In that run jsdom reports the row's spans as `display: inline`, the accessibility name comes out as `SanityMCPOAuth`, and the exact-string query finds nothing. Run through the package's own `vitest`, the same spans report an empty display and the name reads `Sanity MCP OAuth`. Same jsdom 26.1.0, same vitest 4.1.10, same store path. The test asserted the package-run form and has been red on shard 1 since #23110 merged on 2026-09-08; the unit workflow does not run on `main`, so it only shows on pull requests.

`getByRole('button', { name })` for the badge row and the meta row
&nbsp;&nbsp;├─ **was** — exact string `Sanity MCP OAuth`, red in the root run
&nbsp;&nbsp;└─ **now** — `/^Sanity\s*MCP\s*OAuth$/`, same order, any separator

The assertions on child order and the `ml-auto` class are untouched. This is the regex #23500 carried before it was narrowed to its own scope.

The changed-tests gate is red by construction here: it runs the file with `pnpm --dir packages/playground-ui exec vitest`, the package command, where the test already passes on base. It is not a required check. Merge Test Reports is, and it needs this PR in first: every other PR's shard 1 fails on these two rows until then.

### Not verified

- [ ] why the root-config run and the package run compute a different `display` for the same spans; the regex sidesteps it, it does not explain it

## Related issue(s)

Red since #23110. Carried inside #23500 until that PR was narrowed.

## Type of change

- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] Documentation changes are not applicable
- [x] The test fails on `main` in the root run and passes here in both runs
- [ ] I have addressed all Coderabbit comments on this PR

---

> ██████████████████ **tests** `+2 −2`
