### PR TITLE
feat(observability): define queryThreads contract and semantics

### DIFF
--- a/.changeset/hip-glasses-dance.md
+++ b/.changeset/hip-glasses-dance.md
@@ -5,15 +5,14 @@
 Added the observability storage contract for querying thread identities with cross-trace predicates.
 
 ```ts
-await observabilityStore.queryThreads({
-  result: 'threads',
+const input = parseQueryThreadsInput({
   traces: {
     timeRange: { from, to },
     where: eligibleTracePredicate,
   },
   where: threadPredicate,
-  orderBy: { field: 'threadId', direction: 'asc' },
-  limit: 100,
-  binding,
 });
+
+const plan = planThreadQuery(input);
+const result = await observabilityStore.queryThreads(plan);
 ```

--- a/.changeset/hip-glasses-dance.md
+++ b/.changeset/hip-glasses-dance.md
@@ -3,3 +3,5 @@
 ---
 
 Added a storage contract for observability adapters to query thread identities using cross-trace predicates.
+
+Trace and thread queries now accept any valid bounded time range instead of rejecting ranges longer than 31 days.

--- a/.changeset/hip-glasses-dance.md
+++ b/.changeset/hip-glasses-dance.md
@@ -3,5 +3,3 @@
 ---
 
 Added a storage contract for observability adapters to query thread identities using cross-trace predicates.
-
-Trace and thread queries now accept any valid bounded time range instead of rejecting ranges longer than 31 days.

--- a/.changeset/hip-glasses-dance.md
+++ b/.changeset/hip-glasses-dance.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': minor
+---
+
+Added the observability storage contract for querying thread identities with cross-trace predicates.
+
+```ts
+await observabilityStore.queryThreads({
+  result: 'threads',
+  traces: {
+    timeRange: { from, to },
+    where: eligibleTracePredicate,
+  },
+  where: threadPredicate,
+  orderBy: { field: 'threadId', direction: 'asc' },
+  limit: 100,
+  binding,
+});
+```

--- a/.changeset/hip-glasses-dance.md
+++ b/.changeset/hip-glasses-dance.md
@@ -2,17 +2,4 @@
 '@mastra/core': minor
 ---
 
-Added the observability storage contract for querying thread identities with cross-trace predicates.
-
-```ts
-const input = parseQueryThreadsInput({
-  traces: {
-    timeRange: { from, to },
-    where: eligibleTracePredicate,
-  },
-  where: threadPredicate,
-});
-
-const plan = planThreadQuery(input);
-const result = await observabilityStore.queryThreads(plan);
-```
+Added a storage contract for observability adapters to query thread identities using cross-trace predicates.

--- a/packages/core/src/storage/domains/observability/base.ts
+++ b/packages/core/src/storage/domains/observability/base.ts
@@ -65,7 +65,12 @@ import type {
   GetScorePercentilesArgs,
   GetScorePercentilesResponse,
 } from './scores';
-import type { TraceQueryResponse, TrustedTraceQueryPlan } from './trace-query';
+import type {
+  QueryThreadsResult,
+  TraceQueryResponse,
+  TrustedThreadQueryPlan,
+  TrustedTraceQueryPlan,
+} from './trace-query';
 import type {
   BatchCreateSpansArgs,
   BatchDeleteTracesArgs,
@@ -93,7 +98,7 @@ import type {
 import { extractBranchSpans, getBranchArgsSchema, toLightSpanRecord } from './tracing';
 import type { ObservabilityStorageStrategy, TracingStorageStrategy } from './types';
 
-export type ObservabilityStorageFeature = 'delta-polling' | 'metrics' | 'logs' | 'trace-query';
+export type ObservabilityStorageFeature = 'delta-polling' | 'metrics' | 'logs' | 'trace-query' | 'thread-query';
 
 /**
  * Base storage class for observability data (traces, metrics, logs, scores, feedback).
@@ -355,6 +360,18 @@ export class ObservabilityStorage extends StorageDomain {
       domain: ErrorDomain.MASTRA_OBSERVABILITY,
       category: ErrorCategory.SYSTEM,
       text: 'This storage provider does not support advanced trace queries',
+    });
+  }
+
+  /**
+   * Executes a validated thread-query plan.
+   */
+  async queryThreads(_plan: TrustedThreadQueryPlan): Promise<QueryThreadsResult> {
+    throw new MastraError({
+      id: 'OBSERVABILITY_STORAGE_QUERY_THREADS_NOT_IMPLEMENTED',
+      domain: ErrorDomain.MASTRA_OBSERVABILITY,
+      category: ErrorCategory.SYSTEM,
+      text: 'This storage provider does not support advanced thread queries',
     });
   }
 

--- a/packages/core/src/storage/domains/observability/trace-query.test.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.test.ts
@@ -158,16 +158,19 @@ describe('planTraceQuery', () => {
     });
   });
 
