### PR TITLE
fix(deployer): make tool bundle output deterministic

### DIFF
--- a/.changeset/better-poems-smoke.md
+++ b/.changeset/better-poems-smoke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed repeated builds producing different tool bundle filenames when the source files have not changed.

--- a/deployers/cloudflare/src/index.ts
+++ b/deployers/cloudflare/src/index.ts
@@ -267,6 +267,7 @@ export default { createRequire };
     toolsPaths: (string | string[])[],
     bundlerOptions: BundlerOptions,
     additionalEntries: Record<string, string>,
+    toolProjectRoot: string,
   ) {
     const inputOptions = await super.getBundlerOptions(
       serverFile,
@@ -278,6 +279,7 @@ export default { createRequire };
         enableEsmShim: false,
       },
       additionalEntries,
+      toolProjectRoot,
     );
 
     const hasPostgresStore = (await this.deps.checkDependencies(['@mastra/pg'])) === `ok`;

--- a/deployers/netlify/src/index.ts
+++ b/deployers/netlify/src/index.ts
@@ -109,6 +109,7 @@ export class NetlifyDeployer extends Deployer {
     toolsPaths: (string | string[])[],
     bundlerOptions: BundlerOptions,
     additionalEntries: Record<string, string>,
+    toolProjectRoot: string,
   ) {
     const inputOptions = await super.getBundlerOptions(
       serverFile,
@@ -120,6 +121,7 @@ export class NetlifyDeployer extends Deployer {
         enableEsmShim: this.target !== 'edge',
       },
       additionalEntries,
+      toolProjectRoot,
     );
 
     if (this.target === 'edge' && Array.isArray(inputOptions.plugins)) {

--- a/e2e-tests/monorepo/monorepo.test.ts
+++ b/e2e-tests/monorepo/monorepo.test.ts
@@ -1,7 +1,8 @@
+import { createHash } from 'crypto';
 import { it, describe, expect, beforeAll, afterAll, inject } from 'vitest';
-import { join } from 'path';
+import { join, relative } from 'path';
 import { setupMonorepo } from './prepare';
-import { mkdtemp, mkdir, readdir, rm, readFile, writeFile } from 'fs/promises';
+import { mkdtemp, mkdir, readdir, readFile, readlink, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import getPort from 'get-port';
 import { execa, execaNode } from 'execa';
@@ -47,6 +48,32 @@ async function findInDir(root: string, targetName: string): Promise<boolean> {
     }
   }
   return false;
+}
+
+async function getDirectoryDigests(root: string): Promise<Record<string, string>> {
+  const digests: Record<string, string> = {};
+
+  async function visit(dir: string) {
+    const entries = await readdir(dir, { withFileTypes: true });
+    entries.sort((first, second) => first.name.localeCompare(second.name));
+
+    for (const entry of entries) {
+      const path = join(dir, entry.name);
+      const relativePath = relative(root, path).replaceAll('\\', '/');
+      if (entry.isDirectory()) {
+        await visit(path);
+      } else if (entry.isSymbolicLink()) {
+        digests[relativePath] = `link:${await readlink(path)}`;
+      } else if (entry.isFile()) {
+        digests[relativePath] = createHash('sha256')
+          .update(await readFile(path))
+          .digest('hex');
+      }
+    }
+  }
+
+  await visit(root);
+  return digests;
 }
 
 const activeProcesses: Array<{ controller: AbortController; proc: ReturnType<typeof execa | typeof execaNode> }> = [];
@@ -988,6 +1015,52 @@ export const mastra = new Mastra({
           expect(output).toContain('pnpm blocked build scripts for: bcrypt');
           expect(output).toContain('Add these packages to allowBuilds in pnpm-workspace.yaml and retry the build.');
           expect(output).not.toContain('DEPLOYER_BUNDLER_BUNDLE_STAGE_FAILED');
+        } finally {
+          await rm(isolatedFixturePath, { recursive: true, force: true });
+        }
+      },
+      timeout,
+    );
+  });
+
+  describe.sequential('reproducible tool bundles', () => {
+    it(
+      'produces identical tool bundles when invoked from the app and monorepo roots',
+      async () => {
+        const isolatedFixturePath = await mkdtemp(join(tmpdir(), `mastra-monorepo-reproducible-test-${pkgManager}-`));
+        try {
+          await setupMonorepo(isolatedFixturePath, pkgManager);
+
+          const appDir = join(isolatedFixturePath, 'apps', 'custom');
+          const outputRoot = join(appDir, '.mastra', 'output');
+          const build = async (cwd: string, args: string[], cliPath?: string) => {
+            await rm(join(appDir, '.mastra'), { recursive: true, force: true });
+            const options = {
+              cwd,
+              env: { ...process.env, MASTRA_BUILD_SKIP_INSTALL: 'true' },
+              reject: false,
+            };
+            const result = cliPath ? await execaNode(cliPath, args, options) : await execa(pkgManager, args, options);
+            expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+            const outputDigests = await getDirectoryDigests(outputRoot);
+            return Object.fromEntries(
+              Object.entries(outputDigests).filter(
+                ([path]) => path === 'tools.mjs' || (path.startsWith('tools/') && path.endsWith('.mjs')),
+              ),
+            );
+          };
+
+          const first = await build(appDir, ['build']);
+          const second = await build(
+            isolatedFixturePath,
+            ['build', '--root', 'apps/custom'],
+            join(appDir, 'node_modules', 'mastra', 'dist', 'index.js'),
+          );
+
+          expect(
+            Object.keys(first).filter(path => path.startsWith('tools/') && path.endsWith('.mjs')).length,
+          ).toBeGreaterThan(0);
+          expect(second).toEqual(first);
         } finally {
           await rm(isolatedFixturePath, { recursive: true, force: true });
         }

--- a/packages/deployer/src/bundler/index.test.ts
+++ b/packages/deployer/src/bundler/index.test.ts
@@ -88,9 +88,9 @@ describe('Bundler.listToolsInputOptions', () => {
 
     expect(second).toEqual(first);
     expect(Object.values(first)).toEqual([
-      join(toolsDir, 'a.ts'),
-      join(toolsDir, 'b.ts'),
-      join(toolsDir, 'nested', 'c.ts'),
+      join(toolsDir, 'a.ts').replaceAll('\\', '/'),
+      join(toolsDir, 'b.ts').replaceAll('\\', '/'),
+      join(toolsDir, 'nested', 'c.ts').replaceAll('\\', '/'),
     ]);
     expect(Object.keys(first)).toEqual([
       'tools/a3576fdd-4db8-3860-0363-043d8e044095',

--- a/packages/deployer/src/bundler/index.test.ts
+++ b/packages/deployer/src/bundler/index.test.ts
@@ -70,6 +70,36 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })));
 });
 
+describe('Bundler.listToolsInputOptions', () => {
+  it('returns stable, sorted inputs relative to the project root', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'mastra-bundler-tools-'));
+    tempDirs.push(tempDir);
+    const projectRoot = join(tempDir, 'apps', 'api');
+    const toolsDir = join(projectRoot, 'src', 'mastra', 'tools');
+    await mkdir(join(toolsDir, 'nested'), { recursive: true });
+    for (const file of ['b.ts', 'a.ts', join('nested', 'c.ts')]) {
+      await writeFile(join(toolsDir, file), 'export {}', 'utf-8');
+    }
+
+    const bundler = new TestBundler('Test');
+    const toolsGlob = join(toolsDir, '**/*.ts');
+    const first = await bundler.listToolsInputOptions([toolsGlob], projectRoot);
+    const second = await bundler.listToolsInputOptions([join(toolsDir, 'b.ts'), toolsGlob], projectRoot);
+
+    expect(second).toEqual(first);
+    expect(Object.values(first)).toEqual([
+      join(toolsDir, 'a.ts'),
+      join(toolsDir, 'b.ts'),
+      join(toolsDir, 'nested', 'c.ts'),
+    ]);
+    expect(Object.keys(first)).toEqual([
+      'tools/a3576fdd-4db8-3860-0363-043d8e044095',
+      'tools/c8a75e35-2420-ce8d-d5d1-d6a12388c682',
+      'tools/a34d68f6-b252-bc06-1de9-238ce99e3110',
+    ]);
+  });
+});
+
 describe('Bundler.writePackageJson', () => {
   it('writes npm alias and workspace tarball dependency specs using the package name as the key', async () => {
     const tempDir = await mkdtemp(join(tmpdir(), 'mastra-bundler-package-json-'));

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -1,7 +1,8 @@
 import { execSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { readFile, rm, stat, writeFile } from 'node:fs/promises';
-import { dirname, join, posix } from 'node:path';
+import { dirname, join, posix, relative } from 'node:path';
 import { MastraBundler } from '@mastra/core/bundler';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
 import type { Config } from '@mastra/core/mastra';
@@ -282,6 +283,11 @@ export const applySourceDependencyRange = (
   return { ...dependencyInfo, version: declared };
 };
 
+function toolIdForEntry(relativeEntryFile: string): string {
+  const digest = createHash('sha256').update(relativeEntryFile).digest('hex');
+  return `${digest.slice(0, 8)}-${digest.slice(8, 12)}-${digest.slice(12, 16)}-${digest.slice(16, 20)}-${digest.slice(20, 32)}`;
+}
+
 export abstract class Bundler extends MastraBundler {
   protected analyzeOutputDir = '.build';
   protected outputDir = 'output';
@@ -499,6 +505,7 @@ export abstract class Bundler extends MastraBundler {
     toolsPaths: (string | string[])[],
     { enableSourcemap, enableMinify, enableEsmShim, externals }: BundlerOptions,
     additionalEntries: Record<string, string>,
+    toolProjectRoot: string,
   ) {
     const { workspaceRoot } = await getWorkspaceInformation({ mastraEntryFile });
     const closestPkgJson = pkg.up({ cwd: dirname(mastraEntryFile) });
@@ -520,7 +527,7 @@ export abstract class Bundler extends MastraBundler {
         externalsPreset: externals === true,
       },
     );
-    const toolsInputOptions = await this.listToolsInputOptions(toolsPaths);
+    const toolsInputOptions = await this.listToolsInputOptions(toolsPaths, toolProjectRoot);
     const entryInputs: Record<string, string> = {};
     const virtualEntries: Record<string, string> = {};
     const entries = { index: serverFile, ...additionalEntries };
@@ -571,8 +578,8 @@ export abstract class Bundler extends MastraBundler {
     return [...toolsPaths, defaultPaths];
   }
 
-  async listToolsInputOptions(toolsPaths: (string | string[])[]) {
-    const inputs: Record<string, string> = {};
+  async listToolsInputOptions(toolsPaths: (string | string[])[], projectRoot: string = process.cwd()) {
+    const entries = new Map<string, string>();
 
     for (const toolPath of toolsPaths) {
       const expandedPaths = await glob(toolPath, {
@@ -595,17 +602,20 @@ export abstract class Bundler extends MastraBundler {
             continue;
           }
 
-          const uniqueToolID = crypto.randomUUID();
-          // Normalize Windows paths to forward slashes for consistent handling
           const normalizedEntryFile = entryFile.replaceAll('\\', '/');
-          inputs[`tools/${uniqueToolID}`] = normalizedEntryFile;
+          const relativeEntryFile = relative(projectRoot, entryFile).replaceAll('\\', '/');
+          entries.set(relativeEntryFile, normalizedEntryFile);
         } else {
           this.logger.warn('Tool path does not exist, skipping', { path });
         }
       }
     }
 
-    return inputs;
+    return Object.fromEntries(
+      [...entries.entries()]
+        .sort(([first], [second]) => (first < second ? -1 : first > second ? 1 : 0))
+        .map(([relativeEntryFile, entryFile]) => [`tools/${toolIdForEntry(relativeEntryFile)}`, entryFile]),
+    );
   }
 
   protected async _bundle(
@@ -637,7 +647,7 @@ export abstract class Bundler extends MastraBundler {
 
     let analyzedBundleInfo;
     try {
-      const resolvedToolsPaths = await this.listToolsInputOptions(toolsPaths);
+      const resolvedToolsPaths = await this.listToolsInputOptions(toolsPaths, projectRoot);
       analyzedBundleInfo = await analyzeBundle(
         [serverFile, ...Object.values(additionalEntries), ...Object.values(resolvedToolsPaths)],
         mastraEntryFile,
@@ -727,6 +737,7 @@ export abstract class Bundler extends MastraBundler {
         toolsPaths,
         internalBundlerOptions,
         additionalEntries,
+        projectRoot,
       );
 
       const bundler = await this.createBundler(
@@ -826,8 +837,8 @@ export const tools = [${toolsExports.join(', ')}]`,
     }
   }
 
-  async lint(_entryFile: string, _outputDirectory: string, toolsPaths: (string | string[])[]): Promise<void> {
-    const toolsInputOptions = await this.listToolsInputOptions(toolsPaths);
+  async lint(_entryFile: string, outputDirectory: string, toolsPaths: (string | string[])[]): Promise<void> {
+    const toolsInputOptions = await this.listToolsInputOptions(toolsPaths, dirname(outputDirectory));
     const toolsLength = Object.keys(toolsInputOptions).length;
     if (toolsLength > 0) {
       this.logger.info('Found tools', { count: toolsLength });


### PR DESCRIPTION
## Description

Fixes #23478.

`mastra build` previously assigned every discovered tool a random UUID as its Rollup input name. Because Rollup uses that name for the emitted filename, identical source code produced different `output/tools/*.mjs` filenames and a different `tools.mjs` on every build.

Tool discovery also followed filesystem glob order, which is not guaranteed to be consistent across builds or machines.

This change:

- derives each tool bundle name from a SHA-256 hash of its project-relative entry path;
- uses the CLI-provided project root, so builds remain stable when invoked with `--root`;
- normalizes path separators for consistent names across operating systems;
- sorts discovered tools by project-relative path;
- deduplicates files matched by overlapping tool globs.

The generated identifiers remain UUID-shaped to minimize compatibility risk. Tool registration behavior and public tool IDs are unchanged.

## Before

The same tool received a different filename on each build:

```text
tools/25fec578-18c1-4014-8d45-b69002315e9f.mjs
tools/47882ae3-bfce-4f90-967f-7b2f03dbdd2b.mjs
```

## After

The tool’s project-relative path always produces the same filename:

```text
tools/a3576fdd-4db8-3860-0363-043d8e044095.mjs
```

## Verification

- Added unit coverage for stable IDs, sorted discovery, project-root anchoring, and overlapping globs.
- Added monorepo end-to-end coverage that:
  - builds from the application directory;
  - builds from the monorepo root using `--root`;
  - confirms `tools.mjs` and all `tools/*.mjs` files have identical names and contents.
- `pnpm test:deployer` — 777 tests passed.
- `pnpm --filter @mastra/deployer lint` — 0 warnings and 0 errors.
- CLI dependency build — 53 tasks passed.
- Monorepo reproducible-tool-bundle test passed.

This addresses tool bundle naming and ordering. Other sources of whole-build differences, such as dependency resolution, remain separate concerns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes `mastra build` produce the same files every time when the source files do not change. It replaces random tool names with stable names and uses a stable discovery order.

## Changes

- Derive UUID-shaped tool bundle IDs from normalized, project-relative paths using SHA-256.
- Sort and deduplicate discovered tools before creating Rollup inputs.
- Pass the CLI project root to bundling and linting, including Cloudflare and Netlify deployers.
- Add unit tests for stable tool IDs and input ordering.
- Add a monorepo test for reproducible app-root and `--root` builds.
- Add a patch changeset for `@mastra/deployer`.

## Validation

- 777 deployer tests pass.
- Deployer lint passes.
- CLI dependency build passes.
- Monorepo reproducibility test passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->