### PR TITLE
fix(channels): let ToolDisplayFn own approval resolved state

### DIFF
--- a/.changeset/channels-tool-display-fn-owns-approval-resolved-state.md
+++ b/.changeset/channels-tool-display-fn-owns-approval-resolved-state.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+`ToolDisplayFn` (function-form `toolDisplay`) now owns the full approval lifecycle. Two new `ToolDisplayEvent` kinds — `approved` and `denied` — are dispatched when the user clicks Approve or Deny on a tool-approval card, alongside the existing `running`/`result`/`error`/`approval` kinds. A renderer that returned the original approval card can now return a `{ kind: 'post', message }` to replace it with its own resolved-state rendering (e.g. a localized "Approved ✓" or "Denied ✗ by Alice" message), or `undefined` to opt out of the edit entirely. The framework's hardcoded `formatToolApproved` / `formatToolDenied` is preserved as the fallback for adapters that did not configure a function-form `toolDisplay`, so existing `'cards'` / `'text'` configurations are unchanged.

--- a/packages/core/src/channels/__tests__/stream-helpers.test.ts
+++ b/packages/core/src/channels/__tests__/stream-helpers.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, vi } from 'vitest';
 
-import { ToolTracker, editOrPostMessage, extractErrorMessage, postFileAttachment } from '../stream-helpers';
+import {
+  ToolTracker,
+  editOrPostMessage,
+  extractErrorMessage,
+  isBlankToolMessage,
+  postFileAttachment,
+  renderBuiltInToolEvent,
+} from '../stream-helpers';
+import { getChatModule } from '../chat-lazy';
 
 describe('ToolTracker', () => {
   it('tracks a tool start and returns enrichment', () => {
@@ -270,5 +278,134 @@ describe('extractErrorMessage', () => {
   it('returns null/undefined unchanged', () => {
     expect(extractErrorMessage(null)).toBe(null);
     expect(extractErrorMessage(undefined)).toBe(undefined);
+  });
+});
+
+describe('isBlankToolMessage', () => {
+  it('treats empty/whitespace-only strings as blank', () => {
+    expect(isBlankToolMessage('')).toBe(true);
+    expect(isBlankToolMessage('   ')).toBe(true);
+    expect(isBlankToolMessage('\n\t')).toBe(true);
+  });
+
+  it('treats non-blank strings as not blank', () => {
+    expect(isBlankToolMessage('hello')).toBe(false);
+    expect(isBlankToolMessage('  hi  ')).toBe(false);
+  });
+
+  it('treats empty/whitespace-only { markdown } as blank', () => {
+    expect(isBlankToolMessage({ markdown: '' })).toBe(true);
+    expect(isBlankToolMessage({ markdown: '   \n  ' })).toBe(true);
+  });
+
+  it('treats non-blank { markdown } as not blank', () => {
+    expect(isBlankToolMessage({ markdown: 'hi' })).toBe(false);
+  });
+
+  it('does not treat Block Kit Card objects as blank', () => {
+    expect(isBlankToolMessage({ children: [] } as any)).toBe(false);
+  });
+});
+
+describe('renderBuiltInToolEvent', () => {
+  it('renders an approved event as a plain text "Approved" message', async () => {
+    await getChatModule();
+    const message = renderBuiltInToolEvent(
+      {
+        kind: 'approved',
+        toolCallId: 't1',
+        toolName: 'weather',
+        displayName: 'weather',
+        argsSummary: 'NYC',
+        args: { city: 'NYC' },
+      },
+      'text',
+    );
+    expect(typeof message).toBe('string');
+    expect(message).toContain('*weather*');
+    expect(message).toContain('✓ Approved');
+  });
+
+  it('renders an approved event as a card "Approved" message', async () => {
+    await getChatModule();
+    const message = renderBuiltInToolEvent(
+      {
+        kind: 'approved',
+        toolCallId: 't1',
+        toolName: 'weather',
+        displayName: 'weather',
+        argsSummary: 'NYC',
+        args: { city: 'NYC' },
+      },
+      'cards',
+    );
+    expect(JSON.stringify(message)).toContain('✓ Approved');
+    expect(JSON.stringify(message)).toContain('weather');
+  });
+
+  it('renders a denied event with the user attribution', async () => {
+    await getChatModule();
+    const message = renderBuiltInToolEvent(
+      {
+        kind: 'denied',
+        toolCallId: 't1',
+        toolName: 'weather',
+        displayName: 'weather',
+        argsSummary: 'NYC',
+        args: { city: 'NYC' },
+        byUser: 'alice',
+      },
+      'text',
+    );
+    expect(typeof message).toBe('string');
+    expect(message).toContain('*weather*');
+    expect(message).toContain('✗ Denied');
+    expect(message).toContain('by alice');
+  });
+
+  it('renders a denied event without a "by …" suffix when byUser is undefined', async () => {
+    await getChatModule();
+    const message = renderBuiltInToolEvent(
+      {
+        kind: 'denied',
+        toolCallId: 't1',
+        toolName: 'weather',
+        displayName: 'weather',
+        argsSummary: 'NYC',
+        args: { city: 'NYC' },
+      },
+      'text',
+    );
+    expect(typeof message).toBe('string');
+    expect(message).not.toContain('by ');
+  });
+
+  it('still renders the existing kinds (running/result/error/approval)', async () => {
+    await getChatModule();
+    const running = renderBuiltInToolEvent(
+      {
+        kind: 'running',
+        toolCallId: 't1',
+        toolName: 'weather',
+        displayName: 'weather',
+        argsSummary: 'NYC',
+        args: { city: 'NYC' },
+      },
+      'text',
+    );
+    expect(running).toContain('*weather*');
+
+    const approval = renderBuiltInToolEvent(
+      {
+        kind: 'approval',
+        toolCallId: 't1',
+        toolName: 'weather',
+        displayName: 'weather',
+        argsSummary: 'NYC',
+        args: { city: 'NYC' },
+      },
+      'text',
+    );
+    expect(JSON.stringify(approval)).toContain('Requires approval');
   });
 });

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -36,6 +36,7 @@ import { ChatChannelOutputProcessor, CHAT_CHANNEL_RENDER_CONTEXT_KEY } from './o
 import type { ChatChannelRenderContext } from './output-processor';
 import { ChatChannelProcessor } from './processor';
 import { MastraStateAdapter } from './state-adapter';
+import { isBlankToolMessage } from './stream-helpers';
 import type { PendingApprovalRecord } from './stream-helpers';
 import type {
   ChannelAdapterConfig,
@@ -49,6 +50,7 @@ import type {
   StreamingConfig,
   ThreadHistoryMessage,
   ToolDisplay,
+  ToolDisplayEvent,
   ToolDisplayFn,
 } from './types';
 import { defaultTypingStatus } from './typing-status';
@@ -615,28 +617,53 @@ export class AgentChannels {
               // Build the card header with tool name and args
               const displayName = toolName ? stripToolPrefix(toolName) : 'tool';
               const argsSummary = toolArgs ? formatArgsSummary(toolArgs) : '';
-              // Resolve the tool display mode so the approve/deny edit matches
-              // the original card's rendering (cards → Block Kit, text → plain).
-              // Streaming is irrelevant here — we're outside the agent loop.
-              const { resolved: toolDisplay } = this.resolveToolDisplay(
+              const streamingEnabled = this.resolveStreaming(adapterConfig?.streaming).enabled;
+              const { resolved: toolDisplay, fn: toolDisplayFn } = this.resolveToolDisplay(
                 platform,
                 adapterConfig?.toolDisplay,
-                false,
+                streamingEnabled,
                 adapterConfig?.cards,
                 adapterConfig?.formatToolCall,
               );
               const useCards = toolDisplay === 'cards';
+              const renderMode: 'streaming' | 'static' = streamingEnabled ? 'streaming' : 'static';
+
+              const resolveResolvedMessage = (kind: 'approved' | 'denied', byUser?: string): PostableMessage | null => {
+                if (toolDisplayFn) {
+                  const result = toolDisplayFn(
+                    {
+                      kind,
+                      toolCallId,
+                      toolName: toolName ?? '',
+                      displayName,
+                      argsSummary,
+                      args: toolArgs,
+                      byUser,
+                    },
+                    { mode: renderMode, platform },
+                  );
+                  if (result == null) return null;
+                  if (result.kind === 'post') {
+                    return result.message == null || isBlankToolMessage(result.message) ? null : result.message;
+                  }
+                  return kind === 'approved'
+                    ? formatToolApproved(displayName, argsSummary, useCards)
+                    : formatToolDenied(displayName, argsSummary, byUser, useCards);
+                }
+                return kind === 'approved'
+                  ? formatToolApproved(displayName, argsSummary, useCards)
+                  : formatToolDenied(displayName, argsSummary, byUser, useCards);
+              };
 
               if (!approved) {
                 const byUser = chatThread.isDM ? undefined : event.user.fullName || event.user.userName || 'User';
-                try {
-                  await adapter.editMessage(
-                    chatThread.id,
-                    messageId,
-                    formatToolDenied(displayName, argsSummary, byUser, useCards),
-                  );
-                } catch (err) {
-                  this.log('debug', 'Failed to edit denied card', err);
+                const resolvedMessage = resolveResolvedMessage('denied', byUser);
+                if (resolvedMessage != null) {
+                  try {
+                    await adapter.editMessage(chatThread.id, messageId, resolvedMessage);
+                  } catch (err) {
+                    this.log('debug', 'Failed to edit denied card', err);
+                  }
                 }
 
                 // Resume the suspended run with a denial so the agent can produce a
@@ -682,14 +709,14 @@ export class AgentChannels {
               }
 
               // Immediately edit the card to show "Approved" and remove the buttons
-              try {
-                await adapter.editMessage(
-                  chatThread.id,
-                  messageId,
-                  formatToolApproved(displayName, argsSummary, useCards),
-                );
-              } catch (err) {
-                this.log('debug', 'Failed to edit approved card', err);
+              const approvedByUser = chatThread.isDM ? undefined : event.user.fullName || event.user.userName || 'User';
+              const approvedMessage = resolveResolvedMessage('approved', approvedByUser);
+              if (approvedMessage != null) {
+                try {
+                  await adapter.editMessage(chatThread.id, messageId, approvedMessage);
+                } catch (err) {
+                  this.log('debug', 'Failed to edit approved card', err);
+                }
               }
 
               // Build request context for the resumed stream. Stash the render

--- a/packages/core/src/channels/chat-driver-streaming.ts
+++ b/packages/core/src/channels/chat-driver-streaming.ts
@@ -9,6 +9,7 @@ import type { PendingApprovalRecord } from './stream-helpers';
 import {
   ToolTracker,
   editOrPostMessage,
+  isBlankToolMessage,
   postFileAttachment,
   postStreamError,
   postTripwire,
@@ -297,15 +298,6 @@ export async function runStreamingDriver({
    * chunk reopen a fresh session. Used for `'cards'`/`'text'` tool events
    * and `ToolDisplayFn` `{ kind: 'post' }` returns.
    */
-  /**
-   * Skip blank tool posts so a fn that intentionally returns "" or an empty
-   * `{ markdown }` doesn't post or edit in an empty platform message.
-   * Mirrors the static driver's guard in `renderToolEvent`.
-   */
-  const isBlankToolMessage = (message: PostableMessage): boolean => {
-    if (typeof message === 'string') return message.trim().length === 0;
-    return 'markdown' in message && message.markdown.trim().length === 0;
-  };
 
   const postOutOfBand = async (message: PostableMessage): Promise<string | undefined> => {
     await closeSession();

--- a/packages/core/src/channels/stream-helpers.ts
+++ b/packages/core/src/channels/stream-helpers.ts
@@ -5,6 +5,8 @@ import {
   formatArgsSummary,
   formatResult,
   formatToolApproval,
+  formatToolApproved,
+  formatToolDenied,
   formatToolResult,
   formatToolRunning,
   stripToolPrefix,
@@ -361,9 +363,19 @@ export function renderBuiltInToolEvent(event: ToolDisplayEvent, mode: 'cards' | 
   if (event.kind === 'error') {
     return formatToolResult(event.displayName, event.argsSummary, event.errorText, true, event.durationMs, useCards);
   }
-  // Approval: always cards (need Approve/Deny buttons). `useCards: false`
-  // falls back to a plain "reply approve/deny" hint.
-  return formatToolApproval(event.displayName, event.argsSummary, event.toolCallId, true);
+  if (event.kind === 'approval') {
+    return formatToolApproval(event.displayName, event.argsSummary, event.toolCallId, true);
+  }
+  if (event.kind === 'approved') {
+    return formatToolApproved(event.displayName, event.argsSummary, useCards);
+  }
+  return formatToolDenied(event.displayName, event.argsSummary, event.byUser, useCards);
+}
+
+/** Returns true if `message` is an empty string or an empty `{ markdown }`. */
+export function isBlankToolMessage(message: PostableMessage): boolean {
+  if (typeof message === 'string') return message.trim().length === 0;
+  return 'markdown' in message && message.markdown.trim().length === 0;
 }
 
 /**

--- a/packages/core/src/channels/tool-display-fn-approval.test.ts
+++ b/packages/core/src/channels/tool-display-fn-approval.test.ts
@@ -1,0 +1,283 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('gray-matter', () => ({
+  default: () => ({ data: {}, content: '', matter: '', language: '', stringify: () => '' }),
+  __esModule: true,
+}));
+
+import { getChatModule } from './chat-lazy';
+import { AgentChannels } from './agent-channels';
+import type { ToolDisplayEvent, ToolDisplayFn } from './types';
+
+function makeAdapter(name: string) {
+  return {
+    name,
+    postMessage: vi.fn().mockResolvedValue({ id: 'sent-1', text: 'ok' }),
+    editMessage: vi.fn().mockResolvedValue(undefined),
+    deleteMessage: vi.fn().mockResolvedValue(undefined),
+    addReaction: vi.fn().mockResolvedValue(undefined),
+    removeReaction: vi.fn().mockResolvedValue(undefined),
+    handleWebhook: vi.fn().mockResolvedValue(new Response('ok', { status: 200 })),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    fetchMessages: vi.fn().mockResolvedValue([]),
+    encodeThreadId: vi.fn((...parts: string[]) => parts.join(':')),
+    decodeThreadId: vi.fn((id: string) => id.split(':')),
+    channelIdFromThreadId: vi.fn((id: string) => id.split(':').slice(0, 2).join(':')),
+    renderFormatted: vi.fn((text: string) => text),
+    fetchThread: vi.fn().mockResolvedValue(null),
+    startTyping: vi.fn().mockResolvedValue(undefined),
+    parseMessage: vi.fn((raw: unknown) => raw),
+    userName: 'TestBot',
+  } as any;
+}
+
+function makeAgent() {
+  return {
+    id: 'agent',
+    name: 'agent',
+    stream: vi.fn().mockResolvedValue({ textStream: new ReadableStream({ start(c) { c.close(); } }) }),
+    sendMessage: vi.fn().mockReturnValue({ accepted: Promise.resolve({ action: 'deliver', runId: 'run-1' }) }),
+    subscribeToThread: vi.fn().mockResolvedValue({
+      stream: (async function* () {})(),
+      activeRunId: () => null,
+      abort: () => false,
+      unsubscribe: vi.fn(),
+    }),
+    getMemory: vi.fn().mockResolvedValue(null),
+    logger: { info: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() },
+  } as any;
+}
+
+const FALLBACK_STORAGE = {
+  getStorage: () => ({ getStore: () => ({ listMessages: async () => ({ messages: [] }) }) }),
+  getServer: () => null,
+};
+
+describe('#23512: ToolDisplayFn owns the approval card resolved state', () => {
+  beforeAll(async () => {
+    await getChatModule();
+  });
+
+  function buildChannels(
+    adapter: any,
+    toolDisplay: ToolDisplayFn | 'cards' | 'text' | 'timeline' | 'grouped' | 'hidden' | undefined,
+    streaming = true,
+  ): AgentChannels {
+    const channels = new AgentChannels({
+      adapters: {
+        [adapter.name]: {
+          adapter,
+          streaming,
+          ...(toolDisplay !== undefined ? { toolDisplay } : {}),
+        },
+      },
+    });
+    channels.__setAgent(makeAgent());
+    channels.__setLogger({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as any);
+    return channels;
+  }
+
+  function seedApprovalState(channels: AgentChannels, adapter: any) {
+    (channels as any).findThreadMapping = vi
+      .fn()
+      .mockResolvedValue({ thread: { id: 'mastra-thread-1', resourceId: 'resource-1' } });
+    (channels as any).pendingApprovalCards.set('tool-call-1', {
+      runId: 'run-1',
+      toolName: 'deleteCustomerTool',
+      args: { id: 42 },
+    });
+    (channels as any).dispatchApproval = vi.fn().mockResolvedValue(undefined);
+    (channels as any).dispatchDecline = vi.fn().mockResolvedValue(undefined);
+    adapter.channelIdFromThreadId.mockImplementation((id: string) => id.split(':')[0]);
+  }
+
+  function makeActionEvent(adapter: any, actionId: string, isDM = false) {
+    return {
+      actionId,
+      adapter,
+      messageId: 'card-1',
+      threadId: 'channel-1:thread-1',
+      thread: { id: 'channel-1:thread-1', channelId: 'channel-1', isDM },
+      user: { userId: 'clicker-1', userName: 'clicker', fullName: 'Clicker' },
+      raw: {},
+    } as any;
+  }
+
+  it('routes the post-approve edit through the function-form toolDisplay', async () => {
+    const adapter = makeAdapter('slack');
+    const toolDisplay = vi.fn((event: ToolDisplayEvent) => {
+      if (event.kind === 'approval') return { kind: 'post', message: 'CUSTOM LOCALIZED APPROVAL CARD' };
+      if (event.kind === 'approved') return { kind: 'post', message: 'CUSTOM LOCALIZED APPROVED ✓' };
+      return undefined;
+    });
+    const channels = buildChannels(adapter, toolDisplay, true);
+    await channels.initialize(FALLBACK_STORAGE as any);
+    seedApprovalState(channels, adapter);
+
+    await (channels.sdk as any).processAction(makeActionEvent(adapter, 'tool_approve:tool-call-1'));
+
+    const approvedCall = toolDisplay.mock.calls.find(([event]) => event.kind === 'approved');
+    expect(approvedCall).toBeDefined();
+    expect(approvedCall![0]).toMatchObject({
+      kind: 'approved',
+      toolCallId: 'tool-call-1',
+      toolName: 'deleteCustomerTool',
+      displayName: 'deleteCustomerTool',
+      args: { id: 42 },
+      byUser: 'Clicker',
+    });
+    expect(approvedCall![1]).toEqual({ mode: 'streaming', platform: 'slack' });
+
+    const edits = adapter.editMessage.mock.calls;
+    expect(edits).toHaveLength(1);
+    const [, , content] = edits[0]!;
+    expect(content).toBe('CUSTOM LOCALIZED APPROVED ✓');
+    expect(JSON.stringify(edits)).not.toContain('✓ Approved');
+    expect(JSON.stringify(edits)).not.toContain('deleteCustomerTool ⋯');
+
+    expect((channels as any).dispatchApproval).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes the post-deny edit through the function-form toolDisplay', async () => {
+    const adapter = makeAdapter('slack');
+    const toolDisplay = vi.fn((event: ToolDisplayEvent) => {
+      if (event.kind === 'approval') return { kind: 'post', message: 'CUSTOM LOCALIZED APPROVAL CARD' };
+      if (event.kind === 'denied') return { kind: 'post', message: 'CUSTOM LOCALIZED DENIED ✗' };
+      return undefined;
+    });
+    const channels = buildChannels(adapter, toolDisplay, true);
+    await channels.initialize(FALLBACK_STORAGE as any);
+    seedApprovalState(channels, adapter);
+
+    await (channels.sdk as any).processAction(makeActionEvent(adapter, 'tool_deny:tool-call-1'));
+
+    const deniedCall = toolDisplay.mock.calls.find(([event]) => event.kind === 'denied');
+    expect(deniedCall).toBeDefined();
+    expect(deniedCall![0]).toMatchObject({
+      kind: 'denied',
+      toolCallId: 'tool-call-1',
+      toolName: 'deleteCustomerTool',
+      displayName: 'deleteCustomerTool',
+      args: { id: 42 },
+      byUser: 'Clicker',
+    });
+    expect(deniedCall![1]).toEqual({ mode: 'streaming', platform: 'slack' });
+
+    const edits = adapter.editMessage.mock.calls;
+    expect(edits).toHaveLength(1);
+    const [, , content] = edits[0]!;
+    expect(content).toBe('CUSTOM LOCALIZED DENIED ✗');
+    expect(JSON.stringify(edits)).not.toContain('✗ Denied');
+    expect(JSON.stringify(edits)).not.toContain('deleteCustomerTool ✗');
+
+    expect((channels as any).dispatchDecline).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the post-decision edit when the renderer returns undefined', async () => {
+    const adapter = makeAdapter('slack');
+    const toolDisplay = vi.fn((event: ToolDisplayEvent) =>
+      event.kind === 'approval' ? { kind: 'post', message: 'CUSTOM CARD' } : undefined,
+    );
+    const channels = buildChannels(adapter, toolDisplay, true);
+    await channels.initialize(FALLBACK_STORAGE as any);
+    seedApprovalState(channels, adapter);
+
+    await (channels.sdk as any).processAction(makeActionEvent(adapter, 'tool_approve:tool-call-1'));
+
+    const approvedCall = toolDisplay.mock.calls.find(([event]) => event.kind === 'approved');
+    expect(approvedCall).toBeDefined();
+    expect(approvedCall![0].kind).toBe('approved');
+
+    expect(adapter.editMessage).not.toHaveBeenCalled();
+    expect((channels as any).dispatchApproval).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a whitespace-only message from the renderer as an opt-out', async () => {
+    const adapter = makeAdapter('slack');
+    const toolDisplay = vi.fn((event: ToolDisplayEvent) => {
+      if (event.kind === 'approval') return { kind: 'post', message: 'CUSTOM CARD' };
+      if (event.kind === 'approved') return { kind: 'post', message: '   \n  ' };
+      return undefined;
+    });
+    const channels = buildChannels(adapter, toolDisplay, true);
+    await channels.initialize(FALLBACK_STORAGE as any);
+    seedApprovalState(channels, adapter);
+
+    await (channels.sdk as any).processAction(makeActionEvent(adapter, 'tool_approve:tool-call-1'));
+
+    expect(adapter.editMessage).not.toHaveBeenCalled();
+    expect((channels as any).dispatchApproval).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the framework formatter when no function-form toolDisplay is configured', async () => {
+    const adapter = makeAdapter('slack');
+    const channels = buildChannels(adapter, 'cards', true);
+    await channels.initialize(FALLBACK_STORAGE as any);
+    seedApprovalState(channels, adapter);
+
+    await (channels.sdk as any).processAction(makeActionEvent(adapter, 'tool_approve:tool-call-1'));
+
+    const edits = adapter.editMessage.mock.calls;
+    expect(edits).toHaveLength(1);
+    const [, , content] = edits[0]!;
+    expect(JSON.stringify(content)).toContain('Approved');
+    expect((channels as any).dispatchApproval).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the streaming/static mode through to the function-form toolDisplay', async () => {
+    const adapter = makeAdapter('discord');
+    const toolDisplay = vi.fn((event: ToolDisplayEvent) => {
+      if (event.kind === 'approval') return { kind: 'post', message: 'CUSTOM CARD' };
+      if (event.kind === 'approved') return { kind: 'post', message: 'OK' };
+      return undefined;
+    });
+    const channels = buildChannels(adapter, toolDisplay, false);
+    await channels.initialize(FALLBACK_STORAGE as any);
+    seedApprovalState(channels, adapter);
+
+    await (channels.sdk as any).processAction(makeActionEvent(adapter, 'tool_approve:tool-call-1'));
+
+    const approvedCall = toolDisplay.mock.calls.find(([event]) => event.kind === 'approved');
+    expect(approvedCall).toBeDefined();
+    expect(approvedCall![1]).toEqual({ mode: 'static', platform: 'discord' });
+  });
+
+  it('omits byUser in DMs where no other user can be attributed', async () => {
+    const adapter = makeAdapter('slack');
+    adapter.isDM = vi.fn(() => true);
+    const toolDisplay = vi.fn((event: ToolDisplayEvent) => {
+      if (event.kind === 'approval') return { kind: 'post', message: 'CUSTOM CARD' };
+      if (event.kind === 'approved' || event.kind === 'denied') {
+        return { kind: 'post', message: `OK (${event.byUser ?? 'self'})` };
+      }
+      return undefined;
+    });
+    const channels = buildChannels(adapter, toolDisplay, true);
+    await channels.initialize(FALLBACK_STORAGE as any);
+    seedApprovalState(channels, adapter);
+
+    await (channels.sdk as any).processAction(makeActionEvent(adapter, 'tool_approve:tool-call-1', true));
+
+    const approvedCall = toolDisplay.mock.calls.find(([event]) => event.kind === 'approved');
+    expect(approvedCall).toBeDefined();
+    expect(approvedCall![0].byUser).toBeUndefined();
+  });
+
+  it('passes the clicker name as byUser in non-DM threads', async () => {
+    const adapter = makeAdapter('slack');
+    const toolDisplay = vi.fn((event: ToolDisplayEvent) => {
+      if (event.kind === 'approval') return { kind: 'post', message: 'CUSTOM CARD' };
+      if (event.kind === 'approved' || event.kind === 'denied') return { kind: 'post', message: 'OK' };
+      return undefined;
+    });
+    const channels = buildChannels(adapter, toolDisplay, true);
+    await channels.initialize(FALLBACK_STORAGE as any);
+    seedApprovalState(channels, adapter);
+
+    await (channels.sdk as any).processAction(makeActionEvent(adapter, 'tool_approve:tool-call-1', false));
+
+    const approvedCall = toolDisplay.mock.calls.find(([event]) => event.kind === 'approved');
+    expect(approvedCall).toBeDefined();
+    expect(approvedCall![0].byUser).toBe('Clicker');
+  });
+});

--- a/packages/core/src/channels/types.ts
+++ b/packages/core/src/channels/types.ts
@@ -148,11 +148,12 @@ export type ToolDisplayFn = (event: ToolDisplayEvent, ctx: ToolDisplayContext) =
  * Per-event payload passed to {@link ToolDisplayFn}.
  *
  * Every variant carries `toolCallId` — a stable identifier for this
- * specific tool invocation. Use it to correlate `running`/`result`/`error`/
- * `approval` events for the same call (e.g. to edit a previously posted
- * message, or as the `id` on a streamed `task_update` so the SDK updates
- * the row in place rather than appending a new one). It is unique even
- * when the same tool is called in parallel.
+ * specific tool invocation. Use it to correlate events for the same call
+ * (e.g. to edit a previously posted message, or as the `id` on a streamed
+ * `task_update` so the SDK updates the row in place rather than appending
+ * a new one). It is unique even when the same tool is called in parallel.
+ *
+ * Lifecycle: `running` → (`result` | `error` | `approval` → (`approved` | `denied`) → (`result` | `error`)).
  */
 export type ToolDisplayEvent =
   | {
@@ -193,6 +194,26 @@ export type ToolDisplayEvent =
       displayName: string;
       argsSummary: string;
       args: unknown;
+    }
+  | {
+      /** Fires after the user clicks Approve. Return `{ kind: 'post', message }` to edit the card, or `undefined` to skip. */
+      kind: 'approved';
+      toolCallId: string;
+      toolName: string;
+      displayName: string;
+      argsSummary: string;
+      args: unknown;
+      byUser?: string;
+    }
+  | {
+      /** Fires after the user clicks Deny. Mirrors {@link approved}. */
+      kind: 'denied';
+      toolCallId: string;
+      toolName: string;
+      displayName: string;
+      argsSummary: string;
+      args: unknown;
+      byUser?: string;
     };
 
 /** Context about which driver is consuming the function-form result. */


### PR DESCRIPTION
## Description

Fixes an issue where a function-form `ToolDisplayFn` could render a custom tool approval card, but could not control the card's resolved state after the user clicked Approve or Deny.

The approval action handler was directly formatting the post-decision message with `formatToolApproved()` / `formatToolDenied()` instead of routing the result through the configured `ToolDisplayFn`. Additionally, `ToolDisplayEvent` had no event variants for the resolved approval states.

This PR:

* Adds `approved` and `denied` variants to `ToolDisplayEvent`.
* Routes Approve/Deny results through the same function-form `ToolDisplayFn` that rendered the original approval card.
* Preserves `formatToolApproved()` / `formatToolDenied()` as the fallback when no function-form renderer is configured.
* Allows the renderer to return a custom message, or opt out by returning `undefined` or a blank message.
* Keeps tool execution and approval resolution owned by the framework; `ToolDisplayFn` only owns the message rendering.
* Preserves existing behavior for built-in display modes such as `cards`, `text`, `timeline`, `grouped`, and `hidden`.

One clarification: function-form `toolDisplay` resolves to the default `cards` mode, so the framework-generated resolved message is still a Block Kit Card. The actual issue is that the framework overwrites the custom renderer's output with its own content and internal tool registry name.

## Related issue(s)

Fixes #23512

## Type of change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update
* [ ] Code refactoring
* [ ] Performance improvement
* [x] Test update

## Checklist

* [x] I have linked the related issue(s) in the description above
* [ ] I have made corresponding changes to the documentation (if applicable)
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Custom approval cards can now display their own “Approved” or “Denied” result. The framework uses its default message only when no custom renderer is configured.

## Changes

- Added `approved` and `denied` `ToolDisplayEvent` variants.
- Routed approval decisions through function-form `ToolDisplayFn` renderers.
- Added blank-message handling so renderers can skip the resolved-state edit.
- Preserved built-in `cards` and `text` display behavior.
- Centralized built-in event rendering and blank-message detection.
- Added tests for custom rendering, fallbacks, streaming mode, direct messages, and user attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->