### PR TITLE
fix(studio): preserve chat turns across refresh and navigation

### DIFF
--- a/.changeset/clear-moons-sleep.md
+++ b/.changeset/clear-moons-sleep.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed new signal-based Studio chats losing their thread identity when navigating or refreshing before the first response finishes. Late send acknowledgements no longer navigate away from another conversation.

--- a/.changeset/wide-carpets-sit.md
+++ b/.changeset/wide-carpets-sit.md
@@ -1,0 +1,5 @@
+---
+'@mastra/react': patch
+---
+
+Fixed delayed chat history responses overwriting streamed messages, including after completion. Restore saved tasks during active runs without overwriting newer streamed task updates.

--- a/.changeset/wide-carpets-sit.md
+++ b/.changeset/wide-carpets-sit.md
@@ -2,4 +2,4 @@
 '@mastra/react': patch
 ---
 
-Fixed delayed chat history responses overwriting streamed messages, including after completion. Restore saved tasks during active runs without overwriting newer streamed task updates.
+Fixed delayed chat history responses overwriting streamed messages, including after completion. Restore saved tasks and pending tool approvals during active runs without overwriting newer live updates or restoring resolved approvals.

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -305,6 +305,7 @@ export const useChat = ({
   const _threadSignalsUnsupportedRef = useRef(false);
   const [messages, setMessages] = useState<MastraDBMessage[]>([]);
   const [tasks, setTasks] = useState<TaskItem[]>([]);
+  const liveTasks = useRef<TaskItem[] | undefined>(undefined);
   const [toolCallApprovals, setToolCallApprovals] = useState<{
     [toolCallId: string]: { status: 'approved' | 'declined' };
   }>({});
@@ -317,14 +318,50 @@ export const useChat = ({
   const baseClient = useMastraClient();
   const [isRunning, setIsRunning] = useState(false);
 
+  const lastHydration = useRef<
+    | {
+        agentId: string;
+        resourceId?: string;
+        threadId?: string;
+        initialMessages: MastraChatProps['initialMessages'];
+        formattedMessages: MastraDBMessage[];
+      }
+    | undefined
+  >(undefined);
+
   useEffect(() => {
+    const previous = lastHydration.current;
+    const sameThread =
+      previous?.agentId === agentId && previous.resourceId === resourceId && previous.threadId === threadId;
+    if (sameThread && previous.initialMessages === initialMessages) return;
     const formattedMessages = resolveInitialMessages(initialMessages ?? []);
-    setMessages(formattedMessages);
-    setTasks(extractLatestTasksFromMessages(formattedMessages));
+    lastHydration.current = { agentId, resourceId, threadId, initialMessages, formattedMessages };
+
+    if (sameThread) {
+      // Accumulation replaces changed messages immutably. Keep those local edits
+      // over history snapshots, even if the request returns after the run finishes.
+      const previousById = new Map(previous.formattedMessages.map(message => [message.id, message]));
+      setMessages(current => {
+        const live = current.filter(message => previousById.get(message.id) !== message);
+        const liveById = new Map(live.map(message => [message.id, message]));
+        const historyIds = new Set(formattedMessages.map(message => message.id));
+        return [
+          ...formattedMessages.map(message => liveById.get(message.id) ?? message),
+          ...live.filter(message => !historyIds.has(message.id)),
+        ];
+      });
+      setTasks(liveTasks.current ?? extractLatestTasksFromMessages(formattedMessages));
+      if (isRunning || isAwaitingToolApproval) return;
+    } else {
+      liveTasks.current = undefined;
+      if (previous) setIsRunning(false);
+      setMessages(formattedMessages);
+      setTasks(extractLatestTasksFromMessages(formattedMessages));
+    }
     pendingToolApprovalIdsRef.current = extractPendingToolApprovalIdsFromMessages(formattedMessages);
     setIsAwaitingToolApproval(pendingToolApprovalIdsRef.current.size > 0);
     _currentRunId.current = extractRunIdFromMessages(formattedMessages);
-  }, [initialMessages]);
+  }, [agentId, resourceId, threadId, initialMessages, isRunning, isAwaitingToolApproval]);
 
   useEffect(() => {
     _activeContinuation.current = {
@@ -417,10 +454,11 @@ export const useChat = ({
     async (chunk: ChunkType, onChunk?: (chunk: ChunkType) => Promise<void>) => {
       setMessages(prev => accumulateChunk({ chunk, conversation: prev, metadata: { mode: 'stream' } }));
 
-      const signalTasks = extractTasksFromSignalChunk(chunk);
-      if (signalTasks !== undefined) setTasks(signalTasks);
-      const toolTasks = extractTasksFromToolResultChunk(chunk);
-      if (toolTasks !== undefined) setTasks(toolTasks);
+      const streamedTasks = extractTasksFromToolResultChunk(chunk) ?? extractTasksFromSignalChunk(chunk);
+      if (streamedTasks !== undefined) {
+        liveTasks.current = streamedTasks;
+        setTasks(streamedTasks);
+      }
 
       if (
         chunk.type === 'data-user-message' &&
@@ -828,7 +866,6 @@ export const useChat = ({
       }
     } catch (error) {
       if (isThreadSignalUnsupportedError(error)) {
-        onSignalSent?.(resolvedSignalId, getSignalPreview(coreUserMessages));
         try {
           await agent.sendSignal({
             signal: {
@@ -840,6 +877,7 @@ export const useChat = ({
             threadId,
             ifIdle: { streamOptions },
           });
+          onSignalSent?.(resolvedSignalId, getSignalPreview(coreUserMessages));
           return;
         } catch (signalError) {
           onSignalEcho?.(resolvedSignalId);

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -313,6 +313,9 @@ export const useChat = ({
     [toolName: string]: { status: 'approved' | 'declined' };
   }>({});
   const pendingToolApprovalIdsRef = useRef(new Set<string>());
+  const liveApprovalIds = useRef(new Set<string>());
+  const liveRunId = useRef<string | undefined>(undefined);
+  const liveRunFinished = useRef(false);
   const [isAwaitingToolApproval, setIsAwaitingToolApproval] = useState(false);
 
   const baseClient = useMastraClient();
@@ -351,16 +354,29 @@ export const useChat = ({
         ];
       });
       setTasks(liveTasks.current ?? extractLatestTasksFromMessages(formattedMessages));
-      if (isRunning || isAwaitingToolApproval) return;
+      // History may arrive before the live approval event, but must not undo
+      // a live approval decision or terminal event, nor switch the active run.
+      const historyRunId = extractRunIdFromMessages(formattedMessages);
+      if (liveRunFinished.current) return;
+      if (liveRunId.current && historyRunId && historyRunId !== liveRunId.current) return;
+      if (!liveRunId.current && isRunning && historyRunId !== _currentRunId.current) return;
     } else {
       liveTasks.current = undefined;
+      liveApprovalIds.current.clear();
+      liveRunId.current = undefined;
+      liveRunFinished.current = false;
       if (previous) setIsRunning(false);
       setMessages(formattedMessages);
       setTasks(extractLatestTasksFromMessages(formattedMessages));
     }
-    pendingToolApprovalIdsRef.current = extractPendingToolApprovalIdsFromMessages(formattedMessages);
-    setIsAwaitingToolApproval(pendingToolApprovalIdsRef.current.size > 0);
-    _currentRunId.current = extractRunIdFromMessages(formattedMessages);
+    const pendingApprovals = extractPendingToolApprovalIdsFromMessages(formattedMessages);
+    for (const toolCallId of liveApprovalIds.current) {
+      if (pendingToolApprovalIdsRef.current.has(toolCallId)) pendingApprovals.add(toolCallId);
+      else pendingApprovals.delete(toolCallId);
+    }
+    pendingToolApprovalIdsRef.current = pendingApprovals;
+    setIsAwaitingToolApproval(pendingApprovals.size > 0);
+    _currentRunId.current = liveRunId.current ?? extractRunIdFromMessages(formattedMessages);
   }, [agentId, resourceId, threadId, initialMessages, isRunning, isAwaitingToolApproval]);
 
   useEffect(() => {
@@ -472,6 +488,9 @@ export const useChat = ({
       if (chunk.type === 'start') {
         setIsRunning(true);
         if ('runId' in chunk && typeof chunk.runId === 'string') {
+          if (liveRunId.current !== chunk.runId) liveApprovalIds.current.clear();
+          liveRunFinished.current = false;
+          liveRunId.current = chunk.runId;
           _currentRunId.current = chunk.runId;
         }
       }
@@ -479,6 +498,7 @@ export const useChat = ({
       if (chunk.type === 'tool-call-approval' || chunk.type === 'tool-call-suspended') {
         const toolCallId = chunk.payload?.toolCallId;
         if (typeof toolCallId === 'string') {
+          liveApprovalIds.current.add(toolCallId);
           pendingToolApprovalIdsRef.current.add(toolCallId);
           setIsAwaitingToolApproval(true);
         }
@@ -486,6 +506,8 @@ export const useChat = ({
       }
 
       if (chunk.type === 'finish' || chunk.type === 'abort' || chunk.type === 'error') {
+        if (chunk.runId === liveRunId.current) liveRunFinished.current = true;
+        for (const toolCallId of pendingToolApprovalIdsRef.current) liveApprovalIds.current.add(toolCallId);
         pendingToolApprovalIdsRef.current.clear();
         setIsAwaitingToolApproval(false);
         setIsRunning(false);
@@ -971,6 +993,7 @@ export const useChat = ({
     });
     closeThreadSubscription();
     setMessages(prev => finishStreamingAssistantMessage(prev));
+    liveRunFinished.current = true;
     pendingToolApprovalIdsRef.current.clear();
     setIsAwaitingToolApproval(false);
     setIsRunning(false);
@@ -1004,6 +1027,8 @@ export const useChat = ({
           ...(resumeData !== undefined ? { resumeData } : {}),
           requestContext: continuation.requestContext,
         });
+        liveRunId.current ??= currentRunId;
+        liveApprovalIds.current.add(toolCallId);
         pendingToolApprovalIdsRef.current.delete(toolCallId);
         setIsAwaitingToolApproval(pendingToolApprovalIdsRef.current.size > 0);
         setIsRunning(false);
@@ -1071,6 +1096,8 @@ export const useChat = ({
           ...(continuation.model !== undefined ? { streamOptions: { model: continuation.model } } : {}),
           requestContext: continuation.requestContext,
         });
+        liveRunId.current ??= currentRunId;
+        liveApprovalIds.current.add(toolCallId);
         pendingToolApprovalIdsRef.current.delete(toolCallId);
         setIsAwaitingToolApproval(pendingToolApprovalIdsRef.current.size > 0);
         setIsRunning(false);

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -26,7 +26,7 @@ import { extractRunIdFromMessages } from './extractRunIdFromMessages';
 import { convertSignalDataToBase64String } from './signal-data';
 import type { ClientToolsInput, ModelSettings } from './types';
 
-const extractPendingToolApprovalIdsFromMessages = (messages: MastraDBMessage[]) => {
+const extractPendingToolApprovalIdsFromMessages = (messages: MastraDBMessage[], runId?: string) => {
   const pendingToolApprovalIds = new Set<string>();
 
   for (const message of messages) {
@@ -37,12 +37,13 @@ const extractPendingToolApprovalIdsFromMessages = (messages: MastraDBMessage[]) 
       metadata.pendingToolApprovals,
       metadata.requireApprovalMetadata,
       metadata.suspendedTools,
-    ] as Array<Record<string, { toolCallId?: unknown }> | undefined>;
+    ] as Array<Record<string, { toolCallId?: unknown; runId?: unknown }> | undefined>;
 
     for (const source of metadataSources) {
       if (!source || typeof source !== 'object') continue;
 
       for (const suspensionData of Object.values(source)) {
+        if (runId && suspensionData?.runId !== runId) continue;
         const toolCallId = suspensionData?.toolCallId;
         if (typeof toolCallId === 'string' && toolCallId.length > 0) {
           pendingToolApprovalIds.add(toolCallId);
@@ -358,7 +359,6 @@ export const useChat = ({
       // a live approval decision or terminal event, nor switch the active run.
       const historyRunId = extractRunIdFromMessages(formattedMessages);
       if (liveRunFinished.current) return;
-      if (liveRunId.current && historyRunId && historyRunId !== liveRunId.current) return;
       if (!liveRunId.current && isRunning && historyRunId !== _currentRunId.current) return;
     } else {
       liveTasks.current = undefined;
@@ -369,7 +369,7 @@ export const useChat = ({
       setMessages(formattedMessages);
       setTasks(extractLatestTasksFromMessages(formattedMessages));
     }
-    const pendingApprovals = extractPendingToolApprovalIdsFromMessages(formattedMessages);
+    const pendingApprovals = extractPendingToolApprovalIdsFromMessages(formattedMessages, liveRunId.current);
     for (const toolCallId of liveApprovalIds.current) {
       if (pendingToolApprovalIdsRef.current.has(toolCallId)) pendingApprovals.add(toolCallId);
       else pendingApprovals.delete(toolCallId);

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -63,6 +63,23 @@ const toolCallHasOutput = (parts: MastraDBMessage['content']['parts'], toolCallI
     return invocation.state === 'result' || (invocation as { result?: unknown }).result != null;
   });
 
+const filterUnresolvedApprovals = <T extends { toolCallId: string }>(
+  entries: Record<string, T> | undefined,
+  parts: MastraDBMessage['content']['parts'],
+): Record<string, T> | undefined => {
+  if (!entries || typeof entries !== 'object') return undefined;
+  const pending = Object.fromEntries(
+    Object.entries(entries).filter(
+      ([, approval]) =>
+        approval &&
+        typeof approval === 'object' &&
+        typeof approval.toolCallId === 'string' &&
+        !toolCallHasOutput(parts, approval.toolCallId),
+    ),
+  );
+  return Object.keys(pending).length ? pending : undefined;
+};
+
 /**
  * Normalize persisted initial messages back into the stream-friendly shape the
  * UI renders from. Mirrors `main`'s `resolveInitialMessages`:
@@ -108,23 +125,19 @@ const resolveInitialMessages = (messages: MastraDBMessage[]): MastraDBMessage[] 
           : message;
 
       const normalizedMetadata = normalizedMessage.content?.metadata as MastraDBMessageMetadata | undefined;
-      const pendingToolApprovals = normalizedMetadata?.pendingToolApprovals;
-      if (!pendingToolApprovals || typeof pendingToolApprovals !== 'object') {
+      if (
+        !normalizedMetadata?.pendingToolApprovals &&
+        !normalizedMetadata?.requireApprovalMetadata &&
+        !normalizedMetadata?.suspendedTools
+      ) {
         return normalizedMessage;
       }
 
-      const stillPending = Object.fromEntries(
-        Object.entries(pendingToolApprovals).filter(
-          ([, approval]) =>
-            approval &&
-            typeof approval === 'object' &&
-            typeof approval.toolCallId === 'string' &&
-            !toolCallHasOutput(normalizedMessage.content.parts, approval.toolCallId),
-        ),
-      );
-
-      const { pendingToolApprovals: _omit, ...restMetadata } = normalizedMetadata;
-      const hasStillPending = Object.keys(stillPending).length > 0;
+      const { pendingToolApprovals, requireApprovalMetadata, suspendedTools, ...restMetadata } = normalizedMetadata;
+      const parts = normalizedMessage.content.parts;
+      const pending = filterUnresolvedApprovals(pendingToolApprovals, parts);
+      const required = { ...filterUnresolvedApprovals(requireApprovalMetadata, parts), ...pending };
+      const suspended = filterUnresolvedApprovals(suspendedTools, parts);
 
       return {
         ...normalizedMessage,
@@ -132,8 +145,10 @@ const resolveInitialMessages = (messages: MastraDBMessage[]): MastraDBMessage[] 
           ...normalizedMessage.content,
           metadata: {
             ...restMetadata,
-            mode: 'stream' as const,
-            ...(hasStillPending ? { pendingToolApprovals: stillPending, requireApprovalMetadata: stillPending } : {}),
+            ...(pendingToolApprovals ? { mode: 'stream' as const } : {}),
+            ...(pending ? { pendingToolApprovals: pending } : {}),
+            ...(Object.keys(required).length ? { requireApprovalMetadata: required } : {}),
+            ...(suspended ? { suspendedTools: suspended } : {}),
           },
         },
       };

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -483,6 +483,10 @@ export const useChat = ({
 
   const processStreamChunk = useCallback(
     async (chunk: ChunkType, onChunk?: (chunk: ChunkType) => Promise<void>) => {
+      const isTerminal = chunk.type === 'finish' || chunk.type === 'abort' || chunk.type === 'error';
+      // A delayed terminal event must not finish another run's message, clear
+      // its approvals, or trigger its completion callback.
+      if (isTerminal && liveRunId.current && chunk.runId !== liveRunId.current) return;
       setMessages(prev => accumulateChunk({ chunk, conversation: prev, metadata: { mode: 'stream' } }));
 
       const streamedTasks = extractTasksFromToolResultChunk(chunk) ?? extractTasksFromSignalChunk(chunk);
@@ -520,7 +524,7 @@ export const useChat = ({
         setIsRunning(false);
       }
 
-      if (chunk.type === 'finish' || chunk.type === 'abort' || chunk.type === 'error') {
+      if (isTerminal) {
         if (chunk.runId === liveRunId.current) liveRunFinished.current = true;
         for (const toolCallId of pendingToolApprovalIdsRef.current) liveApprovalIds.current.add(toolCallId);
         pendingToolApprovalIdsRef.current.clear();

--- a/packages/playground/src/lib/ai-ui/chat/__tests__/chat-history.msw.test.tsx
+++ b/packages/playground/src/lib/ai-ui/chat/__tests__/chat-history.msw.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import type { ChunkType, DataChunkType } from '@mastra/core/stream';
+import { ChunkFrom, type ChunkType, type DataChunkType } from '@mastra/core/stream';
 import { MastraReactProvider, useChat } from '@mastra/react';
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
@@ -7,6 +7,8 @@ import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   completedHistory,
+  approvalHistory,
+  approvalChunk,
   emptyHistory,
   finishChunk,
   liveChunks,
@@ -64,6 +66,97 @@ afterEach(() => {
 });
 
 describe('Chat history recovery', () => {
+  describe('when approval history races with live run state', () => {
+    it('hydrates same-run approvals before their live event arrives', async () => {
+      const { result, rerender } = await setup();
+      const history = approvalHistory();
+      rerender({ threadId: 'first', history });
+      expect(result.current.isAwaitingToolApproval).toBe(true);
+      rerender({ threadId: 'first', history });
+      expect(result.current.isAwaitingToolApproval).toBe(true);
+    });
+
+    it('does not replace a live pending approval with empty history', async () => {
+      const { result, rerender } = await setup();
+      await act(async () => push(approvalChunk));
+      await waitFor(() => expect(result.current.isAwaitingToolApproval).toBe(true));
+      rerender({ threadId: 'first', history: { messages: [] } });
+      expect(result.current.isAwaitingToolApproval).toBe(true);
+    });
+
+    it('preserves approval waiting when a suspended transport closes without a finish chunk', async () => {
+      const { result, rerender } = await setup();
+      await act(async () => push(approvalChunk));
+      await waitFor(() => expect(result.current.isAwaitingToolApproval).toBe(true));
+      await act(async () => connections.shift()?.close());
+      rerender({ threadId: 'first', history: { messages: [] } });
+      expect(result.current.isAwaitingToolApproval).toBe(true);
+    });
+
+    it('does not restore stale pending approvals after the run finishes', async () => {
+      const { result, rerender } = await setup();
+      await act(async () => push(finishChunk));
+      await waitFor(() => expect(result.current.isRunning).toBe(false));
+      rerender({ threadId: 'first', history: approvalHistory() });
+      expect(result.current.isAwaitingToolApproval).toBe(false);
+    });
+
+    it('keeps parallel approvals independent and does not resurrect accepted decisions', async () => {
+      const { result, rerender } = await setup();
+      const requests: unknown[] = [];
+      server.use(
+        http.post('http://localhost:4111/api/agents/agent/send-tool-approval', async ({ request }) => {
+          requests.push(await request.json());
+          return HttpResponse.json({ accepted: true, runId: 'recovery-run' });
+        }),
+      );
+      await act(async () => push(approvalChunk));
+      await waitFor(() => expect(result.current.isAwaitingToolApproval).toBe(true));
+      const history = {
+        messages: [...approvalHistory().messages, ...approvalHistory('recovery-run', 'second-tool').messages],
+      };
+      rerender({ threadId: 'first', history });
+      await act(async () => result.current.approveToolCall('approval-tool'));
+      expect(result.current.isAwaitingToolApproval).toBe(true);
+      rerender({ threadId: 'first', history: { messages: [...history.messages] } });
+      await act(async () => result.current.declineToolCall('second-tool'));
+      expect(result.current.isAwaitingToolApproval).toBe(false);
+      rerender({ threadId: 'first', history: { messages: [...history.messages] } });
+      expect(result.current.isAwaitingToolApproval).toBe(false);
+      await act(async () => push({ type: 'start', runId: 'recovery-run', from: ChunkFrom.AGENT, payload: {} }));
+      await waitFor(() => expect(result.current.isRunning).toBe(true));
+      rerender({ threadId: 'first', history: { messages: [...history.messages] } });
+      expect(result.current.isAwaitingToolApproval).toBe(false);
+      expect(requests).toEqual([
+        expect.objectContaining({ toolCallId: 'approval-tool', approved: true }),
+        expect.objectContaining({ toolCallId: 'second-tool', approved: false }),
+      ]);
+    });
+
+    it('hydrates a new run after a previous run has finished', async () => {
+      const { result, rerender } = await setup();
+      await act(async () => push(finishChunk));
+      await waitFor(() => expect(result.current.isRunning).toBe(false));
+      await act(async () => push({ type: 'start', runId: 'next-run', from: ChunkFrom.AGENT, payload: {} }));
+      await waitFor(() => expect(result.current.isRunning).toBe(true));
+      rerender({ threadId: 'first', history: approvalHistory('next-run') });
+      expect(result.current.isAwaitingToolApproval).toBe(true);
+    });
+
+    it('resets live approval authority when changing threads', async () => {
+      const { result, rerender } = await setup();
+      await act(async () => push(finishChunk));
+      await waitFor(() => expect(result.current.isRunning).toBe(false));
+      rerender({ threadId: 'second', history: approvalHistory('other-run') });
+      expect(result.current.isAwaitingToolApproval).toBe(true);
+    });
+
+    it('ignores approvals belonging to an older run while a new run streams', async () => {
+      const { result, rerender } = await setup();
+      rerender({ threadId: 'first', history: approvalHistory('older-run') });
+      expect(result.current.isAwaitingToolApproval).toBe(false);
+    });
+  });
   describe('when the thread changes during a run', () => {
     it('clears the old conversation even if the initial history reference is unchanged', async () => {
       const { result, rerender } = await setup();

--- a/packages/playground/src/lib/ai-ui/chat/__tests__/chat-history.msw.test.tsx
+++ b/packages/playground/src/lib/ai-ui/chat/__tests__/chat-history.msw.test.tsx
@@ -151,6 +151,20 @@ describe('Chat history recovery', () => {
       expect(result.current.isAwaitingToolApproval).toBe(true);
     });
 
+    it.each([false, true])('hydrates only active-run approvals from mixed history (reverse=%s)', async reverse => {
+      const { result, rerender } = await setup();
+      server.use(
+        http.post('http://localhost:4111/api/agents/agent/send-tool-approval', () =>
+          HttpResponse.json({ accepted: true, runId: 'recovery-run' }),
+        ),
+      );
+      const messages = [...approvalHistory('older-run', 'old-tool').messages, ...approvalHistory().messages];
+      rerender({ threadId: 'first', history: { messages: reverse ? messages.reverse() : messages } });
+      expect(result.current.isAwaitingToolApproval).toBe(true);
+      await act(async () => result.current.approveToolCall('approval-tool'));
+      expect(result.current.isAwaitingToolApproval).toBe(false);
+    });
+
     it('ignores approvals belonging to an older run while a new run streams', async () => {
       const { result, rerender } = await setup();
       rerender({ threadId: 'first', history: approvalHistory('older-run') });

--- a/packages/playground/src/lib/ai-ui/chat/__tests__/chat-history.msw.test.tsx
+++ b/packages/playground/src/lib/ai-ui/chat/__tests__/chat-history.msw.test.tsx
@@ -12,6 +12,7 @@ import {
   approvalChunk,
   emptyHistory,
   finishChunk,
+  terminalChunks,
   liveChunks,
   staleHistory,
   taskHistory,
@@ -67,6 +68,27 @@ afterEach(() => {
 });
 
 describe('Chat history recovery', () => {
+  describe.each(terminalChunks)('when a terminal $type arrives', chunk => {
+    it.each([false, true])('ignores stale runs and handles the current run (awaiting approval=%s)', async awaiting => {
+      const { result, rerender } = await setup();
+      if (awaiting) {
+        await act(async () => push(approvalChunk));
+        await waitFor(() => expect(result.current.isAwaitingToolApproval).toBe(true));
+      }
+      const messages = result.current.messages;
+      await act(async () => push({ ...chunk, runId: 'older-run' }));
+      expect(result.current.isAwaitingToolApproval).toBe(awaiting);
+      expect(result.current.isRunning).toBe(!awaiting);
+      expect(result.current.messages).toEqual(messages);
+      rerender({ threadId: 'first', history: { messages: [] } });
+      expect(result.current.isAwaitingToolApproval).toBe(awaiting);
+      await act(async () => push(chunk));
+      await waitFor(() => expect(result.current.isRunning).toBe(false));
+      expect(result.current.isAwaitingToolApproval).toBe(false);
+      rerender({ threadId: 'first', history: approvalHistory() });
+      expect(result.current.isAwaitingToolApproval).toBe(false);
+    });
+  });
   describe.each(['pendingToolApprovals', 'requireApprovalMetadata', 'suspendedTools'] as const)(
     'when history contains %s',
     key => {

--- a/packages/playground/src/lib/ai-ui/chat/__tests__/chat-history.msw.test.tsx
+++ b/packages/playground/src/lib/ai-ui/chat/__tests__/chat-history.msw.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   completedHistory,
   approvalHistory,
+  approvalMetadataHistory,
   approvalChunk,
   emptyHistory,
   finishChunk,
@@ -66,6 +67,24 @@ afterEach(() => {
 });
 
 describe('Chat history recovery', () => {
+  describe.each(['pendingToolApprovals', 'requireApprovalMetadata', 'suspendedTools'] as const)(
+    'when history contains %s',
+    key => {
+      it.each([false, true])('restores only unresolved approvals (resolved=%s)', async resolved => {
+        const { result, rerender } = await setup();
+        rerender({ threadId: 'first', history: approvalMetadataHistory(key, resolved) });
+        expect(result.current.isAwaitingToolApproval).toBe(!resolved);
+        const message = result.current.messages.find(message => message.id === 'approval-fixture');
+        if (resolved) {
+          expect(message?.content.metadata?.[key]).toBeUndefined();
+          expect(message?.content.metadata?.requireApprovalMetadata).toBeUndefined();
+        } else {
+          expect(message?.content.metadata?.[key]).toBeDefined();
+        }
+      });
+    },
+  );
+
   describe('when approval history races with live run state', () => {
     it('hydrates same-run approvals before their live event arrives', async () => {
       const { result, rerender } = await setup();

--- a/packages/playground/src/lib/ai-ui/chat/__tests__/chat-history.msw.test.tsx
+++ b/packages/playground/src/lib/ai-ui/chat/__tests__/chat-history.msw.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import type { ChunkType, DataChunkType } from '@mastra/core/stream';
+import { MastraReactProvider, useChat } from '@mastra/react';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  completedHistory,
+  emptyHistory,
+  finishChunk,
+  liveChunks,
+  staleHistory,
+  taskHistory,
+  savedTasks,
+  taskChunk,
+} from '@/pages/agents/agent/__tests__/fixtures/thread-recovery';
+import { server } from '@/test/msw-server';
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <MastraReactProvider baseUrl="http://localhost:4111">{children}</MastraReactProvider>
+);
+const connections: ReadableStreamDefaultController<Uint8Array>[] = [];
+const push = (chunk: ChunkType | DataChunkType) =>
+  connections[0]?.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+const setup = async () => {
+  server.use(
+    http.post(
+      'http://localhost:4111/api/agents/agent/threads/subscribe',
+      () =>
+        new HttpResponse(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              connections.push(controller);
+            },
+          }),
+          { headers: { 'Content-Type': 'text/event-stream' } },
+        ),
+    ),
+  );
+  const hook = renderHook(
+    ({ threadId, history }) =>
+      useChat({ agentId: 'agent', threadId, initialMessages: history.messages, enableThreadSignals: true }),
+    {
+      wrapper,
+      initialProps: { threadId: 'first', history: emptyHistory },
+    },
+  );
+  await waitFor(() => expect(connections).toHaveLength(1));
+  await act(async () => {
+    for (const chunk of liveChunks) push(chunk);
+  });
+  await waitFor(() =>
+    expect(hook.result.current.messages[0]?.content.parts).toEqual(
+      expect.arrayContaining([expect.objectContaining({ text: 'Live response survives' })]),
+    ),
+  );
+  return hook;
+};
+
+afterEach(() => {
+  for (const controller of connections.splice(0)) controller.close();
+  cleanup();
+});
+
+describe('Chat history recovery', () => {
+  describe('when the thread changes during a run', () => {
+    it('clears the old conversation even if the initial history reference is unchanged', async () => {
+      const { result, rerender } = await setup();
+      rerender({ threadId: 'second', history: emptyHistory });
+      await waitFor(() => expect(result.current.messages).toEqual([]));
+      expect(result.current.isRunning).toBe(false);
+    });
+  });
+
+  describe('when stale history arrives after completion', () => {
+    it.each([emptyHistory, staleHistory])('keeps the completed answer over the stale snapshot %#', async history => {
+      const { result, rerender } = await setup();
+      await act(async () => push(finishChunk));
+      await waitFor(() => expect(result.current.isRunning).toBe(false));
+      rerender({ threadId: 'first', history: { ...history, messages: [...history.messages] } });
+      const response = result.current.messages.find(message => message.id === 'recovery-assistant');
+      expect(response?.content.parts).toEqual(
+        expect.arrayContaining([expect.objectContaining({ text: 'Live response survives' })]),
+      );
+    });
+  });
+
+  describe('when task history arrives during a live run', () => {
+    it('restores saved tasks and clears them on thread change', async () => {
+      const { result, rerender } = await setup();
+      rerender({ threadId: 'first', history: taskHistory });
+      expect(result.current.tasks).toEqual(savedTasks);
+      rerender({ threadId: 'second', history: emptyHistory });
+      expect(result.current.tasks).toEqual([]);
+    });
+
+    it('does not replace newer streamed tasks with saved tasks', async () => {
+      const { result, rerender } = await setup();
+      rerender({ threadId: 'first', history: taskHistory });
+      expect(result.current.tasks).toEqual(savedTasks);
+      await act(async () => push(taskChunk));
+      await waitFor(() => expect(result.current.tasks).toEqual([]));
+      rerender({ threadId: 'first', history: { ...taskHistory, messages: [...taskHistory.messages] } });
+      expect(result.current.tasks).toEqual([]);
+    });
+  });
+
+  describe('when historical messages have not been changed locally', () => {
+    it('allows history refreshes to update and remove them without dropping the live response', async () => {
+      const { result, rerender } = await setup();
+      rerender({ threadId: 'first', history: staleHistory });
+      expect(result.current.messages.some(message => message.id === 'earlier-user')).toBe(true);
+      rerender({ threadId: 'first', history: completedHistory });
+      expect(result.current.messages.map(message => message.id)).toEqual(['recovery-assistant']);
+    });
+  });
+
+  describe('when the run finishes before persisted history is fetched', () => {
+    it('keeps the live response until the new history snapshot arrives', async () => {
+      const { result } = await setup();
+      await act(async () => push(finishChunk));
+      await waitFor(() => expect(result.current.isRunning).toBe(false));
+      expect(result.current.messages).toHaveLength(1);
+      expect(result.current.messages[0]?.content.parts).toEqual(
+        expect.arrayContaining([expect.objectContaining({ text: 'Live response survives' })]),
+      );
+    });
+
+    it('reconciles the completed live message with its persisted copy without duplicating it', async () => {
+      const { result, rerender } = await setup();
+      await act(async () => push(finishChunk));
+      await waitFor(() => expect(result.current.isRunning).toBe(false));
+      rerender({ threadId: 'first', history: completedHistory });
+      await waitFor(() => expect(result.current.messages).toHaveLength(1));
+      expect(result.current.messages[0]?.id).toBe('recovery-assistant');
+      expect(result.current.messages[0]?.content.parts).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Live response survives' })]),
+      );
+    });
+  });
+});

--- a/packages/playground/src/lib/ai-ui/chat/chat-provider.tsx
+++ b/packages/playground/src/lib/ai-ui/chat/chat-provider.tsx
@@ -117,6 +117,9 @@ export function ChatProvider({
     initialMessages,
     requestContext: chatRequestContext,
     enableThreadSignals: threadSignalsEnabled,
+    onSignalSent: () => {
+      void refreshThreadList?.();
+    },
     onThreadSignalsUnsupported: () => {
       threadSignalsUnsupportedRef.current = true;
       setThreadSignalsUnsupported(true);

--- a/packages/playground/src/pages/agents/agent/__tests__/fixtures/thread-recovery.ts
+++ b/packages/playground/src/pages/agents/agent/__tests__/fixtures/thread-recovery.ts
@@ -34,6 +34,29 @@ export const completedHistory: typeof emptyHistory = {
   ],
 };
 
+export const approvalHistory = (runId = 'recovery-run', toolCallId = 'approval-tool'): typeof emptyHistory => ({
+  messages: [
+    {
+      id: `pending-${toolCallId}`,
+      role: 'assistant',
+      createdAt: new Date('2026-01-02'),
+      content: {
+        format: 2,
+        parts: [
+          { type: 'tool-invocation', toolInvocation: { state: 'call', toolCallId, toolName: 'weather', args: {} } },
+        ],
+        metadata: { pendingToolApprovals: { weather: { toolCallId, toolName: 'weather', args: {}, runId } } },
+      },
+    },
+  ],
+});
+export const approvalChunk: ChunkType = {
+  type: 'tool-call-approval',
+  runId: 'recovery-run',
+  from: ChunkFrom.AGENT,
+  payload: { toolCallId: 'approval-tool', toolName: 'weather', args: {}, resumeSchema: '{"type":"object"}' },
+};
+
 export const savedTasks = [{ id: 'saved-task', content: 'Saved task', status: 'pending', activeForm: 'Saving task' }];
 export const taskHistory: typeof emptyHistory = {
   messages: [

--- a/packages/playground/src/pages/agents/agent/__tests__/fixtures/thread-recovery.ts
+++ b/packages/playground/src/pages/agents/agent/__tests__/fixtures/thread-recovery.ts
@@ -125,6 +125,12 @@ export const finishChunk: ChunkType = {
   },
 };
 
+export const terminalChunks = [
+  finishChunk,
+  { type: 'abort', runId: 'recovery-run', from: ChunkFrom.AGENT, payload: {} },
+  { type: 'error', runId: 'recovery-run', from: ChunkFrom.AGENT, payload: { error: 'Test failure' } },
+] satisfies ChunkType[];
+
 export const liveChunks: ChunkType[] = [
   { type: 'start', runId: 'recovery-run', from: ChunkFrom.AGENT, payload: { messageId: 'recovery-assistant' } },
   { type: 'text-start', runId: 'recovery-run', from: ChunkFrom.AGENT, payload: { id: 'recovery-text' } },

--- a/packages/playground/src/pages/agents/agent/__tests__/fixtures/thread-recovery.ts
+++ b/packages/playground/src/pages/agents/agent/__tests__/fixtures/thread-recovery.ts
@@ -1,0 +1,78 @@
+import type { MastraClient } from '@mastra/client-js';
+import { ChunkFrom, type ChunkType, type DataChunkType } from '@mastra/core/stream';
+
+export const emptyHistory: Awaited<ReturnType<MastraClient['listThreadMessages']>> = {
+  messages: [],
+};
+
+export const staleHistory: typeof emptyHistory = {
+  ...emptyHistory,
+  messages: [
+    {
+      id: 'earlier-user',
+      role: 'user',
+      createdAt: new Date('2026-01-01'),
+      content: { format: 2, parts: [{ type: 'text', text: 'Earlier prompt' }] },
+    },
+    {
+      id: 'recovery-assistant',
+      role: 'assistant',
+      createdAt: new Date('2026-01-02'),
+      content: { format: 2, parts: [{ type: 'text', text: 'Old partial output' }] },
+    },
+  ],
+};
+
+export const completedHistory: typeof emptyHistory = {
+  messages: [
+    {
+      id: 'recovery-assistant',
+      role: 'assistant',
+      createdAt: new Date('2026-01-02'),
+      content: { format: 2, parts: [{ type: 'text', text: 'Live response survives' }] },
+    },
+  ],
+};
+
+export const savedTasks = [{ id: 'saved-task', content: 'Saved task', status: 'pending', activeForm: 'Saving task' }];
+export const taskHistory: typeof emptyHistory = {
+  messages: [
+    {
+      id: 'task-message',
+      role: 'signal',
+      createdAt: new Date('2026-01-01'),
+      content: {
+        format: 2,
+        parts: [],
+        metadata: { signal: { id: 'tasks', metadata: { value: { tasks: savedTasks } } } },
+      },
+    },
+  ],
+};
+export const taskChunk: DataChunkType = {
+  type: 'data-task-list',
+  data: { id: 'tasks', metadata: { value: { tasks: [] } } },
+};
+
+export const finishChunk: ChunkType = {
+  type: 'finish',
+  runId: 'recovery-run',
+  from: ChunkFrom.AGENT,
+  payload: {
+    stepResult: { reason: 'stop' },
+    output: { usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+    metadata: {},
+    messages: { all: [], user: [], nonUser: [] },
+  },
+};
+
+export const liveChunks: ChunkType[] = [
+  { type: 'start', runId: 'recovery-run', from: ChunkFrom.AGENT, payload: { messageId: 'recovery-assistant' } },
+  { type: 'text-start', runId: 'recovery-run', from: ChunkFrom.AGENT, payload: { id: 'recovery-text' } },
+  {
+    type: 'text-delta',
+    runId: 'recovery-run',
+    from: ChunkFrom.AGENT,
+    payload: { id: 'recovery-text', text: 'Live response survives' },
+  },
+];

--- a/packages/playground/src/pages/agents/agent/__tests__/fixtures/thread-recovery.ts
+++ b/packages/playground/src/pages/agents/agent/__tests__/fixtures/thread-recovery.ts
@@ -50,6 +50,42 @@ export const approvalHistory = (runId = 'recovery-run', toolCallId = 'approval-t
     },
   ],
 });
+export const approvalMetadataHistory = (
+  key: 'pendingToolApprovals' | 'requireApprovalMetadata' | 'suspendedTools',
+  resolved: boolean,
+): typeof emptyHistory => ({
+  messages: [
+    {
+      id: 'approval-fixture',
+      role: 'assistant',
+      createdAt: new Date('2026-01-02'),
+      content: {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: resolved
+              ? { state: 'result', toolCallId: 'approval-tool', toolName: 'weather', args: {}, result: 'done' }
+              : { state: 'call', toolCallId: 'approval-tool', toolName: 'weather', args: {} },
+          },
+        ],
+        metadata: {
+          mode: 'generate',
+          [key]: {
+            weather: {
+              toolCallId: 'approval-tool',
+              toolName: 'weather',
+              args: {},
+              runId: 'recovery-run',
+              suspendPayload: {},
+            },
+          },
+        },
+      },
+    },
+  ],
+});
+
 export const approvalChunk: ChunkType = {
   type: 'tool-call-approval',
   runId: 'recovery-run',

--- a/packages/playground/src/pages/agents/agent/__tests__/thread-page.msw.test.tsx
+++ b/packages/playground/src/pages/agents/agent/__tests__/thread-page.msw.test.tsx
@@ -9,6 +9,7 @@ import { createMemoryRouter, Outlet, RouterProvider, useLocation } from 'react-r
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import AgentThread from '../thread';
+import { emptyHistory, liveChunks, staleHistory } from './fixtures/thread-recovery';
 import { AgentLayout } from '@/domains/agents/agent-layout';
 import {
   emptyThreadTracesList,
@@ -157,10 +158,12 @@ const buildRouter = (initialEntry: string) =>
     { initialEntries: [initialEntry] },
   );
 
-const renderAt = (initialEntry: string) => {
-  const queryClient = new QueryClient({
+const renderAt = (
+  initialEntry: string,
+  queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-  });
+  }),
+) => {
   const router = buildRouter(initialEntry);
 
   render(
@@ -258,6 +261,156 @@ afterEach(() => {
 });
 
 describe('Standalone thread page', () => {
+  describe('when a history response arrives after live output', () => {
+    it.each([
+      { name: 'empty', history: emptyHistory },
+      { name: 'stale', history: staleHistory },
+    ])('preserves the streamed response with $name history', async ({ history }) => {
+      installHandlers();
+      let releaseHistory = () => {};
+      const gate = new Promise<void>(resolve => {
+        releaseHistory = resolve;
+      });
+      let push: (() => void) | undefined;
+      let close = () => {};
+      const historyReturned = vi.fn();
+      server.use(
+        http.get(`${BASE_URL}/api/agents/${AGENT_ID}/voice/speakers`, () => HttpResponse.json([])),
+        http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json({ config: {} })),
+        http.get(`${BASE_URL}/api/memory/threads/:threadId/working-memory`, () =>
+          HttpResponse.json({ workingMemory: null }),
+        ),
+        http.get(`${BASE_URL}/api/memory/threads/:threadId`, () => HttpResponse.json(threadsResponse.threads[0])),
+        http.get(`${BASE_URL}/api/mcp/v0/servers`, () => HttpResponse.json({ servers: [] })),
+        http.get(`${BASE_URL}/api/memory/threads/:threadId/messages`, async () => {
+          await gate;
+          historyReturned();
+          return HttpResponse.json(history);
+        }),
+        http.post(
+          `${BASE_URL}/api/agents/${AGENT_ID}/threads/subscribe`,
+          () =>
+            new HttpResponse(
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  close = () => controller.close();
+                  push = () => {
+                    for (const chunk of liveChunks)
+                      controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+                  };
+                },
+              }),
+              { headers: { 'Content-Type': 'text/event-stream' } },
+            ),
+        ),
+      );
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`, queryClient);
+      try {
+        await screen.findByText('OpenAI');
+        await waitFor(() => expect(push).toBeDefined());
+        await act(async () => push?.());
+        await waitFor(() => expect(document.body.textContent).toContain('Live response survives'));
+        await act(async () => releaseHistory());
+        await waitFor(() =>
+          expect(queryClient.getQueryState(['memory', 'messages', THREAD_ID, AGENT_ID, 'requestContext'])?.status).toBe(
+            'success',
+          ),
+        );
+        expect(historyReturned).toHaveBeenCalledOnce();
+        await waitFor(() => expect(document.body.textContent?.split('Live response survives')).toHaveLength(2));
+        expect(document.body.textContent).not.toContain('Old partial output');
+        if (history.messages.length) expect(document.body.textContent).toContain('Earlier prompt');
+      } finally {
+        releaseHistory();
+        close();
+      }
+    });
+  });
+
+  describe('when a first signal message is accepted', () => {
+    it.each(['stay', 'navigate', 'reload'] as const)(
+      'preserves thread identity and navigation when the user chooses to %s',
+      async action => {
+        installHandlers();
+        const sent = vi.fn();
+        let release = () => {};
+        const gate = new Promise<void>(resolve => {
+          release = resolve;
+        });
+        const acknowledged = vi.fn();
+        const refreshedAfterAck = vi.fn();
+        const ids: string[] = [];
+        const closes: Array<() => void> = [];
+        server.use(
+          http.get(`${BASE_URL}/api/memory/threads`, () => {
+            if (acknowledged.mock.calls.length) refreshedAfterAck();
+            return HttpResponse.json(threadsResponse);
+          }),
+          http.get(`${BASE_URL}/api/agents/${AGENT_ID}/voice/speakers`, () => HttpResponse.json([])),
+          http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json({ config: {} })),
+          http.get(`${BASE_URL}/api/memory/threads/:threadId/working-memory`, () =>
+            HttpResponse.json({ workingMemory: null }),
+          ),
+          http.get(`${BASE_URL}/api/memory/threads/:threadId`, () => HttpResponse.json(threadsResponse.threads[0])),
+          http.get(`${BASE_URL}/api/mcp/v0/servers`, () => HttpResponse.json({ servers: [] })),
+          http.get(`${BASE_URL}/api/memory/threads/:threadId/messages`, () => HttpResponse.json(emptyHistory)),
+          http.post(`${BASE_URL}/api/agents/${AGENT_ID}/send-message`, async ({ request }) => {
+            sent(await request.json());
+            await gate;
+            acknowledged();
+            return HttpResponse.json({ accepted: true, runId: 'recovery-run' });
+          }),
+          http.post(`${BASE_URL}/api/agents/${AGENT_ID}/threads/subscribe`, async ({ request }) => {
+            const body: unknown = await request.json();
+            if (body && typeof body === 'object' && 'threadId' in body && typeof body.threadId === 'string')
+              ids.push(body.threadId);
+            return new HttpResponse(
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  closes.push(() => controller.close());
+                  if (action === 'reload' && ids.length > 1) {
+                    for (const chunk of liveChunks)
+                      controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+                  }
+                },
+              }),
+              { headers: { 'Content-Type': 'text/event-stream' } },
+            );
+          }),
+        );
+        const router = renderAt(`/agents/${AGENT_ID}/threads/new`);
+        try {
+          await waitFor(() => expect(ids.length).toBeGreaterThan(0));
+          const input = await screen.findByRole('textbox');
+          fireEvent.change(input, { target: { value: 'Keep this conversation' } });
+          fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+          await waitFor(() => expect(sent).toHaveBeenCalledOnce());
+          if (action === 'navigate') await act(() => router.navigate(`/agents/${AGENT_ID}/threads/${THREAD_ID}`));
+          await act(async () => release());
+          await waitFor(() => expect(refreshedAfterAck).toHaveBeenCalled());
+          if (action === 'navigate') {
+            expect(router.state.location.pathname).toBe(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);
+          } else {
+            await waitFor(() => expect(router.state.location.pathname).toBe(`/agents/${AGENT_ID}/threads/${ids[0]}`));
+            expect(router.state.historyAction).toBe('REPLACE');
+            expect(document.body.textContent).toContain('Keep this conversation');
+            if (action === 'reload') {
+              const savedPath = router.state.location.pathname;
+              cleanup();
+              renderAt(savedPath);
+              await waitFor(() => expect(ids).toHaveLength(2));
+              await waitFor(() => expect(document.body.textContent).toContain('Live response survives'));
+            }
+            expect(new Set(ids).size).toBe(1);
+          }
+        } finally {
+          release();
+          for (const close of closes) close();
+        }
+      },
+    );
+  });
   it('shows the thread conversation at /agents/:agentId/threads/:threadId', async () => {
     installHandlers();
     renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);

--- a/packages/playground/src/pages/agents/agent/thread.tsx
+++ b/packages/playground/src/pages/agents/agent/thread.tsx
@@ -5,7 +5,7 @@ import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired'
 import { useIsMobile } from '@mastra/playground-ui/hooks/use-is-mobile';
 import type { CollapsiblePanelHandle } from '@mastra/playground-ui/resize/collapsible-panel';
 import { is401UnauthorizedError, is403ForbiddenError, is404NotFoundError } from '@mastra/playground-ui/utils/errors';
-import { useMemo, useRef } from 'react';
+import { useLayoutEffect, useMemo, useRef } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 import { AgentSidebar } from '@/domains/agents/agent-sidebar';
 import { AgentChat } from '@/domains/agents/components/agent-chat';
@@ -40,6 +40,14 @@ function AgentThread() {
 
   // eslint-disable-next-line react-hooks/exhaustive-deps -- threadId is intentional: we need a new UUID per thread
   const newThreadId = useMemo(() => uuid(), [threadId]);
+  const newThreadKey = `${agentId}:${newThreadId}`;
+  const activeNewThread = useRef<string | undefined>(undefined);
+  useLayoutEffect(() => {
+    activeNewThread.current = isNewThread ? newThreadKey : undefined;
+    return () => {
+      activeNewThread.current = undefined;
+    };
+  }, [isNewThread, newThreadKey]);
 
   const hasMemory = Boolean(memory?.result);
 
@@ -108,11 +116,11 @@ function AgentThread() {
   const actualThreadId = isNewThread ? newThreadId : (threadId ?? newThreadId);
 
   const handleRefreshThreadList = async () => {
-    await refreshThreads();
-
-    if (isNewThread) {
-      void navigate(`/agents/${agentId}/threads/${newThreadId}`);
+    if (isNewThread && activeNewThread.current === newThreadKey) {
+      void navigate(`/agents/${agentId}/threads/${newThreadId}`, { replace: true });
     }
+
+    await refreshThreads();
   };
 
   return (


### PR DESCRIPTION
Keeps signal-based Studio conversations recoverable when you refresh or navigate away during a response. New chats get a permanent URL as soon as the first message is accepted, and delayed history responses preserve locally streamed messages and newer task updates. Send acknowledgements only change the URL while the original new chat is still active. Legacy streaming behavior is unchanged.

Before, sending from `/threads/new` and refreshing mid-response could lose the thread identity; loading history could also erase visible output. After, the URL identifies the accepted conversation and history reconciles underneath locally changed messages, including after completion.

Verified with 77 targeted tests covering delayed history, completion, task hydration, navigation races, and page remount/reconnection with a fresh query cache. Production typechecks and changed-file lint passed. For manual testing, send a long response, refresh or navigate away mid-stream, return, and check that the URL stays stable and the response appears once.

The broader page suite still emits unrelated MSW handler warnings. Full React typechecking has existing test/story errors, and an existing memory-panel refetch test failure blocks the mutation test baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Studio chats now keep their messages and identity when users refresh, navigate, or reconnect during a response. Late server updates no longer replace newer local messages or move users to the wrong chat.

## Changes

- Assigns new chats a permanent URL after the first accepted message.
- Preserves streamed messages, task updates, approvals, and completed-run state when history responses arrive late.
- Restores pending approvals and saved tasks without replacing newer live updates.
- Scopes approvals to the active run and removes resolved approvals during hydration.
- Ignores terminal events from stale runs.
- Prevents late send acknowledgements from navigating away from another active chat.
- Refreshes the thread list after successful signal delivery.
- Keeps legacy streaming behavior unchanged.
- Adds coverage for delayed history, completion, task hydration, approval decisions, navigation races, remounts, reconnections, and fresh query caches.
- Adds patch changesets for `mastra` and `@mastra/react`.

## Validation

- Production typechecks passed.
- Changed-file lint passed.
- Existing unrelated MSW warnings, React test/story type errors, and a memory-panel refetch test failure remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->