### PR TITLE
refactor(playground-ui): share tool-call approval context

### DIFF
--- a/.changeset/empty-rockets-read.md
+++ b/.changeset/empty-rockets-read.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added reusable tool-call approval context to playground-ui with stable provider values.

--- a/packages/playground-ui/src/domains/chat/context/__tests__/tool-call-context.test.tsx
+++ b/packages/playground-ui/src/domains/chat/context/__tests__/tool-call-context.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { cleanup, render, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ToolCallContextValue } from '../tool-call-context';
+import { ToolCallProvider, useToolCall } from '../tool-call-context';
+
+afterEach(() => cleanup());
+
+const baseValue: ToolCallContextValue = {
+  approveToolcall: vi.fn(),
+  declineToolcall: vi.fn(),
+  approveToolcallGenerate: vi.fn(),
+  declineToolcallGenerate: vi.fn(),
+  approveNetworkToolcall: vi.fn(),
+  declineNetworkToolcall: vi.fn(),
+  isRunning: false,
+  toolCallApprovals: { 'call-1': { status: 'approved' } },
+  networkToolCallApprovals: {},
+};
+
+const wrapperFor = (value: ToolCallContextValue) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <ToolCallProvider {...value}>{children}</ToolCallProvider>;
+  };
+
+describe('useToolCall', () => {
+  it('throws when used outside ToolCallProvider', () => {
+    expect(() => renderHook(() => useToolCall())).toThrow('useToolCall must be used within a ToolCallProvider');
+  });
+
+  it('exposes the handlers and approvals passed to the provider', () => {
+    const { result } = renderHook(() => useToolCall(), { wrapper: wrapperFor(baseValue) });
+
+    result.current.approveToolcall('call-1', { ok: true });
+
+    expect(baseValue.approveToolcall).toHaveBeenCalledWith('call-1', { ok: true });
+    expect(result.current.toolCallApprovals).toBe(baseValue.toolCallApprovals);
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it('keeps a stable context value across re-renders with the same props', () => {
+    const { result, rerender } = renderHook(() => useToolCall(), { wrapper: wrapperFor(baseValue) });
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+
+  it('produces a new context value when a prop changes', () => {
+    const seen: ToolCallContextValue[] = [];
+    const Probe = () => {
+      seen.push(useToolCall());
+      return null;
+    };
+    const tree = (isRunning: boolean) => (
+      <ToolCallProvider {...baseValue} isRunning={isRunning}>
+        <Probe />
+      </ToolCallProvider>
+    );
+
+    const { rerender } = render(tree(false));
+    rerender(tree(true));
+
+    expect(seen).toHaveLength(2);
+    expect(seen[1]).not.toBe(seen[0]);
+    expect(seen[1].isRunning).toBe(true);
+  });
+});

--- a/packages/playground-ui/src/domains/chat/context/chat-context.ts
+++ b/packages/playground-ui/src/domains/chat/context/chat-context.ts
@@ -46,10 +46,9 @@ export interface AgentContextValue {
   requestContext?: Record<string, unknown>;
 }
 
-// NOTE: Tool/network approvals are NOT exposed here. The badge approval buttons
-// consume the host application's tool-call provider, which the chat provider
-// renders directly with `useChat`'s handlers. That keeps every badge unchanged
-// and preserves the `approveNetworkToolCall(toolName, runId?)` contract.
+// NOTE: Tool/network approvals are NOT exposed here. They live in a separate
+// slice (`./tool-call-context`) for the same churn reasons, and the badge
+// approval buttons read it via `useToolCall()`.
 
 export const ChatMessagesContext = createContext<MessagesContextValue>({ messages: [] });
 export const ChatRunningContext = createContext<RunningContextValue>({

--- a/packages/playground-ui/src/domains/chat/context/tool-call-context.tsx
+++ b/packages/playground-ui/src/domains/chat/context/tool-call-context.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 
-interface ToolCallContextValue {
+export interface ToolCallContextValue {
   approveToolcall: (toolCallId: string, resumeData?: unknown) => void;
   declineToolcall: (toolCallId: string) => void;
   approveToolcallGenerate: (toolCallId: string) => void;
@@ -15,17 +15,8 @@ interface ToolCallContextValue {
 
 const ToolCallContext = createContext<ToolCallContextValue | undefined>(undefined);
 
-interface ToolCallProviderProps {
+interface ToolCallProviderProps extends ToolCallContextValue {
   children: ReactNode;
-  approveToolcall: (toolCallId: string, resumeData?: unknown) => void;
-  declineToolcall: (toolCallId: string) => void;
-  approveToolcallGenerate: (toolCallId: string) => void;
-  declineToolcallGenerate: (toolCallId: string) => void;
-  approveNetworkToolcall: (toolName: string, runId?: string) => void;
-  declineNetworkToolcall: (toolName: string, runId?: string) => void;
-  isRunning: boolean;
-  toolCallApprovals: { [toolCallId: string]: { status: 'approved' | 'declined' } };
-  networkToolCallApprovals: { [toolName: string]: { status: 'approved' | 'declined' } };
 }
 
 export function ToolCallProvider({
@@ -40,25 +31,35 @@ export function ToolCallProvider({
   toolCallApprovals,
   networkToolCallApprovals,
 }: ToolCallProviderProps) {
-  return (
-    <ToolCallContext.Provider
-      value={{
-        approveToolcall,
-        declineToolcall,
-        approveToolcallGenerate,
-        declineToolcallGenerate,
-        approveNetworkToolcall,
-        declineNetworkToolcall,
-        isRunning,
-        toolCallApprovals,
-        networkToolCallApprovals,
-      }}
-    >
-      {children}
-    </ToolCallContext.Provider>
+  const value = useMemo<ToolCallContextValue>(
+    () => ({
+      approveToolcall,
+      declineToolcall,
+      approveToolcallGenerate,
+      declineToolcallGenerate,
+      approveNetworkToolcall,
+      declineNetworkToolcall,
+      isRunning,
+      toolCallApprovals,
+      networkToolCallApprovals,
+    }),
+    [
+      approveToolcall,
+      declineToolcall,
+      approveToolcallGenerate,
+      declineToolcallGenerate,
+      approveNetworkToolcall,
+      declineNetworkToolcall,
+      isRunning,
+      toolCallApprovals,
+      networkToolCallApprovals,
+    ],
   );
+
+  return <ToolCallContext.Provider value={value}>{children}</ToolCallContext.Provider>;
 }
 
+// eslint-disable-next-line react-refresh/only-export-components -- provider and its hook intentionally share this module
 export function useToolCall() {
   const context = useContext(ToolCallContext);
 

--- a/packages/playground-ui/src/domains/chat/index.ts
+++ b/packages/playground-ui/src/domains/chat/index.ts
@@ -1,5 +1,6 @@
 export * from './components';
 export * from './context/chat-context';
+export * from './context/tool-call-context';
 export * from './messages/message-metadata';
 export * from './messages/signal-data';
 export * from './messages/renderers/tool-part';

--- a/packages/playground/src/domains/traces/components/trace-thread-item-view.tsx
+++ b/packages/playground/src/domains/traces/components/trace-thread-item-view.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { ToolCallProvider } from '@mastra/playground-ui/domains/chat/context/tool-call-context';
 import { TracesErrorContent } from '@mastra/playground-ui/domains/traces/components/traces-error-content';
 import { useTraceSpans } from '@mastra/playground-ui/domains/traces/hooks/use-trace-spans';
 import { cn } from '@mastra/playground-ui/utils/cn';
@@ -8,7 +9,6 @@ import { ListTreeIcon } from 'lucide-react';
 
 import { formatTraceThreadMessages } from './format-trace-thread-messages';
 import { MessageRow } from '@/lib/ai-ui/messages/message-row';
-import { ToolCallProvider } from '@/services/tool-call-provider';
 
 export interface TraceThreadItemViewProps {
   traceId: string;

--- a/packages/playground/src/lib/ai-ui/chat/chat-provider.tsx
+++ b/packages/playground/src/lib/ai-ui/chat/chat-provider.tsx
@@ -14,6 +14,7 @@ import type {
   SendContextValue,
   TasksContextValue,
 } from '@mastra/playground-ui/domains/chat/context/chat-context';
+import { ToolCallProvider } from '@mastra/playground-ui/domains/chat/context/tool-call-context';
 import { memoryStatusQueryKey } from '@mastra/playground-ui/domains/memory/hooks/use-memory-status';
 import { memoryThreadMessagesQueryKey } from '@mastra/playground-ui/domains/memory/hooks/use-memory-thread-messages';
 import { observationalMemoryQueryKey } from '@mastra/playground-ui/domains/memory/hooks/use-observational-memory';
@@ -37,7 +38,6 @@ import {
   scanOmInitialState,
 } from '@/services/om-parts-converter';
 import type { OmTerminalExtractionCache } from '@/services/om-parts-converter';
-import { ToolCallProvider } from '@/services/tool-call-provider';
 import type { ChatProps } from '@/types';
 
 /**

--- a/packages/playground/src/lib/ai-ui/messages/__tests__/message-row.chrome.test.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/__tests__/message-row.chrome.test.tsx
@@ -1,4 +1,5 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
+import { ToolCallProvider } from '@mastra/playground-ui/domains/chat/context/tool-call-context';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -10,7 +11,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DatasetSaveProvider } from '../../context/dataset-save-context';
 import { MessageRow } from '../message-row';
 import { buildListDatasetsResponse } from '@/domains/datasets/components/__tests__/fixtures/datasets';
-import { ToolCallProvider } from '@/services/tool-call-provider';
 import { server } from '@/test/msw-server';
 
 const BASE_URL = 'http://localhost:4111';

--- a/packages/playground/src/lib/ai-ui/messages/__tests__/message-row.test.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/__tests__/message-row.test.tsx
@@ -1,5 +1,6 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
 import { ArrivalScope } from '@mastra/playground-ui/components/Arrival';
+import { ToolCallProvider } from '@mastra/playground-ui/domains/chat/context/tool-call-context';
 import { ARRIVING_CLASS } from '@mastra/playground-ui/tokens';
 import type { MastraTextPart, ToolInvocationPart } from '@mastra/react';
 import { MastraReactProvider } from '@mastra/react';
@@ -12,7 +13,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MessageRow } from '../message-row';
 import { buildGlobalOmPartsByCycleId, convertOmPartsInMastraMessage } from '@/services/om-parts-converter';
-import { ToolCallProvider } from '@/services/tool-call-provider';
 import { server } from '@/test/msw-server';
 
 const BASE_URL = 'http://localhost:4111';

--- a/packages/playground/src/lib/ai-ui/tools/__tests__/ask-user-tool.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/__tests__/ask-user-tool.test.tsx
@@ -1,9 +1,9 @@
 import { TooltipProvider } from '@mastra/playground-ui/components/Tooltip';
 import type { MessageMetadata } from '@mastra/playground-ui/domains/chat';
+import { ToolCallProvider } from '@mastra/playground-ui/domains/chat/context/tool-call-context';
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AskUserTool } from '../ask-user-tool';
-import { ToolCallProvider } from '@/services/tool-call-provider';
 
 type RenderProps = {
   toolName: string;

--- a/packages/playground/src/lib/ai-ui/tools/__tests__/submit-plan-tool.msw.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/__tests__/submit-plan-tool.msw.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { ToolCallProvider } from '@mastra/playground-ui/domains/chat/context/tool-call-context';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
@@ -7,7 +8,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SubmitPlanTool } from '../submit-plan-tool';
 import type { SubmitPlanToolProps } from '../submit-plan-tool';
 import { submittedPlanFile, submittedPlanPath } from './fixtures/submit-plan';
-import { ToolCallProvider } from '@/services/tool-call-provider';
 import { server } from '@/test/msw-server';
 
 const BASE_URL = 'http://localhost:4111';

--- a/packages/playground/src/lib/ai-ui/tools/__tests__/tool-card.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/__tests__/tool-card.test.tsx
@@ -1,4 +1,5 @@
 import { ChatAgentContext, ChatRunningContext } from '@mastra/playground-ui/domains/chat/context/chat-context';
+import { ToolCallProvider } from '@mastra/playground-ui/domains/chat/context/tool-call-context';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -11,7 +12,6 @@ import { ToolCard, ToolCardInner } from '../tool-card';
 import type { ToolCardProps } from '../tool-card';
 import { WorkflowRunContext, WorkflowRunProvider } from '@/domains/workflows';
 import { WORKSPACE_TOOLS } from '@/domains/workspace/constants';
-import { ToolCallProvider } from '@/services/tool-call-provider';
 import { server } from '@/test/msw-server';
 
 const BASE_URL = 'http://localhost:4111';

--- a/packages/playground/src/lib/ai-ui/tools/badges/__tests__/ask-user-badge.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/__tests__/ask-user-badge.test.tsx
@@ -1,9 +1,9 @@
 import { TooltipProvider } from '@mastra/playground-ui/components/Tooltip';
+import { ToolCallProvider } from '@mastra/playground-ui/domains/chat/context/tool-call-context';
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AskUserBadge } from '../ask-user-badge';
 import type { AskUserResult, AskUserSuspendPayload } from '../types';
-import { ToolCallProvider } from '@/services/tool-call-provider';
 
 type ProviderOverrides = {
   approveToolcall?: (toolCallId: string, resumeData?: unknown) => void;

--- a/packages/playground/src/lib/ai-ui/tools/badges/__tests__/code-mode-badge.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/__tests__/code-mode-badge.test.tsx
@@ -1,8 +1,8 @@
+import { ToolCallProvider } from '@mastra/playground-ui/domains/chat/context/tool-call-context';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { CodeModeBadge, getCodeModeCall } from '../code-mode-badge';
-import { ToolCallProvider } from '@/services/tool-call-provider';
 
 const renderWithProvider = (node: ReactNode) =>
   render(

--- a/packages/playground/src/lib/ai-ui/tools/badges/__tests__/tool-badge.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/__tests__/tool-badge.test.tsx
@@ -1,9 +1,9 @@
 import { TooltipProvider } from '@mastra/playground-ui/components/Tooltip';
+import { ToolCallProvider } from '@mastra/playground-ui/domains/chat/context/tool-call-context';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ToolBadge } from '../tool-badge';
-import { ToolCallProvider } from '@/services/tool-call-provider';
 
 const renderWithProviders = (node: ReactNode) =>
   render(

--- a/packages/playground/src/lib/ai-ui/tools/badges/__tests__/workflow-badge.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/__tests__/workflow-badge.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { ToolCallProvider } from '@mastra/playground-ui/domains/chat/context/tool-call-context';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
@@ -9,7 +10,6 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { WorkflowBadge } from '../workflow-badge';
 import { badgeWorkflow, badgeWorkflowRuns, RUN_ID, WORKFLOW_ID } from './fixtures/workflow-badge';
-import { ToolCallProvider } from '@/services/tool-call-provider';
 import { server } from '@/test/msw-server';
 
 const BASE_URL = 'http://localhost:4111';

--- a/packages/playground/src/lib/ai-ui/tools/badges/ask-user-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/ask-user-badge.tsx
@@ -1,6 +1,6 @@
 import { AskUser } from '@mastra/playground-ui/components/ai/ask-user';
 import type { AskUserAnswer, AskUserResult, AskUserPayload } from '@mastra/playground-ui/components/ai/ask-user';
-import { useToolCall } from '@/services/tool-call-provider';
+import { useToolCall } from '@mastra/playground-ui/domains/chat/context/tool-call-context';
 
 export interface AskUserBadgeProps {
   toolCallId: string;

--- a/packages/playground/src/lib/ai-ui/tools/badges/tool-approval-buttons.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/tool-approval-buttons.tsx
@@ -1,8 +1,8 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { SectionLabel } from '@mastra/playground-ui/domains/chat/components/section-label';
+import { useToolCall } from '@mastra/playground-ui/domains/chat/context/tool-call-context';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { Check, X } from 'lucide-react';
-import { useToolCall } from '@/services/tool-call-provider';
 
 export interface ToolApprovalButtonsProps {
   toolCallId: string;

--- a/packages/playground/src/lib/ai-ui/tools/submit-plan-tool.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/submit-plan-tool.tsx
@@ -18,8 +18,8 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import type { MessageMetadata } from '@mastra/playground-ui/domains/chat';
+import { useToolCall } from '@mastra/playground-ui/domains/chat/context/tool-call-context';
 import { useAgentPlan } from '@/domains/agents/hooks/use-agent-plan';
-import { useToolCall } from '@/services/tool-call-provider';
 
 export interface SubmitPlanToolProps {
   agentId: string;


### PR DESCRIPTION
Moves ToolCallProvider and useToolCall into playground-ui so message rendering can be reused without importing playground services. Exports the context type, memoizes provider values, migrates all 14 consumers, and removes the old provider without a re-export shim. The existing API and separate isRunning semantics are preserved; context consolidation is deferred.

Verification: both packages passed typecheck and build, the context's four unit tests passed, and all 240 ai-ui tests passed across 20 files. Pre-commit checks passed. The playground-ui mutation run had no surviving mutants; playground mutation testing was blocked by a dry-run timeout. Manual Studio approval flows and Chrome checks remain unverified.

Includes a patch changeset for playground-ui; playground is private.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR moves tool-call approval handling into the shared UI package. This lets message components reuse it without importing playground services.

## Changes

- Moved `ToolCallProvider` and `useToolCall` into `playground-ui`.
- Exported `ToolCallContextValue`.
- Memoized provider values.
- Migrated all 14 consumers.
- Removed the previous provider without a re-export shim.
- Preserved the existing API and separate `isRunning` behavior.
- Added context contract tests.
- Added a patch changeset for `playground-ui`.

## Verification

- Typechecks and builds passed for both packages.
- Four context unit tests passed.
- 240 `ai-ui` tests passed across 20 files.
- Pre-commit checks passed.
- Playground-ui mutation testing found no surviving mutants.

Manual Studio approval flows and Chrome checks remain unverified. Playground mutation testing was blocked by a dry-run timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->