### PR TITLE
fix(core): retain terminal failures in durable history

### DIFF
--- a/.changeset/hip-trees-lick.md
+++ b/.changeset/hip-trees-lick.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed durable agent failures disappearing from saved conversation history after reopening. Preserve the original memory policy on resume and keep failed recovery evidence when saving the error fails.

--- a/packages/core/src/agent-controller/__tests__/terminal-error-reopen.integration.test.ts
+++ b/packages/core/src/agent-controller/__tests__/terminal-error-reopen.integration.test.ts
@@ -1,0 +1,294 @@
+import { randomUUID } from 'node:crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Memory } from '../../../../memory/src';
+import { Agent } from '../../agent';
+import { createDurableAgent, createEventedAgent } from '../../agent/durable';
+import { DurableStepIds } from '../../agent/durable/constants';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage';
+import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
+import { AgentController } from '../agent-controller';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe.each(['durable', 'evented'] as const)('%s terminal error history', execution => {
+  describe.each([false, true])('observational memory: %s', observationalMemory => {
+    it.each(['input', 'model', 'output'] as const)(
+      'retains a %s failure after controller recreation',
+      async failureAt => {
+        const network = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network forbidden'));
+        const id = randomUUID();
+        const errorMessage = 'The local run failed before producing an answer.';
+        const storage = new InMemoryStore();
+        const memoryModelCall = vi.fn(async () => {
+          throw new Error('Unexpected memory model call');
+        });
+        const memory = new Memory({
+          storage,
+          options: {
+            generateTitle: false,
+            observationalMemory: observationalMemory
+              ? {
+                  model: new MastraLanguageModelV2Mock({ doStream: memoryModelCall }),
+                  scope: 'thread',
+                  observation: { messageTokens: 8000, bufferTokens: 0.2 },
+                  reflection: { observationTokens: 12000 },
+                }
+              : false,
+          },
+        });
+        const rejectedAnswer = 'This answer must not survive output rejection.';
+        const modelCall = vi.fn(async () => {
+          if (failureAt !== 'output') throw new Error(errorMessage);
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+                controller.enqueue({ type: 'text-start', id: 'answer' });
+                controller.enqueue({ type: 'text-delta', id: 'answer', delta: rejectedAnswer });
+                controller.enqueue({ type: 'text-end', id: 'answer' });
+                controller.enqueue({
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                });
+                controller.close();
+              },
+            }),
+          };
+        });
+        const base = new Agent({
+          id,
+          name: 'Terminal error history',
+          instructions: 'Answer the request.',
+          memory,
+          maxRetries: 0,
+          defaultOptions: observationalMemory
+            ? {
+                memory: {
+                  options: {
+                    observationalMemory: memory.getMergedThreadConfig().observationalMemory,
+                  },
+                },
+              }
+            : undefined,
+          model: new MastraLanguageModelV2Mock({ doStream: modelCall }),
+          inputProcessors: [
+            {
+              id: 'local-input-check',
+              processInputStep({ messageList }) {
+                if (failureAt === 'input') throw new Error(errorMessage);
+                return messageList;
+              },
+            },
+          ],
+          outputProcessors: [
+            {
+              id: 'reject-output',
+              processOutputResult({ messageList }) {
+                if (failureAt === 'output') throw new Error(errorMessage);
+                return messageList;
+              },
+            },
+          ],
+        });
+        const agent =
+          execution === 'durable' ? createDurableAgent({ agent: base }) : createEventedAgent({ agent: base });
+        const options = {
+          id: `${id}-controller`,
+          agent,
+          storage,
+          memory,
+          modes: [{ id: 'chat', name: 'Chat', default: true }],
+          disableBuiltinTools: [
+            'ask_user',
+            'submit_plan',
+            'task_write',
+            'task_update',
+            'task_complete',
+            'task_check',
+            'subagent',
+          ],
+        };
+        const controller = new AgentController(options);
+        const mastra = new Mastra({
+          agents: { agent },
+          agentControllers: { controller },
+          storage,
+          logger: false,
+          workers: false,
+          scheduler: { enabled: false },
+          recovery: { durableAgents: 'off' },
+        });
+        let reopened: AgentController | undefined;
+        let off: (() => void) | undefined;
+        try {
+          await controller.init();
+          const session = await controller.createSession({ resourceId: id, threadId: id });
+          const errors: string[] = [];
+          const observer = await controller.createSession({ resourceId: id, threadId: id, scope: 'observer' });
+          expect(observer).not.toBe(session);
+          let observedEnd!: () => void;
+          const observerEnded = new Promise<void>(resolve => {
+            observedEnd = resolve;
+          });
+          observer.subscribe(event => {
+            if (event.type === 'agent_end') observedEnd();
+          });
+          const saveMessages = vi.spyOn(memory, 'saveMessages');
+          const reasons: string[] = [];
+          let end!: () => void;
+          const ended = new Promise<void>(resolve => {
+            end = resolve;
+          });
+          off = session.subscribe(event => {
+            if (event.type === 'error') errors.push(event.error.message);
+            if (event.type === 'agent_end') {
+              reasons.push(event.reason ?? 'missing');
+              end();
+            }
+          });
+          await session.sendMessage({ content: 'Run the local check.' });
+          await Promise.all([ended, observerEnded]);
+          expect(errors.some(message => message.includes(errorMessage))).toBe(true);
+          expect(reasons).toEqual(['error']);
+          expect(modelCall).toHaveBeenCalledTimes(failureAt === 'input' ? 0 : 1);
+          expect(session.run.isRunning()).toBe(false);
+          const saved = await session.thread.listActiveMessages();
+          off();
+          await controller.destroy();
+          reopened = new AgentController({ ...options, id: `${id}-reopened` });
+          await reopened.init();
+          const coldSession = await reopened.createSession({ resourceId: id, threadId: id });
+          const history = await coldSession.thread.listActiveMessages();
+          expect(history.map(row => row.id)).toEqual(saved.map(row => row.id));
+          expect(history.some(row => String(row.content.metadata?.errorMessage ?? '').includes(errorMessage))).toBe(
+            true,
+          );
+          expect(history.filter(row => row.content.metadata?.stopReason === 'error')).toHaveLength(1);
+          expect(
+            saveMessages.mock.calls.filter(([args]) =>
+              args.messages.some(row => row.content.parts.some(part => part.type === 'data-error')),
+            ),
+          ).toHaveLength(1);
+          expect(JSON.stringify(history)).not.toContain(rejectedAnswer);
+          expect(network).not.toHaveBeenCalled();
+          expect(memoryModelCall).not.toHaveBeenCalled();
+          if (observationalMemory && failureAt !== 'input') {
+            const memoryStore = await storage.getStore('memory');
+            expect(await memoryStore!.getObservationalMemory(id, id)).not.toBeNull();
+          }
+        } finally {
+          off?.();
+          await reopened?.destroy();
+          await mastra.shutdown();
+        }
+      },
+    );
+  });
+
+  it.each(['input', 'model'] as const)(
+    'exposes failure to save a %s error without repeating the run',
+    async failureAt => {
+      const network = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network forbidden'));
+      const id = randomUUID();
+      const storage = new InMemoryStore();
+      const memory = new Memory({ storage, options: { generateTitle: false, observationalMemory: false } });
+      const originalSave = memory.saveMessages.bind(memory);
+      let failureWrites = 0;
+      vi.spyOn(memory, 'saveMessages').mockImplementation(async args => {
+        if (args.messages.some(row => row.content.parts.some(part => part.type === 'data-error'))) {
+          failureWrites++;
+          throw new Error('Failure storage unavailable');
+        }
+        return originalSave(args);
+      });
+      const modelCall = vi.fn(async () => {
+        throw new Error('Original run failure');
+      });
+      const base = new Agent({
+        id,
+        name: 'Failure save check',
+        instructions: 'Run the check.',
+        memory,
+        maxRetries: 0,
+        model: new MastraLanguageModelV2Mock({ doStream: modelCall }),
+        inputProcessors: [
+          {
+            id: 'local-failure',
+            processInputStep({ messageList }) {
+              if (failureAt === 'input') throw new Error('Original run failure');
+              return messageList;
+            },
+          },
+        ],
+      });
+      const agent = execution === 'durable' ? createDurableAgent({ agent: base }) : createEventedAgent({ agent: base });
+      const controller = new AgentController({
+        id,
+        agent,
+        memory,
+        storage,
+        modes: [{ id: 'chat', name: 'Chat', default: true }],
+        disableBuiltinTools: [
+          'ask_user',
+          'submit_plan',
+          'task_write',
+          'task_update',
+          'task_complete',
+          'task_check',
+          'subagent',
+        ],
+      });
+      const mastra = new Mastra({
+        agents: { agent },
+        agentControllers: { controller },
+        storage,
+        logger: false,
+        workers: false,
+        scheduler: { enabled: false },
+        recovery: { durableAgents: 'off' },
+      });
+      try {
+        await controller.init();
+        const session = await controller.createSession({ resourceId: id, threadId: id });
+        const errors: string[] = [];
+        let failedRunId: string | null = null;
+        let end!: () => void;
+        const ended = new Promise<void>(resolve => {
+          end = resolve;
+        });
+        session.subscribe(event => {
+          if (event.type === 'error') {
+            errors.push(event.error.message);
+            failedRunId = session.getCurrentRunId();
+          }
+          if (event.type === 'agent_end') {
+            expect(event.reason).toBe('error');
+            end();
+          }
+        });
+        await session.sendMessage({ content: 'Run this once.' });
+        await ended;
+        expect(errors.join('\n')).toContain('Original run failure');
+        expect(errors.join('\n')).toContain('Failure storage unavailable');
+        expect(failureWrites).toBe(1);
+        expect(session.run.isRunning()).toBe(false);
+        expect((await agent.listActiveRuns()).runs).toHaveLength(0);
+        expect(failedRunId).toBeTruthy();
+        const workflows = await storage.getStore('workflows');
+        const retained = await workflows!.getWorkflowRunById({
+          runId: failedRunId!,
+          workflowName: DurableStepIds.AGENTIC_LOOP,
+        });
+        const snapshot = typeof retained?.snapshot === 'string' ? JSON.parse(retained.snapshot) : retained?.snapshot;
+        expect(snapshot?.status).toBe('failed');
+        await agent.recoverActiveRuns();
+        expect(modelCall).toHaveBeenCalledTimes(failureAt === 'input' ? 0 : 1);
+        expect(network).not.toHaveBeenCalled();
+      } finally {
+        await mastra.shutdown();
+      }
+    },
+  );
+});

