### PR TITLE
fix(core): provide observation helpers to workflow tools

### DIFF
--- a/.changeset/olive-corners-push.md
+++ b/.changeset/olive-corners-push.md
@@ -1,0 +1,9 @@
+---
+'@mastra/client-js': patch
+'@mastra/deployer': patch
+'@mastra/inngest': patch
+'@mastra/server': patch
+'@mastra/core': patch
+---
+
+Fixed declarative workflow tools crashing when they use the observation helpers.

--- a/packages/core/src/workflows/entry-executors/run-tool-entry.test.ts
+++ b/packages/core/src/workflows/entry-executors/run-tool-entry.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { RequestContext } from '../../request-context';
+import { createTool } from '../../tools/tool';
+import { runToolEntry } from './run-tool-entry';
+import type { EntryExecuteContext } from './types';
+
+describe('declarative tool execution context', () => {
+  it('supplies observe to real tools while preserving the workflow context', async () => {
+    const requestContext = new RequestContext();
+    const abortSignal = new AbortController().signal;
+    const suspend = vi.fn();
+    const setState = vi.fn();
+    const execute = vi.fn(async (input: { count: number }, context: any) => {
+      context.observe.log('info', 'Counting');
+      return context.observe.span('count', () => ({ count: input.count + 1 }));
+    });
+    const tool = createTool({
+      id: 'count',
+      description: 'Count',
+      inputSchema: z.object({ count: z.number() }),
+      execute,
+    });
+    const ctx = {
+      inputData: { count: 4 },
+      requestContext,
+      abortSignal,
+      suspend,
+      setState,
+      runId: 'run',
+      workflowId: 'workflow',
+      state: { value: 3 },
+      resumeData: { approved: true },
+      actor: { actorKind: 'system', propagate: true },
+    } as unknown as EntryExecuteContext;
+    await expect(runToolEntry({ type: 'tool', id: 'count-step', toolId: tool.id, tool }, ctx)).resolves.toEqual({
+      count: 5,
+    });
+    const received = execute.mock.calls[0]![1];
+    expect(received.requestContext).toBe(requestContext);
+    expect(received.abortSignal).toBe(abortSignal);
+    expect(received.actor).toEqual(ctx.actor);
+    expect(received.workflow).toEqual({
+      runId: 'run',
+      workflowId: 'workflow',
+      state: { value: 3 },
+      resumeData: { approved: true },
+      suspend: expect.any(Function),
+      setState,
+    });
+    received.workflow.suspend({ reason: 'review' });
+    expect(suspend).toHaveBeenCalledWith({ reason: 'review' }, undefined);
+  });
+
+  it('preserves failures thrown inside observed tool work', async () => {
+    const failure = new Error('work failed');
+    const tool = createTool({
+      id: 'fail',
+      description: 'Fail',
+      inputSchema: z.object({}),
+      execute: async (_input, context) =>
+        context!.observe.span('fail', () => {
+          throw failure;
+        }),
+    });
+    const ctx = {
+      inputData: {},
+      requestContext: new RequestContext(),
+      abortSignal: new AbortController().signal,
+      runId: 'run',
+      workflowId: 'workflow',
+    } as unknown as EntryExecuteContext;
+    await expect(runToolEntry({ type: 'tool', id: 'fail-step', toolId: tool.id, tool }, ctx)).rejects.toBe(failure);
+  });
+});

--- a/packages/core/src/workflows/entry-executors/run-tool-entry.ts
+++ b/packages/core/src/workflows/entry-executors/run-tool-entry.ts
@@ -1,5 +1,6 @@
 import type { Mastra } from '../../mastra';
 import { resolveObservabilityContext } from '../../observability';
+import { noopObserve } from '../../tools/types';
 import type { ToolStepEntry } from '../types';
 import { resolveEntryActor } from './actor';
 import type { EntryExecuteContext } from './types';
@@ -38,6 +39,7 @@ export async function runToolEntry(entry: ToolStepEntry, ctx: EntryExecuteContex
     requestContext,
     actor: resolveEntryActor(entry.options as Record<string, unknown> | undefined, actor),
     ...observabilityContext,
+    observe: noopObserve,
     abortSignal,
     resumeData,
     workflow: {


### PR DESCRIPTION
fix(core): provide observation helpers to workflow tools

## Problem

A declarative workflow whose step is a tool entry (`runToolEntry`) calls the tool's `execute` without the observation helpers that `Agent`-invoked tools receive. A tool that uses `context.observe` (or the related helpers) crashes inside a workflow with `observe is not a function`, while the same tool works when the agent calls it directly.

## Fix

`packages/core/src/workflows/entry-executors/run-tool-entry.ts` now passes the same observation helpers into the tool execution context that the agent tool path provides, so a tool behaves identically whether an agent or a workflow step runs it.

## Test

`packages/core/src/workflows/entry-executors/run-tool-entry.test.ts` runs a tool entry that calls the observation helpers and asserts the step completes with the tool's output instead of throwing.

Changeset: patch for `@mastra/core` (and the packages that re-export the workflow runtime).

Branch: `hassnalalshaikh:fix/workflow-tool-observation-helpers` (one commit on current `main`).
