### PR TITLE
fix(core): resume background sub-agents after a tool approval

### DIFF
--- a/.changeset/background-approval-run-id.md
+++ b/.changeset/background-approval-run-id.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed approving a tool inside a background sub-agent. The sub-agent now resumes and runs the approved tool, instead of starting over and asking for approval again.

--- a/packages/core/src/agent/__tests__/subagent-background-approval.test.ts
+++ b/packages/core/src/agent/__tests__/subagent-background-approval.test.ts
@@ -1,0 +1,122 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { Mastra } from '../../mastra';
+import { MockStore } from '../../storage';
+import { createTool } from '../../tools';
+import { Agent } from '../agent';
+
+/**
+ * Regression test for approving a tool inside a background sub-agent.
+ *
+ * The sub-agent pauses on a `requireApproval` tool. Agent-as-tool relays that pause with the
+ * sub-agent's run id in `suspendOptions.runId`; the suspend payload itself carries no run id.
+ * The background-task workflow only restores `suspendedToolRunId` from its suspend payload, so on
+ * `manager.resume(taskId, { approved: true })` the delegation had no run to resume, started the
+ * sub-agent over, and the approved tool never ran.
+ */
+describe('sub-agent background approval', () => {
+  const storage = new MockStore();
+  let mastra: Mastra;
+
+  beforeEach(async () => {
+    mastra = new Mastra({ logger: false, storage, backgroundTasks: { enabled: true } });
+    await mastra.startWorkers();
+  });
+
+  afterEach(async () => {
+    await mastra.backgroundTaskManager?.shutdown();
+    await mastra.stopWorkers();
+    const bgStore = await storage.getStore('backgroundTasks');
+    await bgStore?.dangerouslyClearAll();
+  });
+
+  const finish = (finishReason: 'stop' | 'tool-calls') => ({
+    type: 'finish' as const,
+    finishReason,
+    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+  });
+
+  const toolCallTurn = (toolCallId: string, toolName: string, args: Record<string, unknown>) => ({
+    rawCall: { rawPrompt: null, rawSettings: {} },
+    warnings: [],
+    stream: convertArrayToReadableStream([
+      { type: 'stream-start' as const, warnings: [] },
+      { type: 'tool-call' as const, toolCallId, toolName, input: JSON.stringify(args) },
+      finish('tool-calls'),
+    ]),
+  });
+
+  const textTurn = (text: string) => ({
+    rawCall: { rawPrompt: null, rawSettings: {} },
+    warnings: [],
+    stream: convertArrayToReadableStream([
+      { type: 'stream-start' as const, warnings: [] },
+      { type: 'text-start' as const, id: 't' },
+      { type: 'text-delta' as const, id: 't', delta: text },
+      { type: 'text-end' as const, id: 't' },
+      finish('stop'),
+    ]),
+  });
+
+  const hasToolResult = (prompt: any[]) => prompt.some(message => message?.role === 'tool');
+
+  it('runs the approved tool when the owner approves the background sub-agent', async () => {
+    const bookings: string[] = [];
+    const book = createTool({
+      id: 'book',
+      description: 'Book a slot.',
+      inputSchema: z.object({ slot: z.string() }),
+      requireApproval: true,
+      execute: async ({ slot }) => {
+        bookings.push(slot);
+        return { booked: slot };
+      },
+    });
+
+    const helper = new Agent({
+      id: 'helper',
+      name: 'helper',
+      description: 'Books slots.',
+      instructions: 'Book the slot you are asked for.',
+      model: new MockLanguageModelV2({
+        doStream: async ({ prompt }: any) =>
+          hasToolResult(prompt) ? textTurn('Booked.') : toolCallTurn('book-1', 'book', { slot: '12:45' }),
+      }),
+      tools: { book },
+    });
+
+    const supervisor = new Agent({
+      id: 'supervisor',
+      name: 'supervisor',
+      instructions: 'Delegate bookings to the helper.',
+      model: new MockLanguageModelV2({
+        doStream: async ({ prompt }: any) =>
+          hasToolResult(prompt)
+            ? textTurn('On it.')
+            : toolCallTurn('call-1', 'agent-helper', { prompt: 'Book 12:45.' }),
+      }),
+      agents: { helper },
+      backgroundTasks: { tools: { helper: { enabled: true } } },
+    });
+    mastra.addAgent(supervisor, 'supervisor');
+
+    const stream = await supervisor.streamUntilIdle('Book 12:45.', { maxSteps: 3 });
+    const chunks: any[] = [];
+    for await (const chunk of stream.fullStream) chunks.push(chunk);
+
+    const taskId = chunks.find(c => c.type === 'background-task-started')?.payload.taskId as string;
+    const manager = mastra.backgroundTaskManager!;
+    await vi.waitFor(async () => expect((await manager.getTask(taskId))?.status).toBe('suspended'), {
+      timeout: 2000,
+    });
+    expect(bookings).toEqual([]);
+
+    await manager.resume(taskId, { approved: true });
+
+    await vi.waitFor(async () => expect((await manager.getTask(taskId))?.status).toBe('completed'), {
+      timeout: 2000,
+    });
+    expect(bookings).toEqual(['12:45']);
+  });
+});

--- a/packages/core/src/background-tasks/manager.test.ts
+++ b/packages/core/src/background-tasks/manager.test.ts
@@ -805,6 +805,33 @@ describe('BackgroundTaskManager', () => {
       expect(executeFn).toHaveBeenCalledTimes(2);
     });
 
