### PR TITLE
fix(core): include timeout in processor modelSettings types (#23457)

### DIFF
--- a/.changeset/calm-timeout-processors.md
+++ b/.changeset/calm-timeout-processors.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed processor `modelSettings` types so they accept timeout budgets such as `timeout.stepMs`. (#23457)

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -1,12 +1,13 @@
 import type { LanguageModelV2, LanguageModelV2CallWarning, LanguageModelV2Prompt } from '@ai-sdk/provider-v5';
 import type { CoreMessage as CoreMessageV4 } from '@internal/ai-sdk-v4';
-import type { CallSettings, StepResult, ToolChoice } from '@internal/ai-sdk-v5';
+import type { StepResult, ToolChoice } from '@internal/ai-sdk-v5';
 import type { Agent } from '../agent';
 import type { MessageList, MastraDBMessage } from '../agent/message-list';
 import type { AgentSignalInput, AgentStateSignalInput, CreatedAgentSignal } from '../agent/signals';
 import type { ApplyStateSignalResult } from '../agent/state-signals';
 import type { TripWireOptions } from '../agent/trip-wire';
 import type { ModelRouterModelId } from '../llm/model';
+import type { MastraModelSettings } from '../llm/model/model-settings';
 import type { MastraLanguageModel, OpenAICompatibleConfig, SharedProviderOptions } from '../llm/model/shared.types';
 import type { Mastra } from '../mastra';
 import type { MastraMemory } from '../memory/memory';
@@ -196,7 +197,7 @@ export interface ProcessInputStepArgs<TTripwireMetadata = unknown> extends Proce
   activeTools?: string[];
 
   providerOptions?: SharedProviderOptions;
-  modelSettings?: Omit<CallSettings, 'abortSignal'>;
+  modelSettings?: MastraModelSettings;
   /**
    * Structured output configuration. The schema type is StandardSchemaWithJSON (not the specific OUTPUT)
    * because processors can modify it, and the actual type is only known at runtime.
@@ -244,7 +245,7 @@ export type ProcessInputStepResult = {
    */
   systemMessages?: CoreMessageV4[];
   providerOptions?: SharedProviderOptions;
-  modelSettings?: Omit<CallSettings, 'abortSignal'>;
+  modelSettings?: MastraModelSettings;
   /**
    * Structured output configuration. The schema type is StandardSchemaWithJSON (not the specific OUTPUT)
    * because processors can modify it, and the actual type is only known at runtime.

--- a/packages/core/src/processors/process-input-step.test-d.ts
+++ b/packages/core/src/processors/process-input-step.test-d.ts
@@ -1,0 +1,53 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { AgentExecutionOptions } from '../agent/agent.types';
+import type { MastraModelSettings, ModelTimeoutSettings } from '../llm/model/model-settings';
+import type { ProcessInputStepArgs, ProcessInputStepResult } from './index';
+import type { ProcessorInputStepPhaseType, ProcessorStepOutputType } from './step-schema';
+
+/**
+ * Issue #23457: processor-received and processor-returned modelSettings should
+ * describe Mastra settings (including timeout.stepMs), not only AI SDK CallSettings.
+ */
+describe('ProcessInputStep modelSettings types', () => {
+  it('accepts timeout.stepMs on ProcessInputStepResult without a cast', () => {
+    const inline: ProcessInputStepResult = {
+      modelSettings: {
+        maxOutputTokens: 100,
+        timeout: { stepMs: 1000 },
+      },
+    };
+
+    expectTypeOf(inline.modelSettings).toEqualTypeOf<MastraModelSettings | undefined>();
+    expectTypeOf(inline.modelSettings?.timeout).toEqualTypeOf<ModelTimeoutSettings | undefined>();
+    expectTypeOf(inline.modelSettings?.timeout?.stepMs).toEqualTypeOf<number | undefined>();
+  });
+
+  it('exposes timeout on ProcessInputStepArgs', () => {
+    expectTypeOf<ProcessInputStepArgs['modelSettings']>().toEqualTypeOf<MastraModelSettings | undefined>();
+    expectTypeOf<NonNullable<ProcessInputStepArgs['modelSettings']>['timeout']>().toEqualTypeOf<
+      ModelTimeoutSettings | undefined
+    >();
+  });
+
+  it('accepts AgentExecutionOptions.modelSettings without a cast', () => {
+    const settings: NonNullable<AgentExecutionOptions['modelSettings']> = {
+      maxOutputTokens: 100,
+      timeout: { stepMs: 1000 },
+    };
+    const workaround: ProcessInputStepResult = { modelSettings: settings };
+
+    expectTypeOf(workaround.modelSettings).toEqualTypeOf<MastraModelSettings | undefined>();
+  });
+
+  it('keeps CallSettings fields and still omits abortSignal', () => {
+    expectTypeOf<NonNullable<ProcessInputStepResult['modelSettings']>>().toHaveProperty('maxOutputTokens');
+    expectTypeOf<NonNullable<ProcessInputStepResult['modelSettings']>>().toHaveProperty('temperature');
+    expectTypeOf<NonNullable<ProcessInputStepResult['modelSettings']>>().toHaveProperty('reasoning');
+    expectTypeOf<NonNullable<ProcessInputStepResult['modelSettings']>>().not.toHaveProperty('abortSignal');
+  });
+
+  it('uses the same settings type on the workflow processor step schema', () => {
+    expectTypeOf<ProcessorInputStepPhaseType['modelSettings']>().toEqualTypeOf<MastraModelSettings | undefined>();
+    expectTypeOf<ProcessorStepOutputType['modelSettings']>().toEqualTypeOf<MastraModelSettings | undefined>();
+  });
+});

--- a/packages/core/src/processors/step-schema.ts
+++ b/packages/core/src/processors/step-schema.ts
@@ -1,8 +1,9 @@
 import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
-import type { CallSettings, StepResult, ToolChoice, ToolSet } from '@internal/ai-sdk-v5';
+import type { StepResult, ToolChoice, ToolSet } from '@internal/ai-sdk-v5';
 import { z } from 'zod/v4';
 import type { MastraMessageContentV2, MessageList } from '../agent/message-list';
 import type { ModelRouterModelId } from '../llm/model';
+import type { MastraModelSettings } from '../llm/model/model-settings';
 import type { MastraLanguageModel, OpenAICompatibleConfig, SharedProviderOptions } from '../llm/model/shared.types';
 import type { InferStandardSchemaOutput, StandardSchemaWithJSON } from '../schema';
 import type { InferSchemaOutput, OutputSchema } from '../stream/base/schema';
@@ -122,7 +123,7 @@ export type ProcessorInputStepPhaseType = {
   toolChoice?: ToolChoice<ToolSet>;
   activeTools?: string[];
   providerOptions?: SharedProviderOptions;
-  modelSettings?: Omit<CallSettings, 'abortSignal'>;
+  modelSettings?: MastraModelSettings;
   structuredOutput?: StructuredOutputOptions<InferSchemaOutput<OutputSchema>>;
   steps?: Array<StepResult<ToolSet>>;
   messageId?: string;
@@ -224,7 +225,7 @@ export type ProcessorStepOutputType = {
   toolChoice?: ToolChoice<ToolSet>;
   activeTools?: string[];
   providerOptions?: SharedProviderOptions;
-  modelSettings?: Omit<CallSettings, 'abortSignal'>;
+  modelSettings?: MastraModelSettings;
   structuredOutput?: StructuredOutputOptions<InferSchemaOutput<OutputSchema>>;
   steps?: Array<StepResult<ToolSet>>;
   messageId?: string;
@@ -570,7 +571,7 @@ export const ProcessorInputStepPhaseSchema = z.object({
   activeTools: z.array(z.string()).optional().describe('Currently active tools'),
   providerOptions: z.custom<SharedProviderOptions>().optional().describe('Provider-specific options'),
   modelSettings: z
-    .custom<Omit<CallSettings, 'abortSignal'>>()
+    .custom<MastraModelSettings>()
     .optional()
     .describe('Model settings (temperature, etc.)'),
   structuredOutput: z
@@ -733,7 +734,7 @@ export const ProcessorStepOutputSchema: z.ZodType<ProcessorStepOutputType> = z.o
   toolChoice: z.custom<ToolChoice<ToolSet>>().optional(),
   activeTools: z.array(z.string()).optional(),
   providerOptions: z.custom<SharedProviderOptions>().optional(),
-  modelSettings: z.custom<Omit<CallSettings, 'abortSignal'>>().optional(),
+  modelSettings: z.custom<MastraModelSettings>().optional(),
   structuredOutput: z.custom<StructuredOutputOptions<InferSchemaOutput<OutputSchema>>>().optional(),
   steps: z.custom<Array<StepResult<ToolSet>>>().optional(),
   messageId: z.string().optional(),


### PR DESCRIPTION
## Description

Processor `processInputStep` args and results typed `modelSettings` as the AI SDK `CallSettings` omit, so TypeScript rejected `timeout.stepMs` even though the agent loop already applies that budget to the next model call.

The settings type is now `MastraModelSettings` (same CallSettings fields, still without `abortSignal`, plus Mastra `timeout` and `reasoning`).

**What I chose:** also retarget the workflow processor step schema types (`ProcessorInputStepPhaseType` / `ProcessorStepOutputType` and the matching `z.custom` annotations) to `MastraModelSettings`. **Alternative:** change only `ProcessInputStepArgs` / `ProcessInputStepResult`. Those schema fields already used the same `Omit<CallSettings, 'abortSignal'>`; leaving them would keep the same hole on the workflow processor path. Happy to revert `step-schema.ts` if you want that surface SDK-only.

This does not change runtime timeout behaviour and does not make `timeout.totalMs` a new whole-run deadline after the run has started.

## Related issue(s)

Fixes #23457

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Processor settings now accept the same timeout options supported by Mastra at runtime. This lets TypeScript users read and return settings such as `timeout.stepMs` without casts.

## Changes

- Replaced `Omit<CallSettings, 'abortSignal'>` with `MastraModelSettings` in processor input and result types.
- Updated workflow processor step schema types and Zod annotations.
- Preserved supported fields such as `maxOutputTokens`, `temperature`, and `reasoning`.
- Added type tests for processor settings and `timeout.stepMs`.
- Added a patch changeset for `@mastra/core`.

Runtime timeout behavior is unchanged. `timeout.totalMs` does not become a new whole-run deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
