### PR TITLE
fix(otel-exporter): keep workflow step identity and branch attributes

### DIFF
--- a/.changeset/otel-workflow-span-identity.md
+++ b/.changeset/otel-workflow-span-identity.md
@@ -1,0 +1,13 @@
+---
+'@mastra/otel-exporter': patch
+---
+
+Keep workflow step identity and branch attributes in exported OTel spans.
+
+`getSpanName` derived every span's name from `entityName`, which workflow control-flow spans inherit from the enclosing workflow rather than setting themselves. Sibling steps therefore exported under one shared name, and a branch's predicates were indistinguishable from each other. A step span now names itself by its own step id, and a conditional, parallel, loop, sleep or wait-event span keeps its own name.
+
+`getAttributes` had no case for workflow span types, so their attributes never reached the exporter at all. The routing a run took is now exported: `conditionCount`, `truthyIndexes` and `selectedSteps` for a branch, `conditionIndex` and `result` for each predicate, and the equivalents for parallel, loop, sleep and wait-event spans.
+
+This reaches every consumer of the shared conversion layer, including Langfuse, Arize, Arthur, Sentry and the OTel bridge.
+
+Fixes #23579.

--- a/observability/otel-exporter/src/gen-ai-semantics.test.ts
+++ b/observability/otel-exporter/src/gen-ai-semantics.test.ts
@@ -309,6 +309,23 @@ describe('getSpanName - workflow control flow', () => {
     expect(getSpanName(second)).toBe('condition 1');
   });
 
