### PR TITLE
fix(mcp): preserve structured tool error results

### DIFF
--- a/.changeset/fine-tables-wear.md
+++ b/.changeset/fine-tables-wear.md
@@ -1,0 +1,58 @@
+---
+'@mastra/mcp': minor
+---
+
+Add `onToolError: 'returnEnvelope'` for MCP clients that need the complete failed `CallToolResult`, including `isError`, `content`, `structuredContent`, and result metadata. Existing `onToolError: 'return'` behavior is unchanged: failed calls with structured content still return the bare structured value, while failures without it return the full result.
+
+**Before**
+
+`onToolError: 'return'` unwraps structured error data, so callers receive the bare value without a reliable `isError` signal.
+
+```ts
+import { MCPClient } from '@mastra/mcp';
+
+const mcp = new MCPClient({
+  id: 'recipe-client',
+  servers: {
+    recipes: {
+      url: new URL('https://recipes.example.com/mcp'),
+      onToolError: 'return',
+    },
+  },
+});
+
+const tools = await mcp.listTools();
+const result = await tools.recipes_submitRecipe.execute?.({ title: 'Soup' });
+
+if (result.code === 'VALIDATION_FAILED') {
+  // Handle the bare structured error without a protocol-level failure signal.
+}
+```
+
+**After**
+
+Use `onToolError: 'returnEnvelope'` to inspect the protocol failure signal, content blocks, and structured error details together.
+
+```ts
+import { MCPClient } from '@mastra/mcp';
+
+const mcp = new MCPClient({
+  id: 'recipe-client',
+  servers: {
+    recipes: {
+      url: new URL('https://recipes.example.com/mcp'),
+      onToolError: 'returnEnvelope',
+    },
+  },
+});
+
+const tools = await mcp.listTools();
+const result = await tools.recipes_submitRecipe.execute?.({ title: 'Soup' });
+
+if (result.isError) {
+  const content = result.content;
+  const errorDetails = result.structuredContent;
+}
+```
+
+With `onToolError: 'throw'`, caught `MastraError` instances now include JSON-serialized structured error data in `details.structuredContent`.

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -563,9 +563,9 @@ describe('MastraMCPClient - outputSchema without structuredContent', () => {
       },
     });
 
-    // The Tool-level validator stays a no-op so envelope returns (no structuredContent,
-    // isError + onToolError: 'return') aren't validated against the outputSchema.
-    // Enforcement happens inside the execute wrapper on the structuredContent path.
+    // The Tool-level validator stays a no-op so CallToolResult envelope returns are not
+    // validated against the outputSchema. Enforcement happens inside the execute wrapper
+    // for successful structuredContent results.
     const invalidOutput = { result: 'not-a-number', extraField: true };
     expect(calculateTool.outputSchema?.['~standard'].validate(invalidOutput)).toEqual({ value: invalidOutput });
     expect(toStandardSchema(outputSchema)['~standard'].validate(invalidOutput)).toHaveProperty('issues');
@@ -646,49 +646,61 @@ describe('MastraMCPClient - outputSchema without structuredContent', () => {
     expect(getMcpCallToolContent(result)).toEqual(content);
   });
 
