### PR TITLE
ci(e2e): sync experiment-worker lockfile with @libsql/client ^0.18.0

### DIFF
--- a/e2e-tests/experiment-worker/pnpm-lock.yaml
+++ b/e2e-tests/experiment-worker/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     devDependencies:
       '@libsql/client':
-        specifier: ^0.17.4
-        version: 0.17.4
+        specifier: ^0.18.0
+        version: 0.18.0
       '@types/node':
         specifier: ^26.0.0
         version: 26.1.2
@@ -45,11 +45,11 @@ packages:
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
-  '@libsql/client@0.17.4':
-    resolution: {integrity: sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==}
+  '@libsql/client@0.18.0':
+    resolution: {integrity: sha512-zMCCo58vv7w27j7+cnt/GW+X6/Rih6cHZ86PKi0AxCMOqMfrVgG9OZ5lW2bDMJhSeOjsv2szH2nJF3A9l36UmA==}
 
-  '@libsql/core@0.17.4':
-    resolution: {integrity: sha512-LqF9gIvnJ38nmAH1y/ChizHqDO/MO1wLgA96XrraulEEbqXxLjleSH92YWTolbuJKgPUmGu4aJk9W3UnAcxLOQ==}
+  '@libsql/core@0.18.0':
+    resolution: {integrity: sha512-N8RR2CIpcgtbKZnXs2KVpw2lJQfinUj3I56e7qRDRpK18Hty0Rr8nr00VmFb4R/DsqOanPB/TaP3+QAQLZeXMg==}
 
   '@libsql/darwin-arm64@0.5.29':
     resolution: {integrity: sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==}
@@ -1716,9 +1716,9 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
-  '@libsql/client@0.17.4':
+  '@libsql/client@0.18.0':
     dependencies:
-      '@libsql/core': 0.17.4
+      '@libsql/core': 0.18.0
       '@libsql/hrana-client': 0.10.0
       js-base64: 3.9.2
       libsql: 0.5.29
@@ -1727,7 +1727,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@libsql/core@0.17.4':
+  '@libsql/core@0.18.0':
     dependencies:
       js-base64: 3.9.2
 


### PR DESCRIPTION
## Summary

The **E2E experiments** CI job is failing on every PR that triggers it (e.g. #23530) with:

```
ERR_PNPM_OUTDATED_LOCKFILE ... @libsql/client (lockfile: ^0.17.4, manifest: ^0.18.0)
```

#23164 bumped `@libsql/client` to `^0.18.0` in `e2e-tests/experiment-worker/package.json` but did not regenerate that project's standalone `pnpm-lock.yaml`. Since the job runs `pnpm install --frozen-lockfile` in that directory, install aborts before tests run.

This regenerates the lockfile. Only `@libsql/client` / `@libsql/core` move from 0.17.4 to 0.18.0; the inherited `nanoid` override is preserved.

No changeset: CI-only, no published package changes.

## Test plan

- [x] `pnpm install --frozen-lockfile` in `e2e-tests/experiment-worker` succeeds locally
- [ ] **E2E experiments** job passes on this PR
