### PR TITLE
fix(core): fail closed when evented createStep(agent) produces no structured output

### DIFF
--- a/.changeset/evented-agent-step-structured-output-guard.md
+++ b/.changeset/evented-agent-step-structured-output-guard.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+`createStep(agent)` from `@mastra/core/workflows/evented` now fails when a declared `structuredOutput.schema` produces no object, instead of silently reporting `success` and returning `{ text }`. The step throws a `MastraError` (`STRUCTURED_OUTPUT_OBJECT_UNDEFINED`) carrying `finishReason` and `usage`, matching the existing `.agent()` guard. A validly-parsed falsy object (e.g. `0`) is still treated as produced. Fixes #23403.

--- a/packages/core/src/workflows/evented/create-step-from-agent.test.ts
+++ b/packages/core/src/workflows/evented/create-step-from-agent.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { PUBSUB_SYMBOL, STREAM_FORMAT_SYMBOL } from '../constants';
+import { createStep } from './workflow';
+
+/**
+ * `@mastra/core/workflows/evented` ships its own `createStep(agent)` factory
+ * (issue #23403 leftover). Unlike the default factory, it does not go through
+ * `runAgentEntry`, so a declared `structuredOutput.schema` must still fail
+ * closed here when the agent finishes without an object.
+ */
+
+function makeV2Agent(finish: { text?: string; object?: unknown; finishReason?: string; usage?: unknown }) {
+  return {
+    id: 'evented-agent',
+    name: 'evented-agent',
+    getDescription: () => 'evented-agent',
+    getModel: async () => ({ specificationVersion: 'v2' }),
+    hasOwnMemory: () => false,
+    __setMemory: () => {},
+    getMemory: async () => undefined,
+    getInstructions: () => 'test',
+    generate: async () => ({ text: finish.text ?? '' }),
+    resumeGenerate: async () => ({}),
+    resumeStream: async () => ({}),
+    stream: async (_prompt: string, opts: { onFinish?: (result: any) => void }) => {
+      return {
+        text: Promise.resolve(finish.text ?? ''),
+        fullStream: (async function* () {
+          opts.onFinish?.(finish);
+        })(),
+      };
+    },
+  };
+}
+
+function makeCtx() {
+  return {
+    inputData: { prompt: 'hi' },
+    runId: 'run-1',
+    mastra: { getLogger: () => undefined },
+    [PUBSUB_SYMBOL]: { publish: async () => {} },
+    [STREAM_FORMAT_SYMBOL]: 'vnext',
+    requestContext: {},
+    abortSignal: new AbortController().signal,
+    abort: () => ({ aborted: true }),
+    writer: undefined,
+  } as any;
+}
+
+describe('evented createStep(agent) structured output guard', () => {
+  const structuredOptions = { structuredOutput: { schema: { parse: (v: unknown) => v } } };
+
+  it('fails closed when a declared schema produces no object', async () => {
+    const step = createStep(makeV2Agent({ text: '', object: undefined, finishReason: 'stop' }), structuredOptions);
+
+    await expect(step.execute(makeCtx())).rejects.toMatchObject({ id: 'STRUCTURED_OUTPUT_OBJECT_UNDEFINED' });
+  });
+
+  it('carries the finishReason and usage on the thrown error', async () => {
+    const usage = { totalTokens: 42, inputTokens: 10, outputTokens: 32 };
+    const step = createStep(
+      makeV2Agent({ text: '', object: undefined, finishReason: 'tool-calls', usage }),
+      structuredOptions,
+    );
+
+    await step.execute(makeCtx()).then(
+      () => {
+        throw new Error('expected evented createStep(agent) to reject');
+      },
+      (err: any) => {
+        expect(err.id).toBe('STRUCTURED_OUTPUT_OBJECT_UNDEFINED');
+        expect(err.details?.finishReason).toBe('tool-calls');
+        expect(err.details?.usage).toEqual(usage);
+      },
+    );
+  });
+
+  it('returns a validly-parsed object when one is produced', async () => {
+    const step = createStep(
+      makeV2Agent({ text: '{"decisions":["ok"]}', object: { decisions: ['ok'] } }),
+      structuredOptions,
+    );
+
+    await expect(step.execute(makeCtx())).resolves.toEqual({ decisions: ['ok'] });
+  });
+
+  it('treats a falsy-but-defined object as produced', async () => {
+    const step = createStep(makeV2Agent({ text: '0', object: 0 }), structuredOptions);
+
+    await expect(step.execute(makeCtx())).resolves.toBe(0);
+  });
+
+  it('returns { text } unchanged when no schema is declared', async () => {
+    const step = createStep(makeV2Agent({ text: '' }));
+
+    await expect(step.execute(makeCtx())).resolves.toEqual({ text: '' });
+  });
+});

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -570,12 +570,19 @@ function createStepFromAgent<TStepId extends string, TStepOutput>(
 
       // Track structured output result
       let structuredResult: any = null;
+      // Distinguishes "no object produced" from a validly-parsed falsy object
+      // (e.g. `0`/`false`/`""` for primitive-root schemas) at the return site.
+      let structuredResultProduced = false;
+      // Retained for diagnostics when the structured-output guard fires.
+      let finishResult: any = undefined;
 
       // Common callback to capture structured output
       const handleFinish = (result: { text: string; object?: unknown }) => {
         const resultWithObject = result as typeof result & { object?: unknown };
-        if ((agentOptions as any)?.structuredOutput?.schema && resultWithObject.object) {
+        finishResult = result;
+        if ((agentOptions as any)?.structuredOutput?.schema && resultWithObject.object !== undefined) {
           structuredResult = resultWithObject.object;
+          structuredResultProduced = true;
         }
       };
 
@@ -643,8 +650,25 @@ function createStepFromAgent<TStepId extends string, TStepOutput>(
         throw createTripWireFromChunk(tripwireChunk);
       }
 
+      // A step that declared a structured-output schema but finished without an
+      // object must fail closed rather than silently returning `{ text }` as
+      // success. Matches runAgentEntry (issue #23403).
+      if ((agentOptions as any)?.structuredOutput?.schema && !structuredResultProduced) {
+        throw new MastraError({
+          id: 'STRUCTURED_OUTPUT_OBJECT_UNDEFINED',
+          domain: ErrorDomain.MASTRA_WORKFLOW,
+          category: ErrorCategory.USER,
+          text: `Agent step '${params.id}' declared structuredOutput.schema but the agent finished without producing an object.`,
+          details: {
+            stepId: params.id,
+            finishReason: finishResult?.finishReason ?? 'unknown',
+            usage: finishResult?.usage,
+          },
+        });
+      }
+
       // Return structured output if available, otherwise return text
-      if (structuredResult !== null) {
+      if (structuredResultProduced) {
         return structuredResult as TStepOutput;
       }
 


### PR DESCRIPTION
## Description

`createStep(agent)` from `@mastra/core/workflows/evented` now fails closed when `structuredOutput.schema` is declared and the agent produces no object, instead of reporting `success` and returning `{ text }`. After tripwire handling the evented factory throws `MastraError` `STRUCTURED_OUTPUT_OBJECT_UNDEFINED`, carrying `finishReason` and `usage`. The default `.agent()` path already fails closed (#23559 / #23563). The evented factory used a truthy `result.object` check and the same `{ text }` fallback, including for a valid falsy object such as `0`.

The existing `runAgentEntry` guard is copied into the evented factory. The alternative is to drop the inline stream/watch body, set `__agentRef`, and call `runAgentEntry` (what the default `createStep` already does). That was skipped because `runAgentEntry` only publishes `tool-call-streaming-*` watch events when the stream format is `legacy`, and the evented factory always publishes them. Can switch to a shared call if that is preferred.

## Related issue(s)

Related to #23403 (`.agent()` / `runAgentEntry` already shipped in #23559 / #23563; this is the leftover evented `createStep(agent)` factory)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

If an agent promises structured data but returns none, the workflow now reports an error instead of claiming success. It also accepts valid values such as `0` and `false`.

## Changes

- Updated `createStep(agent)` to throw `MastraError` with code `STRUCTURED_OUTPUT_OBJECT_UNDEFINED` when structured output is missing.
- Included `finishReason` and `usage` in the error details.
- Preserved valid falsy structured outputs.
- Added tests for missing output, valid output, falsy output, and text-only responses.
- Preserved inline evented streaming to retain `tool-call-streaming-*` watch events.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->