### PR TITLE
fix(factory): preserve live running state during session refetches

### DIFF
--- a/.changeset/lazy-items-sin.md
+++ b/.changeset/lazy-items-sin.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed Factory chat showing an idle composer while a run is still streaming when a stale session state request finishes.

--- a/mastracode/factory-ui/src/hooks/useAgentControllerSessionSync.ts
+++ b/mastracode/factory-ui/src/hooks/useAgentControllerSessionSync.ts
@@ -1,9 +1,14 @@
-import type { AgentControllerTaskSnapshot } from '@mastra/client-js';
+import type { AgentControllerSessionState } from '@mastra/client-js';
 import { useQuery } from '@tanstack/react-query';
 import type { RefObject } from 'react';
 
 import { queryKeys } from '../api/keys';
 import { createAgentControllerClient } from '../ui/domains/chat/services/agentControllerClient';
+
+export type AgentControllerLiveState = Pick<AgentControllerSessionState, 'running' | 'tasks'> & {
+  generation: number;
+  threadId?: string;
+};
 
 interface UseAgentControllerSessionSyncArgs {
   agentControllerId: string;
@@ -13,8 +18,7 @@ interface UseAgentControllerSessionSyncArgs {
   baseUrl?: string;
   enabled?: boolean;
   sseConnected: boolean;
-  taskEventGeneration: RefObject<number>;
-  liveTasks: RefObject<{ threadId?: string; tasks: AgentControllerTaskSnapshot[] } | undefined>;
+  liveState: RefObject<AgentControllerLiveState>;
 }
 
 export function reconnectRefetchInterval(sseConnected: boolean, fetchFailureCount: number): false | number {
@@ -31,8 +35,7 @@ export function useAgentControllerSessionSync({
   baseUrl = '',
   enabled = true,
   sseConnected,
-  taskEventGeneration,
-  liveTasks,
+  liveState,
 }: UseAgentControllerSessionSyncArgs) {
   const { session } = createAgentControllerClient({
     agentControllerId,
@@ -45,13 +48,12 @@ export function useAgentControllerSessionSync({
   return useQuery({
     queryKey: queryKeys.agentControllerConnectionState(agentControllerId, resourceId, scope, threadId),
     queryFn: async () => {
-      const generationAtRequestStart = taskEventGeneration.current;
+      const generationAtRequestStart = liveState.current.generation;
+      liveState.current = { generation: generationAtRequestStart, threadId };
       const state = await session!.state({ threadId });
-      const latestTasks = liveTasks.current;
-      const liveEventOvertookRequest = generationAtRequestStart !== taskEventGeneration.current;
-      return liveEventOvertookRequest && latestTasks && latestTasks.threadId === threadId
-        ? { ...state, tasks: latestTasks.tasks }
-        : state;
+      const { generation, threadId: liveThreadId, ...updates } = liveState.current;
+      const liveEventOvertookRequest = generationAtRequestStart !== generation && liveThreadId === threadId;
+      return liveEventOvertookRequest ? { ...state, ...updates } : state;
     },
     enabled: enabled && Boolean(session),
     staleTime: Infinity,

--- a/mastracode/factory-ui/src/hooks/useAgentControllerSessionSync.ts
+++ b/mastracode/factory-ui/src/hooks/useAgentControllerSessionSync.ts
@@ -1,14 +1,15 @@
-import type { AgentControllerSessionState } from '@mastra/client-js';
-import { useQuery } from '@tanstack/react-query';
-import type { RefObject } from 'react';
+import type { AgentControllerEvent, AgentControllerSessionState } from '@mastra/client-js';
+import { isKnownAgentControllerEvent } from '@mastra/client-js';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRef } from 'react';
 
 import { queryKeys } from '../api/keys';
-import { createAgentControllerClient } from '../ui/domains/chat/services/agentControllerClient';
+import {
+  createAgentControllerClient,
+  requireAgentControllerSession,
+} from '../ui/domains/chat/services/agentControllerClient';
 
-export type AgentControllerLiveState = Pick<AgentControllerSessionState, 'running' | 'tasks'> & {
-  generation: number;
-  threadId?: string;
-};
+type SessionStateUpdate = Pick<AgentControllerSessionState, 'running' | 'tasks'>;
 
 interface UseAgentControllerSessionSyncArgs {
   agentControllerId: string;
@@ -18,7 +19,6 @@ interface UseAgentControllerSessionSyncArgs {
   baseUrl?: string;
   enabled?: boolean;
   sseConnected: boolean;
-  liveState: RefObject<AgentControllerLiveState>;
 }
 
 export function reconnectRefetchInterval(sseConnected: boolean, fetchFailureCount: number): false | number {
@@ -35,8 +35,10 @@ export function useAgentControllerSessionSync({
   baseUrl = '',
   enabled = true,
   sseConnected,
-  liveState,
 }: UseAgentControllerSessionSyncArgs) {
+  const queryClient = useQueryClient();
+  const liveStateUpdates = useRef<{ threadId?: string; updates: SessionStateUpdate }>({ updates: {} });
+  const stateQueryKey = queryKeys.agentControllerConnectionState(agentControllerId, resourceId, scope, threadId);
   const { session } = createAgentControllerClient({
     agentControllerId,
     resourceId,
@@ -45,20 +47,62 @@ export function useAgentControllerSessionSync({
     enabled,
   });
 
-  return useQuery({
-    queryKey: queryKeys.agentControllerConnectionState(agentControllerId, resourceId, scope, threadId),
-    queryFn: async () => {
-      const generationAtRequestStart = liveState.current.generation;
-      liveState.current = { generation: generationAtRequestStart, threadId };
-      const state = await session!.state({ threadId });
-      const { generation, threadId: liveThreadId, ...updates } = liveState.current;
-      const liveEventOvertookRequest = generationAtRequestStart !== generation && liveThreadId === threadId;
-      return liveEventOvertookRequest ? { ...state, ...updates } : state;
-    },
+  async function readSessionState() {
+    liveStateUpdates.current = { threadId, updates: {} };
+    const serverState = await requireAgentControllerSession(session).state({ threadId });
+    if (liveStateUpdates.current.threadId !== threadId) return serverState;
+    return { ...serverState, ...liveStateUpdates.current.updates };
+  }
+
+  function recordLiveStateUpdate(update: SessionStateUpdate) {
+    if (liveStateUpdates.current.threadId !== threadId) {
+      liveStateUpdates.current = { threadId, updates: {} };
+    }
+    liveStateUpdates.current.updates = { ...liveStateUpdates.current.updates, ...update };
+  }
+
+  function updateCachedSessionState(update: SessionStateUpdate) {
+    const updatedAt = queryClient.getQueryState(stateQueryKey)?.dataUpdatedAt;
+    queryClient.setQueryData<AgentControllerSessionState>(
+      stateQueryKey,
+      current => (current ? { ...current, ...update } : current),
+      { updatedAt },
+    );
+  }
+
+  function applySessionEvent(event: AgentControllerEvent) {
+    const update = getSessionStateUpdate(event);
+    if (!update) return;
+    recordLiveStateUpdate(update);
+    updateCachedSessionState(update);
+  }
+
+  const stateQuery = useQuery({
+    queryKey: stateQueryKey,
+    queryFn: readSessionState,
     enabled: enabled && Boolean(session),
     staleTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     refetchInterval: query => reconnectRefetchInterval(sseConnected, query.state.fetchFailureCount),
   });
+
+  return { stateQuery, applySessionEvent };
+}
+
+function getSessionStateUpdate(event: AgentControllerEvent): SessionStateUpdate | undefined {
+  if (!isKnownAgentControllerEvent(event)) return undefined;
+
+  switch (event.type) {
+    case 'agent_start':
+      return { running: true };
+    case 'agent_end':
+      return { running: false };
+    case 'display_state_changed':
+      return { running: event.displayState.isRunning };
+    case 'task_updated':
+      return { tasks: event.tasks };
+    default:
+      return undefined;
+  }
 }

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import type { AgentControllerEvent } from '@mastra/client-js';
+import type { AgentControllerEvent, AgentControllerSessionState } from '@mastra/client-js';
 import { waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { useEffect } from 'react';
@@ -7,7 +7,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { server } from '../../../../../../e2e/ui/msw-server';
 import { queryKeys } from '../../../../../api/keys';
-import { renderHookWithProviders, TEST_BASE_URL } from '../../../../../../e2e/ui/render';
+import { renderHookWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../../../../e2e/ui/render';
 import { deriveConnectionStatus, useAgentControllerConnection } from '../useAgentControllerConnection';
 import { reconnectRefetchInterval } from '../../../../../hooks/useAgentControllerSessionSync';
 
@@ -133,11 +133,6 @@ describe('useAgentControllerConnection', () => {
   });
 
   it('given a workspace session with a conventional thread id, when the connection initializes, then session creation binds that exact thread', async () => {
-    // Regression: a factory workspace's thread id is its sessionId (seeded by
-    // FactoryStartCoordinator). If init omits `threadId` and provisioning was
-    // interrupted (or storage was reset), the server binds a fresh random-id
-    // thread and the route's thread lookup 404s forever. Passing the exact id
-    // makes init a get-or-create for the conventional thread.
     let createBody: unknown;
     const onEvent = vi.fn();
 
@@ -273,7 +268,45 @@ describe('useAgentControllerConnection', () => {
     expect(onStream).toHaveBeenCalledTimes(1);
   });
 
-  it('given a state refetch started before a task event, then the stale response does not replace the live tasks', async () => {
+  it.each([
+    {
+      eventName: 'a task event',
+      previousEvent: { type: 'agent_start' },
+      event: {
+        type: 'task_updated',
+        tasks: [{ id: 'new', content: 'New task', status: 'in_progress', activeForm: 'Working on new task' }],
+      },
+      initialState: {
+        running: false,
+        tasks: [{ id: 'old', content: 'Old task', status: 'pending', activeForm: 'Working on old task' }],
+      },
+      liveState: {
+        running: false,
+        tasks: [{ id: 'new', content: 'New task', status: 'in_progress', activeForm: 'Working on new task' }],
+      },
+    },
+    {
+      eventName: 'agent_start',
+      previousEvent: { type: 'agent_end' },
+      event: { type: 'agent_start' },
+      initialState: { running: false },
+      liveState: { running: true },
+    },
+    {
+      eventName: 'agent_end',
+      previousEvent: { type: 'agent_start' },
+      event: { type: 'agent_end' },
+      initialState: { running: true },
+      liveState: { running: false },
+    },
+  ] satisfies {
+    eventName: string;
+    previousEvent: AgentControllerEvent;
+    event: AgentControllerEvent;
+    initialState: Pick<AgentControllerSessionState, 'running' | 'tasks'>;
+    liveState: Pick<AgentControllerSessionState, 'running' | 'tasks'>;
+  }[])('given a refetch before $eventName, then the stale response cannot replace live state', async testCase => {
+    const { previousEvent, event, initialState, liveState } = testCase;
     const encoder = new TextEncoder();
     const onEvent = vi.fn();
     let emit: (event: AgentControllerEvent) => void = () => {};
@@ -297,7 +330,7 @@ describe('useAgentControllerConnection', () => {
           modeId: 'build',
           modelId: 'openai/gpt-4o-mini',
           threadId: 'thread-1',
-          tasks: [{ id: 'old', content: 'Old task', status: 'pending', activeForm: 'Working on old task' }],
+          ...initialState,
         });
       }),
       http.get(
@@ -320,20 +353,21 @@ describe('useAgentControllerConnection', () => {
     );
     await waitFor(() => expect(result.current.status).toBe('ready'));
 
+    emit(previousEvent);
+    await waitFor(() => expect(onEvent).toHaveBeenLastCalledWith(previousEvent));
+
     void client.invalidateQueries({
       queryKey: queryKeys.agentControllerConnectionState(controllerId, resourceId, undefined, 'thread-1'),
       exact: true,
     });
     await waitFor(() => expect(stateReads).toBe(2));
 
-    const liveTasks = [
-      { id: 'new', content: 'New task', status: 'in_progress' as const, activeForm: 'Working on new task' },
-    ];
-    emit({ type: 'task_updated', tasks: liveTasks });
-    await waitFor(() => expect(result.current.state?.tasks).toEqual(liveTasks));
+    emit(event);
+    await waitFor(() => expect(onEvent).toHaveBeenLastCalledWith(event));
 
     releaseRefetch?.();
-    await waitFor(() => expect(result.current.state?.tasks).toEqual(liveTasks));
+    await waitForMutationsIdle(client);
+    expect(result.current.state).toMatchObject(liveState);
   });
 
   it('given reconnect polling is disconnected, then it backs off and stops at the retry cap', () => {

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
@@ -8,6 +8,7 @@ import { createAgentControllerClient } from '../services/agentControllerClient';
 import { useAgentControllerEvents } from './useAgentControllerEvents';
 import { useAgentControllerSessionInit } from '../../../../hooks/useAgentControllerSessionInit';
 import { useAgentControllerSessionSync } from '../../../../hooks/useAgentControllerSessionSync';
+import type { AgentControllerLiveState } from '../../../../hooks/useAgentControllerSessionSync';
 
 export type ConnectionStatus = 'connecting' | 'ready' | 'reconnecting' | 'error';
 type SseConnectionState = 'never' | 'connected' | 'dropped';
@@ -21,7 +22,6 @@ interface UseAgentControllerConnectionArgs {
   agentControllerId: string;
   resourceId: string;
   scope?: string;
-  /** Exact thread id to bind on session creation (see ChatSessionContextApi). */
   sessionThreadId?: string;
   factorySessionState?: FactorySessionState;
   baseUrl?: string;
@@ -42,8 +42,7 @@ export function useAgentControllerConnection({
   const queryClient = useQueryClient();
   const [sseConnectionState, setSseConnectionState] = useState<SseConnectionState>('never');
   const sseStateRef = useRef<SseConnectionState>('never');
-  const taskEventGeneration = useRef(0);
-  const liveTasks = useRef<{ threadId?: string; tasks: NonNullable<AgentControllerSessionState['tasks']> }>(undefined);
+  const liveState = useRef<AgentControllerLiveState>({ generation: 0 });
   const sseConnected = sseConnectionState === 'connected';
   const hasEverConnected = sseConnectionState !== 'never';
   const { session } = createAgentControllerClient({
@@ -70,30 +69,22 @@ export function useAgentControllerConnection({
     baseUrl,
     enabled: enabled && initQuery.isSuccess,
     sseConnected,
-    taskEventGeneration,
-    liveTasks,
+    liveState,
   });
   const handleConnectedChange = (connected: boolean) => {
-    // Ref mirrors the state so back-to-back events see the true previous value
-    // even when React batches the renders in between.
+    // React can batch renders between consecutive connection events.
     const previous = sseStateRef.current;
     const next = nextSseConnectionState(previous, connected);
     if (next === previous) return;
     sseStateRef.current = next;
     setSseConnectionState(next);
     if (next !== 'connected') return;
-    // Events sent while the stream was down are gone for good (the server does
-    // not replay them), so a reconnect refetches the mounted message windows —
-    // mergeWindow folds whatever the gap dropped back into the transcript. A
-    // first connect retries only failed windows: the stream opens after the
-    // session is bound to its thread, so a read that raced that binding works now.
+    // The server does not replay events missed while disconnected.
     const reconnected = previous === 'dropped';
     void queryClient.invalidateQueries({
       queryKey: queryKeys.agentControllerResourceThreadMessages(agentControllerId, resourceId),
       predicate: query => reconnected || query.state.status === 'error',
     });
-    // The gap can also have eaten agent_start/agent_end, so the cached state
-    // snapshot is refetched the same way.
     if (reconnected) {
       void queryClient.invalidateQueries({
         queryKey: queryKeys.agentControllerConnectionState(agentControllerId, resourceId, scope, sessionThreadId),
@@ -109,11 +100,17 @@ export function useAgentControllerConnection({
         : undefined;
     const running = event.type === 'agent_start' ? true : event.type === 'agent_end' ? false : displayStateRunning;
     const tasks = isKnownAgentControllerEvent(event) && event.type === 'task_updated' ? event.tasks : undefined;
-    if (tasks) {
-      taskEventGeneration.current += 1;
-      liveTasks.current = { threadId: sessionThreadId, tasks };
-    }
-    if (typeof running === 'boolean' || tasks) {
+    if (running !== undefined || tasks) {
+      const updates = {
+        ...(running !== undefined ? { running } : {}),
+        ...(tasks ? { tasks } : {}),
+      };
+      liveState.current = {
+        ...(liveState.current.threadId === sessionThreadId ? liveState.current : {}),
+        generation: liveState.current.generation + 1,
+        threadId: sessionThreadId,
+        ...updates,
+      };
       const stateQueryKey = queryKeys.agentControllerConnectionState(
         agentControllerId,
         resourceId,
@@ -123,14 +120,7 @@ export function useAgentControllerConnection({
       const updatedAt = queryClient.getQueryState(stateQueryKey)?.dataUpdatedAt;
       queryClient.setQueryData<AgentControllerSessionState>(
         stateQueryKey,
-        current =>
-          current
-            ? {
-                ...current,
-                ...(typeof running === 'boolean' ? { running } : {}),
-                ...(tasks ? { tasks } : {}),
-              }
-            : current,
+        current => (current ? { ...current, ...updates } : current),
         { updatedAt },
       );
     }

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
@@ -1,5 +1,4 @@
-import type { AgentControllerEvent, AgentControllerSessionState } from '@mastra/client-js';
-import { isKnownAgentControllerEvent } from '@mastra/client-js';
+import type { AgentControllerEvent } from '@mastra/client-js';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRef, useState } from 'react';
 import { queryKeys } from '../../../../api/keys';
@@ -8,7 +7,6 @@ import { createAgentControllerClient } from '../services/agentControllerClient';
 import { useAgentControllerEvents } from './useAgentControllerEvents';
 import { useAgentControllerSessionInit } from '../../../../hooks/useAgentControllerSessionInit';
 import { useAgentControllerSessionSync } from '../../../../hooks/useAgentControllerSessionSync';
-import type { AgentControllerLiveState } from '../../../../hooks/useAgentControllerSessionSync';
 
 export type ConnectionStatus = 'connecting' | 'ready' | 'reconnecting' | 'error';
 type SseConnectionState = 'never' | 'connected' | 'dropped';
@@ -42,7 +40,6 @@ export function useAgentControllerConnection({
   const queryClient = useQueryClient();
   const [sseConnectionState, setSseConnectionState] = useState<SseConnectionState>('never');
   const sseStateRef = useRef<SseConnectionState>('never');
-  const liveState = useRef<AgentControllerLiveState>({ generation: 0 });
   const sseConnected = sseConnectionState === 'connected';
   const hasEverConnected = sseConnectionState !== 'never';
   const { session } = createAgentControllerClient({
@@ -61,7 +58,7 @@ export function useAgentControllerConnection({
     baseUrl,
     enabled,
   });
-  const syncQuery = useAgentControllerSessionSync({
+  const { stateQuery: syncQuery, applySessionEvent } = useAgentControllerSessionSync({
     agentControllerId,
     resourceId,
     scope,
@@ -69,7 +66,6 @@ export function useAgentControllerConnection({
     baseUrl,
     enabled: enabled && initQuery.isSuccess,
     sseConnected,
-    liveState,
   });
   const handleConnectedChange = (connected: boolean) => {
     // React can batch renders between consecutive connection events.
@@ -94,36 +90,7 @@ export function useAgentControllerConnection({
   };
 
   const handleEvent = (event: AgentControllerEvent) => {
-    const displayStateRunning =
-      isKnownAgentControllerEvent(event) && event.type === 'display_state_changed'
-        ? event.displayState.isRunning
-        : undefined;
-    const running = event.type === 'agent_start' ? true : event.type === 'agent_end' ? false : displayStateRunning;
-    const tasks = isKnownAgentControllerEvent(event) && event.type === 'task_updated' ? event.tasks : undefined;
-    if (running !== undefined || tasks) {
-      const updates = {
-        ...(running !== undefined ? { running } : {}),
-        ...(tasks ? { tasks } : {}),
-      };
-      liveState.current = {
-        ...(liveState.current.threadId === sessionThreadId ? liveState.current : {}),
-        generation: liveState.current.generation + 1,
-        threadId: sessionThreadId,
-        ...updates,
-      };
-      const stateQueryKey = queryKeys.agentControllerConnectionState(
-        agentControllerId,
-        resourceId,
-        scope,
-        sessionThreadId,
-      );
-      const updatedAt = queryClient.getQueryState(stateQueryKey)?.dataUpdatedAt;
-      queryClient.setQueryData<AgentControllerSessionState>(
-        stateQueryKey,
-        current => (current ? { ...current, ...updates } : current),
-        { updatedAt },
-      );
-    }
+    applySessionEvent(event);
     onEvent(event);
   };
 


### PR DESCRIPTION
## Description

**─────── TLDR ───────**
> Factory chat keeps the live running state when an earlier session-state request finishes.

A slow state response could put the composer back to idle while the run was still streaming. Running and task updates now share one overlay in the session-sync hook.

A run starts while a state GET is in flight
&nbsp;&nbsp;├─ **was** — the stale response made the composer idle
&nbsp;&nbsp;└─ **now** — the composer stays working until the run ends

A run ends while a state GET is in flight
&nbsp;&nbsp;├─ **was** — the stale response could make the composer busy again
&nbsp;&nbsp;└─ **now** — the composer stays idle

Task updates during the request
&nbsp;&nbsp;└─ **unchanged** — the latest tasks for that thread win

Each request clears the overlay before fetching, then applies events received during that request if the thread still matches. This also lets a reconnect snapshot correct events missed while disconnected. The stream opens after the initial GET in this checkout; the regression exercises an in-flight refetch.

| | Symbol | Why |
|---|---|---|
| **−** | `taskEventGeneration` | Clearing the overlay at request start makes the counter redundant. |
| **~** | `useAgentControllerSessionSync` | Owns fetching, live updates, and cache writes together. |
| **+** | `applySessionEvent(event)` | Gives the connection hook one call for state updates. |

No new production files. Event mapping uses a switch; named functions record live updates and patch the cache.

- [ ] Manual Slow 3G browser reproduction

---

> ██████████████████ **source** `+70 −67`
> █████████████ **tests** `+49 −15`
> █ **changeset** `+5`

## Related issue(s)

No linked issue. Reproduced with a delayed session-state response.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable; no documentation change needed)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory chat now keeps the correct running status when an older session request finishes late. This prevents the composer from showing the wrong state while a run starts or ends.

## Changes

- Unified running-state and task-state tracking in `useAgentControllerSessionSync`.
- Added generation and thread guards for running events.
- Ensured newer live events take precedence over stale session-state responses.
- Created a fresh overlay for each session-state request.
- Updated connection handling to use `applySessionEvent`.
- Added regression tests for task updates, `agent_start`, and `agent_end` events.
- Added a patch changeset for `mastra`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->