### PR TITLE
feat(studio): show message skeleton while thread history loads

### DIFF
--- a/.changeset/studio-thread-history-skeleton.md
+++ b/.changeset/studio-thread-history-skeleton.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Added a loading skeleton in the Studio agent chat while an existing thread's message history is being fetched, instead of briefly showing the empty welcome screen before the messages appear.

--- a/packages/playground/src/domains/agents/components/agent-chat.tsx
+++ b/packages/playground/src/domains/agents/components/agent-chat.tsx
@@ -7,26 +7,6 @@ import { Thread } from '@/lib/ai-ui/thread';
 
 import type { ChatProps } from '@/types';
 
-interface AvailableSuggestedPromptsOptions {
-  suggestedPrompts?: string[];
-  isNewThread?: boolean;
-  isMessagesLoading: boolean;
-}
-
-/**
- * Keeps existing-thread prompts hidden until message history has loaded, so
- * they do not briefly appear before the conversation replaces the welcome UI.
- */
-const getAvailableSuggestedPrompts = ({
-  suggestedPrompts,
-  isNewThread,
-  isMessagesLoading,
-}: AvailableSuggestedPromptsOptions) => {
-  if (isNewThread) return suggestedPrompts;
-  if (isMessagesLoading) return undefined;
-  return suggestedPrompts;
-};
-
 export const AgentChat = ({
   agentId,
   agentName,
@@ -85,11 +65,6 @@ export const AgentChat = ({
   }
 
   const messages = data?.messages ?? emptyMessagesRef.current.messages;
-  const availableSuggestedPrompts = getAvailableSuggestedPrompts({
-    suggestedPrompts,
-    isNewThread,
-    isMessagesLoading,
-  });
 
   return (
     <ChatProvider
@@ -108,11 +83,12 @@ export const AgentChat = ({
         agentName={agentName ?? ''}
         agentId={agentId}
         threadId={threadId}
-        suggestedPrompts={availableSuggestedPrompts}
+        suggestedPrompts={suggestedPrompts}
         hasModelList={Boolean(modelList)}
         hideModelSwitcher={hideModelSwitcher}
         refreshThreadList={refreshThreadList}
         runOptionsSlot={runOptionsSlot}
+        isHistoryLoading={isMessagesLoading}
       />
     </ChatProvider>
   );

--- a/packages/playground/src/domains/agents/components/agent-loading-skeletons.tsx
+++ b/packages/playground/src/domains/agents/components/agent-loading-skeletons.tsx
@@ -78,25 +78,31 @@ function SidebarLoadingRow({ children }: { children: ReactNode }) {
   return <div className="flex h-9 w-full min-w-0 items-center gap-2 rounded-xl px-3">{children}</div>;
 }
 
+export function ChatMessagesLoadingSkeleton() {
+  return (
+    <div className="min-h-0 space-y-4 overflow-hidden pt-6">
+      <div className="flex justify-start">
+        <Skeleton className="h-10 w-2/3 rounded-2xl" />
+      </div>
+      <div className="flex justify-end">
+        <Skeleton className="h-12 w-3/5 rounded-2xl" />
+      </div>
+      <div className="flex justify-start">
+        <div className="w-4/5 space-y-2">
+          <Skeleton className="h-4 w-full rounded-full" />
+          <Skeleton className="h-4 w-5/6 rounded-full" />
+          <Skeleton className="h-4 w-2/3 rounded-full" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function AgentChatLoadingSkeleton() {
   return (
     <div className="grid h-full min-h-0 w-full overflow-hidden px-4 py-6 md:px-10">
       <div className="mx-auto grid h-full min-h-0 w-full max-w-[80ch] grid-rows-[1fr_auto]">
-        <div className="min-h-0 space-y-4 overflow-hidden pt-6">
-          <div className="flex justify-start">
-            <Skeleton className="h-10 w-2/3 rounded-2xl" />
-          </div>
-          <div className="flex justify-end">
-            <Skeleton className="h-12 w-3/5 rounded-2xl" />
-          </div>
-          <div className="flex justify-start">
-            <div className="w-4/5 space-y-2">
-              <Skeleton className="h-4 w-full rounded-full" />
-              <Skeleton className="h-4 w-5/6 rounded-full" />
-              <Skeleton className="h-4 w-2/3 rounded-full" />
-            </div>
-          </div>
-        </div>
+        <ChatMessagesLoadingSkeleton />
 
         <div className="border-border1 bg-surface2 rounded-3xl border px-3 py-2.5">
           <Skeleton className="h-5 w-1/2 rounded-full" />

--- a/packages/playground/src/lib/ai-ui/__tests__/thread.test.tsx
+++ b/packages/playground/src/lib/ai-ui/__tests__/thread.test.tsx
@@ -108,10 +108,11 @@ interface RenderThreadOptions {
   hasModelList?: boolean;
   threadId?: string;
   suggestedPrompts?: string[];
+  isHistoryLoading?: boolean;
 }
 
 const renderThreadTree = (initialMessages: MastraDBMessage[], options: RenderThreadOptions = {}) => {
-  const { hasModelList = true, threadId = 'thread-1', suggestedPrompts } = options;
+  const { hasModelList = true, threadId = 'thread-1', suggestedPrompts, isHistoryLoading } = options;
 
   return (
     <Wrapper threadId={threadId}>
@@ -130,6 +131,7 @@ const renderThreadTree = (initialMessages: MastraDBMessage[], options: RenderThr
             threadId={threadId}
             suggestedPrompts={suggestedPrompts}
             hasModelList={hasModelList}
+            isHistoryLoading={isHistoryLoading}
           />
         </ChatProvider>
       </ThreadInputProvider>
@@ -205,6 +207,69 @@ describe('Thread', () => {
 
     expect(screen.getByText('previous question', { selector: 'p' })).toBeTruthy();
     expect(screen.queryByText('How can I help you today?')).toBeFalsy();
+  });
+
+  describe('Thread history loading', () => {
+    describe('when history is loading and there are no messages', () => {
+      it('shows the history skeleton instead of the welcome screen', async () => {
+        server.use(...baseHandlers());
+
+        await act(async () => {
+          renderThread([], { isHistoryLoading: true });
+        });
+
+        expect(screen.getByTestId('thread-history-skeleton')).toBeTruthy();
+        expect(screen.queryByText('How can I help you today?')).toBeNull();
+      });
+
+      it('keeps the composer available', async () => {
+        server.use(...baseHandlers());
+
+        await act(async () => {
+          renderThread([], { isHistoryLoading: true });
+        });
+
+        expect(screen.getByRole('textbox')).toBeTruthy();
+      });
+
+      it('does not render suggested prompts', async () => {
+        server.use(...baseHandlers());
+
+        await act(async () => {
+          renderThread([], { isHistoryLoading: true, suggestedPrompts: ['Check the weather'] });
+        });
+
+        expect(screen.queryByRole('button', { name: 'Check the weather' })).toBeNull();
+      });
+    });
+
+    describe('when history is loading but live messages already exist', () => {
+      it('renders the messages and no skeleton', async () => {
+        server.use(...baseHandlers());
+
+        await act(async () => {
+          renderThread([userMessage('live question')], { isHistoryLoading: true });
+        });
+
+        expect(screen.getByText('live question', { selector: 'p' })).toBeTruthy();
+        expect(screen.queryByTestId('thread-history-skeleton')).toBeNull();
+        expect(screen.queryByText('How can I help you today?')).toBeNull();
+      });
+    });
+
+    describe('when history finished loading with no messages', () => {
+      it('shows the welcome screen with suggested prompts', async () => {
+        server.use(...baseHandlers());
+
+        await act(async () => {
+          renderThread([], { isHistoryLoading: false, suggestedPrompts: ['Check the weather'] });
+        });
+
+        expect(screen.queryByTestId('thread-history-skeleton')).toBeNull();
+        expect(screen.getByText('How can I help you today?')).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Check the weather' })).toBeTruthy();
+      });
+    });
   });
 
   describe('when suggested prompts are provided for an empty thread', () => {

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -37,6 +37,7 @@ import { MessageRow } from './messages/message-row';
 import { SuggestedPromptList } from './suggested-prompt-list';
 import { TaskPanel } from './task-panel';
 import { BrowserThumbnail, useBrowserSession } from '@/domains/agents';
+import { ChatMessagesLoadingSkeleton } from '@/domains/agents/components/agent-loading-skeletons';
 import { ComposerModelSettings } from '@/domains/agents/components/composer-model-settings';
 import { ComposerModelSwitcher, ComposerModelWarning } from '@/domains/agents/components/composer-model-switcher';
 import { usePermissions } from '@/domains/auth/hooks/use-permissions';
@@ -116,6 +117,11 @@ export interface ThreadProps {
    * thread-list refresh here so the page navigates from /new to the real thread URL.
    */
   refreshThreadList?: () => Promise<void> | void;
+  /**
+   * True while the thread history is being fetched for the first time. The skeleton
+   * only replaces the welcome screen; live messages that arrive earlier take precedence.
+   */
+  isHistoryLoading?: boolean;
 }
 
 export const Thread = ({
@@ -127,6 +133,7 @@ export const Thread = ({
   hideModelSwitcher,
   runOptionsSlot,
   refreshThreadList,
+  isHistoryLoading,
 }: ThreadProps) => {
   const messagesContainerRef = useRef<HTMLDivElement>(null);
 
@@ -159,7 +166,11 @@ export const Thread = ({
           <ChatShell.Viewport style={{ overflowAnchor: 'none' }}>
             <ThreadRailLayer turns={threadRailTurns} />
             <ChatShell.Content>
-              {isEmpty ? (
+              {isEmpty && isHistoryLoading ? (
+                <ChatShell.Column data-testid="thread-history-skeleton" aria-busy="true" className="flex-1 py-6">
+                  <ChatMessagesLoadingSkeleton />
+                </ChatShell.Column>
+              ) : isEmpty ? (
                 <ThreadWelcome agentName={agentName} suggestedPrompts={suggestedPrompts} />
               ) : (
                 <ChatShell.Column

--- a/packages/playground/src/pages/agents/agent/__tests__/suggested-prompts.msw.test.tsx
+++ b/packages/playground/src/pages/agents/agent/__tests__/suggested-prompts.msw.test.tsx
@@ -51,7 +51,7 @@ afterEach(() => cleanup());
 
 describe('agent suggested prompts', () => {
   describe('when an existing thread is still loading its messages', () => {
-    it('withholds the prompts until the message query resolves', async () => {
+    it('shows the history skeleton and withholds the prompts until the message query resolves', async () => {
       const messagesGate = createGate();
 
       server.use(
@@ -90,12 +90,15 @@ describe('agent suggested prompts', () => {
 
       renderPage();
 
-      expect(await screen.findByText('How can I help you today?')).not.toBeNull();
+      expect(await screen.findByTestId('thread-history-skeleton')).not.toBeNull();
+      expect(screen.queryByText('How can I help you today?')).toBeNull();
       expect(screen.queryByRole('button', { name: SUGGESTED_PROMPT })).toBeNull();
 
       messagesGate.release();
 
       expect(await screen.findByRole('button', { name: SUGGESTED_PROMPT })).not.toBeNull();
+      expect(screen.getByText('How can I help you today?')).not.toBeNull();
+      expect(screen.queryByTestId('thread-history-skeleton')).toBeNull();
     });
   });
 });

--- a/packages/playground/src/pages/agents/agent/__tests__/thread-page.msw.test.tsx
+++ b/packages/playground/src/pages/agents/agent/__tests__/thread-page.msw.test.tsx
@@ -25,6 +25,11 @@ import { server } from '@/test/msw-server';
 const BASE_URL = 'http://localhost:4111';
 const AGENT_ID = 'chef-agent';
 const THREAD_ID = 'thread-1';
+// Live output travels through a real SSE stream (subscribe → parse → useChat merge)
+// and is then paced word by word by the markdown reveal buffer, which replays when
+// the message row remounts. Both are far slower than a JSON fetch when the whole
+// suite runs in parallel, so those assertions get more than waitFor's 1s default.
+const SSE_TIMEOUT = { timeout: 5000 };
 
 // jsdom has no layout, so react-resizable-panels never resizes anything and
 // `collapse()`/`expand()` are silently ignored. Replace Group/Panel with a
@@ -310,7 +315,9 @@ describe('Standalone thread page', () => {
         await screen.findByText('OpenAI');
         await waitFor(() => expect(push).toBeDefined());
         await act(async () => push?.());
-        await waitFor(() => expect(document.body.textContent).toContain('Live response survives'));
+        await waitFor(() => expect(document.body.textContent).toContain('Live response survives'), SSE_TIMEOUT);
+        // Live messages take precedence over the history skeleton.
+        expect(screen.queryByTestId('thread-history-skeleton')).toBeNull();
         await act(async () => releaseHistory());
         await waitFor(() =>
           expect(queryClient.getQueryState(['memory', 'messages', THREAD_ID, AGENT_ID, 'requestContext'])?.status).toBe(
@@ -318,13 +325,81 @@ describe('Standalone thread page', () => {
           ),
         );
         expect(historyReturned).toHaveBeenCalledOnce();
-        await waitFor(() => expect(document.body.textContent?.split('Live response survives')).toHaveLength(2));
+        await waitFor(
+          () => expect(document.body.textContent?.split('Live response survives')).toHaveLength(2),
+          SSE_TIMEOUT,
+        );
         expect(document.body.textContent).not.toContain('Old partial output');
         if (history.messages.length) expect(document.body.textContent).toContain('Earlier prompt');
       } finally {
         releaseHistory();
         close();
       }
+    });
+  });
+
+  describe('when opening an existing thread whose history is still loading', () => {
+    it('shows the history skeleton, then the messages once history resolves', async () => {
+      installHandlers();
+      let releaseHistory = () => {};
+      const gate = new Promise<void>(resolve => {
+        releaseHistory = resolve;
+      });
+      server.use(
+        http.get(`${BASE_URL}/api/memory/threads/:threadId/messages`, async () => {
+          await gate;
+          return HttpResponse.json(staleHistory);
+        }),
+      );
+      renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);
+      try {
+        expect(await screen.findByTestId('thread-history-skeleton')).not.toBeNull();
+        expect(screen.queryByText('How can I help you today?')).toBeNull();
+
+        await act(async () => releaseHistory());
+
+        expect(await screen.findByText('Earlier prompt')).not.toBeNull();
+        expect(screen.queryByTestId('thread-history-skeleton')).toBeNull();
+      } finally {
+        releaseHistory();
+      }
+    });
+  });
+
+  describe('when opening a new thread', () => {
+    it('shows the welcome screen immediately without a skeleton', async () => {
+      installHandlers();
+      const messagesRequested = vi.fn();
+      server.use(
+        http.get(`${BASE_URL}/api/memory/threads/:threadId/messages`, () => {
+          messagesRequested();
+          return HttpResponse.json(emptyHistory);
+        }),
+      );
+      renderAt(`/agents/${AGENT_ID}/threads/new`);
+
+      expect(await screen.findByText('How can I help you today?')).not.toBeNull();
+      expect(screen.queryByTestId('thread-history-skeleton')).toBeNull();
+      expect(messagesRequested).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the agent has memory disabled', () => {
+    it('shows the welcome screen immediately without a skeleton', async () => {
+      installHandlers();
+      const messagesRequested = vi.fn();
+      server.use(
+        http.get(`${BASE_URL}/api/memory/status`, () => HttpResponse.json({ result: false })),
+        http.get(`${BASE_URL}/api/memory/threads/:threadId/messages`, () => {
+          messagesRequested();
+          return HttpResponse.json(emptyHistory);
+        }),
+      );
+      renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);
+
+      expect(await screen.findByText('How can I help you today?')).not.toBeNull();
+      expect(screen.queryByTestId('thread-history-skeleton')).toBeNull();
+      expect(messagesRequested).not.toHaveBeenCalled();
     });
   });
 
@@ -400,7 +475,7 @@ describe('Standalone thread page', () => {
               cleanup();
               renderAt(savedPath);
               await waitFor(() => expect(ids).toHaveLength(2));
-              await waitFor(() => expect(document.body.textContent).toContain('Live response survives'));
+              await waitFor(() => expect(document.body.textContent).toContain('Live response survives'), SSE_TIMEOUT);
             }
             expect(new Set(ids).size).toBe(1);
           }


### PR DESCRIPTION
Opening an existing thread in Studio currently shows the empty welcome screen ("How can I help you today?") until the history fetch resolves, then the messages pop in all at once. This renders a message skeleton instead while the initial history query is loading and the chat is still empty.

`ChatProvider` stays mounted the whole time, so the thread signal subscription and the `useChat` history merge are untouched — a live message that arrives before the history always takes precedence over the skeleton. New threads and agents without memory keep showing the welcome screen immediately (the query isn't enabled there), and refetches with data already present don't flash the skeleton. The suggested-prompts guard in `AgentChat` is removed since the welcome screen is no longer rendered during the load.

```tsx
<Thread isHistoryLoading={isMessagesLoading} suggestedPrompts={suggestedPrompts} … />
```

Tests: unit tests on `Thread`, MSW page tests for existing thread / new thread / memory disabled / live-before-history, and `suggested-prompts.msw.test.tsx` adapted to the new rendering. The SSE-driven assertions in `thread-page.msw.test.tsx` also get a longer timeout: streamed text goes through the markdown reveal buffer, which replays when the row remounts after the history merge, and was flaky under parallel load before this change.

Verified manually in Studio with a throttled history request: existing thread → skeleton → messages, `/threads/new` → welcome, no-memory agent → welcome, thread A→B→A → skeleton each time.

Co-Authored-By: mastracode <284800079+mastra-platform[bot]@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Studio now shows a loading placeholder while it fetches messages for an existing chat. New chats still show the welcome screen immediately, and real-time messages replace the placeholder when they arrive.

## Changes

- Added `ChatMessagesLoadingSkeleton` for chat history loading.
- Updated `Thread` to display the skeleton when history is loading and no messages exist.
- Preserved `ChatProvider` to keep thread subscriptions and history merging active.
- Removed the `AgentChat` suggested-prompts loading guard.
- Added tests for existing threads, new threads, memory-disabled agents, live messages, and suggested prompts.
- Increased SSE test timeouts for markdown reveal-buffer replay.
- Added a patch changeset for `mastra`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->