### PR TITLE
fix(studio): simplify span and trace panel headers

### DIFF
--- a/.changeset/silent-geese-prove.md
+++ b/.changeset/silent-geese-prove.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved the span and trace panel headers in Studio: the ID is shown without a `#` prefix, the label and ID button are aligned, hovering shows the copy action, and clicking the ID copies it without an extra icon or layout shift, with a confirmation tooltip. The compact span panel on the Logs page now shows start, end and duration as icons with tooltips instead of `Started`/`Ended`/`Duration` rows, matching the main span panel.

--- a/packages/playground-ui/src/domains/traces/components/__tests__/span-data-panel-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/span-data-panel-view.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { SpanDataPanelView } from '../span-data-panel-view';
@@ -45,6 +45,53 @@ describe('SpanDataPanelView — header summary', () => {
     expect(runId.textContent).toContain('run-abcd');
     expect(runId.textContent).not.toContain('run-abcdefghijklmnop');
     expect(screen.queryByText('Run Id')).toBeNull();
+  });
+});
+
+describe('SpanDataPanelView — span id in the header', () => {
+  const fullId = 'span-0123456789abcdef';
+
+  it('shows the id truncated without a # prefix', () => {
+    render(<SpanDataPanelView {...baseProps} spanId={fullId} />);
+
+    const heading = screen.getByRole('heading', { name: /^Span span-0123456…/ });
+    expect(heading.textContent).not.toContain('#');
+    expect(screen.queryByText(fullId)).toBeNull();
+  });
+
+  it('shows the copy action instead of the full id in a tooltip', async () => {
+    render(<SpanDataPanelView {...baseProps} spanId={fullId} />);
+
+    fireEvent.focus(screen.getByRole('button', { name: 'span-0123456…' }));
+
+    expect((await screen.findByRole('tooltip')).textContent).toBe('Copy to clipboard');
+    expect(screen.queryByText(fullId)).toBeNull();
+  });
+
+  it('copies the full id on click', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<SpanDataPanelView {...baseProps} spanId={fullId} />);
+
+    const button = screen.getByRole('button', { name: 'span-0123456…' });
+    fireEvent.click(button);
+
+    expect(writeText).toHaveBeenCalledWith(fullId);
+    expect((await screen.findByRole('tooltip')).textContent).toBe('Copied to clipboard');
+    expect(button.textContent).toBe('span-0123456…');
+    expect(button.querySelector('svg')).toBeNull();
+  });
+
+  it('copies a short id by clicking the id itself', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(<SpanDataPanelView {...baseProps} spanId="span-1" />);
+
+    expect(screen.getByRole('heading', { name: /^Span span-1/ })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'span-1' }));
+    expect(writeText).toHaveBeenCalledWith('span-1');
+    expect((await screen.findByRole('tooltip')).textContent).toBe('Copied to clipboard');
   });
 });
 

