### PR TITLE
fix(playground): keep purge confirmation open while the request is pending

### DIFF
--- a/.changeset/purge-confirm-stays-open.md
+++ b/.changeset/purge-confirm-stays-open.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Keep the "Purge Data" confirmation open while the purge request is in flight. Previously the dialog dismissed itself as soon as the confirm button was clicked, hiding the pending state and any failure behind a toast.

--- a/packages/playground/src/domains/datasets/components/dataset-detail/__tests__/item-detail-dialog.msw.test.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/__tests__/item-detail-dialog.msw.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -34,16 +34,18 @@ describe('ItemDetailDialog', () => {
 
       fireEvent.click(screen.getByRole('button', { name: 'Purge Data' }));
       const confirmation = await screen.findByRole('alertdialog');
-      const observeDefault = vi.fn((event: MouseEvent) => event.defaultPrevented);
-      document.addEventListener('click', observeDefault);
       fireEvent.click(within(confirmation).getByRole('button', { name: 'Purge Data' }));
-      document.removeEventListener('click', observeDefault);
 
-      expect(observeDefault).toHaveReturnedWith(true);
       expect((await within(confirmation).findByRole('button', { name: 'Purging...' })).hasAttribute('disabled')).toBe(
         true,
       );
+      // Let any close transition settle: a dismissed dialog unmounts a tick later,
+      // so checking synchronously would race the assertion.
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 50));
+      });
       expect(screen.getByRole('alertdialog')).toBe(confirmation);
+      expect(confirmation.hasAttribute('data-open')).toBe(true);
 
       await waitFor(() => expect(resolveRequest).toBeTypeOf('function'));
       resolveRequest?.();

--- a/packages/playground/src/domains/datasets/components/dataset-detail/item-detail-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/item-detail-dialog.tsx
@@ -298,15 +298,18 @@ export function ItemDetailDialog({
           </AlertDialog.Header>
           <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action
-              onClick={event => {
-                event.preventDefault();
-                void handlePurgeConfirm();
-              }}
+            {/* Deliberately a Button rather than AlertDialog.Action: Action is a
+                Close that dismisses the dialog on click regardless of
+                preventDefault, which would hide the pending state and a failed
+                purge behind a toast. */}
+            <Button
+              variant="primary"
+              size="lg"
+              onClick={() => void handlePurgeConfirm()}
               disabled={purgeItem.isPending}
             >
               {purgeItem.isPending ? 'Purging...' : 'Purge Data'}
-            </AlertDialog.Action>
+            </Button>
           </AlertDialog.Footer>
         </AlertDialog.Content>
       </AlertDialog>


### PR DESCRIPTION
## Summary

Clicking **Purge Data** in the dataset item confirmation dialog dismissed the dialog immediately, before the purge request finished. The pending "Purging..." state was never visible and a failed purge was only surfaced as a toast after the dialog was already gone.

Cause: `AlertDialog.Action` is a Base UI `Close`. Base UI runs the consumer `onClick` first and then its own close handler unconditionally; `event.preventDefault()` does not stop it. The confirm button is now a plain `Button` (same approach as `delete-experiment-dialog.tsx`), so the dialog stays open with a disabled "Purging..." button until the request settles.

This is also the cause of the flaky `item-detail-dialog.msw.test.tsx` failure on **UNIT Test (Shard 4)** (e.g. on #23547): the test only passed when its assertion ran before the dialog unmounted. The test now settles a tick before asserting the dialog is still open, and deterministically fails against the old component.

## Test plan

- [x] `item-detail-dialog.msw.test.tsx` passes 3/3 locally; fails at the "still open" assertion when the component change is reverted
- [x] `packages/playground` datasets suite: 31 files / 167 tests pass
- [x] `tsc --noEmit`, oxfmt, eslint clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The purge confirmation stays visible while data is being deleted. Users can see the loading state and any failure instead of the dialog closing too soon.

## Changes

- Replaced `AlertDialog.Action` with `Button` in the purge confirmation.
- Disabled the button while purging to prevent repeated requests.
- Updated the regression test to wait for request settling and verify the dialog remains open.
- Added a patch changeset for `mastra`.

## Validation

- Dataset suite passed: 31 files and 167 tests.
- `tsc --noEmit`, `oxfmt`, and `eslint` passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->