### PR TITLE
fix(core): guard Gemini 3 structured output after assistant turns

### DIFF
--- a/.changeset/funny-guests-eat.md
+++ b/.changeset/funny-guests-eat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Gemini 3 structured output requests failing when conversations end with an assistant message, including automatic structured output and dynamically selected models. Fixes #23320.

--- a/packages/core/src/agent/__tests__/structured-output-memory.test.ts
+++ b/packages/core/src/agent/__tests__/structured-output-memory.test.ts
@@ -244,6 +244,178 @@ describe('Structured output with memory - assistant message in final position (#
     expect(nonSystemMessages.at(-1)).toMatchObject({ role: 'assistant' });
   });
 
+  it('guards Gemini 3 assistant-role input without configured input processors or memory', async () => {
+    const capturedPrompts: any[] = [];
+    const mockModel = new MockLanguageModelV2({
+      provider: 'google.generative-ai',
+      modelId: 'gemini-3.5-flash-lite',
+      doGenerate: async options => {
+        capturedPrompts.push(options.prompt);
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          content: [{ type: 'text', text: JSON.stringify({ answer: 'done' }) }],
+          warnings: [],
+        };
+      },
+    });
+    const agent = new Agent({
+      id: 'gemini-3-trailing-assistant-guard-test',
+      name: 'Gemini 3 Trailing Assistant Guard Test',
+      instructions: 'Return a structured response.',
+      model: mockModel,
+    });
+
+    await agent.generate(
+      [
+        { role: 'user', content: 'Give me a verdict.' },
+        { role: 'assistant', content: 'Draft response' },
+      ],
+      { structuredOutput: { schema: z.object({ answer: z.string() }) } },
+    );
+
+    const nonSystemMessages = capturedPrompts[0].filter((message: any) => message.role !== 'system');
+    expect(nonSystemMessages.at(-1)).toMatchObject({ role: 'user' });
+  });
+
+  it("guards routed Gemini 3 when jsonPromptInjection: 'auto' resolves to native structured output", async () => {
+    const capturedCalls: any[] = [];
+    const mockModel = new MockLanguageModelV2({
+      provider: 'openrouter.chat',
+      modelId: 'google/gemini-3.5-flash-lite',
+      doGenerate: async options => {
+        capturedCalls.push(options);
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          content: [{ type: 'text', text: JSON.stringify({ answer: 'done' }) }],
+          warnings: [],
+        };
+      },
+    });
+    const agent = new Agent({
+      id: 'routed-gemini-3-auto-trailing-assistant-guard-test',
+      name: 'Routed Gemini 3 Auto Trailing Assistant Guard Test',
+      instructions: 'Return a structured response.',
+      model: mockModel,
+    });
+
+    await agent.generate(
+      [
+        { role: 'user', content: 'Give me a verdict.' },
+        { role: 'assistant', content: 'Draft response' },
+      ],
+      {
+        structuredOutput: {
+          schema: z.object({ answer: z.string() }),
+          jsonPromptInjection: 'auto',
+        },
+      },
+    );
+
+    expect(capturedCalls[0].responseFormat?.type).toBe('json');
+    const nonSystemMessages = capturedCalls[0].prompt.filter((message: any) => message.role !== 'system');
+    expect(nonSystemMessages.at(-1)).toMatchObject({ role: 'user' });
+  });
+
+  it('preserves the trailing assistant turn for Gemini 2.5', async () => {
+    const capturedPrompts: any[] = [];
+    const mockModel = new MockLanguageModelV2({
+      provider: 'google.generative-ai',
+      modelId: 'gemini-2.5-flash',
+      doGenerate: async options => {
+        capturedPrompts.push(options.prompt);
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          content: [{ type: 'text', text: JSON.stringify({ answer: 'done' }) }],
+          warnings: [],
+        };
+      },
+    });
+    const agent = new Agent({
+      id: 'gemini-2-5-trailing-assistant-test',
+      name: 'Gemini 2.5 Trailing Assistant Test',
+      instructions: 'Return a structured response.',
+      model: mockModel,
+    });
+
+    await agent.generate(
+      [
+        { role: 'user', content: 'Give me a verdict.' },
+        { role: 'assistant', content: 'Draft response' },
+      ],
+      { structuredOutput: { schema: z.object({ answer: z.string() }) } },
+    );
+
+    const nonSystemMessages = capturedPrompts[0].filter((message: any) => message.role !== 'system');
+    expect(nonSystemMessages.at(-1)).toMatchObject({ role: 'assistant' });
+  });
+
+  it('uses the final processor-selected model when deciding whether to guard', async () => {
+    const geminiPrompts: any[] = [];
+    const openAIPrompts: any[] = [];
+    const result = {
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop' as const,
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      content: [{ type: 'text' as const, text: JSON.stringify({ answer: 'done' }) }],
+      warnings: [],
+    };
+    const initialOpenAI = new MockLanguageModelV2({ provider: 'openai', modelId: 'gpt-5' });
+    const selectedGemini = new MockLanguageModelV2({
+      provider: 'google.generative-ai',
+      modelId: 'gemini-3.5-flash-lite',
+      doGenerate: async options => {
+        geminiPrompts.push(options.prompt);
+        return result;
+      },
+    });
+    const routeToGemini = new Agent({
+      id: 'route-to-gemini-guard-test',
+      name: 'Route to Gemini Guard Test',
+      instructions: 'Return a structured response.',
+      model: initialOpenAI,
+      inputProcessors: [{ id: 'route-to-gemini', processInputStep: () => ({ model: selectedGemini }) }],
+    });
+
+    await routeToGemini.generate([{ role: 'assistant', content: 'Draft response' }], {
+      structuredOutput: { schema: z.object({ answer: z.string() }) },
+    });
+
+    const initialGemini = new MockLanguageModelV2({
+      provider: 'google.generative-ai',
+      modelId: 'gemini-3.5-flash-lite',
+    });
+    const selectedOpenAI = new MockLanguageModelV2({
+      provider: 'openai',
+      modelId: 'gpt-5',
+      doGenerate: async options => {
+        openAIPrompts.push(options.prompt);
+        return result;
+      },
+    });
+    const routeToOpenAI = new Agent({
+      id: 'route-to-openai-guard-test',
+      name: 'Route to OpenAI Guard Test',
+      instructions: 'Return a structured response.',
+      model: initialGemini,
+      inputProcessors: [{ id: 'route-to-openai', processInputStep: () => ({ model: selectedOpenAI }) }],
+    });
+
+    await routeToOpenAI.generate([{ role: 'assistant', content: 'Draft response' }], {
+      structuredOutput: { schema: z.object({ answer: z.string() }) },
+    });
+
+    expect(geminiPrompts[0].filter((message: any) => message.role !== 'system').at(-1)).toMatchObject({ role: 'user' });
+    expect(openAIPrompts[0].filter((message: any) => message.role !== 'system').at(-1)).toMatchObject({
+      role: 'assistant',
+    });
+  });
+
   it('should not send prompt ending with assistant message when using stream with assistant-role input, structuredOutput and memory', async () => {
     const threadId = randomUUID();
     const resourceId = 'user-12800-stream';

--- a/packages/core/src/agent/__tests__/structured-output-memory.test.ts
+++ b/packages/core/src/agent/__tests__/structured-output-memory.test.ts
@@ -21,6 +21,19 @@ import { MockLanguageModelV2, convertArrayToReadableStream } from './mock-model'
  * This test reproduces the issue at the agent level by simulating the network loop's
  * behavior: passing an assistant-role message as input with structuredOutput + memory.
  */
+const TRAILING_ASSISTANT_GUARD_TEXT = 'Generate the structured response.';
+
+function expectTrailingAssistantGuard(prompt: any[]) {
+  const nonSystemMessages = prompt.filter(message => message.role !== 'system');
+  expect(nonSystemMessages.slice(-2)).toMatchObject([
+    { role: 'assistant' },
+    {
+      role: 'user',
+      content: [{ type: 'text', text: TRAILING_ASSISTANT_GUARD_TEXT }],
+    },
+  ]);
+}
+
 describe('Structured output with memory - assistant message in final position (#12800)', () => {
   it('should not send prompt ending with assistant message when input is assistant-role with structuredOutput and memory', async () => {
     const threadId = randomUUID();
@@ -139,16 +152,8 @@ describe('Structured output with memory - assistant message in final position (#
       },
     });
 
-    // The critical assertion: the prompt sent to the model should NOT end with an assistant message
     expect(capturedPrompts.length).toBeGreaterThan(0);
-    const lastPrompt = capturedPrompts[capturedPrompts.length - 1];
-
-    // Find the last non-system message in the prompt
-    const nonSystemMessages = lastPrompt.filter((msg: any) => msg.role !== 'system');
-    expect(nonSystemMessages.length).toBeGreaterThan(0);
-
-    const lastMessage = nonSystemMessages[nonSystemMessages.length - 1];
-    expect(lastMessage.role).toBe('user');
+    expectTrailingAssistantGuard(capturedPrompts.at(-1));
   });
 
   it('guards Claude 5 assistant-role input without configured input processors or memory', async () => {
@@ -178,8 +183,7 @@ describe('Structured output with memory - assistant message in final position (#
       structuredOutput: { schema: z.object({ answer: z.string() }) },
     });
 
-    const nonSystemMessages = capturedPrompts[0].filter((message: any) => message.role !== 'system');
-    expect(nonSystemMessages.at(-1)).toMatchObject({ role: 'user' });
+    expectTrailingAssistantGuard(capturedPrompts[0]);
   });
 
   it('preserves assistant prefill for Claude 4.5', async () => {
@@ -275,8 +279,7 @@ describe('Structured output with memory - assistant message in final position (#
       { structuredOutput: { schema: z.object({ answer: z.string() }) } },
     );
 
-    const nonSystemMessages = capturedPrompts[0].filter((message: any) => message.role !== 'system');
-    expect(nonSystemMessages.at(-1)).toMatchObject({ role: 'user' });
+    expectTrailingAssistantGuard(capturedPrompts[0]);
   });
 
   it("guards routed Gemini 3 when jsonPromptInjection: 'auto' resolves to native structured output", async () => {
@@ -316,8 +319,7 @@ describe('Structured output with memory - assistant message in final position (#
     );
 
     expect(capturedCalls[0].responseFormat?.type).toBe('json');
-    const nonSystemMessages = capturedCalls[0].prompt.filter((message: any) => message.role !== 'system');
-    expect(nonSystemMessages.at(-1)).toMatchObject({ role: 'user' });
+    expectTrailingAssistantGuard(capturedCalls[0].prompt);
   });
 
   it('preserves the trailing assistant turn for Gemini 2.5', async () => {
@@ -410,7 +412,7 @@ describe('Structured output with memory - assistant message in final position (#
       structuredOutput: { schema: z.object({ answer: z.string() }) },
     });
 
-    expect(geminiPrompts[0].filter((message: any) => message.role !== 'system').at(-1)).toMatchObject({ role: 'user' });
+    expectTrailingAssistantGuard(geminiPrompts[0]);
     expect(openAIPrompts[0].filter((message: any) => message.role !== 'system').at(-1)).toMatchObject({
       role: 'assistant',
     });
@@ -553,13 +555,8 @@ describe('Structured output with memory - assistant message in final position (#
 
     await response.consumeStream();
 
-    // The critical assertion: the last message in the prompt should NOT be an assistant message.
     expect(capturedPrompts.length).toBeGreaterThan(0);
-    const lastPrompt = capturedPrompts[capturedPrompts.length - 1];
-    const nonSystemMessages = lastPrompt.filter((msg: any) => msg.role !== 'system');
-    expect(nonSystemMessages.length).toBeGreaterThan(0);
-    const lastMessage = nonSystemMessages[nonSystemMessages.length - 1];
-    expect(lastMessage.role).toBe('user');
+    expectTrailingAssistantGuard(capturedPrompts.at(-1));
   });
 });
 

