### PR TITLE
fix(mastracode): stop /prune vacuum from corrupting vector-indexed databases

### DIFF
--- a/.changeset/lucky-moons-shave.md
+++ b/.changeset/lucky-moons-shave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+`/prune vacuum` no longer compacts local libSQL databases that carry a `libsql_vector_idx` vector index. Any VACUUM over such a database deterministically corrupts its `libsql_vector_meta_shadow` table — silently at first, since vector queries keep returning rows — and compounds over repeated runs until `REINDEX` can no longer repair it. Databases are now detected by schema (not filename), skipped rather than compacted, and reported in `/prune` output with the reason, so the skip is never silent. Detection fails closed: a database whose schema cannot be inspected is left untouched instead of vacuumed. Ordinary databases are still compacted as before.

--- a/mastracode/sdk/src/utils/__tests__/storage-maintenance.test.ts
+++ b/mastracode/sdk/src/utils/__tests__/storage-maintenance.test.ts
@@ -462,14 +462,8 @@ describe('reclaimLibSQLDisk vector-index safety (#23439)', () => {
     const starts: string[] = [];
     const results = await reclaimLibSQLDisk([dbFile], file => starts.push(file));
 
-    expect(results).toHaveLength(1);
-    expect(results[0]!.skipped).toBe('vector-index');
-    expect(results[0]!.bytesAfter).toBe(results[0]!.bytesBefore);
-    // onFileStart logs "vacuuming <file>…" — never emitted for a skipped file.
-    expect(starts).toEqual([]);
-    expect(existsSync(`${dbFile}.vacuum-tmp`)).toBe(false);
-    expect(existsSync(`${dbFile}.old`)).toBe(false);
-
+    // Assert the damage first, so this test's own red output names the defect
+    // (`row not in PRIMARY KEY order …`) rather than a missing result marker.
     const after = inspect(dbFile);
     expect(after.integrity).toBe('ok');
     expect(after.topK).toBeGreaterThan(0);
@@ -478,6 +472,14 @@ describe('reclaimLibSQLDisk vector-index safety (#23439)', () => {
     // a vacuum necessarily rewrites pages and reclaims the freelist.
     expect(after.pageCount).toBe(before.pageCount);
     expect(after.freelist).toBe(before.freelist);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.skipped).toBe('vector-index');
+    expect(results[0]!.bytesAfter).toBe(results[0]!.bytesBefore);
+    // onFileStart logs "vacuuming <file>…" — never emitted for a skipped file.
+    expect(starts).toEqual([]);
+    expect(existsSync(`${dbFile}.vacuum-tmp`)).toBe(false);
+    expect(existsSync(`${dbFile}.old`)).toBe(false);
   });
 
   it('still compacts an ordinary database (detection is not over-broad)', async () => {
@@ -502,6 +504,38 @@ describe('reclaimLibSQLDisk vector-index safety (#23439)', () => {
     expect(results).toHaveLength(1);
     expect(results[0]!.skipped).toBeUndefined();
     expect(results[0]!.bytesAfter).toBeLessThan(results[0]!.bytesBefore);
+  });
+
+  it('detects by schema, not filename: a vector index in the MAIN db is skipped', async () => {
+    dir = mkdtempSync(path.join(tmpdir(), 'mc-vec-mainbd-'));
+    // Deliberately inverted names: the vector index lives in the main db, and
+    // the file called "mastra-vectors.db" has none. A filename shortcut fails.
+    const mainFile = path.join(dir, 'mastra.db');
+    const vectorsNamedFile = path.join(dir, 'mastra-vectors.db');
+    seedVectorDb(mainFile);
+    seedPlainDb(vectorsNamedFile);
+
+    const results = await reclaimLibSQLDisk([mainFile, vectorsNamedFile]);
+
+    expect(results.find(r => r.file === mainFile)!.skipped).toBe('vector-index');
+    expect(results.find(r => r.file === vectorsNamedFile)!.skipped).toBeUndefined();
+  });
+
+  it('skips an index written with a space before the parenthesis', async () => {
+    dir = mkdtempSync(path.join(tmpdir(), 'mc-vec-space-'));
+    const dbFile = path.join(dir, 'spaced.db');
+    const db = new Database(dbFile);
+    db.exec('PRAGMA journal_mode = WAL');
+    db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, embedding F32_BLOB(384))');
+    // SQLite stores CREATE INDEX SQL verbatim — the space must not slip past.
+    db.exec('CREATE INDEX t_vector_idx ON t (libsql_vector_idx (embedding))');
+    db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+    db.exec('PRAGMA journal_mode = DELETE');
+    db.close();
+
+    const results = await reclaimLibSQLDisk([dbFile]);
+
+    expect(results[0]!.skipped).toBe('vector-index');
   });
 
   it('skips exactly the vector db and compacts exactly the plain one', async () => {
@@ -576,5 +610,29 @@ describe('reclaimLibSQLDisk vector-index safety (#23439)', () => {
     expect(output).not.toContain('/tmp/odd.db: skipped — it contains a vector index');
     expect(output).toContain('No database files were compacted;');
     expect(lines).not.toContain('Reclaimed 0 B.');
+  });
+
+  it('keeps the totals line truthful when some files compact and some are skipped', async () => {
+    const lines: string[] = [];
+    await runStorageMaintenance({
+      maintenance: {
+        backend: 'libsql',
+        retention: {},
+        prune: vi.fn().mockResolvedValue([]),
+        closeStorage: vi.fn().mockResolvedValue(undefined),
+        reclaimDisk: vi.fn().mockResolvedValue([
+          { file: '/tmp/a.db', bytesBefore: 10, bytesAfter: 10, skipped: 'vector-index' },
+          { file: '/tmp/b.db', bytesBefore: 20, bytesAfter: 20, skipped: 'vector-index' },
+          { file: '/tmp/main.db', bytesBefore: 2048, bytesAfter: 1024 },
+        ]),
+      },
+      vacuum: true,
+      log: line => lines.push(line),
+    });
+
+    const output = lines.join('\n');
+    // Savings count only the compacted file, and the skips stay visible.
+    expect(output).toContain('/tmp/main.db: 2.0 KB → 1.0 KB');
+    expect(output).toContain('Reclaimed 1.0 KB; 2 skipped because they contain a vector index.');
   });
 });

--- a/mastracode/sdk/src/utils/__tests__/storage-maintenance.test.ts
+++ b/mastracode/sdk/src/utils/__tests__/storage-maintenance.test.ts
@@ -391,3 +391,190 @@ describe('reclaimLibSQLDisk', () => {
     verify.close();
   });
 });
