### PR TITLE
fix(factory): hydrate project OM settings for web sessions

### DIFF
--- a/.changeset/eight-wings-dream.md
+++ b/.changeset/eight-wings-dream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Factory web sessions using personal observational-memory defaults instead of the Factory project's configured models.

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -1084,6 +1084,7 @@ export class MastraFactory {
       session =>
         hydrateSessionMemorySettings(session, {
           sourceControl: sourceControlStorage.forIntegration('github'),
+          projects: factoryProjectsStorage,
           memorySettings: memorySettingsStorage,
         }),
       { blocking: true },

--- a/mastracode/factory/src/session/memory-settings-hydration.test.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.test.ts
@@ -316,6 +316,51 @@ describe('hydrateSessionMemorySettings', () => {
     });
   });
 
+  it('preserves current models for threshold-only settings when the project has no default model', async () => {
+    const session = createSession(
+      { factoryProjectId: 'project-1', factoryOrgId: 'org-1' },
+      { observer: 'anthropic/claude-haiku-4-5', reflector: 'openai/gpt-5.4-mini' },
+    );
+    const dependencies = createDependencies({
+      projectDefaultModelId: null,
+      settings: memorySettingsRow({
+        userId: 'factory-project:project-1',
+        observerModelId: null,
+        reflectorModelId: null,
+        observationThreshold: 12_000,
+      }),
+    });
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(session.om.observer.switchModel).not.toHaveBeenCalled();
+    expect(session.om.reflector.switchModel).not.toHaveBeenCalled();
+    expect(session.state.set).toHaveBeenCalledExactlyOnceWith({
+      observationThreshold: 12_000,
+      reflectionThreshold: DEFAULT_REFLECTION_THRESHOLD,
+    });
+  });
+
+  it('applies an explicit role model without replacing the unset role when the project has no default model', async () => {
+    const session = createSession(
+      { factoryProjectId: 'project-1', factoryOrgId: 'org-1' },
+      { observer: 'anthropic/claude-haiku-4-5', reflector: 'openai/gpt-5.4-mini' },
+    );
+    const dependencies = createDependencies({
+      projectDefaultModelId: null,
+      settings: memorySettingsRow({
+        userId: 'factory-project:project-1',
+        observerModelId: 'openai/gpt-5.6-sol',
+        reflectorModelId: null,
+      }),
+    });
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(session.om.observer.switchModel).toHaveBeenCalledExactlyOnceWith({ modelId: 'openai/gpt-5.6-sol' });
+    expect(session.om.reflector.switchModel).not.toHaveBeenCalled();
+  });
+
   it('uses an explicit project role model and the project provider fallback for the unset role', async () => {
     const session = createSession(
       { factoryProjectId: 'project-1', factoryOrgId: 'org-1' },

--- a/mastracode/factory/src/session/memory-settings-hydration.test.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.test.ts
@@ -36,6 +36,7 @@ function sourceControlRow(): SourceControlSession {
     userId: 'user-1',
     branch: 'user/session-1',
     title: null,
+    visibility: 'private',
     baseBranch: 'main',
     sandboxId: null,
     sandboxWorkdir: null,
@@ -65,12 +66,25 @@ function memorySettingsRow(overrides: Partial<MemorySettingsRecord> = {}): Memor
 function createDependencies({
   row = sourceControlRow(),
   settings = memorySettingsRow(),
+  projectDefaultModelId = 'anthropic/claude-sonnet-4-5',
 }: {
   row?: SourceControlSession | null;
   settings?: MemorySettingsRecord | null;
+  projectDefaultModelId?: string | null;
 } = {}): MemorySettingsHydrationDependencies {
   return {
     sourceControl: { sessions: { getBySessionId: vi.fn().mockResolvedValue(row) } },
+    projects: {
+      get: vi.fn().mockResolvedValue(
+        projectDefaultModelId === null
+          ? null
+          : {
+              id: 'project-1',
+              orgId: 'org-1',
+              defaultModelId: projectDefaultModelId,
+            },
+      ),
+    } as MemorySettingsHydrationDependencies['projects'],
     memorySettings: { get: vi.fn().mockResolvedValue(settings) },
   };
 }
@@ -275,6 +289,52 @@ describe('hydrateSessionMemorySettings', () => {
     });
     expect(session.om.observer.switchModel).toHaveBeenCalledExactlyOnceWith({ modelId: 'openai/gpt-5.6-sol' });
     expect(session.om.reflector.switchModel).toHaveBeenCalledExactlyOnceWith({ modelId: 'openai/gpt-5.6-sol' });
+  });
+
+  it('uses the project provider fallback when a project settings row only configures thresholds', async () => {
+    const session = createSession(
+      { factoryProjectId: 'project-1', factoryOrgId: 'org-1' },
+      { observer: 'anthropic/claude-haiku-4-5', reflector: 'anthropic/claude-haiku-4-5' },
+    );
+    const dependencies = createDependencies({
+      settings: memorySettingsRow({
+        userId: 'factory-project:project-1',
+        observerModelId: null,
+        reflectorModelId: null,
+        observationThreshold: 12_000,
+      }),
+    });
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(dependencies.projects.get).toHaveBeenCalledExactlyOnceWith({ orgId: 'org-1', id: 'project-1' });
+    expect(session.om.observer.switchModel).not.toHaveBeenCalled();
+    expect(session.om.reflector.switchModel).not.toHaveBeenCalled();
+    expect(session.state.set).toHaveBeenCalledExactlyOnceWith({
+      observationThreshold: 12_000,
+      reflectionThreshold: DEFAULT_REFLECTION_THRESHOLD,
+    });
+  });
+
+  it('uses an explicit project role model and the project provider fallback for the unset role', async () => {
+    const session = createSession(
+      { factoryProjectId: 'project-1', factoryOrgId: 'org-1' },
+      { observer: 'anthropic/claude-haiku-4-5', reflector: 'openai/gpt-5.4-mini' },
+    );
+    const dependencies = createDependencies({
+      settings: memorySettingsRow({
+        userId: 'factory-project:project-1',
+        observerModelId: 'openai/gpt-5.6-sol',
+        reflectorModelId: null,
+      }),
+    });
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(session.om.observer.switchModel).toHaveBeenCalledExactlyOnceWith({ modelId: 'openai/gpt-5.6-sol' });
+    expect(session.om.reflector.switchModel).toHaveBeenCalledExactlyOnceWith({
+      modelId: 'anthropic/claude-haiku-4-5',
+    });
   });
 
   it('repairs a tagged web session whose org was previously seeded without project settings', async () => {

--- a/mastracode/factory/src/session/memory-settings-hydration.test.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.test.ts
@@ -256,29 +256,65 @@ describe('hydrateSessionMemorySettings', () => {
     expect(session.state.set).toHaveBeenCalledWith({ factoryOrgUnresolved: true });
   });
 
-  it('seeds the org on a tagged session that never went through the coordinator', async () => {
-    // A web chat session persists `factoryProjectId` from its browser seed, so on
-    // resume it carries the tag with no org. Skipping on the tag alone would leave
-    // it mis-scoped forever. Settings still belong to the coordinator.
+  it('applies project-scoped settings to a tagged web session that never went through the coordinator', async () => {
     const session = createSession({ factoryProjectId: 'project-1' });
-    const dependencies = createDependencies();
+    const dependencies = createDependencies({
+      settings: memorySettingsRow({
+        userId: 'factory-project:project-1',
+        observerModelId: 'openai/gpt-5.6-sol',
+        reflectorModelId: 'openai/gpt-5.6-sol',
+      }),
+    });
 
     await hydrateSessionMemorySettings(session, dependencies);
 
-    expect(session.state.set).toHaveBeenCalledExactlyOnceWith({ factoryOrgId: 'org-1' });
-    expect(dependencies.memorySettings.get).not.toHaveBeenCalled();
-    expect(session.om.observer.switchModel).not.toHaveBeenCalled();
+    expect(session.state.set).toHaveBeenCalledWith({ factoryOrgId: 'org-1' });
+    expect(dependencies.memorySettings.get).toHaveBeenCalledExactlyOnceWith({
+      orgId: 'org-1',
+      userId: 'factory-project:project-1',
+    });
+    expect(session.om.observer.switchModel).toHaveBeenCalledExactlyOnceWith({ modelId: 'openai/gpt-5.6-sol' });
+    expect(session.om.reflector.switchModel).toHaveBeenCalledExactlyOnceWith({ modelId: 'openai/gpt-5.6-sol' });
   });
 
-  it('skips fully hydrated factory-run sessions, which the start coordinator owns', async () => {
-    const session = createSession({ factoryProjectId: 'project-1', factoryOrgId: 'org-1' });
-    const dependencies = createDependencies();
+  it('repairs a tagged web session whose org was previously seeded without project settings', async () => {
+    const session = createSession(
+      { factoryProjectId: 'project-1', factoryOrgId: 'org-1' },
+      { observer: 'openai/gpt-5.4-mini', reflector: 'openai/gpt-5.4-mini' },
+    );
+    const dependencies = createDependencies({
+      settings: memorySettingsRow({
+        userId: 'factory-project:project-1',
+        observerModelId: 'openai/gpt-5.6-sol',
+        reflectorModelId: 'openai/gpt-5.6-sol',
+      }),
+    });
 
     await hydrateSessionMemorySettings(session, dependencies);
 
-    expect(dependencies.sourceControl.sessions.getBySessionId).not.toHaveBeenCalled();
-    expect(session.state.set).not.toHaveBeenCalled();
+    expect(dependencies.memorySettings.get).toHaveBeenCalledExactlyOnceWith({
+      orgId: 'org-1',
+      userId: 'factory-project:project-1',
+    });
+    expect(session.om.observer.switchModel).toHaveBeenCalledExactlyOnceWith({ modelId: 'openai/gpt-5.6-sol' });
+    expect(session.om.reflector.switchModel).toHaveBeenCalledExactlyOnceWith({ modelId: 'openai/gpt-5.6-sol' });
+  });
+
+  it('preserves a coordinator-hydrated provider fallback when the project has no stored settings', async () => {
+    const session = createSession(
+      { factoryProjectId: 'project-1', factoryOrgId: 'org-1' },
+      { observer: 'anthropic/claude-haiku-4-5', reflector: 'anthropic/claude-haiku-4-5' },
+    );
+    const dependencies = createDependencies({ settings: null });
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(dependencies.memorySettings.get).toHaveBeenCalledExactlyOnceWith({
+      orgId: 'org-1',
+      userId: 'factory-project:project-1',
+    });
     expect(session.om.observer.switchModel).not.toHaveBeenCalled();
+    expect(session.om.reflector.switchModel).not.toHaveBeenCalled();
   });
 
   it('skips sessions without a source-control row', async () => {

--- a/mastracode/factory/src/session/memory-settings-hydration.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.ts
@@ -144,7 +144,17 @@ export async function hydrateSessionMemorySettings(
     const fallbackOmModelId = provider
       ? resolveProviderOMDefault(provider, project.defaultModelId ?? undefined).modelId
       : undefined;
-    await applyStoredMemorySettings(session, settings, fallbackOmModelId);
+    await applyStoredMemorySettings(
+      session,
+      factoryProjectId && settings && !fallbackOmModelId
+        ? {
+            ...settings,
+            observerModelId: settings?.observerModelId ?? session.om.observer.modelId() ?? null,
+            reflectorModelId: settings?.reflectorModelId ?? session.om.reflector.modelId() ?? null,
+          }
+        : settings,
+      fallbackOmModelId,
+    );
   } catch (error) {
     console.warn('[Factory memory-settings hydration] Unable to apply stored memory settings.', error);
     // A failed lookup is an unresolved org, not an absent one — unless the seed

--- a/mastracode/factory/src/session/memory-settings-hydration.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.ts
@@ -1,10 +1,12 @@
 import { DEFAULT_OM_MODEL_ID } from '@mastra/code-sdk/constants';
+import { resolveProviderOMDefault } from '@mastra/code-sdk/onboarding/packs';
 
 import {
   factoryMemorySettingsUserId,
   type MemorySettingsRecord,
   type MemorySettingsStorage,
 } from '../storage/domains/memory-settings/base.js';
+import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
 import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
 import { seedSessionOrg } from './org-seed.js';
 
@@ -88,6 +90,7 @@ export interface MemorySettingsHydrationDependencies {
   sourceControl: {
     sessions: Pick<SourceControlStorageHandle['sessions'], 'getBySessionId'>;
   };
+  projects: Pick<FactoryProjectsStorage, 'get'>;
   memorySettings: Pick<MemorySettingsStorage, 'get'>;
 }
 
@@ -116,7 +119,7 @@ export interface MemorySettingsHydrationDependencies {
  */
 export async function hydrateSessionMemorySettings(
   session: MemorySettingsHydrationSession,
-  { sourceControl, memorySettings }: MemorySettingsHydrationDependencies,
+  { sourceControl, projects, memorySettings }: MemorySettingsHydrationDependencies,
 ): Promise<void> {
   const state = session.state.get() ?? {};
   const isFactoryRun = Boolean(state.factoryProjectId);
@@ -128,14 +131,20 @@ export async function hydrateSessionMemorySettings(
     // under the local scope — the same bug wearing a different rung.
     await seedSessionOrg(session, record?.orgId);
     if (!record) return;
+    const factoryProjectId = isFactoryRun ? String(state.factoryProjectId) : undefined;
     const settings = await memorySettings.get({
       orgId: record.orgId,
-      userId: isFactoryRun ? factoryMemorySettingsUserId(String(state.factoryProjectId)) : record.userId,
+      userId: factoryProjectId ? factoryMemorySettingsUserId(factoryProjectId) : record.userId,
     });
     // Coordinator hydration applies a provider-aware fallback when no project row
     // exists. Do not replace that fallback with the generic OM default here.
-    if (isFactoryRun && !settings) return;
-    await applyStoredMemorySettings(session, settings);
+    if (factoryProjectId && !settings) return;
+    const project = factoryProjectId ? await projects.get({ orgId: record.orgId, id: factoryProjectId }) : null;
+    const provider = project?.defaultModelId?.split('/')[0];
+    const fallbackOmModelId = provider
+      ? resolveProviderOMDefault(provider, project.defaultModelId ?? undefined).modelId
+      : undefined;
+    await applyStoredMemorySettings(session, settings, fallbackOmModelId);
   } catch (error) {
     console.warn('[Factory memory-settings hydration] Unable to apply stored memory settings.', error);
     // A failed lookup is an unresolved org, not an absent one — unless the seed

--- a/mastracode/factory/src/session/memory-settings-hydration.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.ts
@@ -1,8 +1,12 @@
 import { DEFAULT_OM_MODEL_ID } from '@mastra/code-sdk/constants';
 
-import type { MemorySettingsRecord, MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
+import {
+  factoryMemorySettingsUserId,
+  type MemorySettingsRecord,
+  type MemorySettingsStorage,
+} from '../storage/domains/memory-settings/base.js';
 import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
-import { hasResolvedOrg, seedSessionOrg } from './org-seed.js';
+import { seedSessionOrg } from './org-seed.js';
 
 /** Default thresholds mirror the TUI `/om` fallbacks. */
 export const DEFAULT_OBSERVATION_THRESHOLD = 30_000;
@@ -102,13 +106,13 @@ export interface MemorySettingsHydrationDependencies {
  * comes from the row the session was created from, never improvised from an
  * owner id.
  *
- * Memory settings for sessions tagged `factoryProjectId` (work/review runs) are
- * owned by the start coordinator, and sessions without a GitHub source-control
- * row (e.g. chat-only channel sessions) hydrate through `hydrateFactorySession`
- * with their own resolved tenant; both are skipped here. The org seed is not
- * skipped on the tag alone: a web chat session persists `factoryProjectId` from
- * its browser seed, so on resume it carries the tag without ever having been
- * through the coordinator. Best-effort: failures are logged, never thrown.
+ * Tagged sessions may be coordinator-owned runs or web sessions that only carry
+ * browser-seeded Factory state. This path resolves their source-control row and
+ * reapplies a stored project settings row when one exists. If no project row
+ * exists, it preserves the coordinator's provider-aware fallback.
+ * Sessions without a GitHub source-control row (e.g. chat-only channel sessions)
+ * hydrate through `hydrateFactorySession` with their own resolved tenant.
+ * Best-effort: failures are logged, never thrown.
  */
 export async function hydrateSessionMemorySettings(
   session: MemorySettingsHydrationSession,
@@ -116,8 +120,6 @@ export async function hydrateSessionMemorySettings(
 ): Promise<void> {
   const state = session.state.get() ?? {};
   const isFactoryRun = Boolean(state.factoryProjectId);
-  // A coordinator-hydrated run already carries both halves. Nothing to add.
-  if (isFactoryRun && hasResolvedOrg(state.factoryOrgId)) return;
   try {
     const record = await sourceControl.sessions.getBySessionId(session.identity.getResourceId());
     // No row, or a row whose org is blank, leaves the session with no tenant.
@@ -126,8 +128,13 @@ export async function hydrateSessionMemorySettings(
     // under the local scope — the same bug wearing a different rung.
     await seedSessionOrg(session, record?.orgId);
     if (!record) return;
-    if (isFactoryRun) return;
-    const settings = await memorySettings.get({ orgId: record.orgId, userId: record.userId });
+    const settings = await memorySettings.get({
+      orgId: record.orgId,
+      userId: isFactoryRun ? factoryMemorySettingsUserId(String(state.factoryProjectId)) : record.userId,
+    });
+    // Coordinator hydration applies a provider-aware fallback when no project row
+    // exists. Do not replace that fallback with the generic OM default here.
+    if (isFactoryRun && !settings) return;
     await applyStoredMemorySettings(session, settings);
   } catch (error) {
     console.warn('[Factory memory-settings hydration] Unable to apply stored memory settings.', error);


### PR DESCRIPTION
## Summary

Factory web sessions tagged with a `factoryProjectId` could skip project-scoped observational-memory hydration and continue using the model already present on the session, such as the seeded OpenAI default `openai/gpt-5.4-mini`, even though Factory settings displayed a different configured model such as `openai/gpt-5.6-sol`.

This change:

- hydrates Factory-tagged web sessions from the project's stored observational-memory settings
- repairs resumed sessions whose organization was already seeded but whose OM settings were never applied
- uses the existing `factoryMemorySettingsUserId(factoryProjectId)` scope so runtime hydration reads the same row as Factory settings and coordinator-created runs
- preserves coordinator-selected provider-aware fallbacks when the project has no stored memory-settings row

## Where this could happen

The mismatch occurs in the generic session-created hydration path in `memory-settings-hydration.ts`.

Factory has multiple session lifecycle paths:

- Coordinator-created board/rules-engine sessions are explicitly hydrated through `hydrateFactorySession` before execution.
- Interactive Factory web sessions can instead arrive at the generic hydration hook already tagged with `factoryProjectId` from browser/session state.
- Resumed web sessions may also already carry a resolved `factoryOrgId` from an earlier hydration attempt.

The previous implementation assumed every session carrying `factoryProjectId` was coordinator-owned. It therefore seeded the organization when necessary and then returned without reading the project's memory-settings row. That assumption does not hold for tagged web sessions that did not pass through coordinator hydration.

As a result, the settings API could correctly read and display the project-scoped model while the live session retained its personal or seeded default OM model. This was observed as Factory settings showing `openai/gpt-5.6-sol` while the `memory: observe` execution used `openai/gpt-5.4-mini`.

## Likely regression

This behavior appears to have been introduced by [PR #21823](https://github.com/mastra-ai/mastra/pull/21823), specifically commit `00707f376a` (`fix: scope Subconscious knowledge capture to the real organization on every session path`). That change added the early return for sessions tagged with `factoryProjectId` and encoded the assumption that those sessions had already been hydrated by the start coordinator.

The organization-scoping fix itself was necessary, but tagged interactive web sessions can bypass the coordinator. For those sessions, the early return prevented the project-scoped OM settings lookup introduced for web-user sessions from running.

## Fix

For Factory-tagged sessions with a source-control session row, the generic hydration path now looks up memory settings using:

```ts
factoryMemorySettingsUserId(factoryProjectId)
```

This is the existing synthetic user ID already used by Factory configuration routes, `hydrateFactorySession`, and coordinator runs to address project-shared memory settings.

If a stored project row exists, its observer and reflector models are applied. If no row exists, the generic hook leaves the current models unchanged so it does not overwrite the provider-aware fallback already selected by coordinator hydration.

## Regression coverage

The tests cover:

- a tagged web session that has not passed through coordinator hydration
- an affected resumed session that already has `factoryOrgId` but still carries `openai/gpt-5.4-mini`
- applying the project-scoped observer and reflector model `openai/gpt-5.6-sol`
- preserving a coordinator-selected provider fallback when no stored project settings row exists

The focused suite was also run with the tests present but the implementation reverted to the previous behavior. It failed three tests because the project settings lookup was never performed, confirming the tests reproduce the regression rather than merely exercising the fixed path.

## Test plan

- Previous implementation with regression tests: 3 failed, 16 passed
- `pnpm test src/session/memory-settings-hydration.test.ts` (19/19)
- `pnpm test` (127 files, 2,473 passed, 6 skipped)
- `pnpm lint` (0 warnings/errors)
- `git diff --check`

## Typecheck

`pnpm check` remains blocked by the pre-existing `coAuthor` error in `mastracode/factory/src/factory.ts:740`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Factory web sessions now use the project’s saved memory settings instead of personal defaults. If a setting is missing, the session keeps its existing provider-aware fallback.

## Changes

- Hydrate Factory-tagged sessions with project-scoped settings.
- Repair resumed sessions whose organization was already seeded.
- Apply stored observer and reflector models when configured.
- Preserve provider-aware fallback models when settings or model fields are unset.
- Pass project storage into `hydrateSessionMemorySettings`.
- Add regression tests for project settings, resumed sessions, threshold-only settings, partial model settings, and fallback preservation.
- Add a patch changeset for `@mastra/factory`.

## Validation

- Focused and full test suites pass.
- Lint passes.
- `git diff --check` passes.
- Typecheck remains blocked by the pre-existing `coAuthor` error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->