--- a/packages/core/src/agent/durable/__tests__/durable-agent-structured-output.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-structured-output.test.ts
@@ -87,6 +87,40 @@ function createChunkedStructuredOutputModel(jsonOutput: object) {
   });
 }
 
+function createCapturingStructuredOutputModel({
+  provider,
+  modelId,
+  capturedCalls,
+}: {
+  provider: string;
+  modelId: string;
+  capturedCalls: any[];
+}) {
+  return new MockLanguageModelV2({
+    provider,
+    modelId,
+    doStream: async options => {
+      capturedCalls.push(options);
+      return {
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId, timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: JSON.stringify({ answer: 'done' }) },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      };
+    },
+  });
+}
+
 /**
  * Creates a mock model that returns tool-calls finishReason (Bedrock-style)
  */
@@ -265,6 +299,115 @@ describe('DurableAgent structured output', () => {
   });
 
   describe('streaming structured output', () => {
+    it('guards a trailing assistant turn for Gemini 3 without configured input processors', async () => {
+      const capturedCalls: any[] = [];
+      const mockModel = createCapturingStructuredOutputModel({
+        provider: 'google.generative-ai',
+        modelId: 'gemini-3.5-flash-lite',
+        capturedCalls,
+      });
+      const baseAgent = new Agent({
+        id: 'durable-gemini-3-trailing-assistant-test',
+        name: 'Durable Gemini 3 Trailing Assistant Test',
+        instructions: 'Return a structured response.',
+        model: mockModel as LanguageModelV2,
+      });
+      const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+      const result = await durableAgent.stream(
+        [
+          { role: 'user', content: 'Give me a verdict.' },
+          { role: 'assistant', content: 'Draft response' },
+        ],
+        { structuredOutput: { schema: z.object({ answer: z.string() }) } },
+      );
+
+      try {
+        for await (const _chunk of result.fullStream as AsyncIterable<any>) {
+        }
+      } finally {
+        result.cleanup();
+      }
+
+      const nonSystemMessages = capturedCalls[0].prompt.filter((message: any) => message.role !== 'system');
+      expect(nonSystemMessages.at(-1)).toMatchObject({ role: 'user' });
+    });
+
+    it('uses the final processor-selected model when deciding whether to guard', async () => {
+      const geminiCalls: any[] = [];
+      const selectedGemini = createCapturingStructuredOutputModel({
+        provider: 'openrouter.chat',
+        modelId: 'google/gemini-3.5-flash-lite',
+        capturedCalls: geminiCalls,
+      });
+      const routeToGemini = createDurableAgent({
+        agent: new Agent({
+          id: 'durable-route-to-gemini-test',
+          name: 'Durable Route to Gemini Test',
+          instructions: 'Return a structured response.',
+          model: new MockLanguageModelV2({ provider: 'openai', modelId: 'gpt-5' }),
+          inputProcessors: [{ id: 'route-to-gemini', processInputStep: () => ({ model: selectedGemini }) }],
+        }),
+        pubsub,
+      });
+
+      const geminiResult = await routeToGemini.stream([{ role: 'assistant', content: 'Draft response' }], {
+        structuredOutput: {
+          schema: z.object({ answer: z.string() }),
+          jsonPromptInjection: 'auto',
+        },
+      });
+      try {
+        for await (const _chunk of geminiResult.fullStream as AsyncIterable<any>) {
+        }
+      } finally {
+        geminiResult.cleanup();
+      }
+
+      expect(geminiCalls[0].responseFormat?.type).toBe('json');
+      expect(geminiCalls[0].prompt.filter((message: any) => message.role !== 'system').at(-1)).toMatchObject({
+        role: 'user',
+      });
+
+      const openAICalls: any[] = [];
+      const selectedOpenAI = createCapturingStructuredOutputModel({
+        provider: 'openai',
+        modelId: 'gpt-5',
+        capturedCalls: openAICalls,
+      });
+      const routeToOpenAI = createDurableAgent({
+        agent: new Agent({
+          id: 'durable-route-to-openai-test',
+          name: 'Durable Route to OpenAI Test',
+          instructions: 'Return a structured response.',
+          model: new MockLanguageModelV2({
+            provider: 'google.generative-ai',
+            modelId: 'gemini-3.5-flash-lite',
+          }),
+          inputProcessors: [{ id: 'route-to-openai', processInputStep: () => ({ model: selectedOpenAI }) }],
+        }),
+        pubsub,
+      });
+
+      const openAIResult = await routeToOpenAI.stream([{ role: 'assistant', content: 'Draft response' }], {
+        structuredOutput: {
+          schema: z.object({ answer: z.string() }),
+          jsonPromptInjection: 'auto',
+        },
+      });
+      try {
+        for await (const _chunk of openAIResult.fullStream as AsyncIterable<any>) {
+        }
+      } finally {
+        openAIResult.cleanup();
+      }
+
+      expect(openAICalls[0].responseFormat?.type).toBe('json');
+      expect(openAICalls[0].prompt.filter((message: any) => message.role !== 'system').at(-1)).toMatchObject({
+        role: 'assistant',
+      });
+    });
+
     it('should stream structured output correctly in chunks', async () => {
       const expectedOutput = {
         name: 'Alice',

--- a/packages/core/src/agent/durable/__tests__/durable-agent-structured-output.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-structured-output.test.ts
@@ -13,6 +13,19 @@ import { EventEmitterPubSub } from '../../../events/event-emitter';
 import { Agent } from '../../agent';
 import { createDurableAgent } from '../create-durable-agent';
 
+const TRAILING_ASSISTANT_GUARD_TEXT = 'Generate the structured response.';
+
+function expectTrailingAssistantGuard(prompt: any[]) {
+  const nonSystemMessages = prompt.filter(message => message.role !== 'system');
+  expect(nonSystemMessages.slice(-2)).toMatchObject([
+    { role: 'assistant' },
+    {
+      role: 'user',
+      content: [{ type: 'text', text: TRAILING_ASSISTANT_GUARD_TEXT }],
+    },
+  ]);
+}
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -329,8 +342,7 @@ describe('DurableAgent structured output', () => {
         result.cleanup();
       }
 
-      const nonSystemMessages = capturedCalls[0].prompt.filter((message: any) => message.role !== 'system');
-      expect(nonSystemMessages.at(-1)).toMatchObject({ role: 'user' });
+      expectTrailingAssistantGuard(capturedCalls[0].prompt);
     });
 
     it('uses the final processor-selected model when deciding whether to guard', async () => {
@@ -365,9 +377,7 @@ describe('DurableAgent structured output', () => {
       }
 
       expect(geminiCalls[0].responseFormat?.type).toBe('json');
-      expect(geminiCalls[0].prompt.filter((message: any) => message.role !== 'system').at(-1)).toMatchObject({
-        role: 'user',
-      });
+      expectTrailingAssistantGuard(geminiCalls[0].prompt);
 
       const openAICalls: any[] = [];
       const selectedOpenAI = createCapturingStructuredOutputModel({

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -26,7 +26,7 @@ import { EntityType } from '../../../../observability';
 import { getRootExportSpan, getStepAvailableToolNames } from '../../../../observability/utils';
 import type { CachedLLMStepResponse } from '../../../../processors';
 import { PrepareStepProcessor } from '../../../../processors/processors/prepare-step';
-import { isMaybeAnthropicWithoutAssistantPrefill } from '../../../../processors/provider-history-compat';
+import { requiresTrailingAssistantGuard } from '../../../../processors/provider-history-compat';
 import { ProcessorRunner } from '../../../../processors/runner';
 import { execute } from '../../../../stream/aisdk/v5/execute';
 import { MastraModelOutput } from '../../../../stream/base/output';
@@ -396,7 +396,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             const stepInputProcessors = registryEntry?.prepareStep
               ? [...baseInputProcessors, new PrepareStepProcessor({ prepareStep: registryEntry.prepareStep })]
               : baseInputProcessors;
-            if (stepInputProcessors.length || isMaybeAnthropicWithoutAssistantPrefill(currentModel)) {
+            if (stepInputProcessors.length || requiresTrailingAssistantGuard(currentModel)) {
               const inputStepWriter = pubsub
                 ? {
                     custom: async (data: { type: string }) => {

--- a/packages/core/src/agent/structured-output.ts
+++ b/packages/core/src/agent/structured-output.ts
@@ -1,0 +1,24 @@
+import { modelSupportsStructuredOutput } from '../llm/model/provider-registry';
+import type { MastraLanguageModel } from '../llm/model/shared.types';
+import type { StructuredOutputOptions } from './types';
+
+type JsonPromptInjection = StructuredOutputOptions<unknown>['jsonPromptInjection'];
+type ResolvedJsonPromptInjection = Exclude<JsonPromptInjection, 'auto'>;
+
+export function resolveJsonPromptInjection(
+  value: JsonPromptInjection,
+  capability: boolean | undefined,
+): ResolvedJsonPromptInjection {
+  if (value !== 'auto') return value;
+  return capability === true ? undefined : 'inline';
+}
+
+export function resolveJsonPromptInjectionForModel(
+  value: JsonPromptInjection,
+  model: MastraLanguageModel,
+): ResolvedJsonPromptInjection {
+  if (value !== 'auto') return value;
+
+  const modelRoute = `${model.provider.split('.')[0]}/${model.modelId}`;
+  return resolveJsonPromptInjection(value, modelSupportsStructuredOutput(modelRoute));
+}

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -33,7 +33,7 @@ import type {
 } from '../../../processors/index';
 import { isProcessorWorkflow } from '../../../processors/index';
 import { PrepareStepProcessor } from '../../../processors/processors/prepare-step';
-import { isMaybeAnthropicWithoutAssistantPrefill } from '../../../processors/provider-history-compat';
+import { requiresTrailingAssistantGuard } from '../../../processors/provider-history-compat';
 import type { ProcessorState } from '../../../processors/runner';
 import { ProcessorRunner } from '../../../processors/runner';
 import { RequestContext } from '../../../request-context';
@@ -1396,7 +1396,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           ...(inputProcessors || []),
           ...(options?.prepareStep ? [new PrepareStepProcessor({ prepareStep: options.prepareStep })] : []),
         ];
-        if (inputStepProcessors.length > 0 || isMaybeAnthropicWithoutAssistantPrefill(model)) {
+        if (inputStepProcessors.length > 0 || requiresTrailingAssistantGuard(model)) {
           const processorRunner = new ProcessorRunner({
             inputProcessors: inputStepProcessors,
             outputProcessors: [],

--- a/packages/core/src/processors/provider-history-compat.test.ts
+++ b/packages/core/src/processors/provider-history-compat.test.ts
@@ -11,6 +11,7 @@ import {
   isMaybeAnthropicWithoutAssistantPrefill,
   isMaybeAzure,
   isMaybeCerebras,
+  isMaybeGeminiWithoutTrailingModelTurn,
   ProviderHistoryCompat,
   stripForeignProviderExecutedTools,
 } from './provider-history-compat';
@@ -358,6 +359,57 @@ describe('isMaybeAnthropicWithoutAssistantPrefill', () => {
       isMaybeAnthropicWithoutAssistantPrefill([
         { model: 'anthropic/claude-haiku-4-5-20251001' },
         { model: 'anthropic/claude-opus-5' },
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe('isMaybeGeminiWithoutTrailingModelTurn', () => {
+  it('matches Gemini 3 and later across direct, Vertex, and routed models', () => {
+    expect(
+      isMaybeGeminiWithoutTrailingModelTurn({ provider: 'google.generative-ai', modelId: 'gemini-3.5-flash-lite' }),
+    ).toBe(true);
+    expect(
+      isMaybeGeminiWithoutTrailingModelTurn({ provider: 'vertex-ai.google-ai', modelId: 'gemini-3.1-pro-preview' }),
+    ).toBe(true);
+    expect(isMaybeGeminiWithoutTrailingModelTurn('google/gemini-3-pro-preview')).toBe(true);
+    expect(isMaybeGeminiWithoutTrailingModelTurn('google:gemini-3-pro-preview')).toBe(true);
+    expect(isMaybeGeminiWithoutTrailingModelTurn('google-ai-studio/gemini-3.5-flash-lite')).toBe(true);
+    expect(isMaybeGeminiWithoutTrailingModelTurn('google-vertex/gemini-3.5-flash-lite')).toBe(true);
+    expect(
+      isMaybeGeminiWithoutTrailingModelTurn({
+        provider: 'openrouter.chat',
+        modelId: 'google/gemini-3.5-flash-lite',
+      }),
+    ).toBe(true);
+  });
+
+  it('preserves trailing model turns for Gemini 2', () => {
+    expect(
+      isMaybeGeminiWithoutTrailingModelTurn({ provider: 'google.generative-ai', modelId: 'gemini-2.5-flash' }),
+    ).toBe(false);
+    expect(isMaybeGeminiWithoutTrailingModelTurn('google/gemini-2.0-flash')).toBe(false);
+  });
+
+  it('does not match unrelated models hosted by Google or other providers', () => {
+    expect(isMaybeGeminiWithoutTrailingModelTurn({ provider: 'google.generative-ai', modelId: 'gemma-4-26b' })).toBe(
+      false,
+    );
+    expect(isMaybeGeminiWithoutTrailingModelTurn({ provider: 'openai.chat', modelId: 'gpt-5' })).toBe(false);
+    expect(
+      isMaybeGeminiWithoutTrailingModelTurn({ provider: 'openai.chat', modelId: 'google/gemini-3.5-flash-lite' }),
+    ).toBe(false);
+  });
+
+  it('matches unknown Gemini versions and fallback arrays conservatively', () => {
+    expect(
+      isMaybeGeminiWithoutTrailingModelTurn({ provider: 'google.generative-ai', modelId: 'gemini-flash-latest' }),
+    ).toBe(true);
+    expect(isMaybeGeminiWithoutTrailingModelTurn(() => 'google/gemini-3.5-flash-lite')).toBe(true);
+    expect(
+      isMaybeGeminiWithoutTrailingModelTurn([
+        { model: 'google/gemini-2.5-flash' },
+        { model: 'google/gemini-3.5-flash-lite' },
       ]),
     ).toBe(true);
   });

--- a/packages/core/src/processors/provider-history-compat.ts
+++ b/packages/core/src/processors/provider-history-compat.ts
@@ -287,6 +287,16 @@ export const stripForeignProviderExecutedTools: CompatRule = {
 };
 
 const CLAUDE_VERSION_PATTERN = /claude-(?:(?:opus|sonnet|haiku)-)?(\d+)(?:[.-](\d+))?/i;
+const GEMINI_MODEL_PATTERN = /(?:^|[/:])gemini-/i;
+const GEMINI_VERSION_PATTERN = /gemini-(\d+)/i;
+
+function getModelId(model: unknown): string | undefined {
+  if (typeof model === 'string') return model;
+  if (model && typeof model === 'object' && typeof (model as { modelId?: unknown }).modelId === 'string') {
+    return (model as { modelId: string }).modelId;
+  }
+  return undefined;
+}
 
 function supportsAssistantPrefill(modelId: string): boolean | undefined {
   const match = CLAUDE_VERSION_PATTERN.exec(modelId);
@@ -312,15 +322,43 @@ export function isMaybeAnthropicWithoutAssistantPrefill(model: unknown): boolean
 
   if (!isMaybeAnthropic(model)) return false;
 
-  const modelId =
-    typeof model === 'string'
-      ? model
-      : model && typeof model === 'object' && typeof (model as { modelId?: unknown }).modelId === 'string'
-        ? (model as { modelId: string }).modelId
-        : undefined;
-
+  const modelId = getModelId(model);
   if (!modelId) return true;
   return supportsAssistantPrefill(modelId) !== true;
+}
+
+function supportsTrailingModelTurn(modelId: string): boolean | undefined {
+  const match = GEMINI_VERSION_PATTERN.exec(modelId);
+  if (!match) return undefined;
+  return Number(match[1]) < 3;
+}
+
+/**
+ * Detects Gemini models that reject requests ending on a model turn.
+ * Gemini 3 and later reject this shape, while Gemini 2.x accepts it.
+ * Unversioned Gemini aliases are matched conservatively.
+ */
+export function isMaybeGeminiWithoutTrailingModelTurn(model: unknown): boolean {
+  if (typeof model === 'function') return true;
+
+  if (Array.isArray(model)) {
+    return model.some(entry => isMaybeGeminiWithoutTrailingModelTurn((entry as { model?: unknown }).model ?? entry));
+  }
+
+  const isGoogleFamily =
+    getModelProviderFamily(model) === 'google' ||
+    matchesProviderPrefix(model, 'google-ai-studio') ||
+    matchesProviderPrefix(model, 'google-vertex');
+  if (!isGoogleFamily) return false;
+
+  const modelId = getModelId(model);
+  if (!modelId) return true;
+  if (!GEMINI_MODEL_PATTERN.test(modelId)) return false;
+  return supportsTrailingModelTurn(modelId) !== true;
+}
+
+export function requiresTrailingAssistantGuard(model: unknown): boolean {
+  return isMaybeAnthropicWithoutAssistantPrefill(model) || isMaybeGeminiWithoutTrailingModelTurn(model);
 }
 
 export function isMaybeAzure(

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -29,7 +29,7 @@ import type { MastraModelOutput } from '../stream/base/output';
 import type { LanguageModelUsage, ProviderMetadata } from '../stream/types';
 import type { OutputWriter } from '../workflows/types';
 import { isProcessorWorkflow } from './is-processor-workflow';
-import { isMaybeAnthropicWithoutAssistantPrefill } from './provider-history-compat';
+import { requiresTrailingAssistantGuard } from './provider-history-compat';
 import { createProcessorSendSignal } from './send-signal';
 import { resolveProcessorSpanAttributes, resolveProcessorSpanName } from './span-declaration';
 import {
@@ -1485,14 +1485,15 @@ export class ProcessorRunner {
       retryCount: args.retryCount ?? 0,
     };
 
-    // Append the trailing assistant guard when the resolved model does not support assistant prefill
-    const processors =
-      stepInput.model && isMaybeAnthropicWithoutAssistantPrefill(stepInput.model)
-        ? [...this.inputProcessors, new TrailingAssistantGuard()]
-        : this.inputProcessors;
-
-    // Run through all input processors that have processInputStep
-    for (const [index, processorOrWorkflow] of processors.entries()) {
+    // Run through configured processors, then conditionally run the compatibility guard against their final output.
+    for (let index = 0; index <= this.inputProcessors.length; index++) {
+      const processorOrWorkflow =
+        index < this.inputProcessors.length
+          ? this.inputProcessors[index]!
+          : requiresTrailingAssistantGuard(stepInput.model)
+            ? new TrailingAssistantGuard()
+            : undefined;
+      if (!processorOrWorkflow) continue;
       const processableMessages: MastraDBMessage[] = messageList.get.all.db();
       const idsBeforeProcessing = processableMessages.map((m: MastraDBMessage) => m.id);
       const check = messageList.makeMessageSourceChecker();

--- a/packages/core/src/processors/trailing-assistant-guard.test.ts
+++ b/packages/core/src/processors/trailing-assistant-guard.test.ts
@@ -17,10 +17,11 @@ const createMessage = (role: 'user' | 'assistant', text: string): MastraDBMessag
 });
 
 const makeArgs = (
-  overrides: Pick<Partial<ProcessInputStepArgs>, 'messages' | 'structuredOutput'> = {},
+  overrides: Pick<Partial<ProcessInputStepArgs>, 'messages' | 'model' | 'structuredOutput'> = {},
 ): ProcessInputStepArgs =>
   ({
     messages: overrides.messages ?? [createMessage('assistant', 'draft response')],
+    model: overrides.model ?? { provider: 'anthropic.messages', modelId: 'claude-opus-5' },
     structuredOutput:
       'structuredOutput' in overrides ? overrides.structuredOutput : { schema: z.object({ answer: z.string() }) },
   }) as ProcessInputStepArgs;
@@ -50,6 +51,17 @@ describe('TrailingAssistantGuard', () => {
     });
     expect(result?.messages?.[2]?.id).toEqual(expect.any(String));
     expect(result?.messages?.[2]?.createdAt).toBeInstanceOf(Date);
+  });
+
+  it.each([
+    { provider: 'openai.chat', modelId: 'gpt-5' },
+    { provider: 'google.generative-ai', modelId: 'gemini-2.5-flash' },
+  ])('does not append a message for $provider/$modelId', model => {
+    const guard = new TrailingAssistantGuard();
+
+    const result = guard.processInputStep(makeArgs({ model: model as any }));
+
+    expect(result).toBeUndefined();
   });
 
   it('does not append a message when structured output has no schema', () => {

--- a/packages/core/src/processors/trailing-assistant-guard.ts
+++ b/packages/core/src/processors/trailing-assistant-guard.ts
@@ -1,27 +1,28 @@
 import { randomUUID } from 'node:crypto';
 
+import { resolveJsonPromptInjectionForModel } from '../agent/structured-output';
+import { requiresTrailingAssistantGuard } from './provider-history-compat';
 import type { Processor, ProcessInputStepArgs, ProcessInputStepResult } from './index';
 
 /**
- * Guards against trailing assistant messages when using native structured output
- * with Anthropic models.
+ * Guards native structured output requests against a trailing assistant turn.
  *
- * Anthropic rejects requests where the last message is an assistant message when
- * using output format (structured output), interpreting it as pre-filling the response.
- * This processor appends a user message to prevent that error.
- *
- * This processor should only be added when the agent uses an Anthropic model.
+ * Claude 4.6 and later reject assistant prefill, while Gemini 3 and later reject
+ * requests ending on a model turn. This processor runs after configured input
+ * processors so it evaluates the final selected model and structured output mode.
  *
  * @see https://github.com/mastra-ai/mastra/issues/12800
+ * @see https://github.com/mastra-ai/mastra/issues/23320
  */
 export class TrailingAssistantGuard implements Processor<'trailing-assistant-guard'> {
   readonly id = 'trailing-assistant-guard' as const;
   readonly name = 'Trailing Assistant Guard';
 
-  processInputStep({ messages, structuredOutput }: ProcessInputStepArgs): ProcessInputStepResult | undefined {
-    const willUseResponseFormat =
-      structuredOutput?.schema && !structuredOutput?.model && !structuredOutput?.jsonPromptInjection;
+  processInputStep({ messages, structuredOutput, model }: ProcessInputStepArgs): ProcessInputStepResult | undefined {
+    if (!requiresTrailingAssistantGuard(model)) return;
 
+    const jsonPromptInjection = resolveJsonPromptInjectionForModel(structuredOutput?.jsonPromptInjection, model);
+    const willUseResponseFormat = structuredOutput?.schema && !structuredOutput?.model && !jsonPromptInjection;
     if (!willUseResponseFormat) return;
 
     const lastMessage = messages[messages.length - 1];

--- a/packages/core/src/stream/aisdk/v5/execute.test.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.test.ts
@@ -1,8 +1,9 @@
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
+import { resolveJsonPromptInjection } from '../../../agent/structured-output';
 import { coreFeatures } from '../../../features';
-import { execute, resolveJsonPromptInjection } from './execute';
+import { execute } from './execute';
 import { testUsage } from './test-utils';
 
 const inputMessages = [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'Summarize the plan.' }] }];

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -3,9 +3,10 @@ import type { LanguageModelV2Prompt } from '@ai-sdk/provider-v5';
 import { APICallError } from '@internal/ai-sdk-v5';
 import type { IdGenerator, ToolChoice, ToolSet } from '@internal/ai-sdk-v5';
 import { prepareJsonSchemaForOpenAIStrictMode } from '@mastra/schema-compat';
+import { resolveJsonPromptInjectionForModel } from '../../../agent/structured-output';
 import type { StructuredOutputOptions } from '../../../agent/types';
 import type { ModelMethodType } from '../../../llm/model/model.loop.types';
-import { modelSupportsStructuredOutput, modelSupportsTemperature } from '../../../llm/model/provider-registry';
+import { modelSupportsTemperature } from '../../../llm/model/provider-registry';
 import type { MastraLanguageModel, SharedProviderOptions } from '../../../llm/model/shared.types';
 import {
   createTimeoutAbortSignal,
@@ -22,9 +23,6 @@ import { attachModelStreamTransport, readModelStreamTransport } from '../../type
 import { prepareToolsAndToolChoice } from './compat';
 import type { ModelSpecVersion } from './compat';
 import { AISDKV5InputStream } from './input';
-
-type JsonPromptInjection = StructuredOutputOptions<unknown>['jsonPromptInjection'];
-type ResolvedJsonPromptInjection = Exclude<JsonPromptInjection, 'auto'>;
 
 /**
  * p-retry's own defaults, pinned explicitly so the delay it schedules between
@@ -66,14 +64,6 @@ function isRetryableModelError(error: unknown): boolean {
     return error.isRetryable;
   }
   return true;
-}
-
-export function resolveJsonPromptInjection(
-  value: JsonPromptInjection,
-  capability: boolean | undefined,
-): ResolvedJsonPromptInjection {
-  if (value !== 'auto') return value;
-  return capability === true ? undefined : 'inline';
 }
 
 type InjectJsonInstructionArgs = Parameters<typeof injectJsonInstructionIntoMessagesV3>[0];
@@ -214,10 +204,7 @@ export function execute<OUTPUT = undefined>({
   let prompt = inputMessages;
   const jsonPromptInjection = structuredOutput?.jsonPromptInjection;
   const modelRoute = `${model.provider.split('.')[0]}/${model.modelId}`;
-  const resolvedJsonPromptInjection = resolveJsonPromptInjection(
-    jsonPromptInjection,
-    jsonPromptInjection === 'auto' ? modelSupportsStructuredOutput(modelRoute) : undefined,
-  );
+  const resolvedJsonPromptInjection = resolveJsonPromptInjectionForModel(jsonPromptInjection, model);
   const injectionMode = resolvedJsonPromptInjection === true ? 'system' : resolvedJsonPromptInjection;
 
   // For direct mode (no model provided for structuring agent), inject JSON schema instruction if opting out of native response format with jsonPromptInjection


### PR DESCRIPTION
## Summary

Fixes Gemini 3 structured-output requests that fail when the conversation ends with an assistant message.

Gemini 3 rejects this request shape:

```text
system → user → assistant
```

with:

```text
400 Requests ending with a model turn are not supported
```

Mastra already handles the equivalent restriction for newer Claude models by appending a short user instruction. This change extends that protection to Gemini 3 and newer:

```text
system → user → assistant → user
```

The appended message is:

```text
Generate the structured response.
```

Fixes #23320.

An earlier fix exists in #23609. This version also handles `jsonPromptInjection: 'auto'` and models selected by input processors, including durable execution.

## Changes

- Detect Gemini 3+ across direct Google, Vertex AI, OpenRouter, and nested Google model routes.
- Preserve existing behavior for Gemini 2.x and unrelated Google-hosted models.
- Evaluate the guard after input processors so it uses the final selected model.
- Handle `jsonPromptInjection: 'auto'` consistently with the model execution path.
- Apply the fix to regular and durable agent execution.
- Add a patch changeset for `@mastra/core`.

## Before

```text
Google direct: system → user → assistant
OpenRouter:    system → user → assistant
Vertex AI:     system → user → assistant
```

All three requests used native JSON output and would be rejected by Gemini 3.

## After

```text
Google direct: system → user → assistant → user
OpenRouter:    system → user → assistant → user
Vertex AI:     system → user → assistant → user
```

Gemini 2.x and OpenAI requests remain unchanged.

## Verification

- 103 focused compatibility and agent tests passed.
- 131 processor runner tests passed.
- Gemini recording replay passed: 23 passed, 1 skipped.
- `@mastra/core` type checking passed.
- `@mastra/core` lint passed with no warnings or errors.
- `@mastra/core` build passed.
- Standalone before-and-after request-shape reproduction passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Gemini 3 rejects structured-output requests that end with an assistant message. This PR adds `Generate the structured response.` as a user message when required and preserves existing behavior for Gemini 2.x and unrelated models.

## Changes

- Added Gemini 3+ detection for direct Google, Vertex AI, OpenRouter, routed, and fallback model forms.
- Applied the trailing-assistant guard after input processors select the final model.
- Added model-specific handling for `jsonPromptInjection: 'auto'`.
- Covered regular and durable agent execution.
- Preserved assistant prefills for Gemini 2.x and unrelated models.
- Added regression tests for request roles, routing, streaming, and structured-output behavior.
- Added a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->