### PR TITLE
fix(ci): reject unknown and ignored changeset packages

### DIFF
--- a/.github/scripts/check-changeset-packages.mjs
+++ b/.github/scripts/check-changeset-packages.mjs
@@ -1,0 +1,35 @@
+import { createRequire } from 'node:module';
+
+// Use the CLI's own parsers and workspace discovery so ignore glob semantics stay in sync.
+const require = createRequire(import.meta.url);
+const requireChangesets = createRequire(require.resolve('@changesets/cli/package.json'));
+const { getPackages } = requireChangesets('@manypkg/get-packages');
+const { read: readConfig } = requireChangesets('@changesets/config');
+const { default: readChangesets } = requireChangesets('@changesets/read');
+
+const cwd = process.cwd();
+const packages = await getPackages(cwd);
+const config = await readConfig(cwd, packages);
+const changesets = await readChangesets(cwd);
+const packageNames = new Set(packages.packages.map(pkg => pkg.packageJson.name));
+const ignored = new Set(config.ignore);
+const errors = [];
+
+for (const changeset of changesets) {
+  for (const release of changeset.releases) {
+    if (!packageNames.has(release.name)) {
+      errors.push(`.changeset/${changeset.id}.md: unknown workspace package "${release.name}".`);
+    } else if (ignored.has(release.name)) {
+      errors.push(
+        `.changeset/${changeset.id}.md: package "${release.name}" is ignored by Changesets. Remove it from the changeset; delete the file if no release entries remain.`,
+      );
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error(errors.join('\n'));
+  process.exitCode = 1;
+} else {
+  console.log('All changeset packages exist and are not ignored.');
+}

--- a/.github/scripts/check-changeset-packages.test.mjs
+++ b/.github/scripts/check-changeset-packages.test.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const script = fileURLToPath(new URL('./check-changeset-packages.mjs', import.meta.url));
+
+function validate(t, frontmatter) {
+  const cwd = mkdtempSync(path.join(tmpdir(), 'check-changeset-packages-'));
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+  writeFileSync(path.join(cwd, 'package.json'), JSON.stringify({ name: 'fixture', private: true }));
+  writeFileSync(path.join(cwd, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n');
+  for (const name of ['@mastra/core', '@mastra/playground-ui', '@internal/auth', '@internal/playground', 'mastra']) {
+    const dir = path.join(cwd, 'packages', name.replaceAll('/', '-'));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ name, version: '1.0.0', private: name.startsWith('@internal/') }),
+    );
+  }
+  mkdirSync(path.join(cwd, '.changeset'));
+  writeFileSync(
+    path.join(cwd, '.changeset/config.json'),
+    JSON.stringify({ ignore: ['*', '@internal/*', '!mastra', '!@mastra/*', '!@internal/playground'] }),
+  );
+  writeFileSync(path.join(cwd, '.changeset/README.md'), '# Not a changeset');
+  if (frontmatter !== undefined) {
+    writeFileSync(path.join(cwd, '.changeset/test-change.md'), `---\n${frontmatter}\n---\n\nTest change.\n`);
+  }
+  const result = spawnSync(process.execPath, [script], { cwd, encoding: 'utf8' });
+  assert.ifError(result.error);
+  return result;
+}
+
+test('accepts a repository without pending changesets', t => {
+  const result = validate(t);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('accepts release packages and explicit internal ignore exceptions', t => {
+  const result = validate(
+    t,
+    '"@mastra/core": patch\n"@mastra/playground-ui": minor\n"@internal/playground": patch\n"mastra": patch',
+  );
+  assert.equal(result.status, 0, result.stderr);
+});
+
+for (const name of ['@internal/core', '@internal/playground-ui']) {
+  test(`rejects unknown package ${name}`, t => {
+    const result = validate(t, `"${name}": patch`);
+    assert.equal(result.status, 1);
+    assert.ok(result.stderr.includes(`.changeset/test-change.md: unknown workspace package "${name}"`), result.stderr);
+  });
+}
+
+test('rejects an ignored-only changeset even though the package exists', t => {
+  const result = validate(t, '"@internal/auth": patch');
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /test-change\.md: package "@internal\/auth" is ignored/);
+});
+
+test('rejects ignored packages mixed with release packages', t => {
+  const result = validate(t, '"@internal/auth": patch\n"@mastra/core": patch');
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /"@internal\/auth" is ignored/);
+});
+
+test('rejects malformed frontmatter', t => {
+  const result = validate(t, '"@mastra/core": [');
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /could not parse changeset/);
+});

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,6 +64,33 @@ jobs:
             fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `## Quality assurance routing\n\n- AGENTS validation: \`${hasAgentsInputs}\` — ${formatReasons(agentsReasons)}\n- Peer dependency validation: \`${hasPeerdepsInputs}\` — ${formatReasons(peerdepsReasons)}\n- README validation: \`${hasReadmeInputs}\` — ${formatReasons(readmeReasons)}\n`);
           '
 
+  changeset-check:
+    name: Validate changeset packages
+    runs-on: starsling-ubuntu-24.04-2
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm and Node.js
+        uses: ./.github/actions/setup-pnpm-node
+
+      - name: Test changeset package validator
+        run: node --test .github/scripts/check-changeset-packages.test.mjs
+
+      # Check all pending changesets, including on changeset-only PRs.
+      - name: Reject unknown or ignored changeset packages
+        run: node .github/scripts/check-changeset-packages.mjs
+
+      # Without --since, validation does not need Git history or require a new changeset.
+      - name: Validate changeset release plan
+        run: pnpm changeset-cli status
+
   lint:
     name: Lint
     needs: changes


### PR DESCRIPTION
Adds a PR check for unknown and ignored packages in pending changesets. Ignored-only changesets currently pass `changeset status` and can linger in the repo, making publishing fetch unnecessary history to find their creation commits.

For example, `"@internal/auth": patch` now fails even on its own, and nonexistent names like `@internal/core` fail too. Release packages and explicit ignore exceptions like `@internal/playground` still pass. The validator uses Changesets' own parsers and ignore configuration, runs on changeset-only PRs, and does not need Git history.

Verified with seven regression tests, the repository's release-plan validation, lint, and formatting. Also reproduced the ignored-only case against both commands: the old status check passes, while the new validator rejects it. No package changeset is needed because this only changes CI.

The `Validate changeset packages` check needs to be required in branch protection to block merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR checks that changesets name real packages before merge. It blocks unknown or ignored packages while allowing valid release changesets.

## Changes

- Added `check-changeset-packages.mjs` with Changesets package discovery and configuration handling.
- Added tests for valid, unknown, ignored, mixed, empty, and malformed changesets.
- Added the `Validate changeset packages` CI job for changeset-only pull requests.
- Passes `origin/main` to Changesets for merge-base resolution.
- Validates the Changesets release plan.
- The check must be required in branch protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->