### PR TITLE
fix(memory): preserve provider detail in OM errors

### DIFF
--- a/.changeset/slick-queens-wink.md
+++ b/.changeset/slick-queens-wink.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed observational memory errors hiding provider diagnostics returned in a string detail field, including Codex rejection messages.

--- a/packages/memory/src/processors/observational-memory/__tests__/error.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/error.test.ts
@@ -21,6 +21,45 @@ describe('formatOmError', () => {
     expect(formatOmError(providerError())).toBe(diagnostic);
   });
 
+  it.each([
+    {
+      provider: 'Anthropic',
+      statusCode: 529,
+      responseBody: {
+        type: 'error',
+        error: { type: 'overloaded_error', message: 'Synthetic provider overload' },
+        request_id: 'private-request-id',
+      },
+      diagnostic: 'Synthetic provider overload',
+    },
+    {
+      provider: 'Gemini',
+      statusCode: 429,
+      responseBody: {
+        error: {
+          code: 429,
+          status: 'RESOURCE_EXHAUSTED',
+          message: 'Synthetic quota exhausted',
+          details: [{ metadata: { consumer: 'private-project-id', apiKey: 'secret-key' } }],
+        },
+      },
+      diagnostic: 'Synthetic quota exhausted',
+    },
+  ])(
+    'preserves $provider diagnostics without including other response fields',
+    ({ statusCode, responseBody, diagnostic }) => {
+      const error = Object.assign(new Error('Provider request failed'), {
+        statusCode,
+        responseBody: JSON.stringify(responseBody),
+      });
+      expect(formatOmError(error)).toBe(`Provider request failed: HTTP ${statusCode}: ${diagnostic}`);
+
+      // SDKs may also copy the provider diagnostic into the outer error message.
+      error.message = diagnostic;
+      expect(formatOmError(error)).toBe(`${diagnostic}: HTTP ${statusCode}`);
+    },
+  );
+
   it('preserves Codex string details without including other response fields', () => {
     const error = Object.assign(new Error('Bad Request'), {
       statusCode: 400,

--- a/packages/memory/src/processors/observational-memory/__tests__/error.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/error.test.ts
@@ -21,6 +21,38 @@ describe('formatOmError', () => {
     expect(formatOmError(providerError())).toBe(diagnostic);
   });
 
+  it('preserves Codex string details without including other response fields', () => {
+    const error = Object.assign(new Error('Bad Request'), {
+      statusCode: 400,
+      responseBody: JSON.stringify({
+        detail: 'Synthetic Codex rejection for diagnostic testing',
+        request: { prompt: 'private conversation', apiKey: 'secret-key' },
+      }),
+    });
+    const expected = 'Bad Request: HTTP 400: Synthetic Codex rejection for diagnostic testing';
+    expect(formatOmError(error)).toBe(expected);
+    for (const createMarker of [createBufferingFailedMarker, createObservationFailedMarker]) {
+      const marker = createMarker({
+        cycleId: 'cycle',
+        operationType: 'observation',
+        startedAt: new Date().toISOString(),
+        tokensAttempted: 100,
+        error,
+        recordId: 'record',
+        threadId: 'thread',
+      });
+      expect(JSON.parse(JSON.stringify(marker)).data.error).toBe(expected);
+    }
+  });
+
+  it.each([null, 400, { message: 'private conversation' }, [{ input: 'secret-key' }]])(
+    'ignores non-string provider details: %j',
+    detail => {
+      const error = Object.assign(new Error('Bad Request'), { responseBody: JSON.stringify({ detail }) });
+      expect(formatOmError(error)).toBe('Bad Request');
+    },
+  );
+
   it('preserves nested causes and plain serialized errors', () => {
     expect(formatOmError(new Error('Observer failed', { cause: providerError() }))).toBe(
       `Observer failed: ${diagnostic}`,

--- a/packages/memory/src/processors/observational-memory/error.ts
+++ b/packages/memory/src/processors/observational-memory/error.ts
@@ -28,6 +28,7 @@ export function formatOmError(error: unknown): string {
         const body: unknown = JSON.parse(value.responseBody);
         if (isRecord(body)) {
           add(body.message);
+          add(body.detail);
           if (isRecord(body.error)) add(body.error.message);
           else add(body.error);
         }


### PR DESCRIPTION
Preserves string `detail` fields from provider JSON error responses in observational memory failure messages, including Codex rejections that otherwise show only a generic HTTP error.

For a response like `{"detail":"Synthetic Codex rejection for diagnostic testing"}`:

```text
Before: Bad Request: HTTP 400
After:  Bad Request: HTTP 400: Synthetic Codex rejection for diagnostic testing
```

Unrelated response fields and non-string details stay out of the failure markers. Retry and abort behavior are unchanged; this exposes the provider's diagnostic rather than fixing the underlying rejection.

Verified with 49 focused tests, both memory typechecks, lint, the memory build, and a before/after demonstration through the built public buffering API. Includes an `@mastra/memory` patch changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a provider rejects a request, memory errors now include the provider’s useful explanation instead of only a generic error. Unrelated data stays hidden, and retry behavior is unchanged.

## Changes

- Preserve string `detail` fields from provider JSON error responses.
- Support Anthropic, Gemini, and Codex provider diagnostics.
- Ignore non-string `detail` values and unrelated response fields.
- Preserve diagnostics in observational memory failure markers.
- Add an `@mastra/memory` patch changeset.

## Verification

- 49 focused tests passed.
- Memory typechecks, linting, and build completed successfully.
- Verified behavior through the built public buffering API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->