+    it('resumes a delegation whose run id arrives only in the suspend options', async () => {
+      // Agent-as-tool relays a nested approval this way: the payload describes the gated tool,
+      // and the nested run id travels in `suspendOptions.runId` only.
+      const approvalPayload = { requireToolApproval: { toolCallId: 'inner-call', toolName: 'book', args: {} } };
+      const executeFn = vi.fn(async (args, opts: any) => {
+        if (!opts.resumeData) {
+          await opts.suspend(approvalPayload, { runId: 'delegated-run-id', isAgentSuspend: true });
+          return undefined;
+        }
+        return { suspendedToolRunId: args.suspendedToolRunId };
+      });
+
+      const { task } = await manager.enqueue(
+        { toolName: 'agent-helper', toolCallId: 'cres-opts', args: { prompt: 'book it' }, agentId: 'a1', runId: 'r3b' },
+        ctx(executeFn),
+      );
+      await tick(200);
+      const suspended = await manager.getTask(task.id);
+      expect(suspended?.status).toBe('suspended');
+      expect(suspended?.suspendPayload).toEqual(approvalPayload);
+
+      await manager.resume(task.id, { approved: true });
+      await tick(200);
+
+      expect((await manager.getTask(task.id))?.result).toEqual({ suspendedToolRunId: 'delegated-run-id' });
+    });
+
     it('emits background-task-resumed on the stream when resumed', async () => {
       const executeFn = vi.fn(async (_args, opts: any) => {
         if (!opts.resumeData) {

--- a/packages/core/src/background-tasks/workflow.ts
+++ b/packages/core/src/background-tasks/workflow.ts
@@ -33,6 +33,22 @@ const bodyOutputSchema = z.object({
 const WORKFLOW_STATUS_TO_PERSIST = ['suspended', 'pending', 'paused', 'waiting'];
 
 /**
+ * Delegating tools (agent-as-tool, workflow-as-tool) relay a nested run's
+ * suspension and hand that run's id back in `suspendOptions.runId`; the
+ * payload itself carries no id (an approval pause's payload only describes the
+ * gated tool). Keep the id on the `run-attempt` step's suspend payload, which
+ * the runtime returns as `suspendData` on resume, so the resumed delegation
+ * reaches the suspended run. The task row keeps the payload as reported.
+ */
+function withDelegatedRunId(data: unknown, suspendOptions?: SuspendOptions): unknown {
+  const runId = suspendOptions?.runId;
+  if (typeof runId !== 'string') return data;
+  if (data === undefined || data === null) return { suspendedToolRunId: runId };
+  if (typeof data !== 'object' || Array.isArray(data)) return data;
+  return { suspendedToolRunId: runId, ...data };
+}
+
+/**
  * Builds the per-task workflow that owns executor + retries.
  *
  * Uses the standard (default) execution engine so the workflow runs entirely
@@ -173,7 +189,10 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
         });
 
         if (pendingSuspend) {
-          return suspend(pendingSuspend.data, pendingSuspend.suspendOptions as SuspendOptions);
+          return suspend(
+            withDelegatedRunId(pendingSuspend.data, pendingSuspend.suspendOptions),
+            pendingSuspend.suspendOptions as SuspendOptions,
+          );
         }
 
         return { taskId, outcome: 'success' as const, result };


### PR DESCRIPTION
## Description

Approving a tool inside a background sub-agent restarted the sub-agent instead of resuming it, so the approved tool never ran.

Agent-as-tool relays the nested approval pause with the sub-agent's run id in `suspendOptions.runId` only. The payload describes the gated tool and carries no id. #22139 restores `suspendedToolRunId` from the `run-attempt` step's `suspendData`, but nothing wrote it there. Its regression test put the id into the payload by hand, so it passed.

This change carries `suspendOptions.runId` onto the `run-attempt` step's suspend payload. The runtime persists that payload in the run snapshot and returns it as `suspendData` on resume, where #22139 already reads it. The task row keeps the payload the tool reported, so the internal id does not leak onto `task.suspended` events. Tools that suspend on their own pass no run id and behave as before. A payload that already carries `suspendedToolRunId` keeps its own value.

Tests:

- `manager.test.ts`: a delegation whose run id arrives only in the suspend options resumes with it, and the task row keeps the reported payload.
- `subagent-background-approval.test.ts`: a supervisor, a background sub-agent and a `requireApproval` tool, on mock models. Before the fix the task suspends again after `resume(taskId, { approved: true })` and the tool never runs. After it, the tool runs once and the task completes.

Both fail on `main` and pass with the fix. The background-task, durable-agent background and aimock background scenario suites pass, and `@mastra/core` typechecks. A downstream app on 1.66.0 runs an equivalent postinstall patch in production, and its integration test (real Mastra, mock models, libsql) goes from red to green.

## Related issue(s)

Fixes #23626

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a background helper pauses for tool approval, it now continues the same run after approval instead of starting over. This allows the approved tool to run and the background task to finish.

## Changes

- Preserve the delegated sub-agent run ID in `run-attempt` suspend data.
- Restore the sub-agent run ID when the background task resumes.
- Preserve existing task payloads and behavior when no run ID is available.
- Add a patch changeset for `@mastra/core`.

## Tests

- Verify delegated run ID persistence and resume behavior.
- Verify task payload preservation.
- Verify end-to-end background tool approval completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->