-  it('does not schema-validate isError results when onToolError is "return"', async () => {
-    const returnClient = new InternalMastraMCPClient({
-      name: 'output-schema-test-client-return',
-      server: { url: testServer.baseUrl, onToolError: 'return' },
-    });
-    await returnClient.connect();
-    try {
-      const sdkClient = (returnClient as any).client as Client;
-
-      vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
-        tools: [
-          {
-            name: 'calculate',
-            description: 'Calculates a math expression',
-            inputSchema: { type: 'object' as const, properties: { expression: { type: 'string' } } },
-            outputSchema: {
-              type: 'object' as const,
-              properties: { result: { type: 'number' } },
-              required: ['result'],
-            },
-          },
-        ],
+  it.each(['return', 'returnEnvelope'] as const)(
+    'does not schema-validate isError results when onToolError is "%s"',
+    async onToolError => {
+      const returnClient = new InternalMastraMCPClient({
+        name: `output-schema-test-client-${onToolError}`,
+        server: { url: testServer.baseUrl, onToolError },
       });
+      await returnClient.connect();
+      try {
+        const sdkClient = (returnClient as any).client as Client;
 
-      const tools = await returnClient.tools();
-      const calculateTool = tools['calculate'];
+        vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+          tools: [
+            {
+              name: 'calculate',
+              description: 'Calculates a math expression',
+              inputSchema: { type: 'object' as const, properties: { expression: { type: 'string' } } },
+              outputSchema: {
+                type: 'object' as const,
+                properties: { result: { type: 'number' } },
+                required: ['result'],
+              },
+            },
+          ],
+        });
 
-      // An error envelope with structuredContent that doesn't match the schema must not
-      // be masked by a validation error — the isError path owns this result.
-      const callToolResult = {
-        content: [{ type: 'text', text: 'boom' }],
-        structuredContent: { result: 'not-a-number' },
-        isError: true,
-      };
-      vi.spyOn(sdkClient, 'callTool').mockResolvedValue(callToolResult);
+        const tools = await returnClient.tools();
+        const calculateTool = tools['calculate'];
 
-      const result = await calculateTool.execute?.({ expression: '1 + 1' });
-      expect(result).toEqual(callToolResult.structuredContent);
-      expect((result as any).error).toBeUndefined();
-    } finally {
-      await returnClient.disconnect().catch(() => {});
-    }
-  });
+        // An error result with structuredContent that does not match the schema must not
+        // be masked by a validation error. Legacy return mode still unwraps this value.
+        const callToolResult = {
+          content: [{ type: 'text', text: 'boom' }],
+          structuredContent: { result: 'not-a-number' },
+          isError: true,
+        };
+        vi.spyOn(sdkClient, 'callTool').mockResolvedValue(callToolResult);
+        const logSpy = vi.spyOn(returnClient as any, 'log');
+
+        const result = await calculateTool.execute?.({ expression: '1 + 1' });
+        if (onToolError === 'returnEnvelope') {
+          expect(result).toEqual(callToolResult);
+          expect((result as any).isError).toBe(true);
+        } else {
+          expect(result).toEqual(callToolResult.structuredContent);
+          expect((result as any).isError).toBeUndefined();
+          expect(getMcpCallToolContent(result)).toEqual(callToolResult.content);
+        }
+        expect((result as any).error).toBeUndefined();
+        expect(logSpy).not.toHaveBeenCalledWith('debug', 'Tool executed successfully: calculate');
+      } finally {
+        await returnClient.disconnect().catch(() => {});
+      }
+    },
+  );
 });
 
 describe('MastraMCPClient - isError handling', () => {
@@ -765,10 +777,85 @@ describe('MastraMCPClient - isError handling', () => {
     await client.disconnect().catch(() => {});
   });
 
-  it('returns the raw envelope when onToolError is "return" (legacy behaviour)', async () => {
+  it.each(['return', 'returnEnvelope'] as const)(
+    'returns the raw envelope without structuredContent when onToolError is "%s"',
+    async onToolError => {
+      const client = new InternalMastraMCPClient({
+        name: `iserror-${onToolError}-client`,
+        server: { url: testServer.baseUrl, onToolError },
+      });
+      await client.connect();
+
+      const sdkClient = (client as any).client as Client;
+      vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+        tools: [{ name: 'fetch', description: 'Fetches data', inputSchema: { type: 'object' as const } }],
+      });
+      vi.spyOn(sdkClient, 'callTool').mockResolvedValue(failingResult);
+
+      const tools = await client.tools();
+      const result = await tools['fetch'].execute?.({});
+      expect(result).toEqual(failingResult);
+
+      await client.disconnect().catch(() => {});
+    },
+  );
+
+  it('returns the full error envelope in returnEnvelope mode when structuredContent is present', async () => {
     const client = new InternalMastraMCPClient({
-      name: 'iserror-return-client',
-      server: { url: testServer.baseUrl, onToolError: 'return' },
+      name: 'iserror-return-envelope-structured-client',
+      server: { url: testServer.baseUrl, onToolError: 'returnEnvelope' },
+    });
+    await client.connect();
+
+    const sdkClient = (client as any).client as Client;
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'submitRecipe',
+          description: 'Submits a recipe',
+          inputSchema: { type: 'object' as const },
+          outputSchema: {
+            type: 'object' as const,
+            properties: { code: { type: 'string' as const } },
+          },
+        },
+      ],
+    });
+    const errorResult = {
+      content: [{ type: 'text' as const, text: 'Recipe validation failed.' }],
+      structuredContent: {
+        code: 'VALIDATION_FAILED',
+        validationResults: [
+          { code: 'MISSING_INGREDIENTS', level: 'ERROR', message: 'Ingredient list is required.' },
+        ],
+      },
+      isError: true,
+      _meta: { ui: { resourceUri: 'ui://submit-recipe/error.html' } },
+    };
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue(errorResult);
+
+    const tools = await client.tools();
+    const result = await tools['submitRecipe'].execute?.({});
+    expect(result).toEqual({
+      ...errorResult,
+      _meta: {
+        ui: {
+          resourceUri: 'ui://submit-recipe/error.html',
+          serverId: 'iserror-return-envelope-structured-client',
+        },
+      },
+    });
+
+    await client.disconnect().catch(() => {});
+  });
+
+  it.each([
+    ['number', 0],
+    ['null', null],
+  ])('returns the full error envelope for %s structuredContent in returnEnvelope mode', async (_label, structuredContent) => {
+    const client = new InternalMastraMCPClient({
+      name: 'iserror-return-envelope-scalar-client',
+      server: { url: testServer.baseUrl, onToolError: 'returnEnvelope' },
     });
     await client.connect();
 
@@ -776,11 +863,60 @@ describe('MastraMCPClient - isError handling', () => {
     vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
       tools: [{ name: 'fetch', description: 'Fetches data', inputSchema: { type: 'object' as const } }],
     });
-    vi.spyOn(sdkClient, 'callTool').mockResolvedValue(failingResult);
+    const errorResult = {
+      content: [{ type: 'text' as const, text: 'Fetch failed.' }],
+      structuredContent,
+      isError: true,
+    };
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue(errorResult);
 
     const tools = await client.tools();
     const result = await tools['fetch'].execute?.({});
-    expect(result).toEqual(failingResult);
+    expect(result).toEqual(errorResult);
+
+    await client.disconnect().catch(() => {});
+  });
+
+  it('includes structuredContent in the thrown MastraError details', async () => {
+    const client = new InternalMastraMCPClient({
+      name: 'iserror-throw-structured-client',
+      server: { url: testServer.baseUrl },
+    });
+    await client.connect();
+
+    const sdkClient = (client as any).client as Client;
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [{ name: 'submitRecipe', description: 'Submits a recipe', inputSchema: { type: 'object' as const } }],
+    });
+    const structuredContent = {
+      code: 'VALIDATION_FAILED',
+      validationResults: [
+        { code: 'MISSING_INGREDIENTS', level: 'ERROR', message: 'Ingredient list is required.' },
+      ],
+    };
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
+      content: [{ type: 'text', text: 'Recipe validation failed.' }],
+      structuredContent,
+      isError: true,
+    });
+
+    const tools = await client.tools();
+    let caught: unknown;
+    try {
+      await tools['submitRecipe'].execute?.({});
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toMatchObject({
+      id: 'MCP_CLIENT_TOOL_EXECUTION_FAILED',
+      message: 'Recipe validation failed.',
+      details: {
+        toolName: 'submitRecipe',
+        serverName: 'iserror-throw-structured-client',
+        structuredContent: JSON.stringify(structuredContent),
+      },
+    });
 
     await client.disconnect().catch(() => {});
   });

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -320,7 +320,7 @@ export class InternalMastraMCPClient extends MastraBase {
   private _roots: Root[];
   private hasElicitationCapability: boolean;
   private readonly requireToolApproval: RequireToolApproval | undefined;
-  private readonly onToolError: 'throw' | 'return';
+  private readonly onToolError: 'throw' | 'return' | 'returnEnvelope';
 
   /** Provides access to resource operations (list, read, subscribe, etc.) */
   public readonly resources: ResourceClientActions;
@@ -1244,10 +1244,10 @@ export class InternalMastraMCPClient extends MastraBase {
 
   /**
    * Wraps the output schema with a validator that always succeeds. The tool's execute wrapper
-   * returns the full CallToolResult envelope when there is no structuredContent (and for
-   * in-band errors with `onToolError: 'return'`), which would never match the advertised
-   * outputSchema — so enforcement happens inside the execute wrapper, scoped to the
-   * structuredContent path (see buildToolFromListEntry). The JSON schema is surfaced here
+   * can return the full CallToolResult envelope when there is no structuredContent or when
+   * `onToolError: 'returnEnvelope'` handles an in-band error, which would never match the
+   * advertised outputSchema. Enforcement happens inside the execute wrapper on successful
+   * structuredContent results (see buildToolFromListEntry). The JSON schema is surfaced here
    * for documentation.
    */
   private convertOutputSchema(
@@ -1486,20 +1486,41 @@ export class InternalMastraMCPClient extends MastraBase {
 
                 // Per the MCP spec, tool *execution* failures are reported in-band:
                 // the server returns a normal CallToolResult with `isError: true` and
-                // the failure details in `content`. Map that onto Mastra's failed-tool-call
-                // path (unless the consumer opted into the legacy `'return'` behaviour) so
-                // tool spans, stream chunks, scorers, and persisted message parts reflect the
-                // failure, and the model sees the error text so it can self-correct.
-                if (res.isError && this.onToolError === 'throw') {
+                // the failure details in `content`. Handle those before successful-result
+                // normalization so they are never validated or logged as successful.
+                if (res.isError) {
                   const errorText = extractToolErrorText(res.content);
                   this.log('debug', `Tool reported an error: ${tool.name}`, { error: errorText });
-                  throw new MastraError({
-                    id: 'MCP_CLIENT_TOOL_EXECUTION_FAILED',
-                    domain: ErrorDomain.MCP,
-                    category: ErrorCategory.THIRD_PARTY,
-                    text: errorText,
-                    details: { toolName: tool.name, serverName: this.name },
-                  });
+
+                  if (this.onToolError === 'throw') {
+                    throw new MastraError({
+                      id: 'MCP_CLIENT_TOOL_EXECUTION_FAILED',
+                      domain: ErrorDomain.MCP,
+                      category: ErrorCategory.THIRD_PARTY,
+                      text: errorText,
+                      details: {
+                        toolName: tool.name,
+                        serverName: this.name,
+                        ...(res.structuredContent !== undefined
+                          ? { structuredContent: JSON.stringify(res.structuredContent) }
+                          : {}),
+                      },
+                    });
+                  }
+
+                  if (this.onToolError === 'returnEnvelope') {
+                    return res._meta ? { ...res, _meta: this.stampServerIdInMeta(res._meta) } : res;
+                  }
+
+                  if (res.structuredContent !== undefined) {
+                    return attachMcpCallToolContent(
+                      res.structuredContent,
+                      res.content,
+                      res._meta ? this.stampServerIdInMeta(res._meta) : undefined,
+                    );
+                  }
+
+                  return res;
                 }
 
                 this.log('debug', `Tool executed successfully: ${tool.name}`);
@@ -1510,9 +1531,8 @@ export class InternalMastraMCPClient extends MastraBase {
                   // cached catalog (which never populate the MCP SDK's tools/list output-schema
                   // cache, so the SDK's own AJV check does not fire for them). On mismatch,
                   // return the same structured ValidationError shape createTool produces so
-                  // the model can self-correct. Skipped for isError results, which are handled
-                  // above / by the `onToolError: 'return'` envelope path.
-                  if (!res.isError && outputValidator) {
+                  // the model can self-correct. Error results have already returned or thrown.
+                  if (outputValidator) {
                     const validation = validateToolOutput(outputValidator, res.structuredContent, tool.name);
                     if (validation.error) {
                       this.log('debug', `Tool output failed schema validation: ${tool.name}`, {

--- a/packages/mcp/src/client/types.ts
+++ b/packages/mcp/src/client/types.ts
@@ -232,15 +232,19 @@ export type BaseServerOptions = {
    * and the failure details in `content`.
    *
    * - `'throw'` (default): surface the failure on Mastra's failed-tool-call path
-   *   by throwing a `MastraError` that carries the server's `content` text. Tool
+   *   by throwing a `MastraError` that carries the server's `content` text and
+   *   JSON-serialized `structuredContent` in `details.structuredContent`. Tool
    *   spans, stream chunks, scorers, and persisted message parts then reflect the
    *   failure, and the model sees the error text so it can self-correct.
-   * - `'return'`: preserve the legacy behaviour and resolve successfully with the
-   *   raw result (or `structuredContent`), ignoring `isError`.
+   * - `'return'`: preserve the legacy behavior by resolving successfully with
+   *   `structuredContent` when present, or the full `CallToolResult` otherwise.
+   * - `'returnEnvelope'`: resolve successfully with the full `CallToolResult` for
+   *   every failed result so `isError`, `content`, `structuredContent`, and result
+   *   metadata remain available. Successful calls keep their existing return shape.
    *
    * @default 'throw'
    */
-  onToolError?: 'throw' | 'return';
+  onToolError?: 'throw' | 'return' | 'returnEnvelope';
   /**
    * Optional custom JSON Schema validator forwarded to the underlying MCP
    * client. Use this to opt into a non-default validator implementation.


### PR DESCRIPTION
MCP servers report tool execution failures in-band with `isError: true`. Existing `onToolError: 'return'` consumers receive bare `structuredContent` when it is present, while the default `'throw'` mode previously kept the readable message but dropped structured error details.

This PR preserves the legacy `'return'` behavior and adds an explicit `onToolError: 'returnEnvelope'` option. The new mode returns the full failed `CallToolResult`, including `isError`, `content`, `structuredContent`, and stamped result metadata. The `'throw'` mode now stores JSON-serialized structured error data in `MastraError.details.structuredContent`.

Error results are handled before successful-result normalization, so they are not logged as successful or checked against output schemas. Successful structured tool calls keep their existing bare return shape.

Validation:

- `pnpm --filter @mastra/mcp test:client`: 253 tests passed.
- `pnpm --filter @mastra/mcp lint`: passed.
- `git diff --check`: passed.
- Changeset status reports `@mastra/mcp` as minor with no major bump.
- Package build type generation remains blocked by the existing unused `@ts-expect-error` in `packages/mcp/src/server/server.ts`.

Closes #23330

Model: gpt-5.6-sol
Harness: Grok harness in T3 Code