+  it('still identifies a step span that carries an id but no entity type', () => {
+    // Both producers in the repo set entityType, but entityType is absent only
+    // when no ancestor set one either, so an entityId here is the step's own.
+    const step = createWorkflowSpan(
+      SpanType.WORKFLOW_STEP,
+      "workflow step: 'lone'",
+      {},
+      {
+        entityType: undefined,
+        entityId: 'lone',
+        entityName: undefined,
+      },
+    );
+
+    expect(getSpanName(step)).toBe('workflow_step lone');
+  });
+
   it('leaves span types that own their entity alone', () => {
     const run = createWorkflowSpan(
       SpanType.WORKFLOW_RUN,
@@ -403,6 +420,34 @@ describe('getAttributes - workflow control flow', () => {
       'mastra.workflow_sleep.duration_ms': 500,
       'mastra.workflow_sleep.until_date': until.toISOString(),
       'mastra.workflow_sleep.sleep_type': 'dynamic',
+    });
+  });
+
+  it('exports what a wait-event span was waiting for', () => {
+    const span = createWorkflowSpan(SpanType.WORKFLOW_WAIT_EVENT, 'wait', {
+      eventName: 'approval',
+      timeoutMs: 30000,
+    });
+
+    expect(getAttributes(span)).toMatchObject({
+      'mastra.workflow_wait_event.event_name': 'approval',
+      'mastra.workflow_wait_event.timeout_ms': 30000,
+    });
+  });
+
+  it('exports the status of a workflow run', () => {
+    const span = createWorkflowSpan(
+      SpanType.WORKFLOW_RUN,
+      'workflow run',
+      { status: 'failed' },
+      {
+        entityType: EntityType.WORKFLOW_RUN,
+        entityId: 'demo-workflow',
+      },
+    );
+
+    expect(getAttributes(span)).toMatchObject({
+      'mastra.workflow_run.status': 'failed',
     });
   });
 

--- a/observability/otel-exporter/src/gen-ai-semantics.test.ts
+++ b/observability/otel-exporter/src/gen-ai-semantics.test.ts
@@ -1,4 +1,4 @@
-import { SpanType } from '@mastra/core/observability';
+import { EntityType, SpanType } from '@mastra/core/observability';
 import type {
   AnyExportedSpan,
   ModelGenerationAttributes,
@@ -7,7 +7,7 @@ import type {
 } from '@mastra/core/observability';
 import { describe, it, expect } from 'vitest';
 import { MODEL_TOKENS } from '../../../docs/src/plugins/remark-model-tokens/models';
-import { getAttributes, formatUsageMetrics } from './gen-ai-semantics';
+import { getAttributes, formatUsageMetrics, getSpanName } from './gen-ai-semantics';
 
 function createModelGenerationSpan(attributes: ModelGenerationAttributes): AnyExportedSpan {
   return {
@@ -223,5 +223,192 @@ describe('getAttributes - conversation id', () => {
     const attrs = getAttributes(createSpan(SpanType.MODEL_GENERATION, { resourceId: 'resource-123' }));
 
     expect(attrs).not.toHaveProperty('gen_ai.conversation.id');
+  });
+});
+
+/**
+ * Workflow control-flow spans inherit entityName from the enclosing workflow, so
+ * the exported span has to fall back to its own identity to stay distinguishable.
+ */
+function createWorkflowSpan(
+  type: SpanType,
+  name: string,
+  attributes: Record<string, unknown>,
+  entity?: { entityType?: EntityType; entityId?: string; entityName?: string },
+): AnyExportedSpan {
+  return {
+    id: 'test-span-id',
+    traceId: 'test-trace-id',
+    name,
+    type,
+    startTime: new Date(),
+    isRootSpan: false,
+    isEvent: false,
+    attributes,
+    // Every span below sits inside 'demo-workflow', which is what entityName
+    // resolves to once it has been inherited down the tree.
+    entityName: 'demo-workflow',
+    ...entity,
+  } as AnyExportedSpan;
+}
+
+describe('getSpanName - workflow control flow', () => {
+  it('keeps sibling steps apart instead of naming both after the workflow', () => {
+    const left = createWorkflowSpan(
+      SpanType.WORKFLOW_STEP,
+      "workflow step: 'left'",
+      {},
+      {
+        entityType: EntityType.WORKFLOW_STEP,
+        entityId: 'left',
+      },
+    );
+    const right = createWorkflowSpan(
+      SpanType.WORKFLOW_STEP,
+      "workflow step: 'right'",
+      {},
+      {
+        entityType: EntityType.WORKFLOW_STEP,
+        entityId: 'right',
+      },
+    );
+
+    expect(getSpanName(left)).toBe('workflow_step left');
+    expect(getSpanName(right)).toBe('workflow_step right');
+    expect(getSpanName(left)).not.toBe(getSpanName(right));
+  });
+
+  it('keeps a step identified by itself rather than by the workflow that encloses it', () => {
+    // A nested workflow: the inner step inherits the outer workflow's entityName.
+    const step = createWorkflowSpan(
+      SpanType.WORKFLOW_STEP,
+      "workflow step: 'inner-step'",
+      {},
+      {
+        entityType: EntityType.WORKFLOW_STEP,
+        entityId: 'inner-step',
+        entityName: 'outer-workflow',
+      },
+    );
+
+    expect(getSpanName(step)).toBe('workflow_step inner-step');
+    expect(getSpanName(step)).not.toContain('outer-workflow');
+  });
+
+  it('tells two predicates of the same branch apart', () => {
+    const first = createWorkflowSpan(SpanType.WORKFLOW_CONDITIONAL_EVAL, "condition '0'", {
+      conditionIndex: 0,
+      result: true,
+    });
+    const second = createWorkflowSpan(SpanType.WORKFLOW_CONDITIONAL_EVAL, "condition '1'", {
+      conditionIndex: 1,
+      result: false,
+    });
+
+    expect(getSpanName(first)).toBe('condition 0');
+    expect(getSpanName(second)).toBe('condition 1');
+  });
+
+  it('leaves span types that own their entity alone', () => {
+    const run = createWorkflowSpan(
+      SpanType.WORKFLOW_RUN,
+      'workflow run',
+      {},
+      {
+        entityType: EntityType.WORKFLOW_RUN,
+        entityId: 'demo-workflow',
+      },
+    );
+
+    expect(getSpanName(run)).toBe('invoke_workflow demo-workflow');
+  });
+});
+
+describe('getAttributes - workflow control flow', () => {
+  it('exports the branch decision', () => {
+    const span = createWorkflowSpan(SpanType.WORKFLOW_CONDITIONAL, "conditional: '2 conditions'", {
+      conditionCount: 2,
+      truthyIndexes: [0],
+      selectedSteps: ['left'],
+    });
+
+    expect(getAttributes(span)).toMatchObject({
+      'mastra.workflow_conditional.condition_count': 2,
+      'mastra.workflow_conditional.truthy_indexes': '[0]',
+      'mastra.workflow_conditional.selected_steps': '["left"]',
+    });
+  });
+
+  it('exports which predicate this was and how it evaluated', () => {
+    const span = createWorkflowSpan(SpanType.WORKFLOW_CONDITIONAL_EVAL, "condition '1'", {
+      conditionIndex: 1,
+      result: false,
+    });
+
+    // result is false, so a truthiness check on the way out would drop it.
+    expect(getAttributes(span)).toMatchObject({
+      'mastra.workflow_conditional_eval.condition_index': 1,
+      'mastra.workflow_conditional_eval.result': false,
+    });
+  });
+
+  it('exports the step id of a step span', () => {
+    const span = createWorkflowSpan(
+      SpanType.WORKFLOW_STEP,
+      "workflow step: 'left'",
+      { status: 'success' },
+      {
+        entityType: EntityType.WORKFLOW_STEP,
+        entityId: 'left',
+      },
+    );
+
+    expect(getAttributes(span)).toMatchObject({
+      'mastra.workflow_step.step_id': 'left',
+      'mastra.workflow_step.status': 'success',
+    });
+  });
+
+  it('exports parallel and loop routing', () => {
+    const parallel = createWorkflowSpan(SpanType.WORKFLOW_PARALLEL, 'parallel', {
+      branchCount: 2,
+      parallelSteps: ['a', 'b'],
+    });
+    const loop = createWorkflowSpan(SpanType.WORKFLOW_LOOP, 'loop', {
+      loopType: 'foreach',
+      iteration: 3,
+      concurrency: 2,
+    });
+
+    expect(getAttributes(parallel)).toMatchObject({
+      'mastra.workflow_parallel.branch_count': 2,
+      'mastra.workflow_parallel.parallel_steps': '["a","b"]',
+    });
+    expect(getAttributes(loop)).toMatchObject({
+      'mastra.workflow_loop.loop_type': 'foreach',
+      'mastra.workflow_loop.iteration': 3,
+      'mastra.workflow_loop.concurrency': 2,
+    });
+  });
+
+  it('serialises a sleep deadline rather than dropping it', () => {
+    const until = new Date('2026-01-01T00:00:00.000Z');
+    const span = createWorkflowSpan(SpanType.WORKFLOW_SLEEP, 'sleep', {
+      durationMs: 500,
+      untilDate: until,
+      sleepType: 'dynamic',
+    });
+
+    expect(getAttributes(span)).toMatchObject({
+      'mastra.workflow_sleep.duration_ms': 500,
+      'mastra.workflow_sleep.until_date': until.toISOString(),
+      'mastra.workflow_sleep.sleep_type': 'dynamic',
+    });
+  });
+
+  it('adds nothing for a span type that carries no workflow attributes', () => {
+    const attrs = getAttributes(createSpan(SpanType.AGENT_RUN));
+
+    expect(Object.keys(attrs).some(key => key.startsWith('mastra.workflow_'))).toBe(false);
   });
 });

--- a/observability/otel-exporter/src/gen-ai-semantics.ts
+++ b/observability/otel-exporter/src/gen-ai-semantics.ts
@@ -9,7 +9,7 @@
  * @see https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/
  */
 
-import { SpanType } from '@mastra/core/observability';
+import { EntityType, SpanType } from '@mastra/core/observability';
 import type {
   AgentRunAttributes,
   AnyExportedSpan,
@@ -172,6 +172,23 @@ function getSpanIdentifier(span: AnyExportedSpan): string | undefined {
       return attrs?.model;
     }
 
+    case SpanType.WORKFLOW_STEP:
+    case SpanType.WORKFLOW_CONDITIONAL:
+    case SpanType.WORKFLOW_CONDITIONAL_EVAL:
+    case SpanType.WORKFLOW_PARALLEL:
+    case SpanType.WORKFLOW_LOOP:
+    case SpanType.WORKFLOW_SLEEP:
+    case SpanType.WORKFLOW_WAIT_EVENT: {
+      // These spans inherit entityName from the enclosing workflow, so it names
+      // the workflow and not the step, and every sibling would share one name.
+      // A step span sets its own entity, and its id is the step id; the other
+      // control-flow spans set none, so they keep their own name instead.
+      if (span.entityType === EntityType.WORKFLOW_STEP) {
+        return span.entityId;
+      }
+      return undefined;
+    }
+
     default:
       return span.entityName ?? span.entityId;
   }
@@ -190,6 +207,68 @@ export function getSpanName(span: AnyExportedSpan): string {
 
   // For other types, use a simplified version of the original name
   return sanitizeSpanName(span.name);
+}
+
+/**
+ * Attributes carried by workflow control-flow spans, per span type.
+ *
+ * These spans describe how a run was routed: which predicate this was, how it
+ * evaluated, which branches were taken. Nothing else in the export carries that,
+ * so without these the exported trace shows that a branch happened but not what
+ * it decided.
+ */
+const WORKFLOW_ATTRIBUTE_KEYS: Partial<Record<SpanType, readonly string[]>> = {
+  [SpanType.WORKFLOW_RUN]: ['status'],
+  [SpanType.WORKFLOW_STEP]: ['status'],
+  [SpanType.WORKFLOW_CONDITIONAL]: ['conditionCount', 'truthyIndexes', 'selectedSteps'],
+  [SpanType.WORKFLOW_CONDITIONAL_EVAL]: ['conditionIndex', 'result'],
+  [SpanType.WORKFLOW_PARALLEL]: ['branchCount', 'parallelSteps'],
+  [SpanType.WORKFLOW_LOOP]: ['loopType', 'iteration', 'totalIterations', 'concurrency'],
+  [SpanType.WORKFLOW_SLEEP]: ['durationMs', 'untilDate', 'sleepType'],
+  [SpanType.WORKFLOW_WAIT_EVENT]: ['eventName', 'timeoutMs'],
+};
+
+function toSnakeCase(key: string): string {
+  return key.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+}
+
+/**
+ * Copy the workflow attributes of a control-flow span onto the exported span.
+ *
+ * Arrays and dates have no OTel attribute representation, so they are serialised
+ * the same way the model and agent attributes above serialise theirs.
+ */
+function addWorkflowAttributes(attributes: Attributes, span: AnyExportedSpan, spanType: string): void {
+  const keys = WORKFLOW_ATTRIBUTE_KEYS[span.type];
+  if (!keys) {
+    return;
+  }
+
+  // A step span carries its own step id as its entity id, and that is the only
+  // place the step's identity survives on the exported span.
+  if (span.type === SpanType.WORKFLOW_STEP && span.entityType === EntityType.WORKFLOW_STEP && span.entityId) {
+    attributes[`mastra.${spanType}.step_id`] = span.entityId;
+  }
+
+  const workflowAttrs = span.attributes as Record<string, unknown> | undefined;
+  if (!workflowAttrs) {
+    return;
+  }
+
+  for (const key of keys) {
+    const value = workflowAttrs[key];
+    if (value === undefined || value === null) {
+      continue;
+    }
+    const name = `mastra.${spanType}.${toSnakeCase(key)}`;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      attributes[name] = value;
+    } else if (value instanceof Date) {
+      attributes[name] = value.toISOString();
+    } else {
+      attributes[name] = JSON.stringify(value);
+    }
+  }
 }
 
 /**
@@ -389,6 +468,8 @@ export function getAttributes(span: AnyExportedSpan): Attributes {
 
     attributes[ATTR_GEN_AI_SYSTEM_INSTRUCTIONS] = agentAttrs.instructions;
   }
+
+  addWorkflowAttributes(attributes, span, spanType);
 
   // Add error information if present
   if (span.errorInfo) {

--- a/observability/otel-exporter/src/gen-ai-semantics.ts
+++ b/observability/otel-exporter/src/gen-ai-semantics.ts
@@ -161,6 +161,20 @@ function sanitizeSpanName(name: string): string {
   return name.replace(/[^\p{L}\p{N}._ -]/gu, '');
 }
 
+/**
+ * The step id of a workflow step span, or undefined if it does not carry one.
+ *
+ * A step span sets its own entity, so entityId is the step id. entityType is
+ * absent only when no ancestor set one either, and in that case an entityId can
+ * only have come from this span, so it is still the step's own id.
+ */
+function getWorkflowStepId(span: AnyExportedSpan): string | undefined {
+  if (span.entityType === EntityType.WORKFLOW_STEP || span.entityType === undefined) {
+    return span.entityId;
+  }
+  return undefined;
+}
+
 function getSpanIdentifier(span: AnyExportedSpan): string | undefined {
   switch (span.type) {
     case SpanType.MODEL_GENERATION: {
@@ -172,22 +186,20 @@ function getSpanIdentifier(span: AnyExportedSpan): string | undefined {
       return attrs?.model;
     }
 
+    // These spans inherit entityName from the enclosing workflow, so it names
+    // the workflow rather than the step, and every sibling would share one name.
     case SpanType.WORKFLOW_STEP:
+      return getWorkflowStepId(span);
+
+    // The remaining control-flow spans set no entity of their own, so they fall
+    // through to their own name, which already identifies them.
     case SpanType.WORKFLOW_CONDITIONAL:
     case SpanType.WORKFLOW_CONDITIONAL_EVAL:
     case SpanType.WORKFLOW_PARALLEL:
     case SpanType.WORKFLOW_LOOP:
     case SpanType.WORKFLOW_SLEEP:
-    case SpanType.WORKFLOW_WAIT_EVENT: {
-      // These spans inherit entityName from the enclosing workflow, so it names
-      // the workflow and not the step, and every sibling would share one name.
-      // A step span sets its own entity, and its id is the step id; the other
-      // control-flow spans set none, so they keep their own name instead.
-      if (span.entityType === EntityType.WORKFLOW_STEP) {
-        return span.entityId;
-      }
+    case SpanType.WORKFLOW_WAIT_EVENT:
       return undefined;
-    }
 
     default:
       return span.entityName ?? span.entityId;
@@ -246,8 +258,11 @@ function addWorkflowAttributes(attributes: Attributes, span: AnyExportedSpan, sp
 
   // A step span carries its own step id as its entity id, and that is the only
   // place the step's identity survives on the exported span.
-  if (span.type === SpanType.WORKFLOW_STEP && span.entityType === EntityType.WORKFLOW_STEP && span.entityId) {
-    attributes[`mastra.${spanType}.step_id`] = span.entityId;
+  if (span.type === SpanType.WORKFLOW_STEP) {
+    const stepId = getWorkflowStepId(span);
+    if (stepId) {
+      attributes[`mastra.${spanType}.step_id`] = stepId;
+    }
   }
 
   const workflowAttrs = span.attributes as Record<string, unknown> | undefined;


### PR DESCRIPTION
Fixes #23579.

Two separate losses in the shared conversion layer, both reproduced from the report.

### Names

`getSpanName` derives a name from `getSpanIdentifier`, which falls back to `entityName ?? entityId`. Workflow control-flow spans never set `entityName`, they inherit it from the enclosing workflow (`observability/mastra/src/spans/base.ts`), so the identifier resolves to the workflow for every one of them. Sibling steps collapse onto a single name and the predicates of a branch become indistinguishable.

A step span does set its own entity (`entityType: EntityType.WORKFLOW_STEP`, `entityId: step.id`), so it can be named by its step id. The conditional, conditional-eval, parallel, loop, sleep and wait-event spans set no entity of their own, so they fall through to their own span name, which already carries the condition index.

| span | before | after |
|--|--|--|
| step `left` | `workflow_step demo-workflow` | `workflow_step left` |
| step `right` | `workflow_step demo-workflow` | `workflow_step right` |
| predicate 0 | `workflow_conditional_eval demo-workflow` | `condition 0` |
| predicate 1 | `workflow_conditional_eval demo-workflow` | `condition 1` |

A step inside a nested workflow is named by its own id rather than by the outer workflow.

### Attributes

`getAttributes` handles model generation, RAG embedding, tool call and agent run spans. There was no case for any workflow span type, so `span.attributes` for those spans was dropped entirely. That is why `conditionCount`, `truthyIndexes`, `selectedSteps`, `conditionIndex` and `result` are absent from the export while the predicate's boolean output survives, since the output is carried separately.

They are now exported under the existing `mastra.<span_type>.<snake_case>` convention:

| span type | attributes |
|--|--|
| `workflow_conditional` | `condition_count`, `truthy_indexes`, `selected_steps` |
| `workflow_conditional_eval` | `condition_index`, `result` |
| `workflow_step` | `step_id`, `status` |
| `workflow_parallel` | `branch_count`, `parallel_steps` |
| `workflow_loop` | `loop_type`, `iteration`, `total_iterations`, `concurrency` |
| `workflow_sleep` | `duration_ms`, `until_date`, `sleep_type` |
| `workflow_wait_event` | `event_name`, `timeout_ms` |
| `workflow_run` | `status` |

The report named the conditional and step cases. The others come from the same missing branch, so they are covered here rather than left for a second report. Arrays and dates are serialised the way `stopSequences` and `completionStartTime` already are, and `result: false` is written rather than dropped, since a truthiness check on the way out would lose exactly the interesting half of a branch.

### Tests

Thirteen cases added to `gen-ai-semantics.test.ts`. Against `main` eight of them fail, including:

```
expected 'workflow_step demo-workflow' to be 'workflow_step left'
expected 'workflow_step outer-workflow' to be 'workflow_step inner-step'
expected 'workflow_conditional_eval demo-workfl…' to be 'condition 0'
```

They cover distinctly named sibling steps, a step nested inside another workflow, two predicates of one branch with mixed results, the branch and predicate attributes, parallel and loop routing, a sleep deadline, and that a span type carrying no workflow attributes gains none.

### Consumers of the shared layer

Run locally on this branch:

| package | tests |
|--|--|
| `@mastra/otel-exporter` | 116 passed |
| `@mastra/arize` | 26 passed |
| `@mastra/sentry` | 45 passed |
| `@mastra/otel-bridge` | 36 passed |
| `@mastra/arthur` | 15 passed |

No existing test asserted the collapsed names, and the Arize span-kind mapping keys off span type rather than name, so it is unaffected.

### Note on compatibility

Exported step names change, which is the point of the fix, but anything that matched on the old shared name will now see per-step names. Span ids, parent relationships, inputs, outputs and correlation metadata are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Workflow traces now keep the correct name and details for each step and control-flow action. Exported traces remain easier to understand because workflow metadata is preserved.

## Changes

- Names workflow steps by their own step IDs, including nested workflows and steps with an `entityId` but no `entityType`.
- Preserves distinct names for conditions and other control-flow spans.
- Exports workflow attributes using the `mastra.<span_type>.<snake_case>` format.
- Preserves branch, predicate, parallel, loop, sleep, wait-event, step, and run metadata.
- Serializes arrays, dates, and `false` values correctly.
- Keeps existing span IDs, parent relationships, inputs, outputs, and correlation metadata unchanged.
- Adds regression tests for naming, nested workflows, branch attributes, control-flow routing, wait-event attributes, workflow-run attributes, and spans without workflow attributes.
- Verifies the shared conversion layer across OTEL Exporter, Arize, Sentry, OTEL Bridge, Arthur, and Langfuse consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->