--- a/packages/core/src/agent/durable/__tests__/final-output-failure-resume.integration.test.ts
+++ b/packages/core/src/agent/durable/__tests__/final-output-failure-resume.integration.test.ts
@@ -1,0 +1,193 @@
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { Memory } from '../../../../../memory/src';
+import { Mastra } from '../../../mastra';
+import { InMemoryDB, InMemoryMemory, InMemoryStore, MastraCompositeStore } from '../../../storage';
+import { MastraLanguageModelV2Mock } from '../../../test-utils/llm-mock';
+import { createTool } from '../../../tools';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../create-durable-agent';
+import { createEventedAgent } from '../create-evented-agent';
+import { globalRunRegistry } from '../run-registry';
+
+describe.each([
+  ['durable', 'warm'],
+  ['durable', 'rehydrated'],
+  ['evented', 'warm'],
+] as const)('terminal error history after %s resume with %s registry', (execution, registry) => {
+  it.each(['none', 'save', 'processor', 'processor-readonly', 'processor-no-registry'] as const)(
+    'preserves the real terminal outcome: %s',
+    async fault => {
+      const network = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network forbidden'));
+      const id = randomUUID();
+      const answer = 'The resumed answer.';
+      let modelCalls = 0;
+      let toolCalls = 0;
+      let outputChecks = 0;
+      let failedWrites = 0;
+      let resumedRunId: string | undefined;
+      class FailingMemory extends InMemoryMemory {
+        override async saveMessages(args: Parameters<InMemoryMemory['saveMessages']>[0]) {
+          if (
+            fault === 'save' &&
+            args.messages.some(
+              message =>
+                message.role === 'assistant' &&
+                message.content.parts.some(part => part.type === 'text' && part.text === answer),
+            )
+          ) {
+            failedWrites++;
+            throw new Error('Resumed answer save failed');
+          }
+          return super.saveMessages(args);
+        }
+      }
+      const storage = new MastraCompositeStore({
+        id,
+        default: new InMemoryStore(),
+        domains: { memory: new FailingMemory({ db: new InMemoryDB() }) },
+      });
+      const instances: Mastra[] = [];
+      const makeAgent = () => {
+        const base = new Agent({
+          id,
+          name: 'Resumed final output',
+          instructions: 'Get approval, then answer.',
+          memory: new Memory({ storage, options: { generateTitle: false, observationalMemory: false } }),
+          tools: {
+            localAction: createTool({
+              id: 'localAction',
+              description: 'Local action',
+              inputSchema: z.object({}),
+              requireApproval: true,
+              execute: async () => {
+                toolCalls++;
+                return { ok: true };
+              },
+            }),
+          },
+          outputProcessors: [
+            {
+              id: 'resumed-output-check',
+              processOutputResult({ messageList }) {
+                outputChecks++;
+                if (fault === 'processor-no-registry') {
+                  expect(resumedRunId).toBeDefined();
+                  expect(globalRunRegistry.delete(resumedRunId!)).toBe(true);
+                }
+                if (fault === 'processor' || fault === 'processor-readonly' || fault === 'processor-no-registry')
+                  throw new Error('Resumed output processor failed');
+                return messageList;
+              },
+            },
+          ],
+          model: new MastraLanguageModelV2Mock({
+            doStream: async () => {
+              const step = ++modelCalls;
+              if (step > 2) throw new Error('Unexpected repeated model execution');
+              return {
+                stream: new ReadableStream({
+                  start(controller) {
+                    controller.enqueue({ type: 'stream-start', warnings: [] });
+                    if (step === 1) {
+                      controller.enqueue({
+                        type: 'tool-call',
+                        toolCallId: 'approved-action',
+                        toolName: 'localAction',
+                        input: '{}',
+                      });
+                    } else {
+                      controller.enqueue({ type: 'text-start', id: 'answer' });
+                      controller.enqueue({ type: 'text-delta', id: 'answer', delta: answer });
+                      controller.enqueue({ type: 'text-end', id: 'answer' });
+                    }
+                    controller.enqueue({
+                      type: 'finish',
+                      finishReason: step === 1 ? 'tool-calls' : 'stop',
+                      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                    });
+                    controller.close();
+                  },
+                }),
+              };
+            },
+          }),
+        });
+        const agent =
+          execution === 'evented' ? createEventedAgent({ agent: base }) : createDurableAgent({ agent: base });
+        instances.push(
+          new Mastra({
+            agents: { agent },
+            storage,
+            logger: false,
+            workers: false,
+            scheduler: { enabled: false },
+            recovery: { durableAgents: 'off' },
+          }),
+        );
+        return agent;
+      };
+      let agent = makeAgent();
+      try {
+        if (fault === 'processor-readonly') {
+          await (await agent.getMemory())!.createThread({ threadId: id, resourceId: id });
+        }
+        const suspended = await agent.generate('Do the approved task.', {
+          memory: { thread: id, resource: id, options: { readOnly: fault === 'processor-readonly' } },
+        });
+        expect(suspended.finishReason).toBe('suspended');
+        expect(modelCalls).toBe(1);
+        expect(toolCalls).toBe(0);
+        expect(outputChecks).toBe(0);
+        const runId = suspended.runId;
+        expect(typeof runId).toBe('string');
+        if (!runId) throw new Error('Missing suspended run ID');
+        resumedRunId = runId;
+        expect(agent.runRegistry.has(runId)).toBe(true);
+        if (registry === 'rehydrated') {
+          // This proves restoration from actual saved snapshots in one process;
+          // a separate-process restart is a distinct public-package proof.
+          agent.runRegistry.cleanup(runId);
+          agent = makeAgent();
+          expect(agent.runRegistry.has(runId)).toBe(false);
+        }
+        let failure: unknown;
+        const result = await agent
+          .resumeGenerate(runId, { approved: true }, { toolCallId: 'approved-action' })
+          .catch(error => {
+            failure = error;
+          });
+        expect(modelCalls).toBe(2);
+        expect(toolCalls).toBe(1);
+        expect(outputChecks).toBe(1);
+        if (fault === 'none') {
+          expect(failure).toBeUndefined();
+          expect(result?.finishReason).toBe('stop');
+          expect(result?.text).toBe(answer);
+        } else {
+          expect(failure).toBeInstanceOf(Error);
+          expect((failure as Error).message).toContain(
+            fault === 'save' ? 'Resumed answer save failed' : 'Resumed output processor failed',
+          );
+          expect(result).toBeUndefined();
+        }
+        expect(failedWrites > 0).toBe(fault === 'save');
+        const history = await storage.stores.memory!.listMessages({ threadId: id, resourceId: id, perPage: false });
+        const failures = history.messages.filter(message => message.content.metadata?.stopReason === 'error');
+        expect(failures).toHaveLength(['save', 'processor', 'processor-no-registry'].includes(fault) ? 1 : 0);
+        if (fault === 'processor' || fault === 'processor-readonly' || fault === 'processor-no-registry') {
+          expect(JSON.stringify(history.messages)).not.toContain(answer);
+        }
+        await vi.waitFor(async () => {
+          expect((await agent.listActiveRuns()).runs).toHaveLength(0);
+        });
+        expect(network).not.toHaveBeenCalled();
+      } finally {
+        for (const mastra of instances.reverse()) await mastra.shutdown();
+        network.mockRestore();
+      }
+    },
+    15_000,
+  );
+});