-  it('enforces ordered and maximum time ranges', () => {
+  it('enforces ordered time ranges and permits ranges longer than 31 days', () => {
     const reversed = validationError(() =>
       planTraceQuery(parsed({ timeRange: { from: '2026-08-02T00:00:00Z', to: '2026-08-01T00:00:00Z' } })),
     );
     expect(reversed.issues).toEqual([expect.objectContaining({ code: 'invalid_time_range', path: ['timeRange'] })]);
 
-    const tooLarge = validationError(() =>
-      planTraceQuery(parsed({ timeRange: { from: '2026-07-31T23:59:59Z', to: '2026-09-01T00:00:00Z' } })),
+    const longRange = planTraceQuery(
+      parsed({ timeRange: { from: '2026-01-01T00:00:00Z', to: '2026-09-01T00:00:00Z' } }),
     );
-    expect(tooLarge.issues[0]).toMatchObject({ code: 'time_range_too_large', path: ['timeRange'] });
+    expect(longRange.timeRange).toEqual({
+      from: '2026-01-01T00:00:00.000Z',
+      to: '2026-09-01T00:00:00.000Z',
+    });
   });
 
   it('plans recursive trace and same-record collection predicates', () => {
@@ -1059,6 +1062,16 @@ describe('queryThreads input and planning', () => {
     expect(invalidRange.issues).toContainEqual(
       expect.objectContaining({ code: 'invalid_time_range', path: ['traces', 'timeRange'] }),
     );
+
+    const longRange = planThreadQuery(
+      parsedThreads({
+        traces: { timeRange: { from: '2026-01-01T00:00:00Z', to: '2026-09-01T00:00:00Z' } },
+      }),
+    );
+    expect(longRange.traces.timeRange).toEqual({
+      from: '2026-01-01T00:00:00.000Z',
+      to: '2026-09-01T00:00:00.000Z',
+    });
 
     const invalidField = validationError(() =>
       planThreadQuery(

--- a/packages/core/src/storage/domains/observability/trace-query.test.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.test.ts
@@ -3,7 +3,9 @@ import { ObservabilityStorage } from './base';
 import {
   compareTraceQueryStrings,
   encodeTraceQueryCursor,
+  parseQueryThreadsInput,
   parseTraceQueryRequest,
+  planThreadQuery,
   planTraceQuery,
   TRACE_QUERY_MAX_DEPTH,
   TRACE_QUERY_MAX_LITERAL_UNITS,
@@ -14,6 +16,8 @@ import {
   TRACE_QUERY_DEFAULT_TIMEOUT_MS,
   TRACE_QUERY_MAX_STRING_BYTES,
   TRACE_QUERY_MAX_TIMEOUT_MS,
+  queryThreadsInputSchema,
+  queryThreadsResultSchema,
   resolveTraceQueryTimeoutMs,
   traceQueryGroupResponseSchema,
   traceQueryRequestSchema,
@@ -33,6 +37,12 @@ const baseRequest = {
 
 function parsed(request: unknown = baseRequest) {
   return parseTraceQueryRequest(request);
+}
+
+const baseThreadRequest = { traces: baseRequest };
+
+function parsedThreads(request: unknown = baseThreadRequest) {
+  return parseQueryThreadsInput(request);
 }
 
 function validationError(fn: () => unknown): TraceQueryValidationError {
@@ -958,6 +968,234 @@ describe('planTraceQuery', () => {
   });
 });
 
+describe('queryThreads input and planning', () => {
+  const traceExists = { op: 'exists', path: 'traceId' } as const;
+
+  it('normalizes defaults and rejects grouping, aggregation, and malformed thread predicates', () => {
+    expect(parsedThreads()).toEqual({ traces: baseRequest, page: { limit: 100 } });
+    expect(queryThreadsInputSchema.safeParse({ ...baseThreadRequest, page: { limit: '10' } }).success).toBe(false);
+
+    for (const property of ['timeRange', 'group', 'groupBy', 'by', 'having']) {
+      expect(queryThreadsInputSchema.safeParse({ ...baseThreadRequest, [property]: {} }).success, property).toBe(false);
+    }
+
+    for (const where of [
+      traceExists,
+      { op: 'and', args: [] },
+      { traces: {} },
+      { traces: { some: traceExists, none: traceExists } },
+    ]) {
+      expect(queryThreadsInputSchema.safeParse({ ...baseThreadRequest, where }).success).toBe(false);
+    }
+  });
+
+  it('builds separate eligibility and thread predicates with fixed identity ordering', () => {
+    const plan = planThreadQuery(
+      parsedThreads({
+        traces: {
+          ...baseRequest,
+          where: { op: 'eq', left: { path: 'environment' }, right: { literal: 'production' } },
+        },
+        where: {
+          op: 'and',
+          args: [
+            {
+              traces: {
+                some: {
+                  scores: {
+                    some: { op: 'lt', left: { path: 'score' }, right: { literal: 0.6 } },
+                  },
+                },
+              },
+            },
+            { traces: { none: { feedback: { some: { op: 'exists', path: 'comment' } } } } },
+          ],
+        },
+        page: { limit: 25 },
+      }),
+    );
+
+    expect(plan).toMatchObject({
+      result: 'threads',
+      traces: {
+        timeRange: {
+          from: '2026-08-01T00:00:00.000Z',
+          to: '2026-09-01T00:00:00.000Z',
+        },
+        where: { type: 'comparison', field: 'environment', operator: 'eq', value: 'production' },
+      },
+      where: {
+        type: 'boolean',
+        operator: 'and',
+        args: [
+          {
+            type: 'relation',
+            collection: 'traces',
+            quantifier: 'some',
+            predicate: { type: 'relation', collection: 'scores', quantifier: 'some' },
+          },
+          {
+            type: 'relation',
+            collection: 'traces',
+            quantifier: 'none',
+            predicate: { type: 'relation', collection: 'feedback', quantifier: 'some' },
+          },
+        ],
+      },
+      orderBy: { field: 'threadId', direction: 'asc' },
+      limit: 25,
+      binding: expect.any(String),
+    });
+  });
+
+  it('validates the nested trace time range and nested trace predicates', () => {
+    const invalidRange = validationError(() =>
+      planThreadQuery(
+        parsedThreads({
+          traces: { timeRange: { from: baseRequest.timeRange.to, to: baseRequest.timeRange.from } },
+        }),
+      ),
+    );
+    expect(invalidRange.issues).toContainEqual(
+      expect.objectContaining({ code: 'invalid_time_range', path: ['traces', 'timeRange'] }),
+    );
+
+    const invalidField = validationError(() =>
+      planThreadQuery(
+        parsedThreads({
+          ...baseThreadRequest,
+          where: {
+            traces: {
+              some: { scores: { some: { op: 'eq', left: { path: 'unknown' }, right: { literal: 'secret' } } } },
+            },
+          },
+        }),
+      ),
+    );
+    expect(invalidField.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'field_not_allowed',
+        path: ['where', 'traces', 'some', 'scores', 'some', 'left', 'path'],
+      }),
+    );
+    expect(JSON.stringify(invalidField.issues)).not.toContain('secret');
+  });
+
+  it('shares node and literal budgets across eligibility and thread qualification', () => {
+    const values = Array.from({ length: TRACE_QUERY_MAX_SET_VALUES }, (_, index) => `value-${index}`);
+    const membership = { op: 'in', value: { path: 'traceId' }, set: values } as const;
+    const eligibilityArgs = Array.from({ length: 7 }, () => membership);
+    const threadArgs = Array.from({ length: 4 }, () => ({ traces: { some: membership } }) as const);
+
+    const literalError = validationError(() =>
+      planThreadQuery(
+        parsedThreads({
+          traces: { ...baseRequest, where: { op: 'and', args: eligibilityArgs } },
+          where: { op: 'and', args: threadArgs },
+        }),
+      ),
+    );
+    expect(literalError.issues).toContainEqual(expect.objectContaining({ code: 'predicate_too_complex' }));
+
+    const eligibilityNodes = Array.from({ length: 50 }, () => traceExists);
+    const threadNodes = Array.from({ length: 50 }, () => ({ traces: { some: traceExists } }) as const);
+    const nodeError = validationError(() =>
+      parsedThreads({
+        traces: { ...baseRequest, where: { op: 'and', args: eligibilityNodes } },
+        where: { op: 'and', args: threadNodes },
+      }),
+    );
+    expect(nodeError.issues).toContainEqual(expect.objectContaining({ code: 'predicate_too_complex' }));
+  });
+
+  it('shares the related-clause budget across both scopes', () => {
+    const scoreClause = { scores: { some: { op: 'exists', path: 'scorerId' } } } as const;
+    const eligibilityArgs = Array.from({ length: 4 }, () => scoreClause);
+    const threadClause = { traces: { some: scoreClause } } as const;
+
+    expect(() =>
+      planThreadQuery(
+        parsedThreads({
+          traces: { ...baseRequest, where: { op: 'and', args: eligibilityArgs } },
+          where: { op: 'and', args: [threadClause, threadClause] },
+        }),
+      ),
+    ).not.toThrow();
+
+    const error = validationError(() =>
+      planThreadQuery(
+        parsedThreads({
+          traces: { ...baseRequest, where: { op: 'and', args: eligibilityArgs } },
+          where: { op: 'and', args: [threadClause, threadClause, threadClause] },
+        }),
+      ),
+    );
+    expect(error.issues).toContainEqual(expect.objectContaining({ code: 'predicate_too_complex' }));
+  });
+
+  it('rejects adversarial recursion inside a thread quantifier before schema recursion', () => {
+    let nested: unknown = { op: 'not' };
+    for (let index = 0; index < 10_000; index += 1) nested = { op: 'not', arg: nested };
+
+    const error = validationError(() => parsedThreads({ ...baseThreadRequest, where: { traces: { some: nested } } }));
+    expect(error.issues[0]).toMatchObject({ code: 'predicate_too_complex' });
+  });
+});
+
+describe('thread-query cursors', () => {
+  it('round-trips thread keys and rejects changed query or authorization state', () => {
+    const plan = planThreadQuery(parsedThreads(), { authorizationBinding: 'scope-a' });
+    const cursor = encodeTraceQueryCursor(plan, { result: 'threads', threadId: 'thread-2' });
+
+    expect(
+      planThreadQuery(parsedThreads({ ...baseThreadRequest, page: { after: cursor } }), {
+        authorizationBinding: 'scope-a',
+      }),
+    ).toMatchObject({ cursor: { threadId: 'thread-2' } });
+
+    expect(() =>
+      planThreadQuery(
+        parsedThreads({
+          ...baseThreadRequest,
+          where: { traces: { some: { op: 'exists', path: 'threadId' } } },
+          page: { after: cursor },
+        }),
+        { authorizationBinding: 'scope-a' },
+      ),
+    ).toThrowError(expect.objectContaining<Partial<TraceQueryCursorError>>({ code: 'TRACE_QUERY_CURSOR_CONFLICT' }));
+
+    expect(() =>
+      planThreadQuery(
+        parsedThreads({
+          traces: { ...baseRequest, where: { op: 'exists', path: 'environment' } },
+          page: { after: cursor },
+        }),
+        { authorizationBinding: 'scope-a' },
+      ),
+    ).toThrowError(expect.objectContaining<Partial<TraceQueryCursorError>>({ code: 'TRACE_QUERY_CURSOR_CONFLICT' }));
+
+    expect(() =>
+      planThreadQuery(parsedThreads({ ...baseThreadRequest, page: { after: cursor } }), {
+        authorizationBinding: 'scope-b',
+      }),
+    ).toThrowError(expect.objectContaining<Partial<TraceQueryCursorError>>({ code: 'TRACE_QUERY_CURSOR_CONFLICT' }));
+  });
+
+  it('does not exchange cursors with legacy grouped trace queries', () => {
+    const legacyPlan = planTraceQuery(parsed({ ...baseRequest, group: { by: ['threadId'] } }));
+    const legacyCursor = encodeTraceQueryCursor(legacyPlan, { result: 'groups', threadId: 'thread-1' });
+    expect(() => planThreadQuery(parsedThreads({ ...baseThreadRequest, page: { after: legacyCursor } }))).toThrowError(
+      expect.objectContaining<Partial<TraceQueryCursorError>>({ code: 'TRACE_QUERY_CURSOR_CONFLICT' }),
+    );
+
+    const threadPlan = planThreadQuery(parsedThreads());
+    const threadCursor = encodeTraceQueryCursor(threadPlan, { result: 'threads', threadId: 'thread-1' });
+    expect(() =>
+      planTraceQuery(parsed({ ...baseRequest, group: { by: ['threadId'] }, page: { after: threadCursor } })),
+    ).toThrowError(expect.objectContaining<Partial<TraceQueryCursorError>>({ code: 'TRACE_QUERY_CURSOR_CONFLICT' }));
+  });
+});
+
 describe('trace-query cursors', () => {
   it('uses locale-independent ordering and stable cursor bindings', () => {
     expect(['Ω', 'é', 'a', 'A'].sort(compareTraceQueryStrings)).toEqual(['A', 'a', 'é', 'Ω']);
@@ -1043,7 +1281,7 @@ describe('trace-query execution timeout contract', () => {
 });
 
 describe('trace-query responses and storage capability', () => {
-  it('enforces fixed trace and group projections', () => {
+  it('enforces fixed trace, legacy group, and thread projections', () => {
     const trace = {
       traceId: 'trace-1',
       rootSpanId: 'span-1',
@@ -1064,12 +1302,22 @@ describe('trace-query responses and storage capability', () => {
       traceQueryGroupResponseSchema.safeParse({ groups: [{ threadId: 'thread-1', count: 1 }], page: { next: null } })
         .success,
     ).toBe(false);
+    expect(
+      queryThreadsResultSchema.safeParse({ threads: [{ threadId: 'thread-1' }], page: { next: null } }).success,
+    ).toBe(true);
+    expect(
+      queryThreadsResultSchema.safeParse({ threads: [{ threadId: 'thread-1', count: 1 }], page: { next: null } })
+        .success,
+    ).toBe(false);
   });
 
-  it('fails closed for stores that do not implement advanced trace queries', async () => {
+  it('fails closed for stores that do not implement advanced trace or thread queries', async () => {
     const storage = new ObservabilityStorage();
     await expect(storage.queryTraces(planTraceQuery(parsed()))).rejects.toMatchObject({
       id: 'OBSERVABILITY_STORAGE_QUERY_TRACES_NOT_IMPLEMENTED',
+    });
+    await expect(storage.queryThreads(planThreadQuery(parsedThreads()))).rejects.toMatchObject({
+      id: 'OBSERVABILITY_STORAGE_QUERY_THREADS_NOT_IMPLEMENTED',
     });
   });
 });

--- a/packages/core/src/storage/domains/observability/trace-query.test.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.test.ts
@@ -158,19 +158,21 @@ describe('planTraceQuery', () => {
     });
   });
 
-  it('enforces ordered time ranges and permits ranges longer than 31 days', () => {
+  it('enforces ordered and maximum time ranges', () => {
     const reversed = validationError(() =>
       planTraceQuery(parsed({ timeRange: { from: '2026-08-02T00:00:00Z', to: '2026-08-01T00:00:00Z' } })),
     );
     expect(reversed.issues).toEqual([expect.objectContaining({ code: 'invalid_time_range', path: ['timeRange'] })]);
 
-    const longRange = planTraceQuery(
-      parsed({ timeRange: { from: '2026-01-01T00:00:00Z', to: '2026-09-01T00:00:00Z' } }),
-    );
-    expect(longRange.timeRange).toEqual({
-      from: '2026-01-01T00:00:00.000Z',
+    expect(planTraceQuery(parsed()).timeRange).toEqual({
+      from: '2026-08-01T00:00:00.000Z',
       to: '2026-09-01T00:00:00.000Z',
     });
+
+    const tooLarge = validationError(() =>
+      planTraceQuery(parsed({ timeRange: { from: '2026-07-31T23:59:59Z', to: '2026-09-01T00:00:00Z' } })),
+    );
+    expect(tooLarge.issues[0]).toMatchObject({ code: 'time_range_too_large', path: ['timeRange'] });
   });
 
   it('plans recursive trace and same-record collection predicates', () => {
@@ -1063,14 +1065,21 @@ describe('queryThreads input and planning', () => {
       expect.objectContaining({ code: 'invalid_time_range', path: ['traces', 'timeRange'] }),
     );
 
-    const longRange = planThreadQuery(
-      parsedThreads({
-        traces: { timeRange: { from: '2026-01-01T00:00:00Z', to: '2026-09-01T00:00:00Z' } },
-      }),
-    );
-    expect(longRange.traces.timeRange).toEqual({
-      from: '2026-01-01T00:00:00.000Z',
+    expect(planThreadQuery(parsedThreads()).traces.timeRange).toEqual({
+      from: '2026-08-01T00:00:00.000Z',
       to: '2026-09-01T00:00:00.000Z',
+    });
+
+    const tooLarge = validationError(() =>
+      planThreadQuery(
+        parsedThreads({
+          traces: { timeRange: { from: '2026-07-31T23:59:59Z', to: '2026-09-01T00:00:00Z' } },
+        }),
+      ),
+    );
+    expect(tooLarge.issues[0]).toMatchObject({
+      code: 'time_range_too_large',
+      path: ['traces', 'timeRange'],
     });
 
     const invalidField = validationError(() =>

--- a/packages/core/src/storage/domains/observability/trace-query.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.ts
@@ -392,6 +392,7 @@ export type TraceQueryCursorValues =
 export type TraceQueryIssueCode =
   | 'invalid_request'
   | 'invalid_time_range'
+  | 'time_range_too_large'
   | 'predicate_too_complex'
   | 'field_not_allowed'
   | 'invalid_metadata_key'
@@ -624,6 +625,12 @@ export function planTraceQuery(
   const to = new Date(request.timeRange.to);
   if (from >= to) {
     issues.push({ code: 'invalid_time_range', path: ['timeRange'], message: '`from` must be earlier than `to`' });
+  } else if (to.getTime() - from.getTime() > 31 * 24 * 60 * 60 * 1000) {
+    issues.push({
+      code: 'time_range_too_large',
+      path: ['timeRange'],
+      message: 'The time range cannot exceed 31 days',
+    });
   }
 
   if (request.group && request.orderBy) {
@@ -690,6 +697,12 @@ export function planThreadQuery(
       code: 'invalid_time_range',
       path: ['traces', 'timeRange'],
       message: '`from` must be earlier than `to`',
+    });
+  } else if (to.getTime() - from.getTime() > 31 * 24 * 60 * 60 * 1000) {
+    issues.push({
+      code: 'time_range_too_large',
+      path: ['traces', 'timeRange'],
+      message: 'The time range cannot exceed 31 days',
     });
   }
 

--- a/packages/core/src/storage/domains/observability/trace-query.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.ts
@@ -392,7 +392,6 @@ export type TraceQueryCursorValues =
 export type TraceQueryIssueCode =
   | 'invalid_request'
   | 'invalid_time_range'
-  | 'time_range_too_large'
   | 'predicate_too_complex'
   | 'field_not_allowed'
   | 'invalid_metadata_key'
@@ -625,12 +624,6 @@ export function planTraceQuery(
   const to = new Date(request.timeRange.to);
   if (from >= to) {
     issues.push({ code: 'invalid_time_range', path: ['timeRange'], message: '`from` must be earlier than `to`' });
-  } else if (to.getTime() - from.getTime() > 31 * 24 * 60 * 60 * 1000) {
-    issues.push({
-      code: 'time_range_too_large',
-      path: ['timeRange'],
-      message: 'The time range cannot exceed 31 days',
-    });
   }
 
   if (request.group && request.orderBy) {
@@ -697,12 +690,6 @@ export function planThreadQuery(
       code: 'invalid_time_range',
       path: ['traces', 'timeRange'],
       message: '`from` must be earlier than `to`',
-    });
-  } else if (to.getTime() - from.getTime() > 31 * 24 * 60 * 60 * 1000) {
-    issues.push({
-      code: 'time_range_too_large',
-      path: ['traces', 'timeRange'],
-      message: 'The time range cannot exceed 31 days',
     });
   }
 

--- a/packages/core/src/storage/domains/observability/trace-query.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.ts
@@ -114,12 +114,39 @@ export const traceQueryPredicateSchema: z.ZodType<TraceQueryPredicate> = z.lazy(
   ]),
 );
 
-const timeRangeSchema = z
+export const traceQueryTimeRangeSchema = z
   .object({
     from: z.string().datetime({ offset: true }),
     to: z.string().datetime({ offset: true }),
   })
   .strict();
+
+export const traceSelectionSchema = z
+  .object({
+    timeRange: traceQueryTimeRangeSchema,
+    where: traceQueryPredicateSchema.optional(),
+  })
+  .strict();
+
+export const threadPredicateSchema: z.ZodType<ThreadPredicate> = z.lazy(() =>
+  z.union([
+    z
+      .object({
+        op: z.enum(['and', 'or']),
+        args: z.array(threadPredicateSchema).min(1),
+      })
+      .strict(),
+    z.object({ op: z.literal('not'), arg: threadPredicateSchema }).strict(),
+    z
+      .object({
+        traces: z.union([
+          z.object({ some: traceQueryPredicateSchema }).strict(),
+          z.object({ none: traceQueryPredicateSchema }).strict(),
+        ]),
+      })
+      .strict(),
+  ]),
+);
 
 const pageSchema = z
   .object({
@@ -131,7 +158,7 @@ const pageSchema = z
 
 const traceQueryRequestObjectSchema = z
   .object({
-    timeRange: timeRangeSchema,
+    timeRange: traceQueryTimeRangeSchema,
     where: traceQueryPredicateSchema.optional(),
     group: z
       .object({ by: z.tuple([z.literal('threadId')]) })
@@ -153,13 +180,30 @@ const traceQueryRequestObjectSchema = z
   .strict();
 
 export const traceQueryRequestSchema = z.preprocess((input, context) => {
-  const issuePath = findPredicateComplexityIssue(input);
+  const issuePath = findPredicateComplexityIssue(input, [['where']]);
   if (issuePath) {
     context.addIssue({ code: 'custom', path: issuePath, message: PREDICATE_COMPLEXITY_MESSAGE });
     return z.NEVER;
   }
   return input;
 }, traceQueryRequestObjectSchema);
+
+const queryThreadsInputObjectSchema = z
+  .object({
+    traces: traceSelectionSchema,
+    where: threadPredicateSchema.optional(),
+    page: pageSchema,
+  })
+  .strict();
+
+export const queryThreadsInputSchema = z.preprocess((input, context) => {
+  const issuePath = findPredicateComplexityIssue(input, [['traces', 'where'], ['where']]);
+  if (issuePath) {
+    context.addIssue({ code: 'custom', path: issuePath, message: PREDICATE_COMPLEXITY_MESSAGE });
+    return z.NEVER;
+  }
+  return input;
+}, queryThreadsInputObjectSchema);
 
 export const traceQueryTraceSchema = z
   .object({
@@ -189,6 +233,14 @@ export const traceQueryGroupResponseSchema = z
   .strict();
 export const traceQueryResponseSchema = z.union([traceQueryTraceResponseSchema, traceQueryGroupResponseSchema]);
 
+export const threadIdentitySchema = z.object({ threadId: z.string() }).strict();
+export const queryThreadsResultSchema = z
+  .object({
+    threads: z.array(threadIdentitySchema),
+    page: responsePageSchema,
+  })
+  .strict();
+
 export type TraceQueryLiteral = string | number | boolean | null;
 export type TraceQueryPathOrLiteral = { path: string } | { literal: TraceQueryLiteral };
 export type TraceQueryScalarPredicate =
@@ -209,6 +261,19 @@ export type TraceQueryPredicate =
   | { spans: { some: TraceQueryScalarPredicate } | { none: TraceQueryScalarPredicate } }
   | { scores: { some: TraceQueryScalarPredicate } | { none: TraceQueryScalarPredicate } }
   | { feedback: { some: TraceQueryScalarPredicate } | { none: TraceQueryScalarPredicate } };
+
+export type ThreadPredicate =
+  | { op: 'and' | 'or'; args: ThreadPredicate[] }
+  | { op: 'not'; arg: ThreadPredicate }
+  | { traces: { some: TraceQueryPredicate } | { none: TraceQueryPredicate } };
+
+export type TimeRange = z.infer<typeof traceQueryTimeRangeSchema>;
+export type TraceSelection = z.input<typeof traceSelectionSchema>;
+export type NormalizedTraceSelection = z.output<typeof traceSelectionSchema>;
+export type QueryThreadsInput = z.input<typeof queryThreadsInputObjectSchema>;
+export type NormalizedQueryThreadsInput = z.output<typeof queryThreadsInputObjectSchema>;
+export type ThreadIdentity = z.infer<typeof threadIdentitySchema>;
+export type QueryThreadsResult = z.infer<typeof queryThreadsResultSchema>;
 
 export type TraceQueryRequest = z.input<typeof traceQueryRequestObjectSchema>;
 export type NormalizedTraceQueryRequest = z.output<typeof traceQueryRequestObjectSchema>;
@@ -271,6 +336,16 @@ export type TrustedTraceQueryPredicate =
       predicate: TrustedTraceQueryScalarPredicate;
     };
 
+export type TrustedThreadPredicate =
+  | { type: 'boolean'; operator: 'and' | 'or'; args: TrustedThreadPredicate[] }
+  | { type: 'not'; arg: TrustedThreadPredicate }
+  | {
+      type: 'relation';
+      collection: 'traces';
+      quantifier: 'some' | 'none';
+      predicate: TrustedTraceQueryPredicate;
+    };
+
 export interface TrustedTraceQueryBasePlan {
   timeRange: { from: string; to: string };
   where?: TrustedTraceQueryPredicate;
@@ -294,9 +369,25 @@ export interface TrustedTraceQueryGroupsPlan extends TrustedTraceQueryBasePlan {
 }
 
 export type TrustedTraceQueryPlan = TrustedTraceQueryTracesPlan | TrustedTraceQueryGroupsPlan;
+
+export interface TrustedThreadQueryPlan {
+  result: 'threads';
+  traces: {
+    timeRange: { from: string; to: string };
+    where?: TrustedTraceQueryPredicate;
+  };
+  where?: TrustedThreadPredicate;
+  orderBy: { field: 'threadId'; direction: 'asc' };
+  limit: number;
+  binding: string;
+  cursor?: { threadId: string };
+}
+
+export type TraceQueryCursorPlan = TrustedTraceQueryPlan | TrustedThreadQueryPlan;
 export type TraceQueryCursorValues =
   | { result: 'traces'; sortValue: string; traceId: string }
-  | { result: 'groups'; threadId: string };
+  | { result: 'groups'; threadId: string }
+  | { result: 'threads'; threadId: string };
 
 export type TraceQueryIssueCode =
   | 'invalid_request'
@@ -438,17 +529,27 @@ function addPredicateComplexityIssue(path: Array<string | number>, message: stri
   }
 }
 
-function findPredicateComplexityIssue(input: unknown): Array<string | number> | undefined {
-  if (!input || typeof input !== 'object' || !Object.hasOwn(input, 'where')) return undefined;
+function findPredicateComplexityIssue(
+  input: unknown,
+  rootPaths: Array<Array<string | number>>,
+): Array<string | number> | undefined {
+  if (!input || typeof input !== 'object') return undefined;
 
-  const where = (input as { where?: unknown }).where;
-  if (where === undefined) return undefined;
+  const stack: Array<{ predicate: unknown; path: Array<string | number>; depth: number }> = [];
+  for (let index = rootPaths.length - 1; index >= 0; index -= 1) {
+    const path = rootPaths[index]!;
+    let predicate: unknown = input;
+    for (const part of path) {
+      if (!predicate || typeof predicate !== 'object' || !Object.hasOwn(predicate, part)) {
+        predicate = undefined;
+        break;
+      }
+      predicate = (predicate as Record<string | number, unknown>)[part];
+    }
+    if (predicate !== undefined) stack.push({ predicate, path, depth: 1 });
+  }
 
-  const stack: Array<{ predicate: unknown; path: Array<string | number>; depth: number }> = [
-    { predicate: where, path: ['where'], depth: 1 },
-  ];
   let nodes = 0;
-
   while (stack.length > 0) {
     const frame = stack.pop()!;
     nodes += 1;
@@ -467,7 +568,7 @@ function findPredicateComplexityIssue(input: unknown): Array<string | number> | 
       continue;
     }
 
-    for (const collection of ['feedback', 'scores', 'spans'] as const) {
+    for (const collection of ['traces', 'feedback', 'scores', 'spans'] as const) {
       const clause = predicate[collection];
       if (!clause || typeof clause !== 'object') continue;
       for (const quantifier of ['none', 'some'] as const) {
@@ -499,6 +600,12 @@ export function formatTraceQuerySchemaIssues(error: z.ZodError): TraceQueryIssue
 
 export function parseTraceQueryRequest(input: unknown): NormalizedTraceQueryRequest {
   const result = traceQueryRequestSchema.safeParse(input);
+  if (!result.success) throw new TraceQueryValidationError(formatTraceQuerySchemaIssues(result.error));
+  return result.data;
+}
+
+export function parseQueryThreadsInput(input: unknown): NormalizedQueryThreadsInput {
+  const result = queryThreadsInputSchema.safeParse(input);
   if (!result.success) throw new TraceQueryValidationError(formatTraceQuerySchemaIssues(result.error));
   return result.data;
 }
@@ -572,14 +679,68 @@ export function planTraceQuery(
   };
 }
 
-export function encodeTraceQueryCursor(plan: TrustedTraceQueryPlan, values: TraceQueryCursorValues): string {
+/**
+ * Converts a structurally valid thread-query request into the canonical plan consumed by
+ * observability storage adapters.
+ *
+ * @internal This is a trusted server/storage boundary, not a client-side query builder.
+ */
+export function planThreadQuery(
+  request: NormalizedQueryThreadsInput,
+  options: { authorizationBinding?: string } = {},
+): TrustedThreadQueryPlan {
+  const issues: TraceQueryIssue[] = [];
+  const from = new Date(request.traces.timeRange.from);
+  const to = new Date(request.traces.timeRange.to);
+  if (from >= to) {
+    issues.push({
+      code: 'invalid_time_range',
+      path: ['traces', 'timeRange'],
+      message: '`from` must be earlier than `to`',
+    });
+  } else if (to.getTime() - from.getTime() > 31 * 24 * 60 * 60 * 1000) {
+    issues.push({
+      code: 'time_range_too_large',
+      path: ['traces', 'timeRange'],
+      message: 'The time range cannot exceed 31 days',
+    });
+  }
+
+  const state: PlannerState = { nodes: 0, relatedClauses: 0, literalUnits: 0, issues };
+  const traceWhere = request.traces.where
+    ? planPredicate(request.traces.where, 'trace', ['traces', 'where'], 1, state)
+    : undefined;
+  const where = request.where ? planThreadPredicate(request.where, ['where'], 1, state) : undefined;
+  if (issues.length > 0) throw new TraceQueryValidationError(issues);
+
+  const result = 'threads' as const;
+  const traces = {
+    timeRange: { from: from.toISOString(), to: to.toISOString() },
+    where: traceWhere,
+  };
+  const orderBy = { field: 'threadId', direction: 'asc' } as const;
+  const binding = digestBinding({ traces, where, result, orderBy, authorization: options.authorizationBinding });
+  const cursor = request.page.after ? decodeTraceQueryCursor(request.page.after, result, binding) : undefined;
+
+  return {
+    result,
+    traces,
+    where,
+    orderBy,
+    limit: request.page.limit,
+    binding,
+    cursor: cursor?.result === 'threads' ? { threadId: cursor.threadId } : undefined,
+  };
+}
+
+export function encodeTraceQueryCursor(plan: TraceQueryCursorPlan, values: TraceQueryCursorValues): string {
   if (values.result !== plan.result) throw new TraceQueryCursorError('TRACE_QUERY_CURSOR_CONFLICT');
   return Buffer.from(JSON.stringify({ version: 1, binding: plan.binding, values }), 'utf8').toString('base64url');
 }
 
 function decodeTraceQueryCursor(
   cursor: string,
-  expectedResult: 'traces' | 'groups',
+  expectedResult: TraceQueryCursorValues['result'],
   expectedBinding: string,
 ): TraceQueryCursorValues {
   let parsed: unknown;
@@ -610,9 +771,52 @@ const cursorEnvelopeSchema = z
         })
         .strict(),
       z.object({ result: z.literal('groups'), threadId: z.string().min(1) }).strict(),
+      z.object({ result: z.literal('threads'), threadId: z.string().min(1) }).strict(),
     ]),
   })
   .strict();
+
+function planThreadPredicate(
+  predicate: ThreadPredicate,
+  path: Array<string | number>,
+  depth: number,
+  state: PlannerState,
+): TrustedThreadPredicate | undefined {
+  state.nodes += 1;
+  if (depth > TRACE_QUERY_MAX_DEPTH || state.nodes > TRACE_QUERY_MAX_NODES) {
+    addPredicateComplexityIssue(path, PREDICATE_COMPLEXITY_MESSAGE, state);
+    return undefined;
+  }
+
+  if ('traces' in predicate) {
+    state.relatedClauses += 1;
+    if (state.relatedClauses > TRACE_QUERY_MAX_RELATED_CLAUSES) {
+      addPredicateComplexityIssue(
+        path,
+        `Trace queries are limited to ${TRACE_QUERY_MAX_RELATED_CLAUSES} related collection clauses`,
+        state,
+      );
+    }
+    const quantifier = 'some' in predicate.traces ? 'some' : 'none';
+    const nested = 'some' in predicate.traces ? predicate.traces.some : predicate.traces.none;
+    const planned = planPredicate(nested, 'trace', [...path, 'traces', quantifier], depth + 1, state);
+    return planned ? { type: 'relation', collection: 'traces', quantifier, predicate: planned } : undefined;
+  }
+
+  if (predicate.op === 'and' || predicate.op === 'or') {
+    const args = predicate.args
+      .map((arg, index) => planThreadPredicate(arg, [...path, 'args', index], depth + 1, state))
+      .filter((arg): arg is TrustedThreadPredicate => arg !== undefined);
+    return { type: 'boolean', operator: predicate.op, args };
+  }
+
+  if (predicate.op === 'not') {
+    const arg = planThreadPredicate(predicate.arg, [...path, 'arg'], depth + 1, state);
+    return arg ? { type: 'not', arg } : undefined;
+  }
+
+  return undefined;
+}
 
 function planPredicate(
   predicate: TraceQueryPredicate | TraceQueryScalarPredicate,

--- a/stores/_test-utils/src/domains/observability-vnext/trace-query.test.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/trace-query.test.ts
@@ -1,10 +1,15 @@
-import { parseTraceQueryRequest, planTraceQuery } from '@mastra/core/storage';
+import { parseTraceQueryRequest, planThreadQuery, planTraceQuery } from '@mastra/core/storage';
 import { describe, expect, it } from 'vitest';
 import {
+  collectThreadQueryPages,
   collectTraceQueryPages,
+  evaluateThreadQuery,
+  evaluateThreadQueryRequest,
   evaluateTraceQuery,
   evaluateTraceQueryRequest,
   normalizeTraceQueryResponse,
+  THREAD_QUERY_CONFORMANCE_CASES,
+  THREAD_QUERY_FIXTURE_DATA,
   TRACE_QUERY_CONFORMANCE_CASES,
   TRACE_QUERY_FEEDBACK_REPLACEMENT_SCENARIOS,
   TRACE_QUERY_FIXTURE_DATA,
@@ -141,5 +146,53 @@ describe('trace-query reference evaluator', () => {
     expect(
       normalizeTraceQueryResponse(evaluateTraceQuery(TRACE_QUERY_FIXTURE_DATA, planTraceQuery(normalized))),
     ).toEqual([{ traceId: 'trace-d' }, { traceId: 'trace-c' }]);
+  });
+});
+
+describe('thread-query reference evaluator', () => {
+  for (const testCase of THREAD_QUERY_CONFORMANCE_CASES) {
+    it(testCase.name, () => {
+      expect(evaluateThreadQueryRequest(THREAD_QUERY_FIXTURE_DATA, testCase.request).threads).toEqual(
+        testCase.expected,
+      );
+    });
+  }
+
+  it('returns only thread identities', () => {
+    expect(
+      evaluateThreadQueryRequest(THREAD_QUERY_FIXTURE_DATA, {
+        traces: { timeRange: { from: '2026-08-01T00:00:00Z', to: '2026-09-01T00:00:00Z' } },
+        where: {
+          traces: {
+            some: { op: 'eq', left: { path: 'threadId' }, right: { literal: 'thread-1' } },
+          },
+        },
+      }),
+    ).toEqual({ threads: [{ threadId: 'thread-1' }], page: { next: null } });
+  });
+
+  it('traverses thread pages without duplicates or omissions', async () => {
+    const request = {
+      traces: { timeRange: { from: '2026-08-01T00:00:00Z', to: '2026-09-01T00:00:00Z' } },
+      page: { limit: 1 },
+    };
+    const results = await collectThreadQueryPages(async normalized => {
+      return evaluateThreadQuery(THREAD_QUERY_FIXTURE_DATA, planThreadQuery(normalized));
+    }, request);
+
+    expect(results).toEqual([{ threadId: 'thread-1' }, { threadId: 'thread-2' }]);
+    expect(new Set(results.map(result => result.threadId)).size).toBe(results.length);
+  });
+
+  it('paginates mixed-case and non-ASCII threads using ordinal order', async () => {
+    const results = await collectThreadQueryPages(
+      async normalized => evaluateThreadQuery(TRACE_QUERY_ORDINAL_FIXTURE_DATA, planThreadQuery(normalized)),
+      {
+        traces: { timeRange: { from: '2026-08-01T00:00:00Z', to: '2026-09-01T00:00:00Z' } },
+        page: { limit: 1 },
+      },
+    );
+
+    expect(results).toEqual([{ threadId: 'A' }, { threadId: 'a' }, { threadId: 'é' }, { threadId: 'Ω' }]);
   });
 });

--- a/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
@@ -1,15 +1,22 @@
 import {
   compareTraceQueryStrings,
   encodeTraceQueryCursor,
+  parseQueryThreadsInput,
   parseTraceQueryRequest,
+  planThreadQuery,
   planTraceQuery,
+  type NormalizedQueryThreadsInput,
   type NormalizedTraceQueryRequest,
+  type QueryThreadsInput,
+  type QueryThreadsResult,
   type TraceQueryGroupResponse,
   type TraceQueryPredicate,
   type TraceQueryRequest,
   type TraceQueryResponse,
   type TraceQueryTrace,
   type TraceQueryTraceResponse,
+  type TrustedThreadPredicate,
+  type TrustedThreadQueryPlan,
   type TrustedTraceQueryPlan,
   type TrustedTraceQueryPredicate,
   type TrustedTraceQueryScalarPredicate,
@@ -864,6 +871,27 @@ export const TRACE_QUERY_FIXTURE_DATA: TraceQueryFixtureData = {
   ],
 };
 
+export const THREAD_QUERY_FIXTURE_DATA: TraceQueryFixtureData = {
+  spans: [...TRACE_QUERY_FIXTURE_DATA.spans],
+  scores: [...TRACE_QUERY_FIXTURE_DATA.scores],
+  feedback: [
+    ...TRACE_QUERY_FIXTURE_DATA.feedback,
+    feedbackRecord(
+      10,
+      'feedback-b-cross-trace-correction',
+      'trace-b',
+      'clinician-correction',
+      'clinician',
+      'Use 10 mg',
+      {
+        feedbackUserId: 'clinician-2',
+        sourceId: 'cross-trace-correction',
+        timestamp: '2026-08-21T10:00:00.000Z',
+      },
+    ),
+  ],
+};
+
 const tiedStartedAt = '2026-08-20T10:00:00.000Z';
 const tiedEndedAt = '2026-08-20T10:00:01.000Z';
 const tiedScoreTimestamp = '2026-08-20T10:00:02.000Z';
@@ -920,6 +948,263 @@ const fullRange = {
   from: '2026-08-01T00:00:00Z',
   to: '2026-09-01T00:00:00Z',
 };
+
+const lowFactualityTracePredicate: TraceQueryPredicate = {
+  scores: {
+    some: {
+      op: 'and',
+      args: [
+        { op: 'eq', left: { path: 'scorerId' }, right: { literal: 'factuality' } },
+        { op: 'lt', left: { path: 'score' }, right: { literal: 0.6 } },
+      ],
+    },
+  },
+};
+
+const crossTraceCorrectionPredicate: TraceQueryPredicate = {
+  feedback: {
+    some: {
+      op: 'and',
+      args: [
+        { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'clinician-correction' } },
+        { op: 'eq', left: { path: 'feedbackSource' }, right: { literal: 'clinician' } },
+        { op: 'eq', left: { path: 'sourceId' }, right: { literal: 'cross-trace-correction' } },
+      ],
+    },
+  },
+};
+
+const originalCorrectionPredicate: TraceQueryPredicate = {
+  feedback: {
+    some: {
+      op: 'and',
+      args: [
+        { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'clinician-correction' } },
+        { op: 'eq', left: { path: 'feedbackUserId' }, right: { literal: 'clinician-1' } },
+      ],
+    },
+  },
+};
+
+const clinicalReviewPredicate = {
+  op: 'eq',
+  left: { path: 'feedbackType' },
+  right: { literal: 'clinical-review' },
+} as const;
+
+export interface ThreadQueryConformanceCase {
+  name: string;
+  request: QueryThreadsInput;
+  expected: Array<{ threadId: string }>;
+}
+
+export const THREAD_QUERY_CONFORMANCE_CASES: ThreadQueryConformanceCase[] = [
+  {
+    name: 'returns distinct non-null threads from current completed traces',
+    request: { traces: { timeRange: fullRange } },
+    expected: [{ threadId: 'thread-1' }, { threadId: 'thread-2' }],
+  },
+  {
+    name: 'qualifies a thread with evidence on different traces',
+    request: {
+      traces: { timeRange: fullRange },
+      where: {
+        op: 'and',
+        args: [{ traces: { some: lowFactualityTracePredicate } }, { traces: { some: crossTraceCorrectionPredicate } }],
+      },
+    },
+    expected: [{ threadId: 'thread-1' }],
+  },
+  {
+    name: 'does not combine different traces inside one traces.some',
+    request: {
+      traces: { timeRange: fullRange },
+      where: {
+        traces: {
+          some: { op: 'and', args: [lowFactualityTracePredicate, crossTraceCorrectionPredicate] },
+        },
+      },
+    },
+    expected: [],
+  },
+  {
+    name: 'allows separate traces.some clauses to match the same trace',
+    request: {
+      traces: { timeRange: fullRange },
+      where: {
+        op: 'and',
+        args: [{ traces: { some: lowFactualityTracePredicate } }, { traces: { some: originalCorrectionPredicate } }],
+      },
+    },
+    expected: [{ threadId: 'thread-1' }],
+  },
+  {
+    name: 'distinguishes a trace with no matching feedback from a thread with no matching trace',
+    request: {
+      traces: { timeRange: fullRange },
+      where: { traces: { some: { feedback: { none: clinicalReviewPredicate } } } },
+    },
+    expected: [{ threadId: 'thread-1' }],
+  },
+  {
+    name: 'requires no eligible trace to have matching feedback for traces.none',
+    request: {
+      traces: { timeRange: fullRange },
+      where: { traces: { none: { feedback: { some: clinicalReviewPredicate } } } },
+    },
+    expected: [],
+  },
+  {
+    name: 'applies trace eligibility before thread qualification',
+    request: {
+      traces: {
+        timeRange: fullRange,
+        where: { op: 'eq', left: { path: 'environment' }, right: { literal: 'production' } },
+      },
+      where: {
+        op: 'and',
+        args: [{ traces: { some: lowFactualityTracePredicate } }, { traces: { some: crossTraceCorrectionPredicate } }],
+      },
+    },
+    expected: [],
+  },
+  {
+    name: 'keeps nested span predicates bound to one current span',
+    request: {
+      traces: { timeRange: fullRange },
+      where: {
+        traces: {
+          some: {
+            spans: {
+              some: {
+                op: 'and',
+                args: [
+                  { op: 'eq', left: { path: 'name' }, right: { literal: 'medication_lookup' } },
+                  { op: 'eq', left: { path: 'model' }, right: { literal: 'gpt-5' } },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+    expected: [],
+  },
+  {
+    name: 'keeps nested score predicates bound to one current score',
+    request: {
+      traces: {
+        timeRange: fullRange,
+        where: { op: 'eq', left: { path: 'environment' }, right: { literal: 'staging' } },
+      },
+      where: { traces: { some: lowFactualityTracePredicate } },
+    },
+    expected: [],
+  },
+  {
+    name: 'keeps nested feedback predicates bound to one current feedback record',
+    request: {
+      traces: {
+        timeRange: fullRange,
+        where: { op: 'eq', left: { path: 'environment' }, right: { literal: 'staging' } },
+      },
+      where: {
+        traces: {
+          some: {
+            feedback: {
+              some: {
+                op: 'and',
+                args: [
+                  { op: 'eq', left: { path: 'feedbackType' }, right: { literal: 'clinical-review' } },
+                  { op: 'eq', left: { path: 'feedbackSource' }, right: { literal: 'clinician' } },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+    expected: [],
+  },
+  {
+    name: 'uses current related records inside a matching trace',
+    request: {
+      traces: { timeRange: fullRange },
+      where: {
+        traces: {
+          some: {
+            spans: {
+              some: {
+                op: 'and',
+                args: [
+                  { op: 'eq', left: { path: 'name' }, right: { literal: 'medication_lookup' } },
+                  { op: 'exists', path: 'error' },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+    expected: [{ threadId: 'thread-1' }],
+  },
+  {
+    name: 'does not qualify through a superseded trace root',
+    request: {
+      traces: { timeRange: fullRange },
+      where: {
+        traces: {
+          some: { op: 'eq', left: { path: 'resourceId' }, right: { literal: 'resource-old' } },
+        },
+      },
+    },
+    expected: [],
+  },
+  {
+    name: 'supports thread boolean or',
+    request: {
+      traces: { timeRange: fullRange },
+      where: {
+        op: 'or',
+        args: [
+          {
+            traces: {
+              some: { op: 'eq', left: { path: 'environment' }, right: { literal: 'staging' } },
+            },
+          },
+          {
+            traces: {
+              some: { op: 'eq', left: { path: 'status' }, right: { literal: 'error' } },
+            },
+          },
+        ],
+      },
+    },
+    expected: [{ threadId: 'thread-1' }, { threadId: 'thread-2' }],
+  },
+  {
+    name: 'supports thread boolean not',
+    request: {
+      traces: { timeRange: fullRange },
+      where: {
+        op: 'not',
+        arg: {
+          traces: {
+            some: { op: 'eq', left: { path: 'status' }, right: { literal: 'error' } },
+          },
+        },
+      },
+    },
+    expected: [{ threadId: 'thread-1' }],
+  },
+  {
+    name: 'applies time range to trace starts before deriving threads',
+    request: {
+      traces: { timeRange: { from: '2026-08-06T00:00:00Z', to: '2026-08-09T00:00:00Z' } },
+    },
+    expected: [{ threadId: 'thread-2' }],
+  },
+];
 
 export interface TraceQueryConformanceCase {
   name: string;
@@ -1692,6 +1977,63 @@ export function evaluateTraceQuery(data: TraceQueryFixtureData, plan: TrustedTra
   return { traces: page, page: { next } } satisfies TraceQueryTraceResponse;
 }
 
+export function evaluateThreadQuery(data: TraceQueryFixtureData, plan: TrustedThreadQueryPlan): QueryThreadsResult {
+  const spans = currentSpans(data.spans);
+  const scores = currentScores(data.scores);
+  const feedback = currentFeedback(data.feedback);
+  const eligibleRoots = currentRoots(data.spans)
+    .filter(root => !root.isPending && root.endedAt !== null)
+    .filter(root => root.startedAt >= plan.traces.timeRange.from && root.startedAt < plan.traces.timeRange.to)
+    .filter(root => !plan.traces.where || evaluateTracePredicate(plan.traces.where, root, spans, scores, feedback));
+
+  const rootsByThread = new Map<string, RawTraceQuerySpan[]>();
+  for (const root of eligibleRoots) {
+    if (root.threadId === null) continue;
+    const roots = rootsByThread.get(root.threadId) ?? [];
+    roots.push(root);
+    rootsByThread.set(root.threadId, roots);
+  }
+
+  let threadIds = [...rootsByThread]
+    .filter(([, roots]) => !plan.where || evaluateThreadPredicate(plan.where, roots, spans, scores, feedback))
+    .map(([threadId]) => threadId)
+    .sort(compareTraceQueryStrings);
+  if (plan.cursor) {
+    threadIds = threadIds.filter(threadId => compareTraceQueryStrings(threadId, plan.cursor!.threadId) > 0);
+  }
+
+  const visible = threadIds.slice(0, plan.limit + 1);
+  const hasNext = visible.length > plan.limit;
+  const page = visible.slice(0, plan.limit);
+  const next = hasNext ? encodeTraceQueryCursor(plan, { result: 'threads', threadId: page[page.length - 1]! }) : null;
+  return { threads: page.map(threadId => ({ threadId })), page: { next } };
+}
+
+export function evaluateThreadQueryRequest(
+  data: TraceQueryFixtureData,
+  request: QueryThreadsInput,
+): QueryThreadsResult {
+  return evaluateThreadQuery(data, planThreadQuery(parseQueryThreadsInput(request)));
+}
+
+export async function collectThreadQueryPages(
+  execute: (request: NormalizedQueryThreadsInput) => Promise<QueryThreadsResult>,
+  request: QueryThreadsInput,
+): Promise<Array<{ threadId: string }>> {
+  const results: Array<{ threadId: string }> = [];
+  let after: string | null | undefined;
+  do {
+    const normalized = parseQueryThreadsInput({
+      ...request,
+      page: { ...request.page, after },
+    });
+    const response = await execute(normalized);
+    results.push(...response.threads);
+    after = response.page.next;
+  } while (after);
+  return results;
+}
+
 export function evaluateTraceQueryRequest(data: TraceQueryFixtureData, request: TraceQueryRequest): TraceQueryResponse {
   return evaluateTraceQuery(data, planTraceQuery(parseTraceQueryRequest(request)));
 }
@@ -1765,6 +2107,25 @@ function currentFeedback(feedback: RawTraceQueryFeedback[]): RawTraceQueryFeedba
     if (!current || candidate.cursorId > current.cursorId) records.set(candidate.feedbackId, candidate);
   }
   return [...records.values()];
+}
+
+function evaluateThreadPredicate(
+  predicate: TrustedThreadPredicate,
+  roots: RawTraceQuerySpan[],
+  spans: RawTraceQuerySpan[],
+  scores: RawTraceQueryScore[],
+  feedback: RawTraceQueryFeedback[],
+): boolean {
+  if (predicate.type === 'relation') {
+    const matched = roots.some(root => evaluateTracePredicate(predicate.predicate, root, spans, scores, feedback));
+    return predicate.quantifier === 'some' ? matched : !matched;
+  }
+  if (predicate.type === 'boolean') {
+    return predicate.operator === 'and'
+      ? predicate.args.every(arg => evaluateThreadPredicate(arg, roots, spans, scores, feedback))
+      : predicate.args.some(arg => evaluateThreadPredicate(arg, roots, spans, scores, feedback));
+  }
+  return !evaluateThreadPredicate(predicate.arg, roots, spans, scores, feedback);
 }
 
 function evaluateTracePredicate(


### PR DESCRIPTION
Adds the core and storage-facing contract for querying thread identities across eligible traces. The new planner keeps trace eligibility separate from thread qualification, shares validation budgets across both scopes, binds opaque cursors to the normalized operation, and leaves legacy grouped `queryTraces()` behavior unchanged.

The adapter-facing API is `ObservabilityStorage.queryThreads(plan: TrustedThreadQueryPlan): Promise<QueryThreadsResult>`. It returns identity-only results, while the public Client JS method will be introduced separately as `mastraClient.queryTraceThreads()` to distinguish observability-derived identities from memory threads.

Trace and thread queries require explicit ISO timestamp ranges of no more than 31 days. Storage adapters also retain their configurable execution timeouts.

The shared reference evaluator covers cross-trace qualification, same-trace binding, negative predicates, current-record collapse, null thread exclusion, ordinal ordering, and cursor pagination. Database execution follows in OBS-333; the authenticated server endpoint and Client JS API follow in OBS-334.

Tested with the focused core and reference-evaluator suites, including exact 31-day boundary coverage for both planners, core check and typecheck, the full core suite (15,197 passed), core build, Prettier, and git diff validation.

Linear: https://linear.app/kepler-crm/issue/OBS-332/thread-query-001-define-querythreads-contract-and-semantics