+
+describe('reclaimLibSQLDisk vector-index safety (#23439)', () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  /**
+   * Seed with the native `libsql` driver (the one the source uses), exec()
+   * only, finished before close() — a @libsql/client left in WAL would pin the
+   * shm lock in-process and trip the exclusivity probe for the fixture's own
+   * reason rather than the behaviour under test.
+   *
+   * Rows are deleted before closing so the file carries free pages:
+   * `freelist_count` is the load-bearing "was it vacuumed" signal.
+   */
+  function seedVectorDb(dbFile: string) {
+    const db = new Database(dbFile);
+    db.exec('PRAGMA journal_mode = WAL');
+    db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, body TEXT, embedding F32_BLOB(384))');
+    db.exec('CREATE INDEX t_vector_idx ON t (libsql_vector_idx(embedding))');
+    const vec = (seed: number) =>
+      `vector32('[${Array.from({ length: 384 }, (_, i) => ((seed + i) % 97) / 97).join(',')}]')`;
+    for (let i = 0; i < 400; i++) {
+      db.exec(`INSERT INTO t (body, embedding) VALUES ('${'y'.repeat(512)}', ${vec(i)})`);
+    }
+    db.exec('DELETE FROM t WHERE id > 300');
+    db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+    db.exec('PRAGMA journal_mode = DELETE');
+    db.close();
+  }
+
+  function seedPlainDb(dbFile: string, opts?: { leaveInWal?: boolean }) {
+    const db = new Database(dbFile);
+    db.exec('PRAGMA journal_mode = WAL');
+    db.exec('CREATE TABLE blobs (id INTEGER PRIMARY KEY, data TEXT)');
+    db.exec('CREATE INDEX blobs_data_idx ON blobs (data)');
+    for (let i = 0; i < 400; i++) db.exec(`INSERT INTO blobs (data) VALUES ('${'x'.repeat(2048)}')`);
+    db.exec('DELETE FROM blobs WHERE id > 50');
+    db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+    if (!opts?.leaveInWal) db.exec('PRAGMA journal_mode = DELETE');
+    db.close();
+  }
+
+  function inspect(dbFile: string) {
+    const db = new Database(dbFile);
+    try {
+      const num = (p: string) => Number(Object.values((db.pragma(p) as any[])[0])[0]);
+      const integrity = String(Object.values((db.pragma('integrity_check') as any[])[0])[0]);
+      const rows = Number((db.prepare('SELECT COUNT(*) AS n FROM t').get() as any).n);
+      const topK = db
+        .prepare(`SELECT v.id FROM vector_top_k('t_vector_idx', (SELECT embedding FROM t LIMIT 1), 5) AS v`)
+        .all() as unknown[];
+      return { integrity, rows, topK: topK.length, pageCount: num('page_count'), freelist: num('freelist_count') };
+    } finally {
+      db.close();
+    }
+  }
+
+  it('skips a vector-indexed database instead of vacuuming it', async () => {
+    dir = mkdtempSync(path.join(tmpdir(), 'mc-vec-'));
+    const dbFile = path.join(dir, 'mastra-vectors.db');
+    seedVectorDb(dbFile);
+    const before = inspect(dbFile);
+    expect(before.freelist).toBeGreaterThan(0);
+
+    const starts: string[] = [];
+    const results = await reclaimLibSQLDisk([dbFile], file => starts.push(file));
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.skipped).toBe('vector-index');
+    expect(results[0]!.bytesAfter).toBe(results[0]!.bytesBefore);
+    // onFileStart logs "vacuuming <file>…" — never emitted for a skipped file.
+    expect(starts).toEqual([]);
+    expect(existsSync(`${dbFile}.vacuum-tmp`)).toBe(false);
+    expect(existsSync(`${dbFile}.old`)).toBe(false);
+
+    const after = inspect(dbFile);
+    expect(after.integrity).toBe('ok');
+    expect(after.topK).toBeGreaterThan(0);
+    expect(after.rows).toBe(before.rows);
+    // Not byte-identical (the probe flips the journal-mode header bytes), but
+    // a vacuum necessarily rewrites pages and reclaims the freelist.
+    expect(after.pageCount).toBe(before.pageCount);
+    expect(after.freelist).toBe(before.freelist);
+  });
+
+  it('still compacts an ordinary database (detection is not over-broad)', async () => {
+    dir = mkdtempSync(path.join(tmpdir(), 'mc-vec-plain-'));
+    const dbFile = path.join(dir, 'plain.db');
+    seedPlainDb(dbFile);
+
+    const results = await reclaimLibSQLDisk([dbFile]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.skipped).toBeUndefined();
+    expect(results[0]!.bytesAfter).toBeLessThan(results[0]!.bytesBefore);
+  });
+
+  it('still compacts an ordinary database left in WAL mode', async () => {
+    dir = mkdtempSync(path.join(tmpdir(), 'mc-vec-wal-'));
+    const dbFile = path.join(dir, 'plain-wal.db');
+    seedPlainDb(dbFile, { leaveInWal: true });
+
+    const results = await reclaimLibSQLDisk([dbFile]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.skipped).toBeUndefined();
+    expect(results[0]!.bytesAfter).toBeLessThan(results[0]!.bytesBefore);
+  });
+
+  it('skips exactly the vector db and compacts exactly the plain one', async () => {
+    dir = mkdtempSync(path.join(tmpdir(), 'mc-vec-mixed-'));
+    const vectorFile = path.join(dir, 'vectors.db');
+    const plainFile = path.join(dir, 'main.db');
+    seedVectorDb(vectorFile);
+    seedPlainDb(plainFile);
+
+    const results = await reclaimLibSQLDisk([vectorFile, plainFile]);
+
+    expect(results).toHaveLength(2);
+    expect(results.find(r => r.file === vectorFile)!.skipped).toBe('vector-index');
+    const plain = results.find(r => r.file === plainFile)!;
+    expect(plain.skipped).toBeUndefined();
+    expect(plain.bytesAfter).toBeLessThan(plain.bytesBefore);
+  });
+
+  it('fails closed when detection itself throws after a successful probe', async () => {
+    dir = mkdtempSync(path.join(tmpdir(), 'mc-vec-failclosed-'));
+    const dbFile = path.join(dir, 'plain.db');
+    seedPlainDb(dbFile);
+    const sizeBefore = statSync(dbFile).size;
+
+    // Break only the detection query, on a file that passes the probe.
+    const realPrepare = Database.prototype.prepare;
+    const spy = vi.spyOn(Database.prototype, 'prepare').mockImplementation(function (
+      this: any,
+      sql: string,
+      ...rest: unknown[]
+    ) {
+      if (sql.includes('libsql_vector_idx')) throw new Error('simulated detection failure');
+      return (realPrepare as any).call(this, sql, ...rest);
+    } as any);
+
+    const starts: string[] = [];
+    let results;
+    try {
+      results = await reclaimLibSQLDisk([dbFile], file => starts.push(file));
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.skipped).toBe('detection-failed');
+    expect(starts).toEqual([]);
+    expect(existsSync(`${dbFile}.vacuum-tmp`)).toBe(false);
+    expect(existsSync(`${dbFile}.old`)).toBe(false);
+    expect(statSync(dbFile).size).toBe(sizeBefore);
+  });
+
+  it('reports both skip reasons distinctly in /prune output', async () => {
+    const lines: string[] = [];
+    await runStorageMaintenance({
+      maintenance: {
+        backend: 'libsql',
+        retention: {},
+        prune: vi.fn().mockResolvedValue([]),
+        closeStorage: vi.fn().mockResolvedValue(undefined),
+        reclaimDisk: vi.fn().mockResolvedValue([
+          { file: '/tmp/vectors.db', bytesBefore: 10, bytesAfter: 10, skipped: 'vector-index' },
+          { file: '/tmp/odd.db', bytesBefore: 20, bytesAfter: 20, skipped: 'detection-failed' },
+        ]),
+      },
+      vacuum: true,
+      log: line => lines.push(line),
+    });
+
+    const output = lines.join('\n');
+    expect(output).toContain('/tmp/vectors.db: skipped — it contains a vector index');
+    expect(output).toContain('/tmp/odd.db: skipped — it could not be inspected');
+    expect(output).not.toContain('/tmp/odd.db: skipped — it contains a vector index');
+    expect(output).toContain('No database files were compacted;');
+    expect(lines).not.toContain('Reclaimed 0 B.');
+  });
+});