--- a/packages/core/src/agent/durable/__tests__/terminal-error-recovery.integration.test.ts
+++ b/packages/core/src/agent/durable/__tests__/terminal-error-recovery.integration.test.ts
@@ -1,0 +1,173 @@
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import { Memory } from '../../../../../memory/src';
+import { Mastra } from '../../../mastra';
+import { InMemoryStore } from '../../../storage';
+import { MastraLanguageModelV2Mock } from '../../../test-utils/llm-mock';
+import { Agent } from '../../agent';
+import { DurableStepIds } from '../constants';
+import { createDurableAgent } from '../create-durable-agent';
+import { createEventedAgent } from '../create-evented-agent';
+import { globalRunRegistry } from '../run-registry';
+
+describe.each(['durable', 'evented'] as const)('%s recovered terminal history', execution => {
+  describe.each([false, true])('history storage rejects: %s', rejectSave => {
+    it.each(['input', 'model', 'output'] as const)(
+      'retains a recovered %s failure',
+      async failureAt => {
+        const network = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network forbidden'));
+        const id = randomUUID();
+        const instances: Mastra[] = [];
+        let recovering = false;
+        let modelCalls = 0;
+        const failureMessage = 'Recovered execution failed';
+        const rejectedAnswer = 'Unvalidated recovered answer';
+        const makeAgent = (storage: InMemoryStore) => {
+          const memory = new Memory({ storage, options: { generateTitle: false, observationalMemory: false } });
+          const base = new Agent({
+            id,
+            name: id,
+            instructions: 'Answer.',
+            memory,
+            maxRetries: 0,
+            inputProcessors: [
+              {
+                id: 'fail-input',
+                processInputStep({ messageList }) {
+                  if (!recovering) throw new Error('Original process interrupted');
+                  if (failureAt === 'input') throw new Error(failureMessage);
+                  return messageList;
+                },
+              },
+            ],
+            outputProcessors: [
+              {
+                id: 'fail-output',
+                processOutputResult({ messageList }) {
+                  if (recovering && failureAt === 'output') throw new Error(failureMessage);
+                  return messageList;
+                },
+              },
+            ],
+            model: new MastraLanguageModelV2Mock({
+              doStream: async () => {
+                modelCalls++;
+                if (failureAt !== 'output') throw new Error(failureMessage);
+                return {
+                  stream: new ReadableStream({
+                    start(controller) {
+                      controller.enqueue({ type: 'stream-start', warnings: [] });
+                      controller.enqueue({ type: 'text-start', id: 'answer' });
+                      controller.enqueue({ type: 'text-delta', id: 'answer', delta: rejectedAnswer });
+                      controller.enqueue({ type: 'text-end', id: 'answer' });
+                      controller.enqueue({
+                        type: 'finish',
+                        finishReason: 'stop',
+                        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                      });
+                      controller.close();
+                    },
+                  }),
+                };
+              },
+            }),
+          });
+          const agent =
+            execution === 'durable' ? createDurableAgent({ agent: base }) : createEventedAgent({ agent: base });
+          instances.push(
+            new Mastra({
+              agents: { agent },
+              storage,
+              logger: false,
+              workers: false,
+              scheduler: { enabled: false },
+              recovery: { durableAgents: 'off' },
+            }),
+          );
+          return { agent, memory };
+        };
+        let cleanup: (() => void) | undefined;
+        try {
+          const originalStore = new InMemoryStore();
+          const original = makeAgent(originalStore);
+          const workflows = (await originalStore.getStore('workflows'))!;
+          type SnapshotWrite = Parameters<typeof workflows.persistWorkflowSnapshot>[0];
+          let captured: SnapshotWrite | undefined;
+          const persist = workflows.persistWorkflowSnapshot.bind(workflows);
+          vi.spyOn(workflows, 'persistWorkflowSnapshot').mockImplementation(async args => {
+            if (!captured && args.workflowName === DurableStepIds.AGENTIC_LOOP && args.snapshot.status === 'running') {
+              captured = JSON.parse(JSON.stringify(args)) as SnapshotWrite;
+            }
+            return persist(args);
+          });
+          await expect(
+            original.agent.generate('Recover this task.', { memory: { thread: id, resource: id } }),
+          ).rejects.toThrow('Original process interrupted');
+          expect(modelCalls).toBe(0);
+          expect(captured?.snapshot.status).toBe('running');
+          if (!captured) throw new Error('No real running snapshot captured');
+          const runId = captured.runId;
+          original.agent.runRegistry.cleanup(runId);
+          globalRunRegistry.delete(runId);
+          await instances[0]!.shutdown();
+
+          // Restore the unmodified snapshot captured during real execution into a
+          // fresh store. This exercises actual restart(), not a stubbed terminal;
+          // an operating-system process restart remains separate acceptance proof.
+          const restoredStore = new InMemoryStore();
+          const restored = makeAgent(restoredStore);
+          await restored.memory.createThread({ threadId: id, resourceId: id });
+          const restoredWorkflows = (await restoredStore.getStore('workflows'))!;
+          await restoredWorkflows.persistWorkflowSnapshot(captured);
+          const save = restored.memory.saveMessages.bind(restored.memory);
+          let failureWrites = 0;
+          vi.spyOn(restored.memory, 'saveMessages').mockImplementation(async args => {
+            if (args.messages.some(message => message.content.metadata?.stopReason === 'error')) {
+              failureWrites++;
+              if (rejectSave) throw new Error('History storage rejected');
+            }
+            return save(args);
+          });
+          recovering = true;
+          const recovered = await restored.agent.recover(runId);
+          cleanup = recovered.cleanup;
+          const workflowExecution = globalRunRegistry.get(runId)?.workflowExecution;
+          expect(workflowExecution).toBeDefined();
+          // Model-step failures (including its input processor) complete the
+          // workflow with an error turn. Final-output or history failures reject it.
+          if (failureAt !== 'output' && !rejectSave) await workflowExecution;
+          else
+            await expect(workflowExecution).rejects.toThrow(rejectSave ? 'History storage rejected' : failureMessage);
+          const output = await recovered.output.getFullOutput().catch(error => error);
+          expect(output instanceof Error ? output.message : JSON.stringify(output)).toContain(failureMessage);
+          expect(failureWrites).toBe(1);
+          const history = await restoredStore.stores.memory!.listMessages({
+            threadId: id,
+            resourceId: id,
+            perPage: false,
+          });
+          expect(history.messages.filter(message => message.content.metadata?.stopReason === 'error')).toHaveLength(
+            rejectSave ? 0 : 1,
+          );
+          expect(JSON.stringify(history.messages)).not.toContain(rejectedAnswer);
+          const persisted = await restoredWorkflows.getWorkflowRunById({
+            runId,
+            workflowName: DurableStepIds.AGENTIC_LOOP,
+          });
+          if (rejectSave) {
+            const snapshot =
+              typeof persisted?.snapshot === 'string' ? JSON.parse(persisted.snapshot) : persisted?.snapshot;
+            expect(snapshot?.status).toBe('failed');
+          } else expect(persisted).toBeNull();
+          expect(modelCalls).toBe(failureAt === 'input' ? 0 : 1);
+          expect(network).not.toHaveBeenCalled();
+        } finally {
+          cleanup?.();
+          for (const mastra of instances.reverse()) await mastra.shutdown();
+          network.mockRestore();
+        }
+      },
+      15_000,
+    );
+  });
+});

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -24,11 +24,13 @@ import type { MessageListInput } from '../message-list';
 import { SaveQueueManager } from '../save-queue';
 import { AgentThreadLeaseConflictError, agentThreadStreamRuntime } from '../thread-stream-runtime';
 import type { AgentThreadRunRegistration } from '../thread-stream-runtime';