--- a/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
@@ -332,8 +332,9 @@ describe('TraceDataPanelView — the header', () => {
   it('names the trace by a shortened id in the side panel', () => {
     render(<TraceDataPanelView {...baseProps} traceId="0123456789abcdef0123" />);
 
-    expect(screen.getByText(/# 0123456789ab/)).toBeTruthy();
-    expect(screen.queryByText(/0123456789abcdef0123/)).toBeNull();
+    const heading = screen.getByRole('heading', { name: /^Trace 0123456789ab…/ });
+    expect(heading.textContent).not.toContain('#');
+    expect(screen.queryByText('0123456789abcdef0123')).toBeNull();
   });
 
   it('drops the trace id, and every side-panel control, on the trace page', () => {
@@ -342,7 +343,7 @@ describe('TraceDataPanelView — the header', () => {
     );
 
     expect(screen.getByText('Trace Timeline')).toBeTruthy();
-    expect(screen.queryByText(/# trace-1/)).toBeNull();
+    expect(screen.queryByRole('heading', { name: /trace-1/ })).toBeNull();
     expect(screen.queryByRole('button', { name: /previous trace/i })).toBeNull();
     expect(screen.queryByRole('button', { name: /collapse panel/i })).toBeNull();
     openTraceActions();
@@ -378,7 +379,7 @@ describe('TraceDataPanelView — the header', () => {
 
     expect(screen.queryByText('agent run')).toBeNull();
     // The header stays, so the panel can be expanded again.
-    expect(screen.getByText(/# trace-1/)).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /trace-1/ })).toBeTruthy();
   });
 
   it('offers trace-to-trace navigation as soon as either direction exists', () => {

--- a/packages/playground-ui/src/domains/traces/components/span-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/span-data-panel-view.tsx
@@ -5,12 +5,12 @@ import { getTokenLimitMessage, isTokenLimitExceeded } from '../utils/span-utils'
 import { SpanSummaryDescription } from './span-summary-description';
 import { SpanTokenUsage } from './span-token-usage';
 import type { TokenUsage } from './span-token-usage';
+import { TraceIdButton } from './trace-id-button';
 import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
 import { DataKeysAndValues } from '@/ds/components/DataKeysAndValues';
 import { DataPanel } from '@/ds/components/DataPanel';
 import { Notice } from '@/ds/components/Notice';
 import { Tab, TabContent, TabList, Tabs } from '@/ds/components/Tabs';
-import { truncateString } from '@/lib/truncate-string';
 
 function buildDialogTitle(sectionTitle: string, icon: ReactNode, span: { spanId: string; traceId: string }) {
   return (
@@ -20,10 +20,10 @@ function buildDialogTitle(sectionTitle: string, icon: ReactNode, span: { spanId:
         {sectionTitle}
       </span>
       <span>
-        › Span <b className="text-neutral3">#{span.spanId}</b>
+        › Span <b className="text-neutral3">{span.spanId}</b>
       </span>
       <span>
-        › Trace <b className="text-neutral3">#{span.traceId}</b>
+        › Trace <b className="text-neutral3">{span.traceId}</b>
       </span>
     </>
   );
@@ -77,8 +77,9 @@ export function SpanDataPanelView({
       {/* Two-line header (heading + summary); neighbouring panel headers use min-h-16 to stay level. */}
       <DataPanel.Header className="min-h-16 py-2">
         <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <DataPanel.Heading className="whitespace-nowrap">
-            Span <b># {truncateString(spanId, 12)}</b>
+          <DataPanel.Heading className="items-center whitespace-nowrap">
+            Span
+            <TraceIdButton id={spanId} />
           </DataPanel.Heading>
           {span && <SpanSummaryDescription span={span} />}
         </div>

--- a/packages/playground-ui/src/domains/traces/components/span-details-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/span-details-view.tsx
@@ -1,6 +1,7 @@
 import type { SpanRecord } from '@mastra/core/storage';
 import { BracesIcon, FileInputIcon, FileOutputIcon } from 'lucide-react';
-import { formatSpanDuration, formatSpanPanelTimestamp } from '../utils/span-utils';
+import { SpanSummaryDescription } from './span-summary-description';
+import { TraceIdButton } from './trace-id-button';
 import { DataDetailsPanel } from '@/ds/components/DataDetailsPanel';
 
 const KV = DataDetailsPanel.KeyValueList;
@@ -19,16 +20,16 @@ export interface SpanDetailsViewProps {
  * full-width span view with scoring tab + prev/next nav, use `SpanDataPanelView`.
  */
 export function SpanDetailsView({ spanId, span, isLoading, onClose }: SpanDetailsViewProps) {
-  const duration = formatSpanDuration(span?.startedAt, span?.endedAt);
-  const startedAt = formatSpanPanelTimestamp(span?.startedAt);
-  const endedAt = formatSpanPanelTimestamp(span?.endedAt);
-
   return (
     <DataDetailsPanel>
       <DataDetailsPanel.Header>
-        <DataDetailsPanel.Heading>
-          Span <b># {spanId}</b>
-        </DataDetailsPanel.Heading>
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <DataDetailsPanel.Heading className="items-center">
+            Span
+            <TraceIdButton id={spanId} />
+          </DataDetailsPanel.Heading>
+          {span && <SpanSummaryDescription span={span} />}
+        </div>
         <DataDetailsPanel.CloseButton onClick={onClose} />
       </DataDetailsPanel.Header>
 
@@ -38,34 +39,15 @@ export function SpanDetailsView({ spanId, span, isLoading, onClose }: SpanDetail
         <DataDetailsPanel.NoData>Span not found.</DataDetailsPanel.NoData>
       ) : (
         <DataDetailsPanel.Content>
-          <KV>
-            {span.spanType && (
-              <>
+          {span.spanType && (
+            <>
+              <KV>
                 <KV.Key>Type</KV.Key>
                 <KV.Value>{span.spanType}</KV.Value>
-              </>
-            )}
-            {startedAt && (
-              <>
-                <KV.Key>Started</KV.Key>
-                <KV.Value>{startedAt}</KV.Value>
-              </>
-            )}
-            {endedAt && (
-              <>
-                <KV.Key>Ended</KV.Key>
-                <KV.Value>{endedAt}</KV.Value>
-              </>
-            )}
-            {duration && (
-              <>
-                <KV.Key>Duration</KV.Key>
-                <KV.Value>{duration}</KV.Value>
-              </>
-            )}
-          </KV>
-
-          <br />
+              </KV>
+              <br />
+            </>
+          )}
 
           <DataDetailsPanel.CodeSection
             title="Input"

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -17,6 +17,7 @@ import { useTraceSearch } from '../hooks/use-trace-search';
 import type { TraceUsageSummary } from '../trace-list-columns';
 import type { SearchableSpan } from '../types';
 import { formatHierarchicalSpans } from './format-hierarchical-spans';
+import { TraceIdButton } from './trace-id-button';
 import { TraceSummaryDescription } from './trace-summary-description';
 import { TraceTimeline } from './trace-timeline';
 import { Button } from '@/ds/components/Button';
@@ -29,7 +30,6 @@ import { Tab, TabContent, TabList, Tabs } from '@/ds/components/Tabs';
 import type { LinkComponent } from '@/ds/types/link-component';
 import { useScrollToFirstHighlight } from '@/hooks/use-scroll-to-first-highlight';
 import { useTextHighlight } from '@/hooks/use-text-highlight';
-import { truncateString } from '@/lib/truncate-string';
 import { cn } from '@/lib/utils';
 
 export type TraceDataPanelPlacement = 'traces-list' | 'trace-page';
@@ -265,8 +265,9 @@ export function TraceDataPanelView({
         ) : (
           <>
             <div className="flex min-w-0 flex-1 flex-col gap-1">
-              <DataPanel.Heading>
-                Trace <b># {truncateString(traceId, 12)}</b>
+              <DataPanel.Heading className="items-center">
+                Trace
+                <TraceIdButton id={traceId} />
               </DataPanel.Heading>
               {!collapsed && rootSpan && (
                 <TraceSummaryDescription

--- a/packages/playground-ui/src/domains/traces/components/trace-details-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-details-view.tsx
@@ -2,6 +2,7 @@ import type { LightSpanRecord } from '@mastra/core/storage';
 import { useEffect, useMemo, useState } from 'react';
 import { getAllSpanIds } from '../hooks/get-all-span-ids';
 import { formatHierarchicalSpans } from './format-hierarchical-spans';
+import { TraceIdButton } from './trace-id-button';
 import { TraceTimeline } from './trace-timeline';
 import { DataDetailsPanel } from '@/ds/components/DataDetailsPanel';
 
@@ -47,8 +48,9 @@ export function TraceDetailsView({
   return (
     <DataDetailsPanel>
       <DataDetailsPanel.Header>
-        <DataDetailsPanel.Heading>
-          Trace <b># {traceId}</b>
+        <DataDetailsPanel.Heading className="items-center">
+          Trace
+          <TraceIdButton id={traceId} />
         </DataDetailsPanel.Heading>
         <DataDetailsPanel.CloseButton onClick={onClose} />
       </DataDetailsPanel.Header>

--- a/packages/playground-ui/src/domains/traces/components/trace-id-button.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-id-button.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import { Button } from '@/ds/components/Button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
+import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
+import { truncateString } from '@/lib/truncate-string';
+
+export function TraceIdButton({ id }: { id: string }) {
+  const { isCopied, handleCopy } = useCopyToClipboard({ text: id, showToast: false });
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Tooltip open={isCopied || open} onOpenChange={setOpen}>
+      <TooltipTrigger
+        render={
+          <Button type="button" variant="ghost" size="sm" onClick={handleCopy}>
+            {truncateString(id, 12)}
+          </Button>
+        }
+      />
+      <TooltipContent>{isCopied ? 'Copied to clipboard' : 'Copy to clipboard'}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/packages/playground-ui/src/domains/traces/utils/span-utils.test.ts
+++ b/packages/playground-ui/src/domains/traces/utils/span-utils.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   formatSpanDuration,
   formatSpanDurationExact,
-  formatSpanPanelTimestamp,
   formatSpanTimestamp,
   formatSpanTimestampExact,
   getInputPreview,
@@ -90,28 +89,6 @@ describe('formatSpanTimestampExact', () => {
   it('leaves the timestamp empty instead of throwing', () => {
     expect(formatSpanTimestampExact(undefined)).toBeUndefined();
     expect(formatSpanTimestampExact('not-a-date')).toBeUndefined();
-  });
-});
-
-describe('formatSpanPanelTimestamp', () => {
-  describe('when a span has a valid timestamp', () => {
-    it('formats the zero-padded day and 12-hour time with milliseconds', () => {
-      expect(formatSpanPanelTimestamp(TIMESTAMP)).toBe('Jan 05, 2:03:07.250 pm');
-      expect(formatSpanPanelTimestamp(MIDNIGHT)).toBe('Jan 05, 12:00:00.000 am');
-    });
-
-    it('accepts an ISO string', () => {
-      expect(formatSpanPanelTimestamp('2026-01-05T14:03:07.250Z')).toBe('Jan 05, 2:03:07.250 pm');
-    });
-  });
-
-  describe('when a span timestamp is missing or unparseable', () => {
-    it('leaves the timestamp empty instead of throwing', () => {
-      expect(formatSpanPanelTimestamp(undefined)).toBeUndefined();
-      expect(formatSpanPanelTimestamp(null)).toBeUndefined();
-      expect(formatSpanPanelTimestamp('not-a-date')).toBeUndefined();
-      expect(formatSpanPanelTimestamp(new Date('not-a-date'))).toBeUndefined();
-    });
   });
 });
 

--- a/packages/playground-ui/src/domains/traces/utils/span-utils.ts
+++ b/packages/playground-ui/src/domains/traces/utils/span-utils.ts
@@ -57,11 +57,6 @@ export function formatSpanTimestampExact(value: Date | string | null | undefined
   return timestamp === undefined ? undefined : format(new Date(timestamp), 'MMM d, yyyy, h:mm:ss.SSS a');
 }
 
-export function formatSpanPanelTimestamp(value: Date | string | null | undefined): string | undefined {
-  const timestamp = toTimestamp(value);
-  return timestamp === undefined ? undefined : format(new Date(timestamp), 'MMM dd, h:mm:ss.SSS aaa');
-}
-
 /**
  * Extract a truncated text preview from a span's input field.
  * Agent traces store `input` as an array of message objects.

--- a/packages/playground/e2e/tests/datasets/item-review-panels-layout.spec.ts
+++ b/packages/playground/e2e/tests/datasets/item-review-panels-layout.spec.ts
@@ -206,7 +206,7 @@ test.describe('Item and review panel layout', () => {
       await panel.getByText('Experiment tool call', { exact: true }).click();
       const span = panel
         .locator('section')
-        .filter({ has: page.getByText(/# span-child/) })
+        .filter({ has: page.getByRole('heading', { name: /span-child/ }) })
         .last();
       await expect(span).toBeVisible();
       await expect.poll(async () => (await panel.boundingBox())!.width).toBeGreaterThan(initialBox!.width * 1.5);

--- a/packages/playground/src/domains/experiments/__tests__/experiment-item-route.msw.test.tsx
+++ b/packages/playground/src/domains/experiments/__tests__/experiment-item-route.msw.test.tsx
@@ -425,7 +425,7 @@ describe('experiment item sub-route', () => {
       expect(dialog.parentElement?.className).toContain('grid-cols-[1fr_1fr]');
 
       fireEvent.click(await screen.findByText('Experiment tool call'));
-      const spanHeading = await screen.findByText(/# span-child/);
+      const spanHeading = await screen.findByRole('heading', { name: /span-child/ });
       const spanSection = spanHeading.closest('section');
       if (!spanSection) throw new Error('Expected span detail section');
 
@@ -451,7 +451,7 @@ describe('experiment item sub-route', () => {
       fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
       fireEvent.click(await screen.findByText('Experiment tool call'));
 
-      expect(await screen.findByText(/# span-child/)).toBeDefined();
+      expect(await screen.findByRole('heading', { name: /span-child/ })).toBeDefined();
       const traceSection = screen.getByText('Experiment agent run').closest('section');
       const panelGrid = traceSection?.parentElement;
       const topLevelPanels = Array.from(panelGrid?.children ?? []).filter(child => child.tagName === 'SECTION');
@@ -466,13 +466,13 @@ describe('experiment item sub-route', () => {
       await screen.findByRole('dialog');
       fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
       fireEvent.click(await screen.findByText('Experiment tool call'));
-      expect(await screen.findByText(/# span-child/)).toBeDefined();
+      expect(await screen.findByRole('heading', { name: /span-child/ })).toBeDefined();
 
       fireEvent.click(screen.getByLabelText('Previous span'));
-      expect(await screen.findByText(/# span-root/)).toBeDefined();
+      expect(await screen.findByRole('heading', { name: /span-root/ })).toBeDefined();
 
       fireEvent.click(screen.getByLabelText('Next span'));
-      expect(await screen.findByText(/# span-child/)).toBeDefined();
+      expect(await screen.findByRole('heading', { name: /span-child/ })).toBeDefined();
     });
 
     it('closes span details without closing the trace card', async () => {
@@ -481,13 +481,13 @@ describe('experiment item sub-route', () => {
       const dialog = await screen.findByRole('dialog');
       fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
       fireEvent.click(await screen.findByText('Experiment tool call'));
-      expect(await screen.findByText(/# span-child/)).toBeDefined();
+      expect(await screen.findByRole('heading', { name: /span-child/ })).toBeDefined();
 
-      const spanSection = screen.getByText(/# span-child/).closest('section');
+      const spanSection = screen.getByRole('heading', { name: /span-child/ }).closest('section');
       if (!spanSection) throw new Error('Expected span detail section');
       fireEvent.click(within(spanSection).getByLabelText('Close Panel'));
 
-      await waitFor(() => expect(screen.queryByText(/# span-child/)).toBeNull());
+      await waitFor(() => expect(screen.queryByRole('heading', { name: /span-child/ })).toBeNull());
       expect(screen.getByText('Experiment agent run')).toBeDefined();
       expect(dialog.isConnected).toBe(true);
     });

--- a/packages/playground/src/domains/traces/components/__tests__/trace-span-panel.msw.test.tsx
+++ b/packages/playground/src/domains/traces/components/__tests__/trace-span-panel.msw.test.tsx
@@ -172,7 +172,7 @@ describe('TraceSpanPanel', () => {
     expect(screen.getByText('First tool call')).not.toBeNull();
     expect(screen.getByText('Second tool call')).not.toBeNull();
     // No span selected → no span detail panel.
-    expect(screen.queryByText(/# span-/)).toBeNull();
+    expect(screen.queryByRole('heading', { name: /span-/ })).toBeNull();
     await waitFor(() => expect(queryClient.isFetching()).toBe(0));
   });
 
@@ -184,7 +184,7 @@ describe('TraceSpanPanel', () => {
     fireEvent.click(await screen.findByText('First tool call'));
 
     expect(onSpanSelect).toHaveBeenCalledWith('span-child-1');
-    expect(await screen.findByText(/# span-child-1/)).not.toBeNull();
+    expect(await screen.findByRole('heading', { name: /span-child-1/ })).not.toBeNull();
     await waitFor(() => expect(queryClient.isFetching()).toBe(0));
     expect(onSpanDetailRequest).toHaveBeenCalledWith('span-child-1');
   });
@@ -193,18 +193,18 @@ describe('TraceSpanPanel', () => {
     installHandlers();
     const { queryClient } = renderPanel({ initialSpanId: 'span-child-1' });
 
-    expect(await screen.findByText(/# span-child-1/)).not.toBeNull();
+    expect(await screen.findByRole('heading', { name: /span-child-1/ })).not.toBeNull();
     await waitFor(() => expect(queryClient.isFetching()).toBe(0));
 
     fireEvent.click(screen.getByLabelText('Next span'));
-    expect(await screen.findByText(/# span-child-2/)).not.toBeNull();
+    expect(await screen.findByRole('heading', { name: /span-child-2/ })).not.toBeNull();
     await waitFor(() => expect(queryClient.isFetching()).toBe(0));
 
     fireEvent.click(screen.getByLabelText('Previous span'));
-    expect(await screen.findByText(/# span-child-1/)).not.toBeNull();
+    expect(await screen.findByRole('heading', { name: /span-child-1/ })).not.toBeNull();
 
     fireEvent.click(screen.getByLabelText('Previous span'));
-    expect(await screen.findByText(/# span-root/)).not.toBeNull();
+    expect(await screen.findByRole('heading', { name: /span-root/ })).not.toBeNull();
     await waitFor(() => expect(queryClient.isFetching()).toBe(0));
   });
 
@@ -213,7 +213,7 @@ describe('TraceSpanPanel', () => {
     const onSpanSelect = vi.fn<(spanId: string | undefined) => void>();
     const { queryClient } = renderPanel({ initialSpanId: 'span-child-1', onSpanSelect });
 
-    expect(await screen.findByText(/# span-child-1/)).not.toBeNull();
+    expect(await screen.findByRole('heading', { name: /span-child-1/ })).not.toBeNull();
     await waitFor(() => expect(queryClient.isFetching()).toBe(0));
 
     // Two close buttons are visible (trace panel + span panel); the span panel's is the last.
@@ -221,7 +221,7 @@ describe('TraceSpanPanel', () => {
     fireEvent.click(closeButtons[closeButtons.length - 1]);
 
     expect(onSpanSelect).toHaveBeenCalledWith(undefined);
-    await waitFor(() => expect(screen.queryByText(/# span-child-1/)).toBeNull());
+    await waitFor(() => expect(screen.queryByRole('heading', { name: /span-child-1/ })).toBeNull());
   });
 
   it('when the trace panel is closed, then onClose is called', async () => {
@@ -275,7 +275,7 @@ describe('TraceSpanPanel', () => {
     installHandlers();
     const { queryClient } = renderPanel({ anchorSpanId: 'span-child-1', initialSpanId: 'span-child-1' });
 
-    expect(await screen.findByText(/# span-child-1/)).not.toBeNull();
+    expect(await screen.findByRole('heading', { name: /span-child-1/ })).not.toBeNull();
     await waitFor(() => expect(queryClient.isFetching()).toBe(0));
     // Anchor spans render the trace-context fields (session/request/user…) even though they have a parent.
     expect(screen.getByText('Session Id')).not.toBeNull();

--- a/packages/playground/src/domains/traces/components/__tests__/trace-span-panel.msw.test.tsx
+++ b/packages/playground/src/domains/traces/components/__tests__/trace-span-panel.msw.test.tsx
@@ -167,7 +167,7 @@ describe('TraceSpanPanel', () => {
     installHandlers();
     const { queryClient } = renderPanel();
 
-    expect(await screen.findByText(`# ${TRACE_ID}`)).not.toBeNull();
+    expect(await screen.findByRole('heading', { name: `Trace ${TRACE_ID}` })).not.toBeNull();
     expect(screen.getByText('Root agent run')).not.toBeNull();
     expect(screen.getByText('First tool call')).not.toBeNull();
     expect(screen.getByText('Second tool call')).not.toBeNull();
@@ -229,7 +229,7 @@ describe('TraceSpanPanel', () => {
     const onClose = vi.fn();
     const { queryClient } = renderPanel({ onClose });
 
-    expect(await screen.findByText(`# ${TRACE_ID}`)).not.toBeNull();
+    expect(await screen.findByRole('heading', { name: `Trace ${TRACE_ID}` })).not.toBeNull();
     fireEvent.click(screen.getByLabelText('Close Panel'));
     expect(onClose).toHaveBeenCalledOnce();
     await waitFor(() => expect(queryClient.isFetching()).toBe(0));
@@ -239,7 +239,7 @@ describe('TraceSpanPanel', () => {
     installHandlers();
     const { queryClient } = renderPanel();
 
-    expect(await screen.findByText(`# ${TRACE_ID}`)).not.toBeNull();
+    expect(await screen.findByRole('heading', { name: `Trace ${TRACE_ID}` })).not.toBeNull();
     await waitFor(() => expect(queryClient.isFetching()).toBe(0));
 
     // Entity block: type label + name linking to the agent page. ("Agent" also


### PR DESCRIPTION
Make span and trace IDs directly copyable through small ghost buttons, without the # prefix or an extra copy icon. Align the labels and buttons, show “Copy to clipboard” on hover and “Copied to clipboard” after copying, and replace the compact span panel’s timing rows with the shared icon summary.

Verified both package lint commands and typechecks, the playground-ui trace tests, and all 354 playground trace/experiment tests with two workers. Updated the affected integration and E2E selectors. The affected E2E spec passed earlier in this branch; explicit visual verification of the latest alignment and tooltip changes remains pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Studio trace and span headers now show IDs as small buttons. Users can click a button to copy the full ID without the `#` prefix.

## Changes

- Added reusable `TraceIdButton` components with truncated labels and copy tooltips.
- Updated trace and span headers to align labels and buttons.
- Added “Copy to clipboard” and “Copied to clipboard” tooltip states.
- Replaced compact span timing rows with shared span summary information.
- Removed the unused `formatSpanPanelTimestamp` helper.
- Updated unit, integration, and E2E selectors for the new accessible headings and ID format.
- Added tests for truncation, copying, tooltips, and collapsed panels.
- Added a patch changeset for `@mastra/playground-ui`.

## Validation

- Package lint and typechecks passed.
- Playground UI trace tests passed.
- 354 playground trace and experiment tests passed.
- Latest visual verification of alignment and tooltip changes remains pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->