### PR TITLE
logging(memory): add OM provider failure diagnostics

### DIFF
--- a/.changeset/every-plants-cover.md
+++ b/.changeset/every-plants-cover.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Improved diagnostics for Observational Memory model and provider failures.

--- a/packages/memory/src/processors/observational-memory/observer-runner.ts
+++ b/packages/memory/src/processors/observational-memory/observer-runner.ts
@@ -266,7 +266,20 @@ export class ObserverRunner {
     options?: ObserverCallOptions,
   ): Promise<ObserverCallResult> {
     const inputTokens = this.tokenCounter.countMessages(messagesToObserve);
-    const resolvedModel = options?.model ? { model: options.model } : this.resolveModel(inputTokens);
+    const resolvedModel = (() => {
+      try {
+        return options?.model ? { model: options.model } : this.resolveModel(inputTokens);
+      } catch (error) {
+        this.mastra?.getLogger?.().error('OM observer model resolution failed', {
+          error,
+          errorMessage: error instanceof Error ? error.message : String(error),
+          inputTokens,
+          threadId: messagesToObserve[0]?.threadId,
+          hasRequestContext: Boolean(options?.requestContext),
+        });
+        throw error;
+      }
+    })();
     const activeExtractors = await resolveExtractors(
       filterObserverExtractors(this.observationConfig.extractors, options?.skipContinuationHints),
       {
@@ -324,15 +337,37 @@ export class ObserverRunner {
             },
             callback: childObservabilityContext =>
               this.withAbortCheck(async () => {
-                const streamResult = await agent.stream(observerMessages, {
-                  modelSettings: { ...this.observationConfig.modelSettings },
-                  providerOptions: this.observationConfig.providerOptions as any,
-                  ...(temporaryMemory ? { memory: temporaryMemory.options } : {}),
-                  ...(abortSignal ? { abortSignal } : {}),
-                  ...(internalRequestContext ? { requestContext: internalRequestContext } : {}),
-                  ...childObservabilityContext,
-                });
-                return streamResult.getFullOutput();
+                try {
+                  const streamResult = await agent.stream(observerMessages, {
+                    modelSettings: { ...this.observationConfig.modelSettings },
+                    providerOptions: this.observationConfig.providerOptions as any,
+                    ...(temporaryMemory ? { memory: temporaryMemory.options } : {}),
+                    ...(abortSignal ? { abortSignal } : {}),
+                    ...(internalRequestContext ? { requestContext: internalRequestContext } : {}),
+                    ...childObservabilityContext,
+                  });
+                  return await streamResult.getFullOutput();
+                } catch (error) {
+                  const providerError = error as Record<string, unknown>;
+
+                  this.mastra?.getLogger?.().error('OM observer provider call failed', {
+                    error,
+                    errorName: error instanceof Error ? error.name : undefined,
+                    errorMessage: error instanceof Error ? error.message : String(error),
+                    errorCause: error instanceof Error ? error.cause : providerError?.cause,
+                    status: providerError?.status,
+                    statusCode: providerError?.statusCode,
+                    responseBody: providerError?.responseBody,
+                    model: this.extractModelRouterId(resolvedModel.model, internalRequestContext),
+                    inputTokens,
+                    threadId: messagesToObserve[0]?.threadId,
+                    observedMessageCount: messagesToObserve.length,
+                    providerOptionProviders: Object.keys(this.observationConfig.providerOptions ?? {}),
+                    hasRequestContext: Boolean(internalRequestContext),
+                    aborted: abortSignal?.aborted ?? false,
+                  });
+                  throw error;
+                }
               }, abortSignal),
           }),
         { label: 'observer', abortSignal },
@@ -503,7 +538,20 @@ export class ObserverRunner {
       (total, messages) => total + this.tokenCounter.countMessages(messages),
       0,
     );
-    const resolvedModel = model ? { model } : this.resolveModel(inputTokens);
+    const resolvedModel = (() => {
+      try {
+        return model ? { model } : this.resolveModel(inputTokens);
+      } catch (error) {
+        this.mastra?.getLogger?.().error('OM multi-thread observer model resolution failed', {
+          error,
+          errorMessage: error instanceof Error ? error.message : String(error),
+          inputTokens,
+          threadIds: threadOrder,
+          hasRequestContext: Boolean(requestContext),
+        });
+        throw error;
+      }
+    })();
     const firstThreadMessages = messagesByThread.get(threadOrder[0] ?? '') ?? [];
     const activeExtractors = await resolveExtractors(this.observationConfig.extractors ?? [], {
       source: 'observer',
@@ -601,15 +649,36 @@ export class ObserverRunner {
             },
             callback: childObservabilityContext =>
               this.withAbortCheck(async () => {
-                const streamResult = await agent.stream(observerMessages, {
-                  modelSettings: { ...this.observationConfig.modelSettings },
-                  providerOptions: this.observationConfig.providerOptions as any,
-                  ...(temporaryMemory ? { memory: temporaryMemory.options } : {}),
-                  ...(abortSignal ? { abortSignal } : {}),
-                  ...(internalRequestContext ? { requestContext: internalRequestContext } : {}),
-                  ...childObservabilityContext,
-                });
-                return streamResult.getFullOutput();
+                try {
+                  const streamResult = await agent.stream(observerMessages, {
+                    modelSettings: { ...this.observationConfig.modelSettings },
+                    providerOptions: this.observationConfig.providerOptions as any,
+                    ...(temporaryMemory ? { memory: temporaryMemory.options } : {}),
+                    ...(abortSignal ? { abortSignal } : {}),
+                    ...(internalRequestContext ? { requestContext: internalRequestContext } : {}),
+                    ...childObservabilityContext,
+                  });
+                  return await streamResult.getFullOutput();
+                } catch (error) {
+                  const providerError = error as Record<string, unknown>;
+
+                  this.mastra?.getLogger?.().error('OM multi-thread observer provider call failed', {
+                    error,
+                    errorName: error instanceof Error ? error.name : undefined,
+                    errorMessage: error instanceof Error ? error.message : String(error),
+                    errorCause: error instanceof Error ? error.cause : providerError?.cause,
+                    status: providerError?.status,
+                    statusCode: providerError?.statusCode,
+                    responseBody: providerError?.responseBody,
+                    model: this.extractModelRouterId(resolvedModel.model, internalRequestContext),
+                    inputTokens,
+                    threadIds: threadOrder,
+                    providerOptionProviders: Object.keys(this.observationConfig.providerOptions ?? {}),
+                    hasRequestContext: Boolean(internalRequestContext),
+                    aborted: abortSignal?.aborted ?? false,
+                  });
+                  throw error;
+                }
               }, abortSignal),
           }),
         { label: 'observer-multi-thread', abortSignal },

--- a/packages/memory/src/processors/observational-memory/observer-runner.ts
+++ b/packages/memory/src/processors/observational-memory/observer-runner.ts
@@ -10,6 +10,7 @@ import type { ProviderMetadata } from '@mastra/core/stream';
 
 import type { Memory } from '../..';
 import { omDebug } from './debug';
+import { formatOmError } from './error';
 import { getBuiltInExtractedValues, mergeExtractedValues, mergeExtractionFailures } from './extracted-values';
 import { extractStructuredValues } from './extraction-runner';
 import type { Extractor } from './extractor';
@@ -271,8 +272,7 @@ export class ObserverRunner {
         return options?.model ? { model: options.model } : this.resolveModel(inputTokens);
       } catch (error) {
         this.mastra?.getLogger?.().error('OM observer model resolution failed', {
-          error,
-          errorMessage: error instanceof Error ? error.message : String(error),
+          diagnostic: formatOmError(error),
           inputTokens,
           threadId: messagesToObserve[0]?.threadId,
           hasRequestContext: Boolean(options?.requestContext),
@@ -348,16 +348,8 @@ export class ObserverRunner {
                   });
                   return await streamResult.getFullOutput();
                 } catch (error) {
-                  const providerError = error as Record<string, unknown>;
-
                   this.mastra?.getLogger?.().error('OM observer provider call failed', {
-                    error,
-                    errorName: error instanceof Error ? error.name : undefined,
-                    errorMessage: error instanceof Error ? error.message : String(error),
-                    errorCause: error instanceof Error ? error.cause : providerError?.cause,
-                    status: providerError?.status,
-                    statusCode: providerError?.statusCode,
-                    responseBody: providerError?.responseBody,
+                    diagnostic: formatOmError(error),
                     model: this.extractModelRouterId(resolvedModel.model, internalRequestContext),
                     inputTokens,
                     threadId: messagesToObserve[0]?.threadId,
@@ -543,8 +535,7 @@ export class ObserverRunner {
         return model ? { model } : this.resolveModel(inputTokens);
       } catch (error) {
         this.mastra?.getLogger?.().error('OM multi-thread observer model resolution failed', {
-          error,
-          errorMessage: error instanceof Error ? error.message : String(error),
+          diagnostic: formatOmError(error),
           inputTokens,
           threadIds: threadOrder,
           hasRequestContext: Boolean(requestContext),
@@ -660,16 +651,8 @@ export class ObserverRunner {
                   });
                   return await streamResult.getFullOutput();
                 } catch (error) {
-                  const providerError = error as Record<string, unknown>;
-
                   this.mastra?.getLogger?.().error('OM multi-thread observer provider call failed', {
-                    error,
-                    errorName: error instanceof Error ? error.name : undefined,
-                    errorMessage: error instanceof Error ? error.message : String(error),
-                    errorCause: error instanceof Error ? error.cause : providerError?.cause,
-                    status: providerError?.status,
-                    statusCode: providerError?.statusCode,
-                    responseBody: providerError?.responseBody,
+                    diagnostic: formatOmError(error),
                     model: this.extractModelRouterId(resolvedModel.model, internalRequestContext),
                     inputTokens,
                     threadIds: threadOrder,

--- a/packages/memory/src/processors/observational-memory/observer-runner.ts
+++ b/packages/memory/src/processors/observational-memory/observer-runner.ts
@@ -350,7 +350,10 @@ export class ObserverRunner {
                 } catch (error) {
                   this.mastra?.getLogger?.().error('OM observer provider call failed', {
                     diagnostic: formatOmError(error),
-                    model: this.extractModelRouterId(resolvedModel.model, internalRequestContext),
+                    model:
+                      typeof resolvedModel.model === 'function'
+                        ? '(dynamic-model)'
+                        : this.extractModelRouterId(resolvedModel.model, internalRequestContext),
                     inputTokens,
                     threadId: messagesToObserve[0]?.threadId,
                     observedMessageCount: messagesToObserve.length,
@@ -537,7 +540,10 @@ export class ObserverRunner {
         this.mastra?.getLogger?.().error('OM multi-thread observer model resolution failed', {
           diagnostic: formatOmError(error),
           inputTokens,
-          threadIds: threadOrder,
+          threadIds: {
+            sample: threadOrder.slice(0, 10).map(threadId => threadId.slice(0, 128)),
+            total: threadOrder.length,
+          },
           hasRequestContext: Boolean(requestContext),
         });
         throw error;
@@ -653,9 +659,15 @@ export class ObserverRunner {
                 } catch (error) {
                   this.mastra?.getLogger?.().error('OM multi-thread observer provider call failed', {
                     diagnostic: formatOmError(error),
-                    model: this.extractModelRouterId(resolvedModel.model, internalRequestContext),
+                    model:
+                      typeof resolvedModel.model === 'function'
+                        ? '(dynamic-model)'
+                        : this.extractModelRouterId(resolvedModel.model, internalRequestContext),
                     inputTokens,
-                    threadIds: threadOrder,
+                    threadIds: {
+                      sample: threadOrder.slice(0, 10).map(threadId => threadId.slice(0, 128)),
+                      total: threadOrder.length,
+                    },
                     providerOptionProviders: Object.keys(this.observationConfig.providerOptions ?? {}),
                     hasRequestContext: Boolean(internalRequestContext),
                     aborted: abortSignal?.aborted ?? false,


### PR DESCRIPTION
## Summary
- log observational-memory model resolution failures with thread and request-context metadata
- log provider call failures with model, token, provider, and HTTP diagnostic fields
- preserve existing retries and error propagation

## Test plan
- `pnpm vitest run src/processors/observational-memory/observer-agent.test.ts src/processors/observational-memory/__tests__/error.test.ts`
- `pnpm eslint src/processors/observational-memory/observer-runner.ts`
- `git diff --check`

The package typecheck remains blocked by existing `includeTotal` errors in `packages/memory/src/index.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds useful error logs when the memory observer cannot find a model or when a provider call fails. It keeps the existing retry behavior and still returns the original errors.

## Changes

- Added bounded, sanitized logging for model resolution failures.
- Added bounded, sanitized logging for provider call failures.
- Included thread, request, model, token, provider, HTTP, and abort-state context.
- Covered single-thread and multi-thread observer paths.
- Avoided repeated dynamic model resolution during failure logging.
- Added a patch changeset for `@mastra/memory`.
- Preserved existing retries and error propagation.

## Validation

- Targeted Vitest tests
- ESLint
- `git diff --check`
- Package typecheck remains blocked by existing `includeTotal` errors in `packages/memory/src/index.ts`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->