+import { TripWire } from '../trip-wire';
 import type { AgentModelManagerConfig, AgentSubscribeToThreadOptions, ToolsInput } from '../types';
 
 import { publishAbortRequest } from './abort-transport';
 import { AGENT_STREAM_TOPIC, DurableStepIds } from './constants';
 import { runDurableStreamUntilIdle, runResumeDurableStreamUntilIdle } from './durable-stream-until-idle';
+import { persistTerminalError, TerminalErrorHistorySaveError } from './persist-terminal-error';
 import { prepareForDurableExecution } from './preparation';
 import { endRunSpansWithError, ExtendedRunRegistry, globalRunRegistry } from './run-registry';
 import { createDurableAgentStream, emitChunkEvent, emitErrorEvent } from './stream-adapter';
@@ -1676,15 +1678,16 @@ export class DurableAgent<
       actor: workflowInput.options?.actor,
       ...createObservabilityContext({ currentSpan: entry?.agentSpan }),
     });
-    if (result?.status === 'failed') {
-      const error = new Error((result as any).error?.message || 'Workflow execution failed');
-      await this.emitError(runId, error);
+    const error = this.getWorkflowFailure(result, 'Workflow execution failed');
+    let historySaveFailed = false;
+    if (error) {
+      historySaveFailed = !(await this.emitError(runId, error, workflowInput));
     }
     // Reaching any non-suspended terminal status means the run is done and its
     // persisted snapshot rows will never be resumed. Delete them so snapshot
     // storage doesn't grow one stale row per completed run. Suspended runs
     // keep their snapshots so `resume()` / `recoverActiveRuns()` can find them.
-    if (result?.status && result.status !== 'suspended') {
+    if (result?.status && result.status !== 'suspended' && !historySaveFailed) {
       await this.deleteRunSnapshots(runId);
     }
   }
@@ -1711,10 +1714,71 @@ export class DurableAgent<
    * @param error - The error to emit
    * @internal
    */
-  protected async emitError(runId: string, error: Error): Promise<void> {
+  async #prepareTerminalError(
+    runId: string,
+    error: Error,
+    input: DurableAgenticWorkflowInput,
+    assertOwned?: () => void,
+  ): Promise<Error> {
+    if (error.name === 'TerminalErrorHistorySaveError') return error;
+    try {
+      const entry = globalRunRegistry.get(runId);
+      const memory = entry
+        ? entry.memory
+        : await this.getMemory({
+            requestContext: new RequestContext<unknown>(Object.entries(input.requestContextEntries ?? {})),
+          });
+      assertOwned?.();
+      await persistTerminalError({ agentId: input.agentId, runId, state: input.state, memory, error, assertOwned });
+      return error;
+    } catch (saveError) {
+      assertOwned?.();
+      return new TerminalErrorHistorySaveError(error, saveError);
+    }
+  }
+
+  protected async emitError(runId: string, error: Error, input?: DurableAgenticWorkflowInput): Promise<boolean> {
+    if (input) error = await this.#prepareTerminalError(runId, error, input);
+    const historySaveFailed = error.name === 'TerminalErrorHistorySaveError';
     // End the root spans on error so the trace exports (mirrors the non-durable map-results-step).
     endRunSpansWithError(runId, error);
+    if (error instanceof TripWire) {
+      await emitChunkEvent(this.pubsub, runId, {
+        type: 'tripwire',
+        runId,
+        from: ChunkFrom.AGENT,
+        payload: {
+          reason: error.message,
+          retry: error.options.retry,
+          metadata: error.options.metadata,
+          processorId: error.processorId,
+        },
+      });
+      return !historySaveFailed;
+    }
     await emitErrorEvent(this.pubsub, runId, error);
+    return !historySaveFailed;
+  }
+
+  /** Preserve native workflow guard failures across start, resume and recovery. */
+  protected getWorkflowFailure(
+    result: Pick<WorkflowRunState, 'status' | 'error' | 'tripwire'> | undefined,
+    fallbackMessage: string,
+  ): Error | undefined {
+    if (result?.status === 'tripwire') {
+      const tripwire = result.tripwire;
+      return new TripWire(
+        tripwire?.reason ?? 'Processor tripwire triggered',
+        { retry: tripwire?.retry, metadata: tripwire?.metadata },
+        tripwire?.processorId,
+      );
+    }
+    if (result?.status === 'failed') {
+      const error = new Error(result.error?.message || fallbackMessage);
+      error.name = result.error?.name ?? 'Error';
+      return error;
+    }
+    return undefined;
   }
 
   /**
@@ -2427,15 +2491,30 @@ export class DurableAgent<
         } finally {
           await stopGoalActivity({ agentId: this.id, runId });
         }
-        if (result?.status === 'failed') {
-          const error = new Error((result as any).error?.message || 'Workflow resume failed');
-          void this.emitError(runId, error);
+        const error = this.getWorkflowFailure(result, 'Workflow resume failed');
+        let historySaveFailed = false;
+        if (error) {
+          let terminalError = error;
+          try {
+            const store = await this.#mastra?.getStorage()?.getStore('workflows');
+            const persisted = await store?.getWorkflowRunById({ runId, workflowName: DurableStepIds.AGENTIC_LOOP });
+            const snapshot =
+              typeof persisted?.snapshot === 'string' ? JSON.parse(persisted.snapshot) : persisted?.snapshot;
+            const input = snapshot?.context?.input as DurableAgenticWorkflowInput | undefined;
+            if (input?.__workflowKind !== 'durable-agent' || input.agentId !== this.id || input.runId !== runId) {
+              throw new Error('Cannot load the original run memory policy.');
+            }
+            terminalError = await this.#prepareTerminalError(runId, error, input);
+          } catch (saveError) {
+            terminalError = new TerminalErrorHistorySaveError(error, saveError);
+          }
+          historySaveFailed = !(await this.emitError(runId, terminalError));
         }
         // Same snapshot cleanup as the initial `start()` path: once resume
         // settles on any non-suspended terminal status the persisted rows are
         // no longer needed. A resume that re-suspends must keep them so the
         // next resume/recover can find the snapshot.
-        if (result?.status && result.status !== 'suspended') {
+        if (result?.status && result.status !== 'suspended' && !historySaveFailed) {
           await this.deleteRunSnapshots(runId);
         }
       })
@@ -2662,15 +2741,22 @@ export class DurableAgent<
           recoveryLease,
         );
         recoveryLease.assertOwned();
-        // Snapshot cleanup runs for every non-suspended terminal (success or
-        // failed) so storage stays bounded — mirrors the start()/resume()
-        // contract.
-        if (result?.status && result.status !== 'suspended') {
+        const error = this.getWorkflowFailure(result, 'Workflow recover failed');
+        const terminalError = error
+          ? await this.#prepareTerminalError(runId, error, workflowInput, () => recoveryLease.assertOwned())
+          : undefined;
+        recoveryLease.assertOwned();
+        // Keep the failed snapshot when its terminal history could not be saved.
+        if (
+          result?.status &&
+          result.status !== 'suspended' &&
+          terminalError?.name !== 'TerminalErrorHistorySaveError'
+        ) {
           await this.deleteRunSnapshots(runId);
           recoveryLease.assertOwned();
         }
-        if (result?.status === 'failed') {
-          throw new Error((result as any).error?.message || 'Workflow recover failed');
+        if (terminalError) {
+          throw terminalError;
         }
       })
       .catch(async error => {

--- a/packages/core/src/agent/durable/evented-agent.ts
+++ b/packages/core/src/agent/durable/evented-agent.ts
@@ -105,6 +105,11 @@ export class EventedAgent<
           ...createObservabilityContext({ currentSpan: entry?.agentSpan }),
         })
         .then(async result => {
+          const error = this.getWorkflowFailure(result, 'Workflow execution failed');
+          let historySaveFailed = false;
+          if (error) {
+            historySaveFailed = !(await this.emitError(runId, error, workflowInput));
+          }
           // Reaching any non-suspended terminal status means the run is done and
           // its persisted snapshot rows will never be resumed. Delete them so
           // finished runs stop showing up in listActiveRuns() and being re-driven
@@ -112,7 +117,7 @@ export class EventedAgent<
           // so `resume()` / `recoverActiveRuns()` can find them. If the process
           // dies before this fires, the run is a genuine orphan and the recover
           // path performs the same cleanup once it reaches a terminal status.
-          if (result?.status && result.status !== 'suspended') {
+          if (result?.status && result.status !== 'suspended' && !historySaveFailed) {
             await this.deleteRunSnapshots(runId);
           }
         })

--- a/packages/core/src/agent/durable/persist-terminal-error.test.ts
+++ b/packages/core/src/agent/durable/persist-terminal-error.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { Memory } from '../../../../memory/src';
+import { InMemoryStore } from '../../storage';
+import { MessageList } from '../message-list';
+import { persistTerminalError } from './persist-terminal-error';
+
+let memory: Memory;
+const state = { threadId: 'failed-thread', resourceId: 'owner' };
+const failure = new Error('The task failed.');
+beforeEach(async () => {
+  vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network forbidden'));
+  memory = new Memory({ storage: new InMemoryStore(), options: { semanticRecall: false, generateTitle: false } });
+  await memory.createThread({ threadId: state.threadId, resourceId: state.resourceId });
+});
+afterEach(() => {
+  expect(fetch).not.toHaveBeenCalled();
+  vi.restoreAllMocks();
+});
+
+function save(overrides: Partial<Parameters<typeof persistTerminalError>[0]> = {}) {
+  return persistTerminalError({ agentId: 'agent', runId: 'run', memory, state, error: failure, ...overrides });
+}
+
+it('retains one framework record after repeated delivery without adding model prose', async () => {
+  await save();
+  await save();
+  const { messages } = await memory.recall({ threadId: state.threadId, resourceId: state.resourceId, perPage: false });
+  expect(messages).toHaveLength(1);
+  expect(messages[0]?.content.metadata).toEqual({ runId: 'run', stopReason: 'error', errorMessage: failure.message });
+  expect(messages[0]?.content.parts).toEqual([{ type: 'data-error', data: { message: failure.message } }]);
+  const prompt = new MessageList().add(messages, 'memory').get.all.aiV5.prompt();
+  expect(JSON.stringify(prompt)).not.toContain(failure.message);
+});
+
+it.each(['readOnly', 'no-memory', 'no-thread'] as const)('honors %s memory policy', async policy => {
+  const write = vi.spyOn(memory, 'saveMessages');
+  await save({
+    memory: policy === 'no-memory' ? undefined : memory,
+    state:
+      policy === 'no-thread'
+        ? undefined
+        : {
+            ...state,
+            memoryConfig: { readOnly: policy === 'readOnly' },
+          },
+  });
+  expect(write).not.toHaveBeenCalled();
+});
+
+it('retains framework failure data when observational memory owns response persistence', async () => {
+  await save({ state: { ...state, observationalMemory: true } });
+  const { messages } = await memory.recall({ threadId: state.threadId, resourceId: state.resourceId, perPage: false });
+  expect(messages).toHaveLength(1);
+  expect(messages[0]?.content.parts).toEqual([{ type: 'data-error', data: { message: failure.message } }]);
+});
+
+it('honors the configured readOnly default', async () => {
+  memory = new Memory({ storage: new InMemoryStore(), options: { readOnly: true } });
+  const write = vi.spyOn(memory, 'saveMessages');
+  await save();
+  expect(write).not.toHaveBeenCalled();
+});
+
+it('rejects another resource without saving into its thread', async () => {
+  const write = vi.spyOn(memory, 'saveMessages');
+  await expect(save({ state: { ...state, resourceId: 'other' } })).rejects.toThrow('owned thread');
+  expect(write).not.toHaveBeenCalled();
+});
+
+it('does not create a missing thread to hide an identity mismatch', async () => {
+  const create = vi.spyOn(memory, 'createThread');
+  await expect(save({ state: { ...state, threadId: 'missing' } })).rejects.toThrow('owned thread');
+  expect(create).not.toHaveBeenCalled();
+});
+
+it('rejects an empty save acknowledgment', async () => {
+  vi.spyOn(memory, 'saveMessages').mockResolvedValue({ messages: [] });
+  await expect(save()).rejects.toThrow('did not retain');
+});
+
+it('propagates a storage failure without retrying', async () => {
+  const write = vi.spyOn(memory, 'saveMessages').mockRejectedValue(new Error('Storage unavailable'));
+  await expect(save()).rejects.toThrow('Storage unavailable');
+  expect(write).toHaveBeenCalledTimes(1);
+});
+
+it('uses distinct records for different runs', async () => {
+  await save();
+  await save({ runId: 'second-run' });
+  const { messages } = await memory.recall({ threadId: state.threadId, resourceId: state.resourceId, perPage: false });
+  expect(new Set(messages.map(row => row.id)).size).toBe(2);
+});

--- a/packages/core/src/agent/durable/persist-terminal-error.ts
+++ b/packages/core/src/agent/durable/persist-terminal-error.ts
@@ -1,0 +1,59 @@
+import { createHash } from 'node:crypto';
+import type { MastraMemory } from '../../memory/memory';
+import type { MastraDBMessage } from '../message-list';
+import type { SerializableDurableState } from './types';
+
+export class TerminalErrorHistorySaveError extends Error {
+  constructor(error: Error, saveError: unknown) {
+    super(`${error.message} The failure could not be saved: ${String(saveError)}`, { cause: saveError });
+    this.name = 'TerminalErrorHistorySaveError';
+  }
+}
+
+/** Saves framework failure data, never the unvalidated streamed answer. */
+export async function persistTerminalError({
+  agentId,
+  runId,
+  state,
+  memory,
+  error,
+  assertOwned,
+}: {
+  agentId: string;
+  runId: string;
+  state: SerializableDurableState | undefined;
+  memory: MastraMemory | undefined;
+  error: Error;
+  assertOwned?: () => void;
+}): Promise<void> {
+  if (!memory || !state?.threadId || !state.resourceId) return;
+  const memoryConfig = memory.getMergedThreadConfig(state.memoryConfig);
+  if (memoryConfig.readOnly) return;
+  // Observational memory owns response persistence. This separate framework
+  // data record contains no response text or observations to flush or embed.
+  const thread = await memory.getThreadById({ threadId: state.threadId });
+  if (!thread || thread.resourceId !== state.resourceId) {
+    throw new Error('Cannot save the run failure without its owned thread.');
+  }
+  const id = createHash('sha256')
+    .update(JSON.stringify(['mastra-terminal-error', agentId, runId, state.resourceId, state.threadId]))
+    .digest('hex');
+  const message: MastraDBMessage = {
+    id,
+    role: 'assistant',
+    threadId: state.threadId,
+    resourceId: state.resourceId,
+    createdAt: new Date(),
+    content: {
+      format: 2,
+      parts: [{ type: 'data-error', data: { message: error.message } }],
+      metadata: { runId, stopReason: 'error', errorMessage: error.message },
+    },
+  };
+  assertOwned?.();
+  const saved = await memory.saveMessages({ messages: [message], memoryConfig });
+  assertOwned?.();
+  if (!saved.messages.some(row => row.id === id && row.content.metadata?.errorMessage === error.message)) {
+    throw new Error('Memory did not retain the run failure.');
+  }
+}

--- a/packages/core/src/agent/durable/stream-adapter.ts
+++ b/packages/core/src/agent/durable/stream-adapter.ts
@@ -243,6 +243,7 @@ export function createDurableAgentStream<OUTPUT = undefined>(
   let lastErrorStack: string | undefined;
   let lastErrorName: string | undefined;
   let lastErrorCause: unknown;
+  let deferredErrorChunk: ChunkType<OUTPUT> | undefined;
 
   // Idle/liveness watchdog. A durable run whose driving process crashed stops
   // emitting chunks but never publishes a terminal FINISH/ERROR/ABORT event, so
@@ -350,6 +351,10 @@ export function createDurableAgentStream<OUTPUT = undefined>(
             lastErrorStack = typeof errPayload?.error?.stack === 'string' ? errPayload.error.stack : undefined;
             lastErrorName = typeof errPayload?.error?.name === 'string' ? errPayload.error.name : undefined;
             lastErrorCause = errPayload?.error ?? errPayload;
+            // A handled model error still finalizes output and saves history.
+            // Consumers treat an error chunk as terminal, so wait for FINISH.
+            deferredErrorChunk = chunk as ChunkType<OUTPUT>;
+            break;
           }
           safeEnqueue(controller, chunk as ChunkType<OUTPUT>);
           await onChunk?.(chunk as ChunkType<OUTPUT>);
@@ -373,6 +378,9 @@ export function createDurableAgentStream<OUTPUT = undefined>(
 
         case AgentStreamEventTypes.FINISH: {
           const data = streamEvent.data as AgentFinishEventData;
+          const errorChunk = deferredErrorChunk;
+          deferredErrorChunk = undefined;
+          if (errorChunk) safeEnqueue(controller, errorChunk);
           // Enqueue finish chunk and close stream even if callback throws
           const finishChunk = {
             type: 'finish' as const,
@@ -384,6 +392,14 @@ export function createDurableAgentStream<OUTPUT = undefined>(
           safeEnqueue(controller, finishChunk);
           safeClose(controller);
           markTerminated();
+
+          if (errorChunk) {
+            try {
+              await onChunk?.(errorChunk);
+            } catch (callbackError) {
+              logError(`[DurableAgentStream] onChunk callback error:`, callbackError);
+            }
+          }
 
           // Build rich onFinish payload from finish event data.
           // The pubsub FINISH event carries output.text, output.steps, and

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -122,6 +122,8 @@ export type SerializableScorersConfig = Record<string, SerializableScorerEntry>;
  * Serializable subset of _internal (StreamInternal) that flows through workflow state
  */
 export interface SerializableDurableState {
+  /** Terminal provider failure retained for the final native memory pass. */
+  terminalError?: string;
   /** Memory configuration options */
   memoryConfig?: MemoryConfig;
   /** Thread identifier for memory persistence */

--- a/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
+++ b/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
@@ -299,6 +299,7 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
           // suspended snapshot with running.
           return (
             params.workflowStatus === 'pending' ||
+            params.workflowStatus === 'failed' ||
             params.workflowStatus === 'paused' ||
             params.workflowStatus === 'suspended' ||
             params.workflowStatus === 'running'
@@ -626,6 +627,7 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
             requestContext,
             tracingContext,
             logger,
+            terminalError: state.state?.terminalError,
             outputResult: {
               text: finalText ?? '',
               usage: state.accumulatedUsage,

--- a/packages/core/src/agent/durable/workflows/finalize-run.ts
+++ b/packages/core/src/agent/durable/workflows/finalize-run.ts
@@ -10,6 +10,7 @@ import { RequestContext } from '../../../request-context';
 import type { Agent } from '../../agent';
 import { convertMessages, coreContentToString, MessageList } from '../../message-list';
 import type { SerializedMessageListState } from '../../message-list/state';
+import { persistTerminalError, TerminalErrorHistorySaveError } from '../persist-terminal-error';
 import { globalRunRegistry } from '../run-registry';
 import type { DurableAgenticWorkflowInput, RunRegistryEntry } from '../types';
 import { resolveRuntimeDependencies } from '../utils/resolve-runtime';
@@ -26,6 +27,7 @@ export interface DurableFinishSideEffectsOptions {
   tracingContext?: TracingContext;
   logger?: IMastraLogger;
   outputResult?: OutputResult;
+  terminalError?: string;
 }
 
 export interface DurableFinishSideEffectsResult {
@@ -78,6 +80,7 @@ export async function runDurableFinishSideEffects({
   tracingContext,
   logger,
   outputResult,
+  terminalError,
 }: DurableFinishSideEffectsOptions): Promise<DurableFinishSideEffectsResult> {
   const effectiveLogger = logger ?? mastra?.getLogger?.() ?? noopLogger;
   const durableState = initData.state;
@@ -111,6 +114,7 @@ export async function runDurableFinishSideEffects({
         runId,
         error,
       });
+      throw error;
     }
   }
 
@@ -161,6 +165,7 @@ export async function runDurableFinishSideEffects({
       );
     } catch (error) {
       effectiveLogger.warn('[DurableAgent] Error running output processors', { runId, error });
+      throw error;
     }
   }
 
@@ -195,12 +200,25 @@ export async function runDurableFinishSideEffects({
         threadId: durableState.threadId,
         error,
       });
+      throw error;
+    }
+  }
+
+  if (terminalError) {
+    const error = new Error(terminalError);
+    try {
+      await persistTerminalError({ agentId: initData.agentId, runId, state: durableState, memory, error });
+    } catch (saveError) {
+      throw new TerminalErrorHistorySaveError(error, saveError);
     }
   }
 
   // Same exclusions as the persistence block above: an observational-memory run writes no
   // messages here, and titling it would create a thread row holding a title and nothing else.
   if (
+    outputResult?.finishReason !== 'abort' &&
+    outputResult?.finishReason !== 'aborted' &&
+    outputResult?.finishReason !== 'error' &&
     durableState?.threadId &&
     durableState?.resourceId &&
     !durableState.observationalMemory &&

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -1927,7 +1927,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
           isContinued: false,
         },
         metadata: { modelId },
-        state: typedInput.state,
+        state: { ...typedInput.state, terminalError: fatalError.message },
       };
     },
   });


### PR DESCRIPTION
Failed durable and evented runs can disappear from history after a controller is recreated. Save one native framework error message under the original run identity and memory policy before reporting terminal failure. Preserve failed snapshots when saving that message fails, and do not persist rejected assistant text.

The change covers initial execution, durable resume, warm evented resume and recovery, including original read-only configuration and missing process-local registry entries. Handled model error chunks wait for native finalization so a viewer cannot finish before the history write. Independent review passed 101 focused and existing regression tests; the full Core typecheck and Core build passed.

This port is separate from the combined application contribution. Its first aggregate run failed 29 tests: 12 premature-terminal failures are fixed here; the remaining 17 concern output filtering and cold evented resume covered by pending PRs #23472 and #23474. This PR does not claim those repairs or production acceptance. The final added resume fixture tests the bounded failure-history responsibility, and no existing upstream tests were removed or weakened. Tests make no provider calls.
