### PR TITLE
feat(playground-ui): add tabbed container

### DIFF
--- a/.changeset/tabbed-data-list.md
+++ b/.changeset/tabbed-data-list.md
@@ -29,8 +29,36 @@ Adds `TabbedContainer`, a contained tab composition for mixed panel types. `Pane
 
 Contained tabs move extra items into a `+N` menu. Closable overflow items can now be closed from that menu without selecting them.
 
+```tsx
+<Tabs defaultTab="runs">
+  <TabList>
+    <Tab value="runs" onClose={() => closeTab('runs')}>Runs</Tab>
+  </TabList>
+  <TabContent value="runs" flush keepMounted>
+    <RunsTable />
+  </TabContent>
+</Tabs>
+```
+
 Adds `DataList.SortableTopCell`, a controlled column header that switches between ascending and descending sort directions.
 
+```tsx
+<DataList.SortableTopCell sortDirection={sortDirection} onSortChange={setSortDirection}>
+  Created at
+</DataList.SortableTopCell>
+```
+
 Multi-select comboboxes can show a `clearLabel` footer action, and combobox triggers accept an explicit `aria-label`.
+
+```tsx
+<Combobox
+  aria-label="Filter by status"
+  multiple
+  options={statusOptions}
+  value={statuses}
+  onValueChange={setStatuses}
+  clearLabel="Clear filters"
+/>
+```
 
 Also adds `flush` and `keepMounted` to `TabContent`. `flush` lets a panel component own the body surface. `keepMounted` keeps a visited panel in the DOM after a tab switch.

--- a/.changeset/tabbed-data-list.md
+++ b/.changeset/tabbed-data-list.md
@@ -1,0 +1,36 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Adds `TabbedContainer`, a contained tab composition for mixed panel types. `Panel` accepts arbitrary content. `DataList` renders a table and can place search and filter controls in the tab rail. Both types support the existing tab states and close behavior. Visited panels stay mounted, preserving their scroll position and local state.
+
+```tsx
+<TabbedContainer defaultTab="overview">
+  <TabbedContainer.Panel value="overview" label="Overview">
+    <Overview />
+  </TabbedContainer.Panel>
+  <TabbedContainer.DataList
+    value="runs"
+    label="Runs"
+    columns="auto minmax(0,1fr) auto"
+    search={{ label: 'Search runs', placeholder: 'Search runs', value: query, onSearch: setQuery }}
+    filter={{
+      'aria-label': 'Filter by status',
+      multiple: true,
+      options: statusOptions,
+      value: statuses,
+      onValueChange: setStatuses,
+    }}
+  >
+    {runRows}
+  </TabbedContainer.DataList>
+</TabbedContainer>
+```
+
+Contained tabs move extra items into a `+N` menu. Closable overflow items can now be closed from that menu without selecting them.
+
+Adds `DataList.SortableTopCell`, a controlled column header that switches between ascending and descending sort directions.
+
+Multi-select comboboxes can show a `clearLabel` footer action, and combobox triggers accept an explicit `aria-label`.
+
+Also adds `flush` and `keepMounted` to `TabContent`. `flush` lets a panel component own the body surface. `keepMounted` keeps a visited panel in the DOM after a tab switch.

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.test.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useRef } from 'react';
+import type { FormEvent } from 'react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { Combobox } from './combobox';
@@ -121,6 +123,35 @@ describe('Combobox', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Clear' }));
 
     expect(onValueChange).toHaveBeenCalledWith([]);
+  });
+
+  it('does not submit a form when clearing a multi-selection from its portal', async () => {
+    const onSubmit = vi.fn((event: FormEvent) => event.preventDefault());
+    const onValueChange = vi.fn();
+
+    function FormCombobox() {
+      const formRef = useRef<HTMLFormElement>(null);
+
+      return (
+        <form ref={formRef} onSubmit={onSubmit}>
+          <Combobox
+            multiple
+            container={formRef}
+            options={options}
+            value={['openai']}
+            onValueChange={onValueChange}
+            clearLabel="Clear"
+          />
+        </form>
+      );
+    }
+
+    render(<FormCombobox />);
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Clear' }));
+
+    expect(onValueChange).toHaveBeenCalledWith([]);
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it('shows the clear action only when a selected multi-combobox provides its label', async () => {

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.test.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.test.tsx
@@ -8,7 +8,7 @@ import { Combobox } from './combobox';
 
 beforeAll(() => {
   if (typeof window.PointerEvent === 'undefined') {
-    window.PointerEvent = window.MouseEvent as unknown as typeof PointerEvent;
+    Object.defineProperty(window, 'PointerEvent', { configurable: true, value: window.MouseEvent });
   }
 });
 
@@ -21,6 +21,12 @@ const options = [
   { label: 'Anthropic', value: 'anthropic' },
   { label: 'Google', value: 'google' },
 ];
+
+function getFirstHTMLElement(element: Element): HTMLElement {
+  const firstElement = element.firstElementChild;
+  if (!(firstElement instanceof HTMLElement)) throw new Error('Expected an HTML element');
+  return firstElement;
+}
 
 function renderCombobox(props?: {
   onValueChange?: (value: string) => void;
@@ -308,13 +314,13 @@ describe('Combobox', () => {
   it('says what went wrong under the field, and nothing when nothing did', () => {
     const withError = render(<Combobox options={options} error="Required" />);
     expect(screen.getByText('Required')).toBeTruthy();
-    const withErrorCount = (withError.container.firstElementChild as HTMLElement).childElementCount;
+    const withErrorCount = getFirstHTMLElement(withError.container).childElementCount;
 
     cleanup();
 
     const withoutError = render(<Combobox options={options} />);
 
-    expect((withoutError.container.firstElementChild as HTMLElement).childElementCount).toBe(withErrorCount - 1);
+    expect(getFirstHTMLElement(withoutError.container).childElementCount).toBe(withErrorCount - 1);
   });
 
   it('takes the medium size unless the caller asks otherwise', () => {
@@ -354,7 +360,7 @@ describe('Combobox', () => {
 
   it('greys out the invitation only while nothing is chosen', () => {
     const { rerender } = render(<Combobox multiple options={options} value={[]} placeholder="Pick providers" />);
-    const label = () => screen.getByRole('combobox').firstElementChild as HTMLElement;
+    const label = () => getFirstHTMLElement(screen.getByRole('combobox'));
     expect(label().classList.contains('text-neutral3')).toBe(true);
 
     rerender(<Combobox multiple options={options} value={['openai']} placeholder="Pick providers" />);
@@ -389,13 +395,13 @@ describe('Combobox', () => {
   it('says what went wrong under a multi-select field too', () => {
     const withError = render(<Combobox multiple options={options} value={[]} error="Required" />);
     expect(screen.getByText('Required')).toBeTruthy();
-    const withErrorCount = (withError.container.firstElementChild as HTMLElement).childElementCount;
+    const withErrorCount = getFirstHTMLElement(withError.container).childElementCount;
 
     cleanup();
 
     const withoutError = render(<Combobox multiple options={options} value={[]} />);
 
-    expect((withoutError.container.firstElementChild as HTMLElement).childElementCount).toBe(withErrorCount - 1);
+    expect(getFirstHTMLElement(withoutError.container).childElementCount).toBe(withErrorCount - 1);
   });
 
   it('picks a single value with nobody listening', async () => {

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.test.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.test.tsx
@@ -105,6 +105,34 @@ describe('Combobox', () => {
     });
   });
 
+  it('clears a multi-selection from the popup footer', async () => {
+    const onValueChange = vi.fn();
+    render(
+      <Combobox
+        multiple
+        options={options}
+        value={['openai', 'anthropic']}
+        onValueChange={onValueChange}
+        clearLabel="Clear"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Clear' }));
+
+    expect(onValueChange).toHaveBeenCalledWith([]);
+  });
+
+  it('shows the clear action only when a selected multi-combobox provides its label', async () => {
+    const { rerender } = render(<Combobox multiple options={options} value={[]} clearLabel="Clear" />);
+
+    fireEvent.click(screen.getByRole('combobox'));
+    expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull();
+
+    rerender(<Combobox multiple options={options} value={['openai']} />);
+    expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull();
+  });
+
   it('selects the first filtered item when pressing Enter after searching', async () => {
     const onValueChange = vi.fn();
     renderCombobox({ onValueChange });

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
@@ -184,7 +184,13 @@ export function Combobox(props: ComboboxProps) {
             </BaseCombobox.List>
             {selectedValues.length > 0 && clearLabel ? (
               <div className={cn('border-t', 'border-border1', 'p-1')}>
-                <Button variant="destructive-ghost" size="sm" className="w-full justify-start" onClick={clearSelection}>
+                <Button
+                  type="button"
+                  variant="destructive-ghost"
+                  size="sm"
+                  className="w-full justify-start"
+                  onClick={clearSelection}
+                >
                   <X />
                   {clearLabel}
                 </Button>

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
@@ -1,8 +1,9 @@
 import { Combobox as BaseCombobox } from '@base-ui/react/combobox';
-import { Check, ChevronsUpDown, Search } from 'lucide-react';
+import { Check, ChevronsUpDown, Search, X } from 'lucide-react';
 import * as React from 'react';
 import { comboboxItemClass, comboboxStyles, comboboxTriggerClass } from './combobox-styles';
 import type { ComboboxVariant } from './combobox-styles';
+import { Button } from '@/ds/components/Button/Button';
 import type { TextButtonSize } from '@/ds/components/Button/Button';
 import { FLOATING_POSITION_METHOD } from '@/ds/primitives/floating';
 import { usePortalContainer } from '@/ds/primitives/portal-container';
@@ -31,6 +32,7 @@ type ComboboxSharedProps = {
   onOpenChange?: (open: boolean) => void;
   container?: HTMLElement | ShadowRoot | null | React.RefObject<HTMLElement | ShadowRoot | null>;
   error?: string;
+  'aria-label'?: string;
   allowCustomValue?: boolean;
   /** Called with the search input text as it changes (and with `''` after a single-mode selection resets it). */
   onInputValueChange?: (value: string) => void;
@@ -46,6 +48,7 @@ export type ComboboxMultipleProps = ComboboxSharedProps & {
   multiple: true;
   value?: readonly string[];
   onValueChange?: (value: string[]) => void;
+  clearLabel?: string;
 };
 
 export type ComboboxProps = ComboboxSingleProps | ComboboxMultipleProps;
@@ -80,10 +83,12 @@ export function Combobox(props: ComboboxProps) {
     onOpenChange,
     container,
     error,
+    'aria-label': ariaLabel,
     allowCustomValue = false,
     onInputValueChange,
   } = props;
   const multiple = isMultipleCombobox(props);
+  const clearLabel = multiple ? props.clearLabel : undefined;
   const [inputValue, setInputValue] = React.useState('');
   const customValue = inputValue.trim();
   const customOption =
@@ -96,13 +101,19 @@ export function Combobox(props: ComboboxProps) {
   const selectedOption = multiple ? null : (options.find(option => option.value === props.value) ?? null);
   const selectedOptions = multiple ? options.filter(option => selectedValueSet.has(option.value)) : EMPTY_OPTIONS;
   const triggerText = selectedOptions.length === 0 ? placeholder : `${selectedOptions.length} selected`;
+  const clearSelection = () => {
+    if (isMultipleCombobox(props)) props.onValueChange?.([]);
+  };
   // Default to the nearest SideDialog/Drawer popup so the list stays
   // interactive inside a modal drawer; an explicit `container` still wins.
   const resolvedContainer = usePortalContainer(container);
 
   const comboboxContent = (
     <>
-      <BaseCombobox.Trigger className={comboboxTriggerClass({ variant, size, error: Boolean(error), className })}>
+      <BaseCombobox.Trigger
+        aria-label={ariaLabel}
+        className={comboboxTriggerClass({ variant, size, error: Boolean(error), className })}
+      >
         {multiple ? (
           <span className={cn('truncate', selectedOptions.length === 0 && comboboxStyles.placeholder)}>
             {triggerText}
@@ -171,6 +182,14 @@ export function Combobox(props: ComboboxProps) {
                 );
               }}
             </BaseCombobox.List>
+            {selectedValues.length > 0 && clearLabel ? (
+              <div className={cn('border-t', 'border-border1', 'p-1')}>
+                <Button variant="destructive-ghost" size="sm" className="w-full justify-start" onClick={clearSelection}>
+                  <X />
+                  {clearLabel}
+                </Button>
+              </div>
+            ) : null}
           </BaseCombobox.Popup>
         </BaseCombobox.Positioner>
       </BaseCombobox.Portal>

--- a/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container-root.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container-root.tsx
@@ -87,7 +87,7 @@ export const DataListControls = ({ dataLists }: { dataLists: ReactElement<Tabbed
                   <div data-slot="tabbed-container-filter" data-active={filterCount > 0 || undefined}>
                     <ListFilterIcon aria-hidden="true" />
                     {filterCount > 0 ? (
-                      <span aria-hidden="true" data-slot="tabbed-container-filter-count">
+                      <span aria-hidden="true" data-slot="tabbed-container-filter-count" className="text-ui-xs">
                         {filterCount}
                       </span>
                     ) : null}

--- a/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container-root.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container-root.tsx
@@ -1,0 +1,174 @@
+import { ListFilterIcon } from 'lucide-react';
+import { Children, isValidElement, useContext } from 'react';
+import type { ReactElement, ReactNode } from 'react';
+import { DataList } from '../data-list';
+import type { DataListFit } from '../data-list-root';
+import './tabbed-container.css';
+import { Combobox } from '@/ds/components/Combobox/combobox';
+import type { ComboboxProps } from '@/ds/components/Combobox/combobox';
+import { ListSearch } from '@/ds/components/ListSearch/list-search';
+import type { ListSearchProps } from '@/ds/components/ListSearch/list-search';
+import { TabContent } from '@/ds/components/Tabs/tabs-content';
+import { TabsContext } from '@/ds/components/Tabs/tabs-context';
+import { TabList } from '@/ds/components/Tabs/tabs-list';
+import { Tabs } from '@/ds/components/Tabs/tabs-root';
+import { Tab } from '@/ds/components/Tabs/tabs-tab';
+import type { TabProps } from '@/ds/components/Tabs/tabs-tab';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/ds/components/Tooltip/tooltip';
+import { cn } from '@/lib/utils';
+
+export type TabbedContainerSearchProps = Pick<
+  ListSearchProps,
+  'debounceMs' | 'label' | 'onSearch' | 'placeholder' | 'value'
+>;
+
+export type TabbedContainerFilterProps = ComboboxProps & { 'aria-label': string };
+
+type TabbedContainerItemProps = Pick<
+  TabProps,
+  'attention' | 'disabled' | 'disabledTooltip' | 'onClick' | 'onClose' | 'value'
+> & {
+  label: ReactNode;
+  children: ReactNode;
+  className?: string;
+  tabClassName?: string;
+};
+
+export type TabbedContainerPanelProps = TabbedContainerItemProps & {
+  flush?: boolean;
+};
+
+export type TabbedContainerDataListProps = TabbedContainerItemProps & {
+  columns: string;
+  search?: TabbedContainerSearchProps;
+  filter?: TabbedContainerFilterProps;
+  fit?: DataListFit;
+};
+
+export const TabbedContainerPanel = ({ value, flush, children, className }: TabbedContainerPanelProps) => (
+  <TabContent value={value} flush={flush} keepMounted className={cn('min-h-0 flex-1', className)}>
+    {children}
+  </TabContent>
+);
+
+export const TabbedContainerDataList = ({ value, columns, fit, children, className }: TabbedContainerDataListProps) => (
+  <TabContent value={value} flush keepMounted className={className}>
+    <DataList columns={columns} fit={fit} className="min-h-0">
+      {children}
+    </DataList>
+  </TabContent>
+);
+
+export const DataListControls = ({ dataLists }: { dataLists: ReactElement<TabbedContainerDataListProps>[] }) => {
+  const tabs = useContext(TabsContext);
+  return dataLists.map(dataList => {
+    const { filter, search, value } = dataList.props;
+    if (!search && !filter) return null;
+    const active = value === tabs?.value;
+    const filterCount = filter ? (Array.isArray(filter.value) ? filter.value.length : filter.value ? 1 : 0) : 0;
+    return (
+      <div
+        key={value}
+        data-slot="tabbed-container-controls"
+        data-active={active || undefined}
+        aria-hidden={!active}
+        inert={!active}
+      >
+        <div data-slot="tabbed-container-query">
+          {search ? (
+            <div data-slot="tabbed-container-search">
+              <ListSearch {...search} size="md" variant="filled" shortcutDisabled={!active} />
+            </div>
+          ) : null}
+          {filter ? (
+            <TooltipProvider delay={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div data-slot="tabbed-container-filter" data-active={filterCount > 0 || undefined}>
+                    <ListFilterIcon aria-hidden="true" />
+                    {filterCount > 0 ? (
+                      <span aria-hidden="true" data-slot="tabbed-container-filter-count">
+                        {filterCount}
+                      </span>
+                    ) : null}
+                    {filter.multiple ? (
+                      <Combobox {...filter} clearLabel="Clear" size="md" variant="default" />
+                    ) : (
+                      <Combobox {...filter} size="md" variant="default" />
+                    )}
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {filterCount > 0 ? `Filter, ${filterCount} selected` : 'Filter'}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : null}
+        </div>
+      </div>
+    );
+  });
+};
+
+export type TabbedContainerProps<T extends string> = {
+  children: ReactNode;
+  defaultTab: T;
+  value?: T;
+  onValueChange?: (value: T) => void;
+  frame?: 'stroke' | 'inset';
+  className?: string;
+};
+
+type TabbedContainerChildProps = TabbedContainerPanelProps | TabbedContainerDataListProps;
+
+const isContainerChild = (child: ReactNode): child is ReactElement<TabbedContainerChildProps> =>
+  isValidElement(child) && (child.type === TabbedContainerPanel || child.type === TabbedContainerDataList);
+
+const isDataList = (
+  child: ReactElement<TabbedContainerChildProps>,
+): child is ReactElement<TabbedContainerDataListProps> => child.type === TabbedContainerDataList;
+
+export function TabbedContainerRoot<T extends string>({
+  children,
+  defaultTab,
+  value,
+  onValueChange,
+  frame = 'inset',
+  className,
+}: TabbedContainerProps<T>) {
+  const panels = Children.toArray(children).filter(isContainerChild);
+  const dataLists = panels.filter(isDataList);
+  return (
+    <Tabs
+      defaultTab={defaultTab}
+      value={value}
+      onValueChange={onValueChange}
+      appearance="contained"
+      frame={frame}
+      className={cn('tabbed-container min-h-0', className)}
+    >
+      <div data-slot="tabbed-container-rail">
+        <div data-slot="tabbed-container-tabs">
+          <TabList>
+            {panels.map(panel => (
+              <Tab
+                key={panel.props.value}
+                value={panel.props.value}
+                disabled={panel.props.disabled}
+                attention={panel.props.attention}
+                disabledTooltip={panel.props.disabledTooltip}
+                onClick={panel.props.onClick}
+                onClose={panel.props.onClose}
+                className={panel.props.tabClassName}
+              >
+                {panel.props.label}
+              </Tab>
+            ))}
+          </TabList>
+        </div>
+        <DataListControls dataLists={dataLists} />
+      </div>
+      {panels}
+    </Tabs>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.css
+++ b/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.css
@@ -1,0 +1,206 @@
+.tabbed-container {
+  container-type: inline-size;
+}
+
+[data-slot='tabbed-container-rail'] {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+[data-slot='tabbed-container-tabs'] {
+  min-width: 0;
+  flex: 1;
+}
+
+[data-slot='tabbed-container-controls'] {
+  position: relative;
+  align-self: stretch;
+  min-width: 0;
+  padding: 4px 4px 0;
+  border-radius: var(--tab-frame-radius) var(--tab-frame-radius) 0 0;
+  background: var(--surface4);
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    transform 160ms cubic-bezier(0.32, 0.72, 0, 1),
+    opacity 140ms ease-out,
+    visibility 160ms allow-discrete;
+}
+
+[data-slot='tabbed-container-controls']:not([data-active]) {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  visibility: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(6px);
+}
+
+[data-slot='tabbed-container-controls']::before {
+  content: '';
+  position: absolute;
+  right: 100%;
+  bottom: 0;
+  width: var(--tab-frame-radius);
+  height: var(--tab-frame-radius);
+  background: radial-gradient(
+    circle at top left,
+    transparent var(--tab-frame-radius),
+    var(--surface4) calc(var(--tab-frame-radius) + 0.5px)
+  );
+}
+
+[data-slot='tabbed-container-query'] {
+  display: flex;
+  width: 296px;
+  min-width: 0;
+  align-items: center;
+  overflow: clip;
+  border: 1px solid var(--border1);
+  border-radius: var(--tab-inner-radius);
+  background: var(--surface4);
+}
+
+[data-slot='tabbed-container-query']:focus-within {
+  border-color: color-mix(in oklab, var(--neutral5) 50%, transparent);
+}
+
+[data-slot='tabbed-container-search'] {
+  min-width: 0;
+  flex: 1;
+}
+
+[data-slot='tabbed-container-search'] input {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+[data-slot='tabbed-container-filter'] {
+  position: relative;
+  width: 34px;
+  height: 20px;
+  flex-shrink: 0;
+  margin-right: 6px;
+}
+
+[data-slot='tabbed-container-filter'] > svg {
+  position: absolute;
+  top: 50%;
+  left: 24px;
+  z-index: 1;
+  width: 12px;
+  height: 12px;
+  translate: -50% -50%;
+  pointer-events: none;
+  color: var(--neutral3);
+}
+
+[data-slot='tabbed-container-filter'][data-active] > svg {
+  left: 9px;
+  color: var(--neutral5);
+}
+
+[data-slot='tabbed-container-filter-count'] {
+  position: absolute;
+  top: 50%;
+  right: 5px;
+  z-index: 1;
+  translate: 0 -50%;
+  pointer-events: none;
+  color: var(--neutral4);
+  font-size: 10px;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+[data-slot='tabbed-container-filter'] button {
+  position: relative;
+  width: 34px;
+  min-width: 0;
+  height: 20px;
+  padding: 0;
+  border: 0;
+  border-radius: 9999px;
+  background: transparent;
+}
+
+[data-slot='tabbed-container-filter'] button::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+  background: var(--surface-overlay-soft);
+}
+
+[data-slot='tabbed-container-filter'][data-active] button::before {
+  width: 34px;
+}
+
+[data-slot='tabbed-container-filter'] button > span {
+  display: none;
+}
+
+[data-slot='tabbed-container-filter'] button:hover::before,
+[data-slot='tabbed-container-filter'] button:focus-visible::before,
+[data-slot='tabbed-container-filter'] button[data-popup-open]::before {
+  background: var(--surface-overlay-strong);
+}
+
+.tabbed-container:has(> [data-slot='tabbed-container-rail'] [data-slot='tabbed-container-controls'][data-active])
+  > [data-slot='tabs-content'] {
+  border-top-right-radius: 0;
+}
+
+@container (max-width: 36rem) {
+  [data-slot='tabbed-container-rail'] {
+    flex-wrap: wrap;
+    gap: 0;
+  }
+
+  [data-slot='tabbed-container-tabs'],
+  [data-slot='tabbed-container-controls'] {
+    width: 100%;
+    flex-basis: 100%;
+  }
+
+  [data-slot='tabbed-container-controls'] {
+    align-self: auto;
+    margin: 0;
+    padding: var(--tab-inset);
+    border-radius: 0 var(--tab-frame-radius) 0 0;
+    background: var(--surface4);
+  }
+
+  [data-slot='tabbed-container-controls']::before {
+    display: none;
+  }
+
+  [data-slot='tabbed-container-query'] {
+    width: 100%;
+    border-radius: var(--tab-inner-radius);
+  }
+
+  [data-slot='tabbed-container-search'] {
+    width: auto;
+    flex: 1;
+  }
+
+  .tabbed-container > [data-slot='tabs-content'] {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-slot='tabbed-container-controls'] {
+    transition: none;
+  }
+}

--- a/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.css
+++ b/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.css
@@ -61,7 +61,7 @@
   align-items: center;
   overflow: clip;
   border: 1px solid var(--border1);
-  border-radius: 9999px;
+  border-radius: var(--tab-inner-radius);
   background: var(--surface4);
 }
 
@@ -185,7 +185,7 @@
 
   [data-slot='tabbed-container-query'] {
     width: 100%;
-    border-radius: 9999px;
+    border-radius: var(--tab-inner-radius);
   }
 
   [data-slot='tabbed-container-search'] {

--- a/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.css
+++ b/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.css
@@ -61,7 +61,7 @@
   align-items: center;
   overflow: clip;
   border: 1px solid var(--border1);
-  border-radius: var(--tab-inner-radius);
+  border-radius: 9999px;
   background: var(--surface4);
 }
 
@@ -185,7 +185,7 @@
 
   [data-slot='tabbed-container-query'] {
     width: 100%;
-    border-radius: var(--tab-inner-radius);
+    border-radius: 9999px;
   }
 
   [data-slot='tabbed-container-search'] {

--- a/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.css
+++ b/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.css
@@ -113,8 +113,6 @@
   translate: 0 -50%;
   pointer-events: none;
   color: var(--neutral4);
-  font-size: 10px;
-  line-height: 1;
   font-variant-numeric: tabular-nums;
 }
 

--- a/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.stories.tsx
@@ -1,0 +1,242 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { DataList } from '../data-list';
+import type { DataListSortDirection } from '../data-list';
+import { TabbedContainer } from './tabbed-container';
+import { cn } from '@/lib/utils';
+
+const meta: Meta<typeof TabbedContainer> = {
+  title: 'DataDisplay/TabbedContainer',
+  component: TabbedContainer,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TabbedContainer>;
+
+const SAMPLE_RUNS = [
+  {
+    id: 'run_8f3a91b2c4d6e8f0',
+    input: 'What is the weather in Tokyo?',
+    status: 'success',
+    createdAt: '2026-05-21T09:14:22.123Z',
+  },
+  {
+    id: 'run_2e7c89d1a3b5f7e9',
+    input: 'Summarize the latest sales report',
+    status: 'success',
+    createdAt: '2026-05-21T08:42:11.456Z',
+  },
+  {
+    id: 'run_5a1b4c7d9e2f3a6b',
+    input: 'Translate hello to Japanese',
+    status: 'failed',
+    createdAt: '2026-05-20T17:03:55.789Z',
+  },
+  {
+    id: 'run_9d4e7f2a5c8b1d3e',
+    input: 'Generate a recipe for banana bread',
+    status: 'success',
+    createdAt: '2026-05-20T11:21:08.012Z',
+  },
+];
+
+const SAMPLE_SCORES = [
+  { id: 'score_1b2c3d4e5f6a7b8c', scorer: 'answer-relevancy', score: 0.92, createdAt: '2026-05-21T09:15:02.001Z' },
+  { id: 'score_2c3d4e5f6a7b8c9d', scorer: 'toxicity', score: 0.01, createdAt: '2026-05-21T09:15:04.210Z' },
+  { id: 'score_3d4e5f6a7b8c9d0e', scorer: 'faithfulness', score: 0.87, createdAt: '2026-05-21T08:43:00.930Z' },
+];
+
+const manyRuns = Array.from({ length: 8 }, (_, index) =>
+  SAMPLE_RUNS.map(run => ({ ...run, id: `${run.id}_${index}` })),
+).flat();
+
+type RunSort = {
+  key: keyof (typeof SAMPLE_RUNS)[number];
+  direction: DataListSortDirection;
+};
+
+function sortRuns(runs: typeof manyRuns, sort: RunSort) {
+  const multiplier = sort.direction === 'ascending' ? 1 : -1;
+  return runs.toSorted((left, right) => left[sort.key].localeCompare(right[sort.key]) * multiplier);
+}
+
+const STATUS_OPTIONS = [
+  { value: 'success', label: 'Success' },
+  { value: 'failed', label: 'Failed' },
+];
+
+export const Default: Story = {
+  render: function DefaultStory() {
+    const [runSearch, setRunSearch] = useState('');
+    const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
+    const [runSort, setRunSort] = useState<RunSort>({ key: 'createdAt', direction: 'descending' });
+    const runs = sortRuns(
+      manyRuns.filter(
+        run =>
+          run.input.toLowerCase().includes(runSearch.toLowerCase()) &&
+          (selectedStatuses.length === 0 || selectedStatuses.includes(run.status)),
+      ),
+      runSort,
+    );
+
+    return (
+      <div className="w-full max-w-4xl" style={{ height: 400 }}>
+        <TabbedContainer defaultTab="overview" className="h-full">
+          <TabbedContainer.Panel value="overview" label="Overview">
+            <div className="grid gap-1">
+              <h2 className={cn('text-ui-md', 'font-medium', 'text-neutral5')}>Evaluation overview</h2>
+              <p className="text-ui-sm text-neutral3">Any product content can share the frame with data-heavy tabs.</p>
+            </div>
+          </TabbedContainer.Panel>
+          <TabbedContainer.DataList
+            value="runs"
+            label="Runs"
+            columns="auto minmax(0,1fr) auto auto auto"
+            search={{
+              label: 'Search runs',
+              placeholder: 'Search runs',
+              value: runSearch,
+              onSearch: setRunSearch,
+            }}
+            filter={{
+              'aria-label': 'Filter by status',
+              multiple: true,
+              options: STATUS_OPTIONS,
+              placeholder: 'Status',
+              searchPlaceholder: 'Search statuses',
+              value: selectedStatuses,
+              onValueChange: setSelectedStatuses,
+            }}
+          >
+            <DataList.Top>
+              <DataList.SortableTopCell
+                sortDirection={runSort.key === 'id' ? runSort.direction : undefined}
+                onSortChange={direction => setRunSort({ key: 'id', direction })}
+              >
+                ID
+              </DataList.SortableTopCell>
+              <DataList.SortableTopCell
+                sortDirection={runSort.key === 'input' ? runSort.direction : undefined}
+                onSortChange={direction => setRunSort({ key: 'input', direction })}
+              >
+                Input
+              </DataList.SortableTopCell>
+              <DataList.SortableTopCell
+                sortDirection={runSort.key === 'status' ? runSort.direction : undefined}
+                onSortChange={direction => setRunSort({ key: 'status', direction })}
+              >
+                Status
+              </DataList.SortableTopCell>
+              <DataList.SortableTopCell
+                sortDirection={runSort.key === 'createdAt' ? runSort.direction : undefined}
+                defaultSortDirection="descending"
+                onSortChange={direction => setRunSort({ key: 'createdAt', direction })}
+              >
+                Date
+              </DataList.SortableTopCell>
+              <DataList.TopCell>Time</DataList.TopCell>
+            </DataList.Top>
+            {runs.map(run => (
+              <DataList.RowButton key={run.id} onClick={() => {}}>
+                <DataList.IdCell id={run.id} />
+                <DataList.TextCell>{run.input}</DataList.TextCell>
+                <DataList.Cell>{run.status}</DataList.Cell>
+                <DataList.DateCell timestamp={run.createdAt} />
+                <DataList.TimeCell timestamp={run.createdAt} />
+              </DataList.RowButton>
+            ))}
+            {runs.length === 0 && <DataList.NoMatch message="No runs match the search" />}
+          </TabbedContainer.DataList>
+          <TabbedContainer.DataList value="scores" label="Scores" columns="auto minmax(0,1fr) auto auto">
+            <DataList.Top>
+              <DataList.TopCell>ID</DataList.TopCell>
+              <DataList.TopCell>Scorer</DataList.TopCell>
+              <DataList.TopCell>Score</DataList.TopCell>
+              <DataList.TopCell>Date</DataList.TopCell>
+            </DataList.Top>
+            {SAMPLE_SCORES.map(score => (
+              <DataList.RowButton key={score.id} onClick={() => {}}>
+                <DataList.IdCell id={score.id} />
+                <DataList.TextCell>{score.scorer}</DataList.TextCell>
+                <DataList.NumberCell>{score.score.toFixed(2)}</DataList.NumberCell>
+                <DataList.DateCell timestamp={score.createdAt} />
+              </DataList.RowButton>
+            ))}
+          </TabbedContainer.DataList>
+        </TabbedContainer>
+      </div>
+    );
+  },
+};
+
+const OVERFLOW_TABS = [
+  { value: 'overview', label: 'Overview' },
+  { value: 'runs', label: 'Runs' },
+  { value: 'scores', label: 'Scores' },
+  { value: 'logs', label: 'Logs' },
+  { value: 'metrics', label: 'Metrics' },
+  { value: 'traces', label: 'Traces' },
+  { value: 'datasets', label: 'Datasets' },
+];
+
+export const OverflowAndClosable: Story = {
+  render: function OverflowAndClosableStory() {
+    const [activeTab, setActiveTab] = useState('runs');
+    const [visibleTabs, setVisibleTabs] = useState(OVERFLOW_TABS.map(tab => tab.value));
+    const [search, setSearch] = useState('');
+    const closeTab = (value: string) =>
+      visibleTabs.length > 1
+        ? () => {
+            const nextTabs = visibleTabs.filter(tab => tab !== value);
+            if (activeTab === value) {
+              const closedIndex = visibleTabs.indexOf(value);
+              const nextActiveTab = nextTabs[Math.min(closedIndex, nextTabs.length - 1)];
+              if (nextActiveTab) setActiveTab(nextActiveTab);
+            }
+            setVisibleTabs(nextTabs);
+          }
+        : undefined;
+
+    return (
+      <div className="h-80 w-full max-w-3xl">
+        <TabbedContainer defaultTab="runs" value={activeTab} onValueChange={setActiveTab} className="h-full">
+          {OVERFLOW_TABS.filter(tab => visibleTabs.includes(tab.value)).map(tab =>
+            tab.value === 'overview' ? (
+              <TabbedContainer.Panel key={tab.value} value={tab.value} label={tab.label} onClose={closeTab(tab.value)}>
+                <div className="grid gap-1">
+                  <h2 className={cn('text-ui-md', 'font-medium', 'text-neutral5')}>Workspace overview</h2>
+                  <p className="text-ui-sm text-neutral3">Arbitrary content shares the same closable tab rail.</p>
+                </div>
+              </TabbedContainer.Panel>
+            ) : (
+              <TabbedContainer.DataList
+                key={tab.value}
+                value={tab.value}
+                label={tab.label}
+                columns="1fr auto"
+                onClose={closeTab(tab.value)}
+                search={
+                  tab.value === 'runs'
+                    ? { label: 'Search runs', placeholder: 'Search runs', value: search, onSearch: setSearch }
+                    : undefined
+                }
+              >
+                <DataList.Top>
+                  <DataList.TopCell>Name</DataList.TopCell>
+                  <DataList.TopCell>Type</DataList.TopCell>
+                </DataList.Top>
+                <DataList.RowStatic>
+                  <DataList.TextCell>{`${tab.label} item`}</DataList.TextCell>
+                  <DataList.Cell>DataList</DataList.Cell>
+                </DataList.RowStatic>
+              </TabbedContainer.DataList>
+            ),
+          )}
+        </TabbedContainer>
+      </div>
+    );
+  },
+};

--- a/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.test.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.test.tsx
@@ -234,7 +234,7 @@ describe('TabbedContainer', () => {
 
     expect(screen.queryByRole('tab', { name: 'Runs' })).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: '1 more tabs' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Close tab' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Close Runs' }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(screen.getByRole('tab', { name: 'Overview' }).getAttribute('aria-selected')).toBe('true');

--- a/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.test.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.test.tsx
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DataList } from '../data-list';
+import { TabbedContainer } from './tabbed-container';
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(1024);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  cleanup();
+});
+
+const renderTables = () =>
+  render(
+    <TabbedContainer defaultTab="runs">
+      <TabbedContainer.DataList
+        value="runs"
+        label="Runs"
+        columns="auto 1fr"
+        search={{ label: 'Search runs', placeholder: 'Search runs', onSearch: vi.fn() }}
+        filter={{
+          'aria-label': 'Filter by status',
+          multiple: true,
+          options: [{ value: 'failed', label: 'Failed' }],
+          placeholder: 'Status',
+          value: ['failed'],
+          onValueChange: vi.fn(),
+        }}
+      >
+        <DataList.Top>
+          <DataList.TopCell>ID</DataList.TopCell>
+          <DataList.TopCell>Input</DataList.TopCell>
+        </DataList.Top>
+        <DataList.RowStatic>
+          <DataList.Cell>run_1</DataList.Cell>
+          <DataList.Cell>What is the weather?</DataList.Cell>
+        </DataList.RowStatic>
+      </TabbedContainer.DataList>
+      <TabbedContainer.DataList
+        value="scores"
+        label="Scores"
+        columns="auto 1fr"
+        search={{ label: 'Search scores', placeholder: 'Search scores', onSearch: vi.fn() }}
+      >
+        <DataList.Top>
+          <DataList.TopCell>ID</DataList.TopCell>
+          <DataList.TopCell>Scorer</DataList.TopCell>
+        </DataList.Top>
+        <DataList.RowStatic>
+          <DataList.Cell>score_1</DataList.Cell>
+          <DataList.Cell>answer-relevancy</DataList.Cell>
+        </DataList.RowStatic>
+      </TabbedContainer.DataList>
+    </TabbedContainer>,
+  );
+
+describe('TabbedContainer', () => {
+  it('builds one tab per child and shows the default table', () => {
+    renderTables();
+    expect(screen.getAllByRole('tab').map(tab => tab.textContent)).toEqual(['Runs', 'Scores']);
+    const filterTrigger = screen.getByRole('combobox', { name: 'Filter by status' });
+    const filterControl = filterTrigger.closest('[data-slot="tabbed-container-filter"]');
+    expect(filterControl?.hasAttribute('data-active')).toBe(true);
+    expect(document.querySelector('[data-slot="tabbed-container-filter-count"]')?.textContent).toBe('1');
+    expect(screen.getByText('What is the weather?')).toBeTruthy();
+    expect(screen.queryByText('answer-relevancy')).toBeNull();
+  });
+
+  it('switches tables and keeps each DataList search control mounted in the shared rail', () => {
+    renderTables();
+    const runsToolbar = screen.getByLabelText('Search runs').closest('[data-slot="tabbed-container-controls"]');
+    const scoresToolbar = screen.getByLabelText('Search scores').closest('[data-slot="tabbed-container-controls"]');
+    const runsSearch = screen.getByLabelText('Search runs');
+    fireEvent.change(runsSearch, { target: { value: 'weather' } });
+    fireEvent.keyDown(window, { key: 'f', ctrlKey: true, shiftKey: true });
+    expect(document.activeElement).toBe(runsSearch);
+    expect(runsToolbar?.hasAttribute('data-active')).toBe(true);
+    expect(runsToolbar?.hasAttribute('inert')).toBe(false);
+    expect(scoresToolbar?.hasAttribute('data-active')).toBe(false);
+    expect(scoresToolbar?.getAttribute('aria-hidden')).toBe('true');
+    expect(scoresToolbar?.hasAttribute('inert')).toBe(true);
+    fireEvent.click(screen.getByRole('tab', { name: 'Scores' }));
+    expect(screen.getByText('answer-relevancy')).toBeTruthy();
+    expect(runsToolbar?.hasAttribute('data-active')).toBe(false);
+    expect(runsToolbar?.getAttribute('aria-hidden')).toBe('true');
+    expect(runsToolbar?.hasAttribute('inert')).toBe(true);
+    expect(scoresToolbar?.hasAttribute('data-active')).toBe(true);
+    expect(scoresToolbar?.hasAttribute('inert')).toBe(false);
+    fireEvent.keyDown(window, { key: 'f', ctrlKey: true, shiftKey: true });
+    expect(document.activeElement).toBe(screen.getByLabelText('Search scores'));
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    expect(screen.getByLabelText<HTMLInputElement>('Search runs').value).toBe('weather');
+  });
+
+  it('keeps an empty multi-filter inactive', () => {
+    render(
+      <TabbedContainer defaultTab="runs">
+        <TabbedContainer.DataList
+          value="runs"
+          label="Runs"
+          columns="auto"
+          filter={{
+            'aria-label': 'Filter by status',
+            multiple: true,
+            options: [{ value: 'failed', label: 'Failed' }],
+            value: [],
+          }}
+        >
+          <DataList.RowStatic>
+            <DataList.Cell>run_1</DataList.Cell>
+          </DataList.RowStatic>
+        </TabbedContainer.DataList>
+      </TabbedContainer>,
+    );
+
+    const filterControl = screen
+      .getByRole('combobox', { name: 'Filter by status' })
+      .closest('[data-slot="tabbed-container-filter"]');
+    expect(filterControl?.hasAttribute('data-active')).toBe(false);
+    expect(document.querySelector('[data-slot="tabbed-container-filter-count"]')).toBeNull();
+  });
+
+  it('switches between arbitrary content and a searchable DataList', () => {
+    render(
+      <TabbedContainer defaultTab="overview">
+        <TabbedContainer.Panel value="overview" label="Overview">
+          <div>Overview content</div>
+        </TabbedContainer.Panel>
+        <TabbedContainer.DataList
+          value="runs"
+          label="Runs"
+          columns="auto"
+          search={{ label: 'Search runs', placeholder: 'Search runs', onSearch: vi.fn() }}
+        >
+          <DataList.RowStatic>
+            <DataList.Cell>run_1</DataList.Cell>
+          </DataList.RowStatic>
+        </TabbedContainer.DataList>
+      </TabbedContainer>,
+    );
+
+    const controls = screen.getByLabelText('Search runs').closest('[data-slot="tabbed-container-controls"]');
+    expect(screen.getByText('Overview content')).toBeTruthy();
+    expect(controls?.hasAttribute('data-active')).toBe(false);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    expect(screen.getByText('run_1')).toBeTruthy();
+    expect(controls?.hasAttribute('data-active')).toBe(true);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Overview' }));
+    expect(controls?.hasAttribute('data-active')).toBe(false);
+    expect(screen.getByText('run_1')).toBeTruthy();
+  });
+
+  it('uses the inset frame by default and honors an explicit frame', () => {
+    const { rerender } = render(
+      <TabbedContainer defaultTab="runs" className="custom-root">
+        <TabbedContainer.DataList value="runs" label="Runs" columns="auto">
+          <DataList.RowStatic>
+            <DataList.Cell>run_1</DataList.Cell>
+          </DataList.RowStatic>
+        </TabbedContainer.DataList>
+      </TabbedContainer>,
+    );
+    const root = () => screen.getByRole('tab', { name: 'Runs' }).closest('[data-slot="tabs"]');
+    expect(root()?.getAttribute('data-frame')).toBe('inset');
+    expect(root()?.getAttribute('data-appearance')).toBe('contained');
+    expect(root()?.classList.contains('tabbed-container')).toBe(true);
+    expect(root()?.classList.contains('custom-root')).toBe(true);
+    rerender(
+      <TabbedContainer defaultTab="runs" frame="stroke" className="custom-root">
+        <TabbedContainer.DataList value="runs" label="Runs" columns="auto">
+          <DataList.RowStatic>
+            <DataList.Cell>run_1</DataList.Cell>
+          </DataList.RowStatic>
+        </TabbedContainer.DataList>
+      </TabbedContainer>,
+    );
+    expect(root()?.getAttribute('data-frame')).toBe('stroke');
+  });
+
+  it('mixes arbitrary panels with DataLists and ignores unrelated children', () => {
+    render(
+      <TabbedContainer defaultTab="overview">
+        <div>stray node</div>
+        <TabbedContainer.Panel value="overview" label="Overview">
+          <div>Overview content</div>
+        </TabbedContainer.Panel>
+        <TabbedContainer.DataList value="scores" label="Scores" columns="auto" disabled attention>
+          <DataList.RowStatic>
+            <DataList.Cell>score_1</DataList.Cell>
+          </DataList.RowStatic>
+        </TabbedContainer.DataList>
+      </TabbedContainer>,
+    );
+
+    expect(screen.getAllByRole('tab').map(tab => tab.textContent)).toEqual(['Overview', 'Scores Needs attention']);
+    expect(screen.getByText('Overview content')).toBeTruthy();
+    expect(screen.queryByText('stray node')).toBeNull();
+    expect(document.querySelectorAll('[data-slot="tabbed-container-controls"]')).toHaveLength(0);
+    const scores = screen.getByRole('tab', { name: /Scores/ });
+    expect(scores.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('forwards close behavior when a DataList moves into overflow', () => {
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(180);
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => new DOMRect(0, 0, 100, 36));
+    const onClose = vi.fn();
+    render(
+      <TabbedContainer defaultTab="overview">
+        <TabbedContainer.Panel value="overview" label="Overview">
+          <div>Overview content</div>
+        </TabbedContainer.Panel>
+        <TabbedContainer.DataList value="runs" label="Runs" columns="auto" onClose={onClose}>
+          <DataList.RowStatic>
+            <DataList.Cell>run_1</DataList.Cell>
+          </DataList.RowStatic>
+        </TabbedContainer.DataList>
+      </TabbedContainer>,
+    );
+
+    expect(screen.queryByRole('tab', { name: 'Runs' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: '1 more tabs' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close tab' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('tab', { name: 'Overview' }).getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('renders DataLists flush inside the frame', () => {
+    renderTables();
+    const panel = screen.getByText('What is the weather?').closest('[data-slot="tabs-content"]');
+    expect(panel?.getAttribute('data-flush')).toBe('true');
+  });
+});

--- a/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TabbedContainer/tabbed-container.tsx
@@ -1,0 +1,14 @@
+import { TabbedContainerDataList, TabbedContainerPanel, TabbedContainerRoot } from './tabbed-container-root';
+
+export type {
+  TabbedContainerDataListProps,
+  TabbedContainerFilterProps,
+  TabbedContainerPanelProps,
+  TabbedContainerProps,
+  TabbedContainerSearchProps,
+} from './tabbed-container-root';
+
+export const TabbedContainer = Object.assign(TabbedContainerRoot, {
+  Panel: TabbedContainerPanel,
+  DataList: TabbedContainerDataList,
+});

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.test.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.test.tsx
@@ -334,4 +334,60 @@ describe('DataListRoot', () => {
       expect(row?.getAttribute('variant')).toBeNull();
     });
   });
+
+  describe('SortableTopCell', () => {
+    it('starts with the default direction and reverses the active direction', () => {
+      const onSortChange = vi.fn();
+      const { rerender } = render(
+        <DataList columns="1fr">
+          <DataList.Top>
+            <DataList.SortableTopCell onSortChange={onSortChange}>Name</DataList.SortableTopCell>
+          </DataList.Top>
+        </DataList>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /Name.*not sorted.*sort ascending/i }));
+      expect(onSortChange).toHaveBeenLastCalledWith('ascending');
+
+      rerender(
+        <DataList columns="1fr">
+          <DataList.Top>
+            <DataList.SortableTopCell sortDirection="ascending" onSortChange={onSortChange}>
+              Name
+            </DataList.SortableTopCell>
+          </DataList.Top>
+        </DataList>,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /Name.*sorted ascending.*sort descending/i }));
+      expect(onSortChange).toHaveBeenLastCalledWith('descending');
+
+      rerender(
+        <DataList columns="1fr">
+          <DataList.Top>
+            <DataList.SortableTopCell sortDirection="descending" onSortChange={onSortChange}>
+              Name
+            </DataList.SortableTopCell>
+          </DataList.Top>
+        </DataList>,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /Name.*sorted descending.*sort ascending/i }));
+      expect(onSortChange).toHaveBeenLastCalledWith('ascending');
+    });
+
+    it('supports descending as the first direction', () => {
+      const onSortChange = vi.fn();
+      render(
+        <DataList columns="1fr">
+          <DataList.Top>
+            <DataList.SortableTopCell defaultSortDirection="descending" onSortChange={onSortChange}>
+              Date
+            </DataList.SortableTopCell>
+          </DataList.Top>
+        </DataList>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /Date.*not sorted.*sort descending/i }));
+      expect(onSortChange).toHaveBeenCalledWith('descending');
+    });
+  });
 });

--- a/packages/playground-ui/src/ds/components/DataList/data-list-sortable-top-cell.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-sortable-top-cell.tsx
@@ -1,0 +1,75 @@
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { DataListTopCell } from './data-list-top-cell';
+import type { DataListTopCellProps } from './data-list-top-cell';
+import { focusRing, transitions } from '@/ds/primitives/transitions';
+import { cn } from '@/lib/utils';
+
+export type DataListSortDirection = 'ascending' | 'descending';
+
+const sortIcons = {
+  ascending: ArrowUp,
+  descending: ArrowDown,
+  none: ArrowUpDown,
+};
+
+function getNextDirection(
+  sortDirection: DataListSortDirection | undefined,
+  defaultSortDirection: DataListSortDirection,
+) {
+  if (!sortDirection) return defaultSortDirection;
+  return sortDirection === 'ascending' ? 'descending' : 'ascending';
+}
+
+export type DataListSortableTopCellProps = Omit<
+  DataListTopCellProps,
+  'aria-sort' | 'as' | 'children' | 'onClick' | 'role'
+> & {
+  children: ReactNode;
+  sortDirection?: DataListSortDirection;
+  defaultSortDirection?: DataListSortDirection;
+  onSortChange: (direction: DataListSortDirection) => void;
+  align?: 'start' | 'end';
+};
+
+export function DataListSortableTopCell({
+  children,
+  sortDirection,
+  defaultSortDirection = 'ascending',
+  onSortChange,
+  align = 'start',
+  className,
+  ...props
+}: DataListSortableTopCellProps) {
+  const nextDirection = getNextDirection(sortDirection, defaultSortDirection);
+  const SortIcon = sortIcons[sortDirection ?? 'none'];
+  const currentDirection = sortDirection ? `, sorted ${sortDirection}` : ', not sorted';
+
+  return (
+    <DataListTopCell
+      as="div"
+      data-sort-direction={sortDirection ?? 'none'}
+      className={cn('overflow-visible py-0', className)}
+      {...props}
+    >
+      <button
+        type="button"
+        onClick={() => onSortChange(nextDirection)}
+        className={cn(
+          'relative flex h-10 w-full touch-manipulation items-center gap-1 overflow-visible rounded-sm outline-none',
+          align === 'start' ? 'justify-start text-left' : 'justify-end text-right',
+          sortDirection ? 'text-neutral4' : 'text-neutral3',
+          'hover:text-neutral4',
+          transitions.colors,
+          focusRing.visible,
+        )}
+      >
+        <span className="min-w-0 truncate">{children}</span>
+        <span className="sr-only">
+          {currentDirection}, sort {nextDirection}
+        </span>
+        <SortIcon aria-hidden="true" className="size-3 shrink-0" />
+      </button>
+    </DataListTopCell>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DataList/data-list.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list.tsx
@@ -19,6 +19,7 @@ import { DataListRowButton } from './data-list-row-button';
 import { DataListRowLink } from './data-list-row-link';
 import { DataListRowStatic } from './data-list-row-static';
 import { DataListRowWrapper } from './data-list-row-wrapper';
+import { DataListSortableTopCell } from './data-list-sortable-top-cell';
 import { DataListSpacer } from './data-list-spacer';
 import { DataListSubheader } from './data-list-subheader';
 import { DataListSubHeading } from './data-list-subheading';
@@ -32,11 +33,13 @@ import {
 import { DataListTopCells } from './data-list-top-cells';
 
 export type { DataListRootProps, DataListVariant } from './data-list-root';
+export type { DataListSortableTopCellProps, DataListSortDirection } from './data-list-sortable-top-cell';
 
 export const DataList = Object.assign(DataListRoot, {
   Top: DataListTop,
   TopCells: DataListTopCells,
   TopCell: DataListTopCell,
+  SortableTopCell: DataListSortableTopCell,
   TopCellWithTooltip: DataListTopCellWithTooltip,
   TopCellSmart: DataListTopCellSmart,
   RowWrapper: DataListRowWrapper,

--- a/packages/playground-ui/src/ds/components/DataList/index.ts
+++ b/packages/playground-ui/src/ds/components/DataList/index.ts
@@ -1,6 +1,14 @@
 export * from './data-list';
 export * from './data-list-skeleton';
 export { ScoresDataList } from './ScoresDataList/scores-data-list';
+export { TabbedContainer } from './TabbedContainer/tabbed-container';
+export type {
+  TabbedContainerFilterProps,
+  TabbedContainerDataListProps,
+  TabbedContainerPanelProps,
+  TabbedContainerProps,
+  TabbedContainerSearchProps,
+} from './TabbedContainer/tabbed-container';
 export { TracesDataList } from './TracesDataList/traces-data-list';
 export { useDataListKeyboard } from './use-data-list-keyboard';
 export type { UseDataListKeyboardArgs } from './use-data-list-keyboard';

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-content.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-content.tsx
@@ -1,22 +1,34 @@
 import { Tabs as BaseTabs } from '@base-ui/react/tabs';
+import { useContext, useEffect, useState } from 'react';
+import { TabsContext } from './tabs-context';
 import { focusRing } from '@/ds/primitives/transitions';
 import { cn } from '@/lib/utils';
 
 export type TabContentProps = {
   children: React.ReactNode;
   value: string;
+  flush?: boolean;
+  keepMounted?: boolean;
   className?: string;
 };
 
-export const TabContent = ({ children, value, className }: TabContentProps) => {
+export const TabContent = ({ children, value, flush = false, keepMounted = false, className }: TabContentProps) => {
+  const tabs = useContext(TabsContext);
+  const selected = tabs?.value === value;
+  const [visited, setVisited] = useState(selected);
+  useEffect(() => {
+    if (keepMounted && selected) setVisited(true);
+  }, [keepMounted, selected]);
   return (
     <BaseTabs.Panel
       value={value}
+      keepMounted={keepMounted}
       data-slot="tabs-content"
+      data-flush={flush || undefined}
       className={cn('ring-offset-background grid overflow-y-auto py-3', focusRing.visible, className)}
     >
       <div data-slot="tabs-content-body" className="contents">
-        {children}
+        {!keepMounted || selected || visited ? children : null}
       </div>
     </BaseTabs.Panel>
   );

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-context.ts
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-context.ts
@@ -8,6 +8,7 @@ export type TabMeasurement = {
   width: number;
   element: HTMLElement;
   onClick?: () => void;
+  onClose?: () => void;
 };
 
 export const TabsContext = createContext<{

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
@@ -58,6 +58,8 @@ export const TabList = ({ children, className, variant, sticky, style }: TabList
   const tabs = useContext(TabsContext);
   const scrollRef = useRef<HTMLDivElement>(null);
   const closeRefs = useRef(new Map<string, HTMLDivElement>());
+  const tabPositions = useRef(new Map<string, number>());
+  const selectedValue = useRef(tabs?.value);
   const [available, setAvailable] = useState<number | null>(null);
   const [measurements, setMeasurements] = useState<TabMeasurement[]>([]);
   const register = useCallback((tab: TabMeasurement) => {
@@ -121,15 +123,52 @@ export const TabList = ({ children, className, variant, sticky, style }: TabList
   const visibleClosableTabs = measurements.filter(tab => !hiddenValues.has(tab.value) && tab.onClose);
   const listContext = useMemo(() => ({ hiddenValues, register, unregister }), [hiddenValues, register, unregister]);
   useLayoutEffect(() => {
-    for (const tab of visibleClosableTabs) {
+    const nextPositions = new Map(tabPositions.current);
+    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+    for (const tab of measurements) {
+      if (hiddenValues.has(tab.value)) continue;
+      const left = tab.element.offsetLeft;
+      const previousLeft = tabPositions.current.get(tab.value);
       const close = closeRefs.current.get(tab.value);
-      if (!close) continue;
-      close.style.left = `${tab.element.offsetLeft}px`;
-      close.style.top = `${tab.element.offsetTop}px`;
-      close.style.width = `${tab.element.offsetWidth}px`;
-      close.style.height = `${tab.element.offsetHeight}px`;
+      if (close) {
+        close.style.left = `${left}px`;
+        close.style.top = `${tab.element.offsetTop}px`;
+        close.style.width = `${tab.element.offsetWidth}px`;
+        close.style.height = `${tab.element.offsetHeight}px`;
+      }
+      const delta = previousLeft === undefined ? 0 : previousLeft - left;
+      const shouldAnimate = tab.value !== tabs?.value && Math.abs(delta) <= 32;
+      if (!reduceMotion && shouldAnimate && delta !== 0 && 'animate' in tab.element) {
+        tab.element.animate([{ transform: `translateX(${delta}px)` }, { transform: 'translateX(0)' }], {
+          duration: 180,
+          easing: 'cubic-bezier(0.32, 0.72, 0, 1)',
+        });
+      }
+      nextPositions.set(tab.value, left);
     }
-  }, [visibleClosableTabs]);
+    for (const value of nextPositions.keys()) {
+      if (!measurements.some(tab => tab.value === value)) nextPositions.delete(value);
+    }
+    tabPositions.current = nextPositions;
+  }, [hiddenValues, measurements, tabs?.value]);
+  useLayoutEffect(() => {
+    const previousValue = selectedValue.current;
+    selectedValue.current = tabs?.value;
+    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+    if (!contained || tabs?.frame !== 'inset' || previousValue === tabs?.value || reduceMotion) return;
+    const indicator = scrollRef.current?.querySelector<HTMLElement>('[data-slot="tabs-indicator"]');
+    if (!indicator || !('animate' in indicator)) return;
+    indicator.animate(
+      [
+        { opacity: 0.72, scale: '0.97' },
+        { opacity: 1, scale: '1' },
+      ],
+      {
+        duration: 140,
+        easing: 'cubic-bezier(0.32, 0.72, 0, 1)',
+      },
+    );
+  }, [contained, tabs?.frame, tabs?.value]);
 
   return (
     <TabListContext.Provider value={listContext}>

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
@@ -58,7 +58,6 @@ export const TabList = ({ children, className, variant, sticky, style }: TabList
   const tabs = useContext(TabsContext);
   const scrollRef = useRef<HTMLDivElement>(null);
   const closeRefs = useRef(new Map<string, HTMLDivElement>());
-  const [activeCloseValue, setActiveCloseValue] = useState<string | null>(null);
   const [available, setAvailable] = useState<number | null>(null);
   const [measurements, setMeasurements] = useState<TabMeasurement[]>([]);
   const register = useCallback((tab: TabMeasurement) => {
@@ -139,21 +138,6 @@ export const TabList = ({ children, className, variant, sticky, style }: TabList
           ref={scrollRef}
           data-slot="tabs-list-scroll"
           className={cn('relative w-full overflow-x-auto', sticky && 'sticky top-0 z-10 bg-surface2')}
-          onPointerMove={event => {
-            if (!(event.target instanceof Element)) return;
-            const item = event.target.closest<HTMLElement>('[data-tab-value]');
-            setActiveCloseValue(item?.dataset.tabValue ?? null);
-          }}
-          onPointerLeave={() => setActiveCloseValue(null)}
-          onFocusCapture={event => {
-            if (!(event.target instanceof Element)) return;
-            const item = event.target.closest<HTMLElement>('[data-tab-value]');
-            setActiveCloseValue(item?.dataset.tabValue ?? null);
-          }}
-          onBlurCapture={event => {
-            const nextTarget = event.relatedTarget;
-            if (!(nextTarget instanceof Node) || !event.currentTarget.contains(nextTarget)) setActiveCloseValue(null);
-          }}
         >
           <BaseTabs.List
             data-slot="tabs-list"
@@ -195,15 +179,14 @@ export const TabList = ({ children, className, variant, sticky, style }: TabList
                   else closeRefs.current.delete(tab.value);
                 }}
                 data-slot="tab-close-item"
-                data-tab-value={tab.value}
-                data-visible={activeCloseValue === tab.value || undefined}
+                data-visible={tabs?.value === tab.value || undefined}
               >
                 <Tooltip>
                   <TooltipTrigger
                     render={
                       <button
                         type="button"
-                        tabIndex={activeCloseValue === tab.value ? 0 : -1}
+                        tabIndex={tabs?.value === tab.value ? 0 : -1}
                         data-slot="tab-close"
                         onClick={tab.onClose}
                         className={cn('rounded p-0.5 hover:bg-surface4 hover:text-accent2', transitions.colors)}

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
@@ -91,9 +91,10 @@ export const TabList = ({ children, className, variant, sticky, style }: TabList
     const viewport = scrollRef.current;
     if (!viewport || !contained) return;
     const measure = () => setAvailable(viewport.clientWidth);
+    measure();
+    if (!('ResizeObserver' in globalThis)) return;
     const observer = new ResizeObserver(measure);
     observer.observe(viewport);
-    measure();
     return () => observer.disconnect();
   }, [contained]);
   const gap = tabs?.frame === 'inset' ? 4 : 0;

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
@@ -1,7 +1,7 @@
 import { Tabs as BaseTabs } from '@base-ui/react/tabs';
 import { cva } from 'class-variance-authority';
 import type { VariantProps } from 'class-variance-authority';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, X } from 'lucide-react';
 import { useCallback, useContext, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { DropdownMenu } from '../DropdownMenu/dropdown-menu';
 import { TabListContext, TabsContext } from './tabs-context';
@@ -66,7 +66,8 @@ export const TabList = ({ children, className, variant, sticky, style }: TabList
         existing.width === tab.width &&
         existing.label === tab.label &&
         existing.disabled === tab.disabled &&
-        existing.onClick === tab.onClick
+        existing.onClick === tab.onClick &&
+        existing.onClose === tab.onClose
       )
         return previous;
       const next = existing ? previous.map(item => (item.value === tab.value ? tab : item)) : [...previous, tab];
@@ -174,7 +175,29 @@ export const TabList = ({ children, className, variant, sticky, style }: TabList
                       tab.onClick?.();
                     }}
                   >
-                    {tab.label}
+                    <span className="min-w-0 flex-1">{tab.label}</span>
+                    {tab.onClose ? (
+                      <button
+                        type="button"
+                        aria-label="Close tab"
+                        className={cn(
+                          'ml-auto',
+                          'shrink-0',
+                          'rounded',
+                          'p-0.5',
+                          'text-neutral3',
+                          'transition-colors',
+                          'hover:bg-surface5',
+                          'hover:text-neutral5',
+                        )}
+                        onClick={event => {
+                          event.stopPropagation();
+                          tab.onClose?.();
+                        }}
+                      >
+                        <X aria-hidden="true" className="size-3" />
+                      </button>
+                    ) : null}
                   </DropdownMenu.Item>
                 ))}
               </DropdownMenu.Content>

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
@@ -2,7 +2,7 @@ import { Tabs as BaseTabs } from '@base-ui/react/tabs';
 import { cva } from 'class-variance-authority';
 import type { VariantProps } from 'class-variance-authority';
 import { ChevronDown, X } from 'lucide-react';
-import { useCallback, useContext, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useContext, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { DropdownMenu } from '../DropdownMenu/dropdown-menu';
 import { TabListContext, TabsContext } from './tabs-context';
 import type { TabMeasurement } from './tabs-context';
@@ -167,38 +167,23 @@ export const TabList = ({ children, className, variant, sticky, style }: TabList
               </DropdownMenu.Trigger>
               <DropdownMenu.Content>
                 {hiddenTabs.map(tab => (
-                  <DropdownMenu.Item
-                    key={tab.value}
-                    disabled={tab.disabled}
-                    onClick={() => {
-                      tabs?.select(tab.value);
-                      tab.onClick?.();
-                    }}
-                  >
-                    <span className="min-w-0 flex-1">{tab.label}</span>
+                  <Fragment key={tab.value}>
+                    <DropdownMenu.Item
+                      disabled={tab.disabled}
+                      onClick={() => {
+                        tabs?.select(tab.value);
+                        tab.onClick?.();
+                      }}
+                    >
+                      {tab.label}
+                    </DropdownMenu.Item>
                     {tab.onClose ? (
-                      <button
-                        type="button"
-                        aria-label="Close tab"
-                        className={cn(
-                          'ml-auto',
-                          'shrink-0',
-                          'rounded',
-                          'p-0.5',
-                          'text-neutral3',
-                          'transition-colors',
-                          'hover:bg-surface5',
-                          'hover:text-neutral5',
-                        )}
-                        onClick={event => {
-                          event.stopPropagation();
-                          tab.onClose?.();
-                        }}
-                      >
+                      <DropdownMenu.Item className="text-neutral3" onClick={tab.onClose}>
                         <X aria-hidden="true" className="size-3" />
-                      </button>
+                        <span>Close {tab.label}</span>
+                      </DropdownMenu.Item>
                     ) : null}
-                  </DropdownMenu.Item>
+                  </Fragment>
                 ))}
               </DropdownMenu.Content>
             </DropdownMenu>

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
@@ -4,8 +4,10 @@ import type { VariantProps } from 'class-variance-authority';
 import { ChevronDown, X } from 'lucide-react';
 import { Fragment, useCallback, useContext, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { DropdownMenu } from '../DropdownMenu/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../Tooltip/tooltip';
 import { TabListContext, TabsContext } from './tabs-context';
 import type { TabMeasurement } from './tabs-context';
+import { transitions } from '@/ds/primitives/transitions';
 import { cn } from '@/lib/utils';
 
 const tabListVariants = cva('relative flex items-center text-ui-lg', {
@@ -55,6 +57,8 @@ export const TabList = ({ children, className, variant, sticky, style }: TabList
   const resolvedVariant = variant ?? 'line';
   const tabs = useContext(TabsContext);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const closeRefs = useRef(new Map<string, HTMLDivElement>());
+  const [activeCloseValue, setActiveCloseValue] = useState<string | null>(null);
   const [available, setAvailable] = useState<number | null>(null);
   const [measurements, setMeasurements] = useState<TabMeasurement[]>([]);
   const register = useCallback((tab: TabMeasurement) => {
@@ -115,81 +119,160 @@ export const TabList = ({ children, className, variant, sticky, style }: TabList
   const overflowX = measurements
     .filter(tab => !hiddenValues.has(tab.value))
     .reduce((sum, tab) => sum + tab.width + gap, tabs?.frame === 'inset' ? 4 : 0);
+  const visibleClosableTabs = measurements.filter(tab => !hiddenValues.has(tab.value) && tab.onClose);
   const listContext = useMemo(() => ({ hiddenValues, register, unregister }), [hiddenValues, register, unregister]);
+  useLayoutEffect(() => {
+    for (const tab of visibleClosableTabs) {
+      const close = closeRefs.current.get(tab.value);
+      if (!close) continue;
+      close.style.left = `${tab.element.offsetLeft}px`;
+      close.style.top = `${tab.element.offsetTop}px`;
+      close.style.width = `${tab.element.offsetWidth}px`;
+      close.style.height = `${tab.element.offsetHeight}px`;
+    }
+  }, [visibleClosableTabs]);
 
   return (
-    <TabListContext.Provider value={contained ? listContext : null}>
-      <div
-        ref={scrollRef}
-        data-slot="tabs-list-scroll"
-        className={cn('w-full overflow-x-auto', sticky && 'sticky top-0 z-10 bg-surface2')}
-      >
-        <BaseTabs.List
-          data-slot="tabs-list"
-          data-overflow={hiddenTabs.length > 0 || undefined}
-          data-variant={resolvedVariant}
-          className={cn('group/tabs-list', tabListVariants({ variant: resolvedVariant }), className)}
-          style={style}
+    <TabListContext.Provider value={listContext}>
+      <TooltipProvider delay={200}>
+        <div
+          ref={scrollRef}
+          data-slot="tabs-list-scroll"
+          className={cn('relative w-full overflow-x-auto', sticky && 'sticky top-0 z-10 bg-surface2')}
+          onPointerMove={event => {
+            if (!(event.target instanceof Element)) return;
+            const item = event.target.closest<HTMLElement>('[data-tab-value]');
+            setActiveCloseValue(item?.dataset.tabValue ?? null);
+          }}
+          onPointerLeave={() => setActiveCloseValue(null)}
+          onFocusCapture={event => {
+            if (!(event.target instanceof Element)) return;
+            const item = event.target.closest<HTMLElement>('[data-tab-value]');
+            setActiveCloseValue(item?.dataset.tabValue ?? null);
+          }}
+          onBlurCapture={event => {
+            const nextTarget = event.relatedTarget;
+            if (!(nextTarget instanceof Node) || !event.currentTarget.contains(nextTarget)) setActiveCloseValue(null);
+          }}
         >
-          {children}
-          {resolvedVariant === 'line' && (
-            <BaseTabs.Indicator
-              className={cn(
-                'absolute bottom-0 left-0 bg-[var(--tab-indicator-color,var(--neutral3))]',
-                'h-0.5 w-[var(--active-tab-width)]',
-                'transition-[width,transform] duration-200 ease-in-out motion-reduce:transition-none',
-              )}
-              data-slot="tabs-indicator"
-              style={{ transform: 'translateX(var(--active-tab-left))' }}
-            />
-          )}
-          {(resolvedVariant === 'pill' || resolvedVariant === 'pill-ghost') && (
-            <BaseTabs.Indicator
-              className={cn(
-                'absolute top-1/2 left-0 z-0 rounded-full bg-[var(--tab-indicator-color,var(--surface4))]',
-                'h-[calc(100%-0.5rem)] w-[var(--active-tab-width)]',
-                'transition-[width,transform] duration-200 ease-in-out motion-reduce:transition-none',
-              )}
-              data-slot="tabs-indicator"
-              style={{ transform: 'translateY(var(--tabs-indicator-y, -50%)) translateX(var(--active-tab-left))' }}
-            />
-          )}
-        </BaseTabs.List>
-        {hiddenTabs.length > 0 && (
-          <div data-slot="tabs-overflow" style={{ transform: `translateX(${overflowX}px)` }} className="tabs-overflow">
-            <DropdownMenu>
-              <DropdownMenu.Trigger
-                aria-label={`${hiddenTabs.length} more tabs`}
-                className="text-ui-sm text-neutral3 hover:bg-surface3 hover:text-neutral5 focus-visible:ring-accent1 flex items-center gap-1 rounded px-1.5 py-1 tabular-nums focus-visible:ring-1 focus-visible:outline-none"
+          <BaseTabs.List
+            data-slot="tabs-list"
+            data-overflow={hiddenTabs.length > 0 || undefined}
+            data-variant={resolvedVariant}
+            className={cn('group/tabs-list', tabListVariants({ variant: resolvedVariant }), className)}
+            style={style}
+          >
+            {children}
+            {resolvedVariant === 'line' && (
+              <BaseTabs.Indicator
+                className={cn(
+                  'absolute bottom-0 left-0 bg-[var(--tab-indicator-color,var(--neutral3))]',
+                  'h-0.5 w-[var(--active-tab-width)]',
+                  'transition-[width,transform] duration-200 ease-in-out motion-reduce:transition-none',
+                )}
+                data-slot="tabs-indicator"
+                style={{ transform: 'translateX(var(--active-tab-left))' }}
+              />
+            )}
+            {(resolvedVariant === 'pill' || resolvedVariant === 'pill-ghost') && (
+              <BaseTabs.Indicator
+                className={cn(
+                  'absolute top-1/2 left-0 z-0 rounded-full bg-[var(--tab-indicator-color,var(--surface4))]',
+                  'h-[calc(100%-0.5rem)] w-[var(--active-tab-width)]',
+                  'transition-[width,transform] duration-200 ease-in-out motion-reduce:transition-none',
+                )}
+                data-slot="tabs-indicator"
+                style={{ transform: 'translateY(var(--tabs-indicator-y, -50%)) translateX(var(--active-tab-left))' }}
+              />
+            )}
+          </BaseTabs.List>
+          <div data-slot="tabs-close-actions">
+            {visibleClosableTabs.map(tab => (
+              <div
+                key={tab.value}
+                ref={element => {
+                  if (element) closeRefs.current.set(tab.value, element);
+                  else closeRefs.current.delete(tab.value);
+                }}
+                data-slot="tab-close-item"
+                data-tab-value={tab.value}
+                data-visible={activeCloseValue === tab.value || undefined}
               >
-                +{hiddenTabs.length}
-                <ChevronDown aria-hidden="true" className="size-3" />
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Content>
-                {hiddenTabs.map(tab => (
-                  <Fragment key={tab.value}>
-                    <DropdownMenu.Item
-                      disabled={tab.disabled}
-                      onClick={() => {
-                        tabs?.select(tab.value);
-                        tab.onClick?.();
-                      }}
-                    >
-                      {tab.label}
-                    </DropdownMenu.Item>
-                    {tab.onClose ? (
-                      <DropdownMenu.Item className="text-neutral3" onClick={tab.onClose}>
-                        <X aria-hidden="true" className="size-3" />
-                        <span>Close {tab.label}</span>
-                      </DropdownMenu.Item>
-                    ) : null}
-                  </Fragment>
-                ))}
-              </DropdownMenu.Content>
-            </DropdownMenu>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        tabIndex={activeCloseValue === tab.value ? 0 : -1}
+                        data-slot="tab-close"
+                        onClick={tab.onClose}
+                        className={cn('rounded p-0.5 hover:bg-surface4 hover:text-accent2', transitions.colors)}
+                      />
+                    }
+                  >
+                    <span className="sr-only">Close {tab.label}</span>
+                    <X aria-hidden="true" className="size-3" />
+                  </TooltipTrigger>
+                  <TooltipContent>Close {tab.label}</TooltipContent>
+                </Tooltip>
+              </div>
+            ))}
           </div>
-        )}
-      </div>
+          {hiddenTabs.length > 0 && (
+            <div
+              data-slot="tabs-overflow"
+              style={{ transform: `translateX(${overflowX}px)` }}
+              className="tabs-overflow"
+            >
+              <DropdownMenu>
+                <DropdownMenu.Trigger
+                  aria-label={`${hiddenTabs.length} more tabs`}
+                  className="text-ui-sm text-neutral3 hover:bg-surface3 hover:text-neutral5 focus-visible:ring-accent1 flex items-center gap-1 rounded px-1.5 py-1 tabular-nums focus-visible:ring-1 focus-visible:outline-none"
+                >
+                  +{hiddenTabs.length}
+                  <ChevronDown aria-hidden="true" className="size-3" />
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Content className="grid">
+                  {hiddenTabs.map((tab, index) => (
+                    <Fragment key={tab.value}>
+                      <DropdownMenu.Item
+                        data-slot="tabs-overflow-tab"
+                        disabled={tab.disabled}
+                        className={tab.onClose ? 'pr-9' : undefined}
+                        style={{ gridArea: `${index + 1} / 1` }}
+                        onClick={() => {
+                          tabs?.select(tab.value);
+                          tab.onClick?.();
+                        }}
+                      >
+                        {tab.label}
+                      </DropdownMenu.Item>
+                      {tab.onClose ? (
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <DropdownMenu.Item
+                                data-slot="tabs-overflow-close"
+                                className="hover:text-accent2 data-[highlighted]:text-accent2 pointer-events-none z-10 m-1 size-6 self-center justify-self-end p-0 opacity-0"
+                                style={{ gridArea: `${index + 1} / 1` }}
+                                onClick={tab.onClose}
+                              />
+                            }
+                          >
+                            <span className="sr-only">Close {tab.label}</span>
+                            <X aria-hidden="true" className="size-3" />
+                          </TooltipTrigger>
+                          <TooltipContent side="right">Close {tab.label}</TooltipContent>
+                        </Tooltip>
+                      ) : null}
+                    </Fragment>
+                  ))}
+                </DropdownMenu.Content>
+              </DropdownMenu>
+            </div>
+          )}
+        </div>
+      </TooltipProvider>
     </TabListContext.Provider>
   );
 };

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-tab.test.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-tab.test.tsx
@@ -128,7 +128,7 @@ describe('Tab', () => {
     expect(screen.queryByRole('tab', { name: 'Second' })).toBeNull();
   });
 
-  it('closes an overflowed tab without selecting it', () => {
+  it('closes an overflowed tab by keyboard without selecting it', () => {
     vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(180);
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => new DOMRect(0, 0, 100, 36));
     const onClose = vi.fn();
@@ -147,7 +147,9 @@ describe('Tab', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: '1 more tabs' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Close tab' }));
+    const closeItem = screen.getByRole('menuitem', { name: 'Close Second' });
+    closeItem.focus();
+    fireEvent.keyDown(closeItem, { key: 'Enter', code: 'Enter' });
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onClick).not.toHaveBeenCalled();

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-tab.test.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-tab.test.tsx
@@ -337,15 +337,19 @@ describe('Tab', () => {
       );
 
       const tab = screen.getByRole('tab', { name: 'Second' });
-      const closeButton = screen.getByRole('button', { name: 'Close tab' });
-      expect(tab.contains(closeButton)).toBe(false);
-      expect(closeButton.parentElement).toBe(tab.parentElement);
+      const closeButton = screen.getByRole('button', { name: 'Close Second' });
+      const tabList = tab.closest('[role="tablist"]');
+      expect(tabList?.contains(closeButton)).toBe(false);
+      expect(closeButton.closest('[data-slot="tabs-list-scroll"]')).toBe(tabList?.parentElement);
+      expect(closeButton.closest('[data-slot="tab-close-item"]')?.hasAttribute('data-visible')).toBe(false);
+      act(() => tab.focus());
+      expect(closeButton.closest('[data-slot="tab-close-item"]')?.hasAttribute('data-visible')).toBe(true);
+      expect(closeButton.tabIndex).toBe(0);
       closeButton.focus();
       expect(document.activeElement).toBe(closeButton);
       fireEvent.click(closeButton);
 
       expect(onClose).toHaveBeenCalledTimes(1);
-      // The click must not bubble into the tab underneath it.
       expect(onClick).not.toHaveBeenCalled();
       expect(screen.getByRole('tab', { name: /First/ }).getAttribute('aria-selected')).toBe('true');
     });
@@ -383,7 +387,7 @@ describe('Tab', () => {
         </Tabs>,
       );
 
-      expect(screen.queryByRole('button', { name: 'Close tab' })).toBeNull();
+      expect(screen.queryByRole('button', { name: /^Close / })).toBeNull();
     });
   });
 

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-tab.test.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-tab.test.tsx
@@ -27,6 +27,24 @@ afterEach(() => {
 });
 
 describe('Tab', () => {
+  it('measures contained tabs once without ResizeObserver', () => {
+    Reflect.deleteProperty(globalThis, 'ResizeObserver');
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(200);
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => new DOMRect(0, 0, 100, 36));
+
+    render(
+      <Tabs defaultTab="first" appearance="contained" frame="inset">
+        <TabList>
+          <Tab value="first">First</Tab>
+          <Tab value="second">Second</Tab>
+        </TabList>
+      </Tabs>,
+    );
+
+    expect(screen.getAllByRole('tab')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: '1 more tabs' })).toBeTruthy();
+  });
+
   it('keeps attention after selection until the caller clears it', () => {
     const content = (attention: boolean) => (
       <Tabs defaultTab="first">

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-tab.test.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-tab.test.tsx
@@ -8,6 +8,7 @@ import { Tabs } from './tabs-root';
 import { Tab } from './tabs-tab';
 
 beforeEach(() => {
+  vi.stubGlobal('PointerEvent', window.MouseEvent);
   vi.stubGlobal(
     'ResizeObserver',
     class {
@@ -127,6 +128,32 @@ describe('Tab', () => {
     expect(screen.queryByRole('tab', { name: 'Second' })).toBeNull();
   });
 
+  it('closes an overflowed tab without selecting it', () => {
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(180);
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => new DOMRect(0, 0, 100, 36));
+    const onClose = vi.fn();
+    const onClick = vi.fn();
+    render(
+      <Tabs defaultTab="first" appearance="contained" frame="inset">
+        <TabList>
+          <Tab value="first">First</Tab>
+          <Tab value="second" onClose={onClose} onClick={onClick}>
+            Second
+          </Tab>
+        </TabList>
+        <TabContent value="first">First panel</TabContent>
+        <TabContent value="second">Second panel</TabContent>
+      </Tabs>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '1 more tabs' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close tab' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+    expect(screen.getByRole('tab', { name: 'First' }).getAttribute('aria-selected')).toBe('true');
+  });
+
   it('restores overflowed tabs when the container grows', () => {
     const callbacks = new Set<() => void>();
     vi.stubGlobal(
@@ -178,6 +205,60 @@ describe('Tab', () => {
     expect(screen.getByRole('tab', { name: 'First' }).getAttribute('aria-selected')).toBe('true');
     rerender(content('second'));
     expect(screen.getByRole('tab', { name: 'Second' }).getAttribute('aria-selected')).toBe('true');
+  });
+
+  describe('keepMounted panels', () => {
+    const renderTabs = () => (
+      <Tabs defaultTab="first" appearance="contained" frame="inset">
+        <TabList>
+          <Tab value="first">First</Tab>
+          <Tab value="second">Second</Tab>
+        </TabList>
+        <TabContent value="first" keepMounted>
+          <input aria-label="First field" />
+        </TabContent>
+        <TabContent value="second" keepMounted>
+          <input aria-label="Second field" />
+        </TabContent>
+      </Tabs>
+    );
+
+    it('mounts a panel on first visit, not upfront', () => {
+      render(renderTabs());
+      expect(screen.getByLabelText('First field')).toBeTruthy();
+      expect(screen.queryByLabelText('Second field')).toBeNull();
+    });
+
+    it('preserves panel state across tab switches', () => {
+      render(renderTabs());
+      const first = screen.getByLabelText<HTMLInputElement>('First field');
+      fireEvent.change(first, { target: { value: 'kept' } });
+      fireEvent.click(screen.getByRole('tab', { name: 'Second' }));
+      expect(screen.getByLabelText('Second field')).toBeTruthy();
+      fireEvent.click(screen.getByRole('tab', { name: 'First' }));
+      expect(screen.getByLabelText<HTMLInputElement>('First field').value).toBe('kept');
+    });
+  });
+
+  it('unmounts non-keepMounted panels and leaves them unflushed by default', () => {
+    render(
+      <Tabs defaultTab="first" appearance="contained" frame="inset">
+        <TabList>
+          <Tab value="first">First</Tab>
+          <Tab value="second">Second</Tab>
+        </TabList>
+        <TabContent value="first">
+          <input aria-label="First field" />
+        </TabContent>
+        <TabContent value="second">
+          <input aria-label="Second field" />
+        </TabContent>
+      </Tabs>,
+    );
+    const panel = screen.getByLabelText('First field').closest('[data-slot="tabs-content"]');
+    expect(panel?.hasAttribute('data-flush')).toBe(false);
+    fireEvent.click(screen.getByRole('tab', { name: 'Second' }));
+    expect(screen.queryByLabelText('First field')).toBeNull();
   });
 
   describe('when tabs use the contained appearance', () => {
@@ -253,12 +334,37 @@ describe('Tab', () => {
         </Tabs>,
       );
 
-      fireEvent.click(screen.getByRole('button', { name: 'Close tab' }));
+      const closeButton = screen.getByRole('button', { name: 'Close tab' });
+      expect(closeButton.closest('[role="tab"]')?.tagName).toBe('DIV');
+      fireEvent.click(closeButton);
 
       expect(onClose).toHaveBeenCalledTimes(1);
       // The click must not bubble into the tab underneath it.
       expect(onClick).not.toHaveBeenCalled();
       expect(screen.getByRole('tab', { name: /First/ }).getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('keeps keyboard activation when a close affordance is present', () => {
+      render(
+        <Tabs defaultTab="first">
+          <TabList>
+            <Tab value="first">First</Tab>
+            <Tab value="second" onClose={() => {}}>
+              Second
+            </Tab>
+          </TabList>
+          <TabContent value="first">First content</TabContent>
+          <TabContent value="second">Second content</TabContent>
+        </Tabs>,
+      );
+
+      const secondTab = screen.getByRole('tab', { name: /Second/ });
+      secondTab.focus();
+      fireEvent.keyDown(secondTab, { key: 'Enter', code: 'Enter' });
+      fireEvent.keyUp(secondTab, { key: 'Enter', code: 'Enter' });
+
+      expect(secondTab.getAttribute('aria-selected')).toBe('true');
+      expect(screen.getByText('Second content')).toBeTruthy();
     });
 
     it('offers no close affordance without a close handler', () => {

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-tab.test.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-tab.test.tsx
@@ -319,12 +319,12 @@ describe('Tab', () => {
   });
 
   describe('when a tab can be closed', () => {
-    it('closes without also selecting the tab', () => {
+    it('closes without also invoking the tab click', () => {
       const onClose = vi.fn();
       const onClick = vi.fn();
 
       render(
-        <Tabs defaultTab="first">
+        <Tabs defaultTab="second">
           <TabList>
             <Tab value="first">First</Tab>
             <Tab value="second" onClose={onClose} onClick={onClick}>
@@ -341,8 +341,6 @@ describe('Tab', () => {
       const tabList = tab.closest('[role="tablist"]');
       expect(tabList?.contains(closeButton)).toBe(false);
       expect(closeButton.closest('[data-slot="tabs-list-scroll"]')).toBe(tabList?.parentElement);
-      expect(closeButton.closest('[data-slot="tab-close-item"]')?.hasAttribute('data-visible')).toBe(false);
-      act(() => tab.focus());
       expect(closeButton.closest('[data-slot="tab-close-item"]')?.hasAttribute('data-visible')).toBe(true);
       expect(closeButton.tabIndex).toBe(0);
       closeButton.focus();
@@ -351,7 +349,32 @@ describe('Tab', () => {
 
       expect(onClose).toHaveBeenCalledTimes(1);
       expect(onClick).not.toHaveBeenCalled();
-      expect(screen.getByRole('tab', { name: /First/ }).getAttribute('aria-selected')).toBe('true');
+      expect(tab.getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('shows the close affordance only for the selected tab', () => {
+      render(
+        <Tabs defaultTab="first">
+          <TabList>
+            <Tab value="first" onClose={() => {}}>
+              First
+            </Tab>
+            <Tab value="second" onClose={() => {}}>
+              Second
+            </Tab>
+          </TabList>
+        </Tabs>,
+      );
+
+      const firstClose = screen.getByRole('button', { name: 'Close First' });
+      const secondClose = screen.getByRole('button', { name: 'Close Second' });
+      expect(firstClose.closest('[data-slot="tab-close-item"]')?.hasAttribute('data-visible')).toBe(true);
+      expect(secondClose.closest('[data-slot="tab-close-item"]')?.hasAttribute('data-visible')).toBe(false);
+
+      fireEvent.click(screen.getByRole('tab', { name: 'Second' }));
+
+      expect(firstClose.closest('[data-slot="tab-close-item"]')?.hasAttribute('data-visible')).toBe(false);
+      expect(secondClose.closest('[data-slot="tab-close-item"]')?.hasAttribute('data-visible')).toBe(true);
     });
 
     it('keeps keyboard activation when a close affordance is present', () => {

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-tab.test.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-tab.test.tsx
@@ -336,8 +336,12 @@ describe('Tab', () => {
         </Tabs>,
       );
 
+      const tab = screen.getByRole('tab', { name: 'Second' });
       const closeButton = screen.getByRole('button', { name: 'Close tab' });
-      expect(closeButton.closest('[role="tab"]')?.tagName).toBe('DIV');
+      expect(tab.contains(closeButton)).toBe(false);
+      expect(closeButton.parentElement).toBe(tab.parentElement);
+      closeButton.focus();
+      expect(document.activeElement).toBe(closeButton);
       fireEvent.click(closeButton);
 
       expect(onClose).toHaveBeenCalledTimes(1);

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
@@ -60,7 +60,6 @@ export const Tab = ({
       value={value}
       disabled={disabled || overflowed}
       data-slot="tab"
-      data-tab-value={value}
       data-closable={onClose ? '' : undefined}
       className={cn(
         'text-ui-md font-normal text-neutral3',

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
@@ -28,7 +28,7 @@ export const Tab = ({
   className,
 }: TabProps) => {
   const list = useContext(TabListContext);
-  const ref = useRef<HTMLButtonElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
   const register = list?.register;
   const unregister = list?.unregister;
   const overflowed = list?.hiddenValues.has(value) ?? false;
@@ -43,16 +43,19 @@ export const Tab = ({
         width: element.getBoundingClientRect().width,
         element,
         onClick,
+        onClose,
       });
     const observer = new ResizeObserver(measure);
     observer.observe(element);
     measure();
     return () => observer.disconnect();
-  }, [register, value, children, disabled, onClick]);
+  }, [register, value, children, disabled, onClick, onClose]);
   useEffect(() => () => unregister?.(value), [unregister, value]);
   const tab = (
     <BaseTabs.Tab
       ref={ref}
+      render={<div />}
+      nativeButton={false}
       data-overflowed={overflowed || undefined}
       aria-hidden={overflowed || undefined}
       value={value}

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
@@ -53,18 +53,16 @@ export const Tab = ({
   useEffect(() => () => unregister?.(value), [unregister, value]);
   const tab = (
     <BaseTabs.Tab
-      ref={ref}
       render={<div />}
       nativeButton={false}
-      data-overflowed={overflowed || undefined}
-      aria-hidden={overflowed || undefined}
       value={value}
       disabled={disabled || overflowed}
       data-slot="tab"
+      data-closable={onClose ? '' : undefined}
       className={cn(
         'text-ui-md font-normal text-neutral3',
         attention && 'relative',
-        'flex shrink-0 cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap outline-none',
+        'flex cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap outline-none',
         transitions.colors,
         focusRing.visible,
         'hover:text-neutral4',
@@ -83,30 +81,38 @@ export const Tab = ({
           <span className="sr-only"> Needs attention</span>
         </>
       )}
-      {onClose && (
+    </BaseTabs.Tab>
+  );
+  const tabWithTooltip =
+    disabled && disabledTooltip ? (
+      <Tooltip>
+        <TooltipTrigger asChild>{tab}</TooltipTrigger>
+        <TooltipContent>{disabledTooltip}</TooltipContent>
+      </Tooltip>
+    ) : (
+      tab
+    );
+
+  return (
+    <div
+      ref={ref}
+      data-slot="tab-item"
+      data-overflowed={overflowed || undefined}
+      aria-hidden={overflowed || undefined}
+      className="relative flex shrink-0 items-center"
+    >
+      {tabWithTooltip}
+      {onClose ? (
         <button
           type="button"
-          onClick={e => {
-            e.stopPropagation();
-            onClose();
-          }}
+          data-slot="tab-close"
+          onClick={onClose}
           className={cn('rounded p-0.5 hover:bg-surface4', transitions.colors, 'hover:text-neutral5')}
           aria-label="Close tab"
         >
           <X className="size-3" />
         </button>
-      )}
-    </BaseTabs.Tab>
+      ) : null}
+    </div>
   );
-
-  if (disabled && disabledTooltip) {
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>{tab}</TooltipTrigger>
-        <TooltipContent>{disabledTooltip}</TooltipContent>
-      </Tooltip>
-    );
-  }
-
-  return tab;
 };

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
@@ -44,9 +44,10 @@ export const Tab = ({
         onClick,
         onClose,
       });
+    measure();
+    if (!('ResizeObserver' in globalThis)) return;
     const observer = new ResizeObserver(measure);
     observer.observe(element);
-    measure();
     return () => observer.disconnect();
   }, [register, value, children, disabled, onClick, onClose]);
   useEffect(() => () => unregister?.(value), [unregister, value]);

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
@@ -1,5 +1,4 @@
 import { Tabs as BaseTabs } from '@base-ui/react/tabs';
-import { X } from 'lucide-react';
 import { useContext, useEffect, useRef } from 'react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip/tooltip';
 import { TabListContext } from './tabs-context';
@@ -53,11 +52,15 @@ export const Tab = ({
   useEffect(() => () => unregister?.(value), [unregister, value]);
   const tab = (
     <BaseTabs.Tab
+      ref={ref}
       render={<div />}
       nativeButton={false}
+      data-overflowed={overflowed || undefined}
+      aria-hidden={overflowed || undefined}
       value={value}
       disabled={disabled || overflowed}
       data-slot="tab"
+      data-tab-value={value}
       data-closable={onClose ? '' : undefined}
       className={cn(
         'text-ui-md font-normal text-neutral3',
@@ -83,36 +86,14 @@ export const Tab = ({
       )}
     </BaseTabs.Tab>
   );
-  const tabWithTooltip =
-    disabled && disabledTooltip ? (
+  if (disabled && disabledTooltip) {
+    return (
       <Tooltip>
         <TooltipTrigger asChild>{tab}</TooltipTrigger>
         <TooltipContent>{disabledTooltip}</TooltipContent>
       </Tooltip>
-    ) : (
-      tab
     );
+  }
 
-  return (
-    <div
-      ref={ref}
-      data-slot="tab-item"
-      data-overflowed={overflowed || undefined}
-      aria-hidden={overflowed || undefined}
-      className="relative flex shrink-0 items-center"
-    >
-      {tabWithTooltip}
-      {onClose ? (
-        <button
-          type="button"
-          data-slot="tab-close"
-          onClick={onClose}
-          className={cn('rounded p-0.5 hover:bg-surface4', transitions.colors, 'hover:text-neutral5')}
-          aria-label="Close tab"
-        >
-          <X className="size-3" />
-        </button>
-      ) : null}
-    </div>
-  );
+  return tab;
 };

--- a/packages/playground-ui/src/ds/components/Tabs/tabs.css
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs.css
@@ -1,15 +1,43 @@
+[data-slot='tabs-overflow-tab']:hover + [data-slot='tabs-overflow-close'],
+[data-slot='tabs-overflow-close']:hover,
+[data-slot='tabs-overflow-close'][data-highlighted] {
+  pointer-events: auto;
+  opacity: 1;
+}
+
 [data-slot='tabs'] {
-  [data-slot='tab-item'][data-overflowed] {
+  [data-slot='tab'][data-overflowed] {
     position: absolute;
     visibility: hidden;
     pointer-events: none;
   }
 
+  [data-slot='tabs-close-actions'] {
+    position: absolute;
+    inset: 0;
+    z-index: 30;
+    pointer-events: none;
+  }
+
+  [data-slot='tab-close-item'] {
+    position: absolute;
+    pointer-events: none;
+    opacity: 0;
+  }
+
+  [data-slot='tab-close-item'][data-visible] {
+    opacity: 1;
+  }
+
   [data-slot='tab-close'] {
     position: absolute;
-    z-index: 30;
     top: 50%;
     transform: translateY(-50%);
+    pointer-events: none;
+  }
+
+  [data-slot='tab-close-item'][data-visible] [data-slot='tab-close'] {
+    pointer-events: auto;
   }
 
   &[data-appearance='default'] {
@@ -88,7 +116,7 @@
       right: 16px;
     }
 
-    [data-slot='tab-item']:not(:first-child) [data-slot='tab'] {
+    [data-slot='tab']:not(:first-child) {
       margin-left: -1px;
     }
     [data-slot='tab']:hover {
@@ -169,7 +197,7 @@
         left: 100%;
         --corner: top right;
       }
-      [data-slot='tab-item']:first-child [data-slot='tab']::before {
+      [data-slot='tab']:first-child::before {
         display: none;
       }
     }
@@ -295,7 +323,7 @@
       padding-right: 56px;
     }
 
-    [data-slot='tab-item'][data-overflowed] {
+    [data-slot='tab'][data-overflowed] {
       position: absolute;
       visibility: hidden;
       width: max-content;

--- a/packages/playground-ui/src/ds/components/Tabs/tabs.css
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs.css
@@ -46,7 +46,7 @@
       border-bottom: 2px solid transparent;
     }
 
-    [data-variant='line'] [data-slot='tab'][data-closable] {
+    [data-variant='line'] [data-slot='tab'][data-active][data-closable] {
       padding-right: 42px;
     }
 
@@ -61,7 +61,7 @@
       border-radius: 9999px;
     }
 
-    :is([data-variant='pill'], [data-variant='pill-ghost']) [data-slot='tab'][data-closable] {
+    :is([data-variant='pill'], [data-variant='pill-ghost']) [data-slot='tab'][data-active][data-closable] {
       padding-right: 34px;
     }
 
@@ -108,7 +108,7 @@
       padding: 6px 16px;
     }
 
-    [data-slot='tab'][data-closable] {
+    [data-slot='tab'][data-active][data-closable] {
       padding-right: 38px;
     }
 

--- a/packages/playground-ui/src/ds/components/Tabs/tabs.css
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs.css
@@ -1,8 +1,15 @@
 [data-slot='tabs'] {
-  [data-slot='tab'][data-overflowed] {
+  [data-slot='tab-item'][data-overflowed] {
     position: absolute;
     visibility: hidden;
     pointer-events: none;
+  }
+
+  [data-slot='tab-close'] {
+    position: absolute;
+    z-index: 30;
+    top: 50%;
+    transform: translateY(-50%);
   }
 
   &[data-appearance='default'] {
@@ -11,11 +18,27 @@
       border-bottom: 2px solid transparent;
     }
 
+    [data-variant='line'] [data-slot='tab'][data-closable] {
+      padding-right: 42px;
+    }
+
+    [data-variant='line'] [data-slot='tab-close'] {
+      right: 20px;
+    }
+
     :is([data-variant='pill'], [data-variant='pill-ghost']) [data-slot='tab'] {
       position: relative;
       z-index: 10;
       padding: 4px 12px;
       border-radius: 9999px;
+    }
+
+    :is([data-variant='pill'], [data-variant='pill-ghost']) [data-slot='tab'][data-closable] {
+      padding-right: 34px;
+    }
+
+    :is([data-variant='pill'], [data-variant='pill-ghost']) [data-slot='tab-close'] {
+      right: 12px;
     }
   }
 
@@ -57,7 +80,15 @@
       padding: 6px 16px;
     }
 
-    [data-slot='tab']:not(:first-child) {
+    [data-slot='tab'][data-closable] {
+      padding-right: 38px;
+    }
+
+    [data-slot='tab-close'] {
+      right: 16px;
+    }
+
+    [data-slot='tab-item']:not(:first-child) [data-slot='tab'] {
       margin-left: -1px;
     }
     [data-slot='tab']:hover {
@@ -138,7 +169,7 @@
         left: 100%;
         --corner: top right;
       }
-      [data-slot='tab']:first-child::before {
+      [data-slot='tab-item']:first-child [data-slot='tab']::before {
         display: none;
       }
     }
@@ -261,7 +292,7 @@
       padding-right: 56px;
     }
 
-    [data-slot='tab'][data-overflowed] {
+    [data-slot='tab-item'][data-overflowed] {
       position: absolute;
       visibility: hidden;
       width: max-content;

--- a/packages/playground-ui/src/ds/components/Tabs/tabs.css
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs.css
@@ -20,6 +20,9 @@
   }
 
   &[data-appearance='contained'] {
+    display: flex;
+    flex-direction: column;
+
     --tab-frame-radius: var(--radius-xl);
     --tab-inset: 4px;
     --tab-inner-radius: calc(var(--tab-frame-radius) - var(--tab-inset));
@@ -28,6 +31,7 @@
     [data-slot='tabs-list-scroll'] {
       position: relative;
       z-index: 10;
+      flex-shrink: 0;
       scrollbar-width: none;
     }
 
@@ -87,6 +91,14 @@
     }
 
     &[data-frame='stroke'] {
+      [data-slot='tabs-content'][data-flush] {
+        padding: var(--tab-inset);
+        grid-template-rows: minmax(0, 1fr);
+        overflow: hidden;
+        flex: 1 1 auto;
+        min-height: 0;
+      }
+
       [data-slot='tabs-list-scroll'] {
         padding-bottom: 10px;
         margin-bottom: -10px;
@@ -179,6 +191,18 @@
         background: var(--surface4);
         padding: var(--tab-inset);
       }
+      [data-slot='tabs-content'][data-flush] {
+        padding: 0;
+        grid-template-rows: minmax(0, 1fr);
+        overflow: hidden;
+        flex: 1 1 auto;
+        min-height: 0;
+      }
+      [data-slot='tabs-content'][data-flush] [data-slot='tabs-content-body'] {
+        display: contents;
+        background: none;
+        padding: 0;
+      }
       [data-slot='tabs-content-body'] {
         display: block;
         min-width: 0;
@@ -242,6 +266,18 @@
       visibility: hidden;
       width: max-content;
       pointer-events: none;
+    }
+
+    &[data-frame='inset']:has([data-slot='tabs-content'][data-flush]:not([hidden])) {
+      [data-slot='tabs-indicator'] {
+        height: var(--active-tab-height);
+        border-radius: var(--tab-inner-radius);
+      }
+
+      [data-slot='tabs-indicator']::before,
+      [data-slot='tabs-indicator']::after {
+        display: none;
+      }
     }
 
     @media (pointer: coarse) {

--- a/packages/playground-ui/src/ds/components/Tabs/tabs.css
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs.css
@@ -222,6 +222,7 @@
         background: var(--surface4);
         padding: var(--tab-inset);
       }
+
       [data-slot='tabs-content'][data-flush] {
         padding: 0;
         grid-template-rows: minmax(0, 1fr);
@@ -229,11 +230,13 @@
         flex: 1 1 auto;
         min-height: 0;
       }
+
       [data-slot='tabs-content'][data-flush] [data-slot='tabs-content-body'] {
         display: contents;
         background: none;
         padding: 0;
       }
+
       [data-slot='tabs-content-body'] {
         display: block;
         min-width: 0;

--- a/packages/playground-ui/src/ds/components/Tabs/tabs.css
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs.css
@@ -291,7 +291,7 @@
         height: calc(var(--active-tab-height) + var(--tab-join-radius));
         border-radius: var(--tab-inner-radius) var(--tab-inner-radius) 0 0;
         background: var(--surface2);
-        transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+        transition: none;
       }
 
       [data-slot='tabs-indicator']::before,

--- a/pubsub/google-cloud-pubsub/src/index.ts
+++ b/pubsub/google-cloud-pubsub/src/index.ts
@@ -196,7 +196,7 @@ export class GoogleCloudPubSub extends PubSub {
       try {
         const activeCbs = this.activeCbs[subscriptionKey] ?? [];
         for (const cb of activeCbs) {
-          cb(
+          await cb(
             event,
             async () => {
               try {
@@ -294,7 +294,7 @@ export class GoogleCloudPubSub extends PubSub {
 
     for (const cb of [...callbacks]) {
       try {
-        cb(
+        await cb(
           localEvent,
           async () => {},
           async () => {},

--- a/pubsub/google-cloud-pubsub/src/index.ts
+++ b/pubsub/google-cloud-pubsub/src/index.ts
@@ -196,7 +196,7 @@ export class GoogleCloudPubSub extends PubSub {
       try {
         const activeCbs = this.activeCbs[subscriptionKey] ?? [];
         for (const cb of activeCbs) {
-          await cb(
+          cb(
             event,
             async () => {
               try {
@@ -294,7 +294,7 @@ export class GoogleCloudPubSub extends PubSub {
 
     for (const cb of [...callbacks]) {
       try {
-        await cb(
+        cb(
           localEvent,
           async () => {},
           async () => {},


### PR DESCRIPTION
## Description

Adds `TabbedContainer` for mixed content and DataList panels, with persistent panel state, rail-integrated controls, sortable columns, and closable overflow tabs. It also awaits Google Cloud Pub/Sub subscriber callbacks to satisfy the async callback contract and keep root lint green.

| Light | Dark |
| --- | --- |
| ![TabbedContainer Runs panel sorted by date in light mode](https://github.com/user-attachments/assets/d06b8919-478a-4f08-8099-36b9324c1b23) | ![TabbedContainer Runs panel sorted by date in dark mode](https://github.com/user-attachments/assets/b416fe06-8421-4253-bf29-c43e00d190ee) |

Verified: 3,140 playground-ui tests, typecheck, builds, root lint, 76.99% targeted mutation score, and Storybook interaction checks. Google Cloud Pub/Sub tests require Google ADC and could not complete locally. The push gate skipped an anti-slop finding in the host workspace's `DeployDetail.test.tsx`; that file is not in this diff.

## Related issue(s)

[PLTFRM-1640](https://linear.app/kepler-crm/issue/PLTFRM-1640/add-a-tabbed-container-for-mixed-data-and-content-panels)

## Type of change

- [x] New feature

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds flexible tabs for panels and data tables. It also improves sorting, filtering, tab closing, state preservation, and asynchronous Pub/Sub callbacks.

## Changes

- Added `TabbedContainer` with panel and `DataList` tabs.
- Added search, filters, sortable columns, overflow menus, and closable tabs.
- Added `keepMounted` and `flush` options to `TabContent`.
- Improved `Combobox` accessibility and multi-select clear actions.
- Added `DataList.SortableTopCell`.
- Improved tab measurement when `ResizeObserver` is unavailable.
- Updated Google Cloud Pub/Sub subscriber callbacks to await asynchronous callbacks.
- Added Storybook examples, tests, and a minor `@mastra/playground-ui` changeset.

## Verification

- 3,140 `playground-ui` tests.
- Typecheck, builds, root lint, and Storybook interaction checks.
- Targeted mutation score: 76.99%.
- Google Cloud Pub/Sub tests require Google ADC and could not run locally.
- An anti-slop finding in `DeployDetail.test.tsx` was skipped because the file is outside this diff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->