--- a/mastracode/sdk/src/utils/__tests__/storage-maintenance.test.ts
+++ b/mastracode/sdk/src/utils/__tests__/storage-maintenance.test.ts
@@ -443,10 +443,19 @@ describe('reclaimLibSQLDisk vector-index safety (#23439)', () => {
       const num = (p: string) => Number(Object.values((db.pragma(p) as any[])[0])[0]);
       const integrity = String(Object.values((db.pragma('integrity_check') as any[])[0])[0]);
       const rows = Number((db.prepare('SELECT COUNT(*) AS n FROM t').get() as any).n);
-      const topK = db
-        .prepare(`SELECT v.id FROM vector_top_k('t_vector_idx', (SELECT embedding FROM t LIMIT 1), 5) AS v`)
-        .all() as unknown[];
-      return { integrity, rows, topK: topK.length, pageCount: num('page_count'), freelist: num('freelist_count') };
+      // A corrupted index can throw here rather than return nothing; treat that
+      // as "search is broken" so the failure stays a clean assertion.
+      let topK = 0;
+      try {
+        topK = (
+          db
+            .prepare(`SELECT v.id FROM vector_top_k('t_vector_idx', (SELECT embedding FROM t LIMIT 1), 5) AS v`)
+            .all() as unknown[]
+        ).length;
+      } catch {
+        topK = 0;
+      }
+      return { integrity, rows, topK, pageCount: num('page_count'), freelist: num('freelist_count') };
     } finally {
       db.close();
     }

--- a/mastracode/sdk/src/utils/storage-maintenance.ts
+++ b/mastracode/sdk/src/utils/storage-maintenance.ts
@@ -136,6 +136,8 @@ function journalModeFromHeader(file: string): 'wal' | 'delete' | 'unknown' {
  * statement, and a statement opened before the exclusivity probe pins the
  * connection past close() (libsql-js#228) and makes the probe's
  * `journal_mode = DELETE` fail with SQLITE_BUSY on files nobody else has open.
+ * The caller's connection must therefore already be in rollback mode — a
+ * pinned statement holds no lock there.
  *
  * Matched by schema, not filename — the main database can carry vector indexes
  * too. SQLite stores `CREATE INDEX` SQL verbatim, so the match is deliberately

--- a/mastracode/sdk/src/utils/storage-maintenance.ts
+++ b/mastracode/sdk/src/utils/storage-maintenance.ts
@@ -57,6 +57,19 @@ export interface ReclaimResult {
   file: string;
   bytesBefore: number;
   bytesAfter: number;
+  /**
+   * Set when the file was left untouched instead of compacted.
+   *
+   * `'vector-index'`: the database carries a `libsql_vector_idx` index.
+   * Vacuuming such a database corrupts its `libsql_vector_meta_shadow` table
+   * (`PRAGMA integrity_check` → `row not in PRIMARY KEY order`), silently at
+   * first, so we never compact it. See
+   * https://github.com/mastra-ai/mastra/issues/23439.
+   *
+   * `'detection-failed'`: the schema could not be inspected, so we cannot
+   * prove the database is safe to vacuum and skip it as a precaution.
+   */
+  skipped?: 'vector-index' | 'detection-failed';
 }
 
 /** Handle the TUI uses to run storage maintenance without reaching into store internals. */
@@ -117,6 +130,25 @@ function journalModeFromHeader(file: string): 'wal' | 'delete' | 'unknown' {
 }
 
 /**
+ * Does this database carry a libsql vector index?
+ *
+ * Takes an already-open connection on purpose: the query needs a prepared
+ * statement, and a statement opened before the exclusivity probe pins the
+ * connection past close() (libsql-js#228) and makes the probe's
+ * `journal_mode = DELETE` fail with SQLITE_BUSY on files nobody else has open.
+ *
+ * Matched by schema, not filename — the main database can carry vector indexes
+ * too. The trailing `(` keeps the pattern on the function-call form libsql
+ * generates (`libsql_vector_idx(embedding)`).
+ */
+function hasVectorIndex(db: InstanceType<typeof Database>): boolean {
+  const row = db
+    .prepare(`SELECT 1 AS hit FROM sqlite_master WHERE type = 'index' AND sql LIKE '%libsql_vector_idx(%' LIMIT 1`)
+    .get() as Record<string, unknown> | undefined;
+  return row !== undefined;
+}
+
+/**
  * Compact each local libsql db file by streaming a `VACUUM INTO` copy next to
  * it, then swapping the copy into place. Reports before/after sizes.
  *
@@ -134,6 +166,11 @@ function journalModeFromHeader(file: string): 'wal' | 'delete' | 'unknown' {
  * MUST run with every connection to these files closed (the swap replaces the
  * inode — a surviving connection would keep writing to the unlinked old file).
  * `runStorageMaintenance()` closes storage before calling this.
+ *
+ * Databases carrying a `libsql_vector_idx` index are skipped, not compacted:
+ * any VACUUM over one corrupts its `libsql_vector_meta_shadow` table (issue
+ * #23439). Detection fails closed — a file we cannot inspect is skipped too.
+ * Skipped files come back with `skipped` set so the caller can report them.
  */
 export async function reclaimLibSQLDisk(
   dbFiles: string[],
@@ -187,6 +224,19 @@ export async function reclaimLibSQLDisk(
     const db = new Database(file);
     try {
       db.exec('PRAGMA busy_timeout = 2000');
+      // First, before any check that can throw: a full disk must not abort the
+      // whole loop over a file we were going to leave alone anyway.
+      let skipped: ReclaimResult['skipped'];
+      try {
+        if (hasVectorIndex(db)) skipped = 'vector-index';
+      } catch {
+        // Fail closed: we could not establish that this file is safe to vacuum.
+        skipped = 'detection-failed';
+      }
+      if (skipped) {
+        results.push({ file, bytesBefore, bytesAfter: bytesBefore, skipped });
+        continue;
+      }
       const pageSize = pragmaNumber(db, 'page_size');
       const pageCount = pragmaNumber(db, 'page_count');
       const freelistCount = pragmaNumber(db, 'freelist_count');
@@ -406,8 +456,29 @@ export async function runStorageMaintenance(opts: {
     return;
   }
   for (const r of reclaimed) {
-    log(`  ${r.file}: ${formatBytes(r.bytesBefore)} → ${formatBytes(r.bytesAfter)}`);
+    if (r.skipped === 'vector-index') {
+      log(`  ${r.file}: skipped — it contains a vector index, and compacting it would corrupt that index.`);
+    } else if (r.skipped === 'detection-failed') {
+      log(`  ${r.file}: skipped — it could not be inspected, so it was left untouched as a precaution.`);
+    } else {
+      log(`  ${r.file}: ${formatBytes(r.bytesBefore)} → ${formatBytes(r.bytesAfter)}`);
+    }
   }
-  const saved = reclaimed.reduce((sum, r) => sum + Math.max(0, r.bytesBefore - r.bytesAfter), 0);
-  log(`Reclaimed ${formatBytes(saved)}.`);
+  const compacted = reclaimed.filter(r => !r.skipped);
+  const vectorSkips = reclaimed.filter(r => r.skipped === 'vector-index').length;
+  const failedSkips = reclaimed.filter(r => r.skipped === 'detection-failed').length;
+  const skipSummary = [
+    vectorSkips > 0
+      ? `${vectorSkips} skipped because ${vectorSkips === 1 ? 'it contains' : 'they contain'} a vector index`
+      : '',
+    failedSkips > 0 ? `${failedSkips} skipped because ${failedSkips === 1 ? 'it' : 'they'} could not be inspected` : '',
+  ]
+    .filter(Boolean)
+    .join('; ');
+  if (compacted.length === 0) {
+    log(`No database files were compacted; ${skipSummary}.`);
+    return;
+  }
+  const saved = compacted.reduce((sum, r) => sum + Math.max(0, r.bytesBefore - r.bytesAfter), 0);
+  log(skipSummary ? `Reclaimed ${formatBytes(saved)}; ${skipSummary}.` : `Reclaimed ${formatBytes(saved)}.`);
 }

--- a/mastracode/sdk/src/utils/storage-maintenance.ts
+++ b/mastracode/sdk/src/utils/storage-maintenance.ts
@@ -138,12 +138,15 @@ function journalModeFromHeader(file: string): 'wal' | 'delete' | 'unknown' {
  * `journal_mode = DELETE` fail with SQLITE_BUSY on files nobody else has open.
  *
  * Matched by schema, not filename — the main database can carry vector indexes
- * too. The trailing `(` keeps the pattern on the function-call form libsql
- * generates (`libsql_vector_idx(embedding)`).
+ * too. SQLite stores `CREATE INDEX` SQL verbatim, so the match is deliberately
+ * loose (no trailing `(`): an index written `libsql_vector_idx (embedding)`
+ * must not slip through. The two errors are not symmetric — a false positive
+ * costs one uncompacted file that we tell the user about, a false negative
+ * silently corrupts their vector index.
  */
 function hasVectorIndex(db: InstanceType<typeof Database>): boolean {
   const row = db
-    .prepare(`SELECT 1 AS hit FROM sqlite_master WHERE type = 'index' AND sql LIKE '%libsql_vector_idx(%' LIMIT 1`)
+    .prepare(`SELECT 1 AS hit FROM sqlite_master WHERE type = 'index' AND sql LIKE '%libsql_vector_idx%' LIMIT 1`)
     .get() as Record<string, unknown> | undefined;
   return row !== undefined;
 }


### PR DESCRIPTION
## Summary

Prevent `/prune vacuum` from compacting local libSQL databases containing a `libsql_vector_idx` index. In the tested libSQL version, vacuuming these databases can corrupt the vector shadow table even with no concurrent connections.

- Detect vector indexes from the database schema, not the filename, so indexes in the main database are covered too.
- Skip compaction and report the reason when a vector index is found or schema inspection fails.
- Continue compacting ordinary databases and distinguish compacted files from skipped files in the output.

The existing exclusivity probe still runs before schema inspection and can change the journal mode. A skip means **no compaction**, not a byte-for-byte untouched file.

## Evidence and scope

A real-file reproduction using `reclaimLibSQLDisk()` starts with a healthy vector database. On the base implementation, one compaction produces `row not in PRIMARY KEY order for libsql_vector_meta_shadow` from `PRAGMA integrity_check`, while `vector_top_k` still returns five results. With this change, the vector database is skipped: integrity remains healthy, vector search returns results, and row count, page count, and freelist count remain unchanged. The ordinary database still shrinks from 3,518,464 to 446,464 bytes.

This demonstrates a corruption path that does **not require** the sidecar race described in #23439. It does not establish the exact libSQL-internal cause, rule out a separate race, or change locking, sidecar handling, or connection lifecycle behavior.

The trade-off is less reclaimed disk space, potentially substantially less when the vector database is the largest file. Logical pruning is unchanged. This change does not repair existing corruption.

## Test plan

- [x] Focused storage-maintenance suite: 29 tests passed.
- [x] `@mastra/code-sdk` typecheck and lint passed after rebasing.
- [x] Real-file red/green proof: base corrupts the vector shadow table; the fix preserves integrity and search while still compacting the ordinary database.
- [x] Regression coverage includes schema-based detection, whitespace in index declarations, mixed vector/plain input, schema-inspection failure, ordinary WAL-mode databases, and skip/summary reporting.

Run the committed regression suite from `mastracode/sdk`:

```sh
pnpm exec vitest run src/utils/__tests__/storage-maintenance.test.ts --reporter=dot
```

Closes #23439


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

`/prune vacuum` now avoids compacting databases that may contain vector data, because compaction can corrupt them. It reports which files it skipped and continues to compact safe databases.

## Changes

- Detects `libsql_vector_idx` indexes from the database schema, including indexes in the main database and declarations with whitespace variations.
- Skips vector-indexed databases before compaction.
- Skips databases when schema inspection fails.
- Reports separate reasons for vector-index and inspection-failure skips.
- Counts reclaimed space only from compacted files.
- Keeps ordinary database compaction unchanged.
- Adds regression coverage for mixed databases, WAL mode, detection failures, integrity, vector search, page counters, and reporting.

The exclusivity probe still runs before schema inspection and may change journal mode. This change does not alter locking, sidecar handling, connection lifecycle behavior, or existing database corruption handling.

Focused tests: 29 passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->