### PR TITLE
fix(observability): supersede storage exporters on Platform

### DIFF
--- a/.changeset/tender-wombats-arrive.md
+++ b/.changeset/tender-wombats-arrive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed built-in storage exporters continuing to write when Mastra Platform observability is enabled. Other exporters remain enabled.

--- a/.changeset/tender-wombats-arrive.md
+++ b/.changeset/tender-wombats-arrive.md
@@ -2,4 +2,4 @@
 '@mastra/observability': patch
 ---
 
-Fixed built-in storage exporters continuing to write when Mastra Platform observability is enabled. Other exporters remain enabled.
+Fixed built-in storage exporters continuing to write in Mastra Platform deployments. Other exporters remain enabled.

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -111,11 +111,17 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
    */
   #excludedModelMeta = new WeakMap<AnySpan, { provider?: string; model?: string }>();
 
+  readonly #supersededStorageExporterNames: string[];
+
   constructor(config: ObservabilityInstanceConfig) {
     super({ component: RegisteredLogger.OBSERVABILITY, name: config.serviceName });
 
     const exporters = config.exporters ?? [];
-    const effectiveExporters = shouldSupersedeStorageExporters()
+    const supersedeStorageExporters = shouldSupersedeStorageExporters();
+    this.#supersededStorageExporterNames = supersedeStorageExporters
+      ? exporters.filter(isBuiltInStorageExporter).map(exporter => exporter.name)
+      : [];
+    const effectiveExporters = supersedeStorageExporters
       ? exporters.filter(exporter => !isBuiltInStorageExporter(exporter))
       : exporters;
 
@@ -181,6 +187,12 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     this.logger.debug(
       `[Observability] Initialized [service=${this.config.serviceName}] [instance=${this.config.name}] [sampling=${this.config.sampling?.type}] [bridge=${!!this.config.bridge}]`,
     );
+
+    if (this.#supersededStorageExporterNames.length > 0) {
+      this.logger.info(
+        `[Observability] Storage exporters superseded by Mastra Platform [service=${this.config.serviceName}] [instance=${this.config.name}] [exporters=${this.#supersededStorageExporterNames.join(',')}]`,
+      );
+    }
   }
 
   // ============================================================================

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -192,6 +192,9 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
       this.logger.info(
         `[Observability] Storage exporters superseded by Mastra Platform [service=${this.config.serviceName}] [instance=${this.config.name}] [exporters=${this.#supersededStorageExporterNames.join(',')}]`,
       );
+      this.logger.info(
+        `[Observability] Active exporters after storage supersession [service=${this.config.serviceName}] [instance=${this.config.name}] [exporters=${this.exporters.map(exporter => exporter.name).join(',') || 'none'}]`,
+      );
     }
   }
 

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -405,6 +405,11 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
    */
   registerExporter(exporter: ObservabilityExporter): void {
     if (isMastraPlatformDeployment() && isMastraBuiltInStorageExporter(exporter)) {
+      this.logger.warn('Storage exporter registration skipped on Mastra Platform', {
+        exporterName: exporter.name,
+        serviceName: this.config.serviceName,
+        instanceName: this.config.name,
+      });
       return;
     }
 

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -44,7 +44,7 @@ import { resolveModelId } from '../model-id';
 import { NoOpSpan } from '../spans';
 import { isPlainRecord, mergeMetadata, stripUndefined } from '../spans/metadata';
 import { addUsageStats } from '../usage';
-import { isBuiltInStorageExporter, shouldSupersedeStorageExporters } from './platform-policy';
+import { isMastraBuiltInStorageExporter, isMastraPlatformDeployment } from './platform-policy';
 
 function hasMetadataKey(metadata: unknown, key: string): boolean {
   if (!metadata || typeof metadata !== 'object') {
@@ -115,8 +115,8 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     super({ component: RegisteredLogger.OBSERVABILITY, name: config.serviceName });
 
     const exporters = config.exporters ?? [];
-    const effectiveExporters = shouldSupersedeStorageExporters()
-      ? exporters.filter(exporter => !isBuiltInStorageExporter(exporter))
+    const effectiveExporters = isMastraPlatformDeployment()
+      ? exporters.filter(exporter => !isMastraBuiltInStorageExporter(exporter))
       : exporters;
 
     // Apply defaults for optional fields

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -44,6 +44,7 @@ import { resolveModelId } from '../model-id';
 import { NoOpSpan } from '../spans';
 import { isPlainRecord, mergeMetadata, stripUndefined } from '../spans/metadata';
 import { addUsageStats } from '../usage';
+import { isBuiltInStorageExporter, shouldSupersedeStorageExporters } from './platform-policy';
 
 function hasMetadataKey(metadata: unknown, key: string): boolean {
   if (!metadata || typeof metadata !== 'object') {
@@ -113,12 +114,17 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
   constructor(config: ObservabilityInstanceConfig) {
     super({ component: RegisteredLogger.OBSERVABILITY, name: config.serviceName });
 
+    const exporters = config.exporters ?? [];
+    const effectiveExporters = shouldSupersedeStorageExporters()
+      ? exporters.filter(exporter => !isBuiltInStorageExporter(exporter))
+      : exporters;
+
     // Apply defaults for optional fields
     this.config = {
       serviceName: config.serviceName,
       name: config.name,
       sampling: config.sampling ?? { type: SamplingStrategyType.ALWAYS },
-      exporters: config.exporters ?? [],
+      exporters: effectiveExporters,
       spanOutputProcessors: config.spanOutputProcessors ?? [],
       bridge: config.bridge ?? undefined,
       includeInternalSpans: config.includeInternalSpans ?? false,

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -111,17 +111,11 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
    */
   #excludedModelMeta = new WeakMap<AnySpan, { provider?: string; model?: string }>();
 
-  readonly #supersededStorageExporterNames: string[];
-
   constructor(config: ObservabilityInstanceConfig) {
     super({ component: RegisteredLogger.OBSERVABILITY, name: config.serviceName });
 
     const exporters = config.exporters ?? [];
-    const supersedeStorageExporters = shouldSupersedeStorageExporters();
-    this.#supersededStorageExporterNames = supersedeStorageExporters
-      ? exporters.filter(isBuiltInStorageExporter).map(exporter => exporter.name)
-      : [];
-    const effectiveExporters = supersedeStorageExporters
+    const effectiveExporters = shouldSupersedeStorageExporters()
       ? exporters.filter(exporter => !isBuiltInStorageExporter(exporter))
       : exporters;
 
@@ -187,15 +181,6 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     this.logger.debug(
       `[Observability] Initialized [service=${this.config.serviceName}] [instance=${this.config.name}] [sampling=${this.config.sampling?.type}] [bridge=${!!this.config.bridge}]`,
     );
-
-    if (this.#supersededStorageExporterNames.length > 0) {
-      this.logger.info(
-        `[Observability] Storage exporters superseded by Mastra Platform [service=${this.config.serviceName}] [instance=${this.config.name}] [exporters=${this.#supersededStorageExporterNames.join(',')}]`,
-      );
-      this.logger.info(
-        `[Observability] Active exporters after storage supersession [service=${this.config.serviceName}] [instance=${this.config.name}] [exporters=${this.exporters.map(exporter => exporter.name).join(',') || 'none'}]`,
-      );
-    }
   }
 
   // ============================================================================

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -404,6 +404,10 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
    * Adds to both the bus (for event routing) and the config (for getExporters).
    */
   registerExporter(exporter: ObservabilityExporter): void {
+    if (isMastraPlatformDeployment() && isMastraBuiltInStorageExporter(exporter)) {
+      return;
+    }
+
     this.observabilityBus.registerExporter(exporter);
     this.config.exporters ??= [];
     if (this.config.exporters.includes(exporter)) {

--- a/observability/mastra/src/instances/platform-policy.test.ts
+++ b/observability/mastra/src/instances/platform-policy.test.ts
@@ -86,6 +86,21 @@ describe('Platform storage exporter supersession', () => {
     expect(instance.getExporters()).toEqual([]);
   });
 
+  it.each(['mastra-storage-exporter', 'mastra-default-observability-exporter'])(
+    'removes a built-in storage exporter from another package copy by name: %s',
+    exporterName => {
+      vi.stubEnv('MASTRA_DEPLOYMENT_ID', 'deployment-id');
+      const storageExporter = new CustomExporter();
+      storageExporter.name = exporterName;
+
+      const instance = createInstance([storageExporter]);
+
+      expect(instance.getExporters()).toEqual([]);
+      expect(instance.getConfig().exporters).toEqual([]);
+      expect(instance.getObservabilityBus().getExporters()).toEqual([]);
+    },
+  );
+
   it('retains Platform, legacy Cloud, and custom exporters in their original order', async () => {
     vi.stubEnv('MASTRA_DEPLOYMENT_ID', 'deployment-id');
     const storageExporter = new MastraStorageExporter();

--- a/observability/mastra/src/instances/platform-policy.test.ts
+++ b/observability/mastra/src/instances/platform-policy.test.ts
@@ -1,0 +1,126 @@
+import type { Mastra } from '@mastra/core/mastra';
+import type { InitExporterOptions, TracingEvent } from '@mastra/core/observability';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Observability } from '../default';
+import { BaseExporter } from '../exporters/base';
+import { CloudExporter } from '../exporters/cloud';
+import { DefaultExporter } from '../exporters/default';
+import { MastraPlatformExporter } from '../exporters/mastra-platform';
+import { MastraStorageExporter } from '../exporters/mastra-storage';
+import { DefaultObservabilityInstance } from './default';
+
+class CustomExporter extends BaseExporter {
+  name = 'custom-exporter';
+
+  protected async _exportTracingEvent(_event: TracingEvent): Promise<void> {}
+}
+
+class TrackingStorageExporter extends MastraStorageExporter {
+  readonly initSpy = vi.fn();
+
+  override async init(options: InitExporterOptions): Promise<void> {
+    this.initSpy(options);
+  }
+}
+
+function createInstance(exporters: BaseExporter[], name = 'default'): DefaultObservabilityInstance {
+  return new DefaultObservabilityInstance({
+    name,
+    serviceName: 'test-service',
+    exporters,
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('Platform storage exporter supersession', () => {
+  it('keeps MastraStorageExporter when the Platform access token is absent', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', undefined);
+    const storageExporter = new MastraStorageExporter();
+
+    const instance = createInstance([storageExporter]);
+
+    expect(instance.getExporters()).toEqual([storageExporter]);
+    expect(instance.getConfig().exporters).toEqual([storageExporter]);
+    expect(instance.getObservabilityBus().getExporters()).toEqual([storageExporter]);
+  });
+
+  it('treats an empty Platform access token as absent', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
+    const storageExporter = new MastraStorageExporter();
+
+    const instance = createInstance([storageExporter]);
+
+    expect(instance.getExporters()).toEqual([storageExporter]);
+  });
+
+  it('removes MastraStorageExporter before registration when the Platform access token is present', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
+    const storageExporter = new MastraStorageExporter();
+
+    const instance = createInstance([storageExporter]);
+
+    expect(instance.getExporters()).toEqual([]);
+    expect(instance.getConfig().exporters).toEqual([]);
+    expect(instance.getObservabilityBus().getExporters()).toEqual([]);
+  });
+
+  it('removes the deprecated DefaultExporter when the Platform access token is present', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
+    const storageExporter = new DefaultExporter();
+
+    const instance = createInstance([storageExporter]);
+
+    expect(instance.getExporters()).toEqual([]);
+  });
+
+  it('retains Platform, legacy Cloud, and custom exporters in their original order', async () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
+    const storageExporter = new MastraStorageExporter();
+    const platformExporter = new MastraPlatformExporter();
+    const cloudExporter = new CloudExporter({ accessToken: 'cloud-token' });
+    const customExporter = new CustomExporter();
+
+    const instance = createInstance([storageExporter, platformExporter, cloudExporter, customExporter]);
+
+    expect(instance.getExporters()).toEqual([platformExporter, cloudExporter, customExporter]);
+    expect(instance.getConfig().exporters).toEqual([platformExporter, cloudExporter, customExporter]);
+    expect(instance.getObservabilityBus().getExporters()).toEqual([platformExporter, cloudExporter, customExporter]);
+
+    await Promise.all([platformExporter.shutdown(), cloudExporter.shutdown()]);
+  });
+
+  it('applies supersession to every SDK observability instance', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
+    const firstCustomExporter = new CustomExporter();
+    const secondCustomExporter = new CustomExporter();
+
+    const firstInstance = createInstance([new MastraStorageExporter(), firstCustomExporter], 'first');
+    const secondInstance = createInstance([new DefaultExporter(), secondCustomExporter], 'second');
+
+    expect(firstInstance.getExporters()).toEqual([firstCustomExporter]);
+    expect(secondInstance.getExporters()).toEqual([secondCustomExporter]);
+  });
+
+  it('does not initialize a superseded storage exporter after setting the Mastra context', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
+    const storageExporter = new TrackingStorageExporter();
+    const observability = new Observability({
+      configs: {
+        default: {
+          serviceName: 'test-service',
+          exporters: [storageExporter],
+        },
+      },
+      sensitiveDataFilter: false,
+    });
+
+    observability.setMastraContext({
+      mastra: { getEnvironment: () => undefined } as Mastra,
+    });
+
+    expect(storageExporter.initSpy).not.toHaveBeenCalled();
+  });
+});

--- a/observability/mastra/src/instances/platform-policy.test.ts
+++ b/observability/mastra/src/instances/platform-policy.test.ts
@@ -36,8 +36,8 @@ afterEach(() => {
 });
 
 describe('Platform storage exporter supersession', () => {
-  it('keeps MastraStorageExporter when the Platform access token is absent', () => {
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', undefined);
+  it('keeps MastraStorageExporter when the Platform deployment ID is absent', () => {
+    vi.stubEnv('MASTRA_DEPLOYMENT_ID', undefined);
     const storageExporter = new MastraStorageExporter();
 
     const instance = createInstance([storageExporter]);
@@ -47,8 +47,8 @@ describe('Platform storage exporter supersession', () => {
     expect(instance.getObservabilityBus().getExporters()).toEqual([storageExporter]);
   });
 
-  it('treats an empty Platform access token as absent', () => {
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
+  it('treats an empty Platform deployment ID as absent', () => {
+    vi.stubEnv('MASTRA_DEPLOYMENT_ID', '');
     const storageExporter = new MastraStorageExporter();
 
     const instance = createInstance([storageExporter]);
@@ -56,8 +56,18 @@ describe('Platform storage exporter supersession', () => {
     expect(instance.getExporters()).toEqual([storageExporter]);
   });
 
-  it('removes MastraStorageExporter before registration when the Platform access token is present', () => {
+  it('keeps MastraStorageExporter when only the Platform access token is present', () => {
+    vi.stubEnv('MASTRA_DEPLOYMENT_ID', undefined);
     vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
+    const storageExporter = new MastraStorageExporter();
+
+    const instance = createInstance([storageExporter]);
+
+    expect(instance.getExporters()).toEqual([storageExporter]);
+  });
+
+  it('removes MastraStorageExporter before registration when the Platform deployment ID is present', () => {
+    vi.stubEnv('MASTRA_DEPLOYMENT_ID', 'deployment-id');
     const storageExporter = new MastraStorageExporter();
 
     const instance = createInstance([storageExporter]);
@@ -67,8 +77,8 @@ describe('Platform storage exporter supersession', () => {
     expect(instance.getObservabilityBus().getExporters()).toEqual([]);
   });
 
-  it('removes the deprecated DefaultExporter when the Platform access token is present', () => {
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
+  it('removes the deprecated DefaultExporter when the Platform deployment ID is present', () => {
+    vi.stubEnv('MASTRA_DEPLOYMENT_ID', 'deployment-id');
     const storageExporter = new DefaultExporter();
 
     const instance = createInstance([storageExporter]);
@@ -77,7 +87,7 @@ describe('Platform storage exporter supersession', () => {
   });
 
   it('retains Platform, legacy Cloud, and custom exporters in their original order', async () => {
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
+    vi.stubEnv('MASTRA_DEPLOYMENT_ID', 'deployment-id');
     const storageExporter = new MastraStorageExporter();
     const platformExporter = new MastraPlatformExporter();
     const cloudExporter = new CloudExporter({ accessToken: 'cloud-token' });
@@ -93,7 +103,7 @@ describe('Platform storage exporter supersession', () => {
   });
 
   it('applies supersession to every SDK observability instance', () => {
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
+    vi.stubEnv('MASTRA_DEPLOYMENT_ID', 'deployment-id');
     const firstCustomExporter = new CustomExporter();
     const secondCustomExporter = new CustomExporter();
 
@@ -105,7 +115,7 @@ describe('Platform storage exporter supersession', () => {
   });
 
   it('does not initialize a superseded storage exporter after setting the Mastra context', () => {
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
+    vi.stubEnv('MASTRA_DEPLOYMENT_ID', 'deployment-id');
     const storageExporter = new TrackingStorageExporter();
     const observability = new Observability({
       configs: {

--- a/observability/mastra/src/instances/platform-policy.test.ts
+++ b/observability/mastra/src/instances/platform-policy.test.ts
@@ -124,12 +124,19 @@ describe('Platform storage exporter supersession', () => {
     });
     const mastra = new Mastra({ logger: false, observability });
     const storageExporter = new MastraStorageExporter();
+    const warnSpy = vi.spyOn(instance.getLogger(), 'warn');
 
     mastra.registerExporter(storageExporter, createInstance([], 'fallback'), observability);
 
     expect(instance.getExporters()).toEqual([customExporter]);
     expect(instance.getConfig().exporters).toEqual([customExporter]);
     expect(instance.getObservabilityBus().getExporters()).toEqual([customExporter]);
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).toHaveBeenCalledWith('Storage exporter registration skipped on Mastra Platform', {
+      exporterName: 'mastra-storage-exporter',
+      serviceName: 'test-service',
+      instanceName: 'default',
+    });
   });
 
   it('registers a storage exporter through Mastra outside a Platform deployment', () => {
@@ -142,12 +149,14 @@ describe('Platform storage exporter supersession', () => {
     });
     const mastra = new Mastra({ logger: false, observability });
     const storageExporter = new MastraStorageExporter();
+    const warnSpy = vi.spyOn(instance.getLogger(), 'warn');
 
     mastra.registerExporter(storageExporter, createInstance([], 'fallback'), observability);
 
     expect(instance.getExporters()).toEqual([customExporter, storageExporter]);
     expect(instance.getConfig().exporters).toEqual([customExporter, storageExporter]);
     expect(instance.getObservabilityBus().getExporters()).toEqual([customExporter, storageExporter]);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('does not initialize a superseded storage exporter after setting the Mastra context', () => {

--- a/observability/mastra/src/instances/platform-policy.test.ts
+++ b/observability/mastra/src/instances/platform-policy.test.ts
@@ -1,4 +1,4 @@
-import type { Mastra } from '@mastra/core/mastra';
+import { Mastra } from '@mastra/core/mastra';
 import type { InitExporterOptions, TracingEvent } from '@mastra/core/observability';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Observability } from '../default';
@@ -112,6 +112,42 @@ describe('Platform storage exporter supersession', () => {
 
     expect(firstInstance.getExporters()).toEqual([firstCustomExporter]);
     expect(secondInstance.getExporters()).toEqual([secondCustomExporter]);
+  });
+
+  it('ignores a storage exporter registered through Mastra on a Platform deployment', () => {
+    vi.stubEnv('MASTRA_DEPLOYMENT_ID', 'deployment-id');
+    const customExporter = new CustomExporter();
+    const instance = createInstance([customExporter]);
+    const observability = new Observability({
+      configs: { default: instance },
+      sensitiveDataFilter: false,
+    });
+    const mastra = new Mastra({ logger: false, observability });
+    const storageExporter = new MastraStorageExporter();
+
+    mastra.registerExporter(storageExporter, createInstance([], 'fallback'), observability);
+
+    expect(instance.getExporters()).toEqual([customExporter]);
+    expect(instance.getConfig().exporters).toEqual([customExporter]);
+    expect(instance.getObservabilityBus().getExporters()).toEqual([customExporter]);
+  });
+
+  it('registers a storage exporter through Mastra outside a Platform deployment', () => {
+    vi.stubEnv('MASTRA_DEPLOYMENT_ID', undefined);
+    const customExporter = new CustomExporter();
+    const instance = createInstance([customExporter]);
+    const observability = new Observability({
+      configs: { default: instance },
+      sensitiveDataFilter: false,
+    });
+    const mastra = new Mastra({ logger: false, observability });
+    const storageExporter = new MastraStorageExporter();
+
+    mastra.registerExporter(storageExporter, createInstance([], 'fallback'), observability);
+
+    expect(instance.getExporters()).toEqual([customExporter, storageExporter]);
+    expect(instance.getConfig().exporters).toEqual([customExporter, storageExporter]);
+    expect(instance.getObservabilityBus().getExporters()).toEqual([customExporter, storageExporter]);
   });
 
   it('does not initialize a superseded storage exporter after setting the Mastra context', () => {

--- a/observability/mastra/src/instances/platform-policy.test.ts
+++ b/observability/mastra/src/instances/platform-policy.test.ts
@@ -76,9 +76,9 @@ describe('Platform storage exporter supersession', () => {
     expect(instance.getExporters()).toEqual([]);
   });
 
-  it('logs the storage exporters superseded by Mastra Platform', () => {
+  it('logs the superseded and active exporters', () => {
     vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
-    const instance = createInstance([new MastraStorageExporter(), new DefaultExporter()]);
+    const instance = createInstance([new MastraStorageExporter(), new DefaultExporter(), new CustomExporter()]);
     const info = vi.fn();
 
     instance.__setLogger({
@@ -92,8 +92,13 @@ describe('Platform storage exporter supersession', () => {
       listLogsByRunId: vi.fn(),
     });
 
-    expect(info).toHaveBeenCalledWith(
+    expect(info).toHaveBeenNthCalledWith(
+      1,
       '[Observability] Storage exporters superseded by Mastra Platform [service=test-service] [instance=default] [exporters=mastra-storage-exporter,mastra-default-observability-exporter]',
+    );
+    expect(info).toHaveBeenNthCalledWith(
+      2,
+      '[Observability] Active exporters after storage supersession [service=test-service] [instance=default] [exporters=custom-exporter]',
     );
   });
 

--- a/observability/mastra/src/instances/platform-policy.test.ts
+++ b/observability/mastra/src/instances/platform-policy.test.ts
@@ -76,6 +76,27 @@ describe('Platform storage exporter supersession', () => {
     expect(instance.getExporters()).toEqual([]);
   });
 
+  it('logs the storage exporters superseded by Mastra Platform', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
+    const instance = createInstance([new MastraStorageExporter(), new DefaultExporter()]);
+    const info = vi.fn();
+
+    instance.__setLogger({
+      debug: vi.fn(),
+      info,
+      warn: vi.fn(),
+      error: vi.fn(),
+      trackException: vi.fn(),
+      getTransports: () => new Map(),
+      listLogs: vi.fn(),
+      listLogsByRunId: vi.fn(),
+    });
+
+    expect(info).toHaveBeenCalledWith(
+      '[Observability] Storage exporters superseded by Mastra Platform [service=test-service] [instance=default] [exporters=mastra-storage-exporter,mastra-default-observability-exporter]',
+    );
+  });
+
   it('retains Platform, legacy Cloud, and custom exporters in their original order', async () => {
     vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
     const storageExporter = new MastraStorageExporter();

--- a/observability/mastra/src/instances/platform-policy.test.ts
+++ b/observability/mastra/src/instances/platform-policy.test.ts
@@ -76,32 +76,6 @@ describe('Platform storage exporter supersession', () => {
     expect(instance.getExporters()).toEqual([]);
   });
 
-  it('logs the superseded and active exporters', () => {
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
-    const instance = createInstance([new MastraStorageExporter(), new DefaultExporter(), new CustomExporter()]);
-    const info = vi.fn();
-
-    instance.__setLogger({
-      debug: vi.fn(),
-      info,
-      warn: vi.fn(),
-      error: vi.fn(),
-      trackException: vi.fn(),
-      getTransports: () => new Map(),
-      listLogs: vi.fn(),
-      listLogsByRunId: vi.fn(),
-    });
-
-    expect(info).toHaveBeenNthCalledWith(
-      1,
-      '[Observability] Storage exporters superseded by Mastra Platform [service=test-service] [instance=default] [exporters=mastra-storage-exporter,mastra-default-observability-exporter]',
-    );
-    expect(info).toHaveBeenNthCalledWith(
-      2,
-      '[Observability] Active exporters after storage supersession [service=test-service] [instance=default] [exporters=custom-exporter]',
-    );
-  });
-
   it('retains Platform, legacy Cloud, and custom exporters in their original order', async () => {
     vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
     const storageExporter = new MastraStorageExporter();

--- a/observability/mastra/src/instances/platform-policy.ts
+++ b/observability/mastra/src/instances/platform-policy.ts
@@ -2,10 +2,19 @@ import type { ObservabilityExporter } from '@mastra/core/observability';
 import { DefaultExporter } from '../exporters/default';
 import { MastraStorageExporter } from '../exporters/mastra-storage';
 
+const MASTRA_BUILT_IN_STORAGE_EXPORTER_NAMES = new Set([
+  'mastra-storage-exporter',
+  'mastra-default-observability-exporter',
+]);
+
 export function isMastraPlatformDeployment(): boolean {
   return Boolean(process.env.MASTRA_DEPLOYMENT_ID);
 }
 
 export function isMastraBuiltInStorageExporter(exporter: ObservabilityExporter): boolean {
-  return exporter instanceof MastraStorageExporter || exporter instanceof DefaultExporter;
+  return (
+    exporter instanceof MastraStorageExporter ||
+    exporter instanceof DefaultExporter ||
+    MASTRA_BUILT_IN_STORAGE_EXPORTER_NAMES.has(exporter.name)
+  );
 }

--- a/observability/mastra/src/instances/platform-policy.ts
+++ b/observability/mastra/src/instances/platform-policy.ts
@@ -1,0 +1,11 @@
+import type { ObservabilityExporter } from '@mastra/core/observability';
+import { DefaultExporter } from '../exporters/default';
+import { MastraStorageExporter } from '../exporters/mastra-storage';
+
+export function shouldSupersedeStorageExporters(): boolean {
+  return Boolean(process.env.MASTRA_PLATFORM_ACCESS_TOKEN);
+}
+
+export function isBuiltInStorageExporter(exporter: ObservabilityExporter): boolean {
+  return exporter instanceof MastraStorageExporter || exporter instanceof DefaultExporter;
+}

--- a/observability/mastra/src/instances/platform-policy.ts
+++ b/observability/mastra/src/instances/platform-policy.ts
@@ -2,10 +2,10 @@ import type { ObservabilityExporter } from '@mastra/core/observability';
 import { DefaultExporter } from '../exporters/default';
 import { MastraStorageExporter } from '../exporters/mastra-storage';
 
-export function shouldSupersedeStorageExporters(): boolean {
-  return Boolean(process.env.MASTRA_PLATFORM_ACCESS_TOKEN);
+export function isMastraPlatformDeployment(): boolean {
+  return Boolean(process.env.MASTRA_DEPLOYMENT_ID);
 }
 
-export function isBuiltInStorageExporter(exporter: ObservabilityExporter): boolean {
+export function isMastraBuiltInStorageExporter(exporter: ObservabilityExporter): boolean {
   return exporter instanceof MastraStorageExporter || exporter instanceof DefaultExporter;
 }


### PR DESCRIPTION
Platform deployments could initialize Mastra's built-in storage exporters alongside hosted observability, causing local storage writes that Platform never queries.

Previously, a Platform deployment kept every configured exporter:

```ts
// Effective exporters
[new MastraStorageExporter(), new MastraPlatformExporter()]
```

Now, when `MASTRA_DEPLOYMENT_ID` is present, Mastra removes `MastraStorageExporter` and the deprecated `DefaultExporter` during SDK instance construction:

```ts
// Effective exporters
[new MastraPlatformExporter()]
```

Constructor filtering happens before exporters reach the observability bus or receive Mastra context. The same policy applies to exporters added later through runtime registration, preventing that path from restoring built-in storage. Platform, legacy Cloud, and third-party exporters remain enabled in their configured order. Local applications without `MASTRA_DEPLOYMENT_ID` retain explicitly configured storage exporters.

Tested with the full `@mastra/observability` test suite, package build, lint, TypeScript checking, and git diff validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Platform deployments no longer start built-in storage exporters that should not run there. Other exporters stay enabled, and local applications keep their configured storage exporters.

## Changes

- Detects Platform deployments through `MASTRA_DEPLOYMENT_ID`.
- Removes `MastraStorageExporter` and deprecated `DefaultExporter` before initialization.
- Recognizes built-in exporters by class identity or stable exporter name.
- Applies the same policy to exporters registered after SDK construction.
- Logs a warning when a built-in storage exporter is rejected at runtime.
- Preserves the configured order of supported exporters.
- Adds tests for Platform, local, multiple-instance, and runtime-registration scenarios.
- Adds a patch changeset for `@mastra/observability`.

## Validation

- Full `@mastra/observability` test suite
- Package build
- Lint
- TypeScript checks
- Git diff validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->