### PR TITLE
fix(workflows): relay nested workflow streams in Inngest

### DIFF
--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -232,6 +232,40 @@ createWorkflowTestSuite({
 const testStorage = new MockStore();
 
 describe('Workflow (Default Engine Specifics)', () => {
+  it('relays nested workflow watch events through the parent run topic', async () => {
+    const step = createStep({
+      id: 'nested-watch-step',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      execute: async () => ({}),
+    });
+    const workflow = createWorkflow({
+      id: 'nested-watch-parent',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      steps: [step],
+    });
+    workflow.then(step).commit();
+
+    const run = await workflow.createRun({ runId: 'nested-watch-parent-run' });
+    const events: unknown[] = [];
+    const unwatch = run.watch(event => events.push(event));
+    await new Promise(resolve => setImmediate(resolve));
+
+    await (run as any).pubsub.publish('nested-watch.nested-watch-parent-run', {
+      type: 'nested-watch',
+      runId: 'nested-watch-child-run',
+      data: {
+        event: { type: 'data-text', data: { text: 'nested chunk' } },
+        workflowId: 'nested-watch-child',
+      },
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    unwatch();
+
+    expect(events).toEqual([{ type: 'data-text', data: { text: 'nested chunk' } }]);
+  });
+
   describe('startAsync', () => {
     it('should start workflow and complete successfully', async () => {
       const step1 = createStep({

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2931,6 +2931,7 @@ export class Workflow<
     const run = isResume
       ? await this.createRun({ runId: resume.runId, resourceId, pubsub: nestedPubsub })
       : await this.createRun({ runId, resourceId, pubsub: nestedPubsub });
+    const parentRunId = runId ?? run.runId;
     const nestedAbortCb = () => {
       abort();
     };
@@ -2944,7 +2945,7 @@ export class Workflow<
     const unwatch = useSharedPubsub
       ? () => {}
       : run.watch(event => {
-          void pubsub.publish('nested-watch', {
+          void pubsub.publish(`nested-watch.${parentRunId}`, {
             type: 'nested-watch',
             runId: run.runId,
             data: { event, workflowId: this.id },
@@ -4263,11 +4264,8 @@ export class Run<
    * @internal
    */
   watch(cb: (event: WorkflowStreamEvent) => void | Promise<void>): () => void {
-    // Both callbacks acknowledge every delivery, including events for other
-    // runs. `nested-watch` is a shared topic, so a watcher sees every nested
-    // workflow's events; leaving the ones it filters out unacknowledged grows
-    // the subscription's pending list on a durable transport for as long as
-    // the watcher is attached. The ack is the last thing each callback does so
+    // The parent run ID scopes nested relays to their intended watcher. The ack
+    // is the last thing each callback does so
     // a failure in the consumer or in the nested republish leaves the delivery
     // unacknowledged and redeliverable.
     const wrappedCb = async (event: Event, ack?: () => Promise<void>) => {
@@ -4278,44 +4276,42 @@ export class Run<
     };
 
     const nestedWatchCb = async (event: Event, ack?: () => Promise<void>) => {
-      if (event.runId === this.runId) {
-        const { event: nestedEvent, workflowId } = event.data as {
-          event: { type: string; payload?: { id: string } & Record<string, unknown>; data?: any };
-          workflowId: string;
-        };
+      const { event: nestedEvent, workflowId } = event.data as {
+        event: { type: string; payload?: { id: string } & Record<string, unknown>; data?: any };
+        workflowId: string;
+      };
 
-        // Data chunks from writer.custom() should bubble up directly without modification
-        // These are events with type starting with 'data-' and have a 'data' property
-        if (nestedEvent.type.startsWith('data-') && nestedEvent.data !== undefined) {
-          // Bubble up custom data events directly to preserve their structure
-          await this.pubsub.publish(`workflow.events.v2.${this.runId}`, {
-            type: 'watch',
-            runId: this.runId,
-            data: nestedEvent,
-          });
-        } else {
-          // Regular workflow events get prefixed with nested workflow ID
-          await this.pubsub.publish(`workflow.events.v2.${this.runId}`, {
-            type: 'watch',
-            runId: this.runId,
-            data: {
-              ...nestedEvent,
-              ...(nestedEvent.payload?.id
-                ? { payload: { ...nestedEvent.payload, id: `${workflowId}.${nestedEvent.payload.id}` } }
-                : {}),
-            },
-          });
-        }
+      // Data chunks from writer.custom() should bubble up directly without modification
+      // These are events with type starting with 'data-' and have a 'data' property
+      if (nestedEvent.type.startsWith('data-') && nestedEvent.data !== undefined) {
+        // Bubble up custom data events directly to preserve their structure
+        await this.pubsub.publish(`workflow.events.v2.${this.runId}`, {
+          type: 'watch',
+          runId: this.runId,
+          data: nestedEvent,
+        });
+      } else {
+        // Regular workflow events get prefixed with nested workflow ID
+        await this.pubsub.publish(`workflow.events.v2.${this.runId}`, {
+          type: 'watch',
+          runId: this.runId,
+          data: {
+            ...nestedEvent,
+            ...(nestedEvent.payload?.id
+              ? { payload: { ...nestedEvent.payload, id: `${workflowId}.${nestedEvent.payload.id}` } }
+              : {}),
+          },
+        });
       }
       await ack?.();
     };
 
     void this.pubsub.subscribe(`workflow.events.v2.${this.runId}`, wrappedCb);
-    void this.pubsub.subscribe('nested-watch', nestedWatchCb);
+    void this.pubsub.subscribe(`nested-watch.${this.runId}`, nestedWatchCb);
 
     return () => {
       void this.pubsub.unsubscribe(`workflow.events.v2.${this.runId}`, wrappedCb);
-      void this.pubsub.unsubscribe('nested-watch', nestedWatchCb);
+      void this.pubsub.unsubscribe(`nested-watch.${this.runId}`, nestedWatchCb);
     };
   }
 

--- a/workflows/inngest/src/pubsub.ts
+++ b/workflows/inngest/src/pubsub.ts
@@ -18,6 +18,7 @@ function buildTopicRef(channel: string, topic: string) {
  * Supported formats:
  * - "workflow.events.v2.{runId}" - workflow events
  * - "agent.stream.{runId}" - agent stream events
+ * - "nested-watch.{runId}" - nested workflow watch relay events
  *
  * @returns { runId, topicType } or null if not a recognized format
  */
@@ -26,6 +27,11 @@ function parseTopic(topic: string): { runId: string; topicType: 'workflow' | 'ag
   const workflowMatch = topic.match(/^workflow\.events\.v2\.(.+)$/);
   if (workflowMatch && workflowMatch[1]) {
     return { runId: workflowMatch[1], topicType: 'workflow' };
+  }
+
+  const nestedWatchMatch = topic.match(/^nested-watch\.(.+)$/);
+  if (nestedWatchMatch && nestedWatchMatch[1]) {
+    return { runId: nestedWatchMatch[1], topicType: 'workflow' };
   }
 
   // Try agent stream format
@@ -48,6 +54,8 @@ function parseTopic(topic: string): { runId: string; topicType: 'workflow' | 'ag
  *
  * Supported topic formats:
  * - "workflow.events.v2.{runId}" - workflow events
+ *   -> Inngest channel: "workflow:{workflowId}:{runId}", topic: "watch"
+ * - "nested-watch.{runId}" - nested workflow watch relay events
  *   -> Inngest channel: "workflow:{workflowId}:{runId}", topic: "watch"
  * - "agent.stream.{runId}" - agent stream events (for InngestAgent)
  *   -> Inngest channel: "agent:{runId}", topic: "agent-stream"

--- a/workflows/inngest/src/realtime-subscription.test.ts
+++ b/workflows/inngest/src/realtime-subscription.test.ts
@@ -48,6 +48,24 @@ describe('Inngest realtime subscriptions', () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  it('publishes nested workflow watch events on the parent workflow channel', async () => {
+    const { InngestPubSub } = await import('./pubsub');
+    const publish = vi.fn().mockResolvedValue(undefined);
+    const inngest = { realtime: { publish } } as unknown as Inngest;
+    const pubsub = new InngestPubSub(inngest, 'parent-workflow');
+
+    await pubsub.publish('nested-watch.parent-run', {
+      type: 'nested-watch',
+      runId: 'child-run',
+      data: { event: { type: 'data-text', data: { text: 'chunk' } }, workflowId: 'child-workflow' },
+    });
+
+    expect(publish).toHaveBeenCalledWith(
+      { channel: 'workflow:parent-workflow:parent-run', topic: 'watch', config: {} },
+      { event: { type: 'data-text', data: { text: 'chunk' } }, workflowId: 'child-workflow' },
+    );
+  });
+
   it('closes a pending run-output subscription after polling wins', async () => {
     const { init } = await import('./index');
     let resolveSubscription!: (subscription: { close: () => void }) => void;


### PR DESCRIPTION
Relays stream events from nested workflows to the parent run when using the Inngest engine. Nested workflow watch events are now scoped to the parent run and mapped to the parent's workflow channel.

Closes #23479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a workflow starts another workflow, the child workflow can now send its stream updates back to the parent run. This keeps nested workflows consistent with regular workflows.

## Changes

- Scope nested workflow watch events to the parent run.
- Route nested events through `nested-watch.<parentRunId>`.
- Relay nested events to the parent run’s workflow channel.
- Support nested workflow events at any nesting depth.
- Add handling for `nested-watch.{runId}` topics in the Inngest pubsub layer.
- Add regression tests for default-engine and Inngest nested workflow event propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->