### PR TITLE
feat(mastracode): add thread resume commands

### DIFF
--- a/.changeset/blue-heads-train.md
+++ b/.changeset/blue-heads-train.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': minor
+---
+
+Added initial metadata support when creating agent controller threads.
+
+```ts
+const thread = await session.thread.create({
+  metadata: { source: 'migration' },
+});
+```

--- a/.changeset/brown-parents-fail.md
+++ b/.changeset/brown-parents-fail.md
@@ -1,0 +1,7 @@
+---
+'mastracode': minor
+---
+
+Added `/fork`, `/resume`, and `/rename` commands. Existing threads resume automatically when Mastra Code starts, and `mastracode resume <thread-id>` resumes a specific thread.
+
+Fixed duplicate status rows after a response completes.

--- a/.changeset/floppy-ants-lie.md
+++ b/.changeset/floppy-ants-lie.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed explicit /new threads being replaced by older threads after restarting Mastra Code.

--- a/.changeset/violet-nails-draw.md
+++ b/.changeset/violet-nails-draw.md
@@ -1,0 +1,6 @@
+---
+'@mastra/code-sdk': minor
+'mastracode': patch
+---
+
+Enabled first-message thread title generation for all Mastra Code clients.

--- a/docs/src/content/en/docs/harness/agent-controller.mdx
+++ b/docs/src/content/en/docs/harness/agent-controller.mdx
@@ -139,7 +139,7 @@ const session = await controller.createSession({
 })
 ```
 
-Use [`session.thread.create()`](/reference/agent-controller/session#sessionthreadcreate-title-id-) and [`session.thread.switch()`](/reference/agent-controller/session#sessionthreadswitch-threadid-emitevent-) to move one live Session between conversations.
+Use [`session.thread.create()`](/reference/agent-controller/session#sessionthreadcreate-title-id-metadata-) and [`session.thread.switch()`](/reference/agent-controller/session#sessionthreadswitch-threadid-emitevent-) to move one live Session between conversations.
 
 ### List stored messages from the client
 

--- a/docs/src/content/en/reference/agent-controller/session.mdx
+++ b/docs/src/content/en/reference/agent-controller/session.mdx
@@ -353,14 +353,15 @@ To change the resource ID, use [`controller.setResourceId()`](/reference/agent-c
 
 `session.thread` owns the active thread binding and resource-scoped thread operations. Stored threads and messages can survive controller recreation when storage is configured. The live session and its event bus don't.
 
-### `session.thread.create({ title?, id? })`
+### `session.thread.create({ title?, id?, metadata? })`
 
-Create a thread, bind the session to it, and open its event stream.
+Create a thread, bind the session to it, and open its event stream. Pass `metadata` to persist values as part of the initial thread record. Session scope metadata takes precedence over matching keys supplied by the caller.
 
 ```typescript
 const thread = await session.thread.create({
   id: 'thread-7',
   title: 'Investigate login failure',
+  metadata: { source: 'support-queue' },
 })
 ```
 

--- a/docs/src/content/en/reference/agent-controller/session.mdx
+++ b/docs/src/content/en/reference/agent-controller/session.mdx
@@ -355,7 +355,7 @@ To change the resource ID, use [`controller.setResourceId()`](/reference/agent-c
 
 ### `session.thread.create({ title?, id?, metadata? })`
 
-Create a thread, bind the session to it, and open its event stream. Pass `metadata` to persist values as part of the initial thread record. Session scope metadata takes precedence over matching keys supplied by the caller.
+Create a thread, bind the session to it, and open its event stream. Pass `metadata` to persist non-reserved values as part of the initial thread record. Session scope metadata takes precedence over matching keys supplied by the caller. Session-managed keys such as `currentModeId`, `tokenUsage`, and `modeModelId_*` are ignored when supplied by the caller.
 
 ```typescript
 const thread = await session.thread.create({

--- a/docs/src/mastra-code/index.mdx
+++ b/docs/src/mastra-code/index.mdx
@@ -86,13 +86,18 @@ Mastra Code requires Node.js 22.19.0 or later. To enable `@` filename suggestion
 
 Mastra Code provides built-in slash commands for managing sessions and settings:
 
+After exit, run `mastracode resume <thread-id>` to continue the same thread directly.
+
 | Command | Description |
 | - | - |
 | `/new` | Start a new conversation thread |
-| `/clone` | Clone the current thread (with optional rename) |
-| `/threads` | List all threads for this project |
+| `/fork` | Fork the current thread (with optional rename) |
+| `/clone` | Alias for `/fork` |
+| `/resume` | Resume an existing thread |
+| `/threads` | Alias for `/resume` |
 | `/thread` | Show current thread info |
-| `/name` | Rename the current thread |
+| `/rename` | Rename the current thread |
+| `/name` | Alias for `/rename` |
 | `/model` | Change the current mode model; create `Custom` when a built-in pack is active, or update the active custom pack |
 | `/models` | Switch the model pack for all modes |
 | `/packs` | Alias for `/models` |

--- a/mastracode/tui/e2e/terminal-backend.ts
+++ b/mastracode/tui/e2e/terminal-backend.ts
@@ -41,8 +41,9 @@ function resolveInitialStateFromEnv(): MastraCodeConfig['initialState'] {
   return Object.keys(initialState).length > 0 ? initialState : undefined;
 }
 
-class EmulatedTerminal implements Terminal {
+export class EmulatedTerminal implements Terminal {
   private readonly xterm: XtermTerminalType;
+  private inputEpoch = 0;
   private inputHandler?: (data: string) => void;
   private inputQueue = Promise.resolve();
   private outputQueue = Promise.resolve();
@@ -82,6 +83,7 @@ class EmulatedTerminal implements Terminal {
   }
 
   stop(): void {
+    this.inputEpoch += 1;
     this.writeToXterm('\x1b[?2004l');
     this.stdinBuffer?.destroy();
     this.stdinBuffer = undefined;
@@ -139,8 +141,10 @@ class EmulatedTerminal implements Terminal {
   setProgress(_active: boolean): void {}
 
   sendInput(data: string): void {
+    const inputEpoch = this.inputEpoch;
     this.inputQueue = this.inputQueue
       .then(async () => {
+        if (inputEpoch !== this.inputEpoch) return;
         this.stdinBuffer?.process(data);
         await sleep(25);
       })
@@ -478,6 +482,7 @@ export async function runTerminalScenario(
       runtime.restartApp = async options => {
         await stopApp?.();
         releaseAllThreadLocks();
+        terminal.clearScreen();
         const app = await startMastraCodeApp(runConfig, terminal, options);
         stopApp = app.stop;
       };

--- a/mastracode/tui/e2e/terminal-backend.ts
+++ b/mastracode/tui/e2e/terminal-backend.ts
@@ -475,6 +475,12 @@ export async function runTerminalScenario(
       runtime.stopApp = async () => {
         await stopApp?.();
       };
+      runtime.restartApp = async options => {
+        await stopApp?.();
+        releaseAllThreadLocks();
+        const app = await startMastraCodeApp(runConfig, terminal, options);
+        stopApp = app.stop;
+      };
 
       await withTerminalProcessOutput(terminal, () =>
         scenario.run({ terminal: scenarioTerminal, runtime, dbPath: runConfig.context.dbPath }),

--- a/mastracode/tui/e2e/tui/goal-fresh-thread-persistence.ts
+++ b/mastracode/tui/e2e/tui/goal-fresh-thread-persistence.ts
@@ -6,20 +6,8 @@ import type { McE2eScenario } from './types.js';
 const OBJECTIVE = 'Keep the fresh thread goal e2e objective alive.';
 
 /**
- * End-to-end coverage for goals started on a thread that does not exist yet:
- * the TUI creates the thread as part of starting the goal, and the goal must
- * still be on that created thread once the app shuts down.
- *
- * This is NOT a discriminating regression test for the persist-flag ordering
- * defect. That defect needs the deferred `thread_created` handler to land
- * between the create and a later save, and this harness does not reproduce
- * that ordering — the scenario was verified green with
- * `src/tui/commands/goal.ts` reverted to its pre-fix version. The deterministic
- * pin for the ordering lives in the unit tests
- * (`src/tui/commands/__tests__/goal.test.ts`), which assert the flag is armed
- * before `thread.create()` and that the condition holds in both directions.
- * What this scenario buys is the real end-to-end path: `/new`, a real goal
- * start, and the goal record actually landing in SQLite on the new thread.
+ * End-to-end coverage for goals started on an explicit new thread. The goal
+ * must still be on the thread created by `/new` once the app shuts down.
  */
 export const goalFreshThreadPersistenceScenario: McE2eScenario = {
   name: 'goal-fresh-thread-persistence',
@@ -41,9 +29,9 @@ export const goalFreshThreadPersistenceScenario: McE2eScenario = {
     runtime.startLiveOutput(terminal);
     await runtime.waitForScreenText(/Mastra Code|Project:/i, terminal);
 
-    // Queue a brand-new thread so the goal start is the thing that creates it.
+    // Create a durable blank thread before starting the goal.
     terminal.submit('/new');
-    await runtime.sleep(500);
+    await runtime.waitForScreenText(/Ready for new conversation/i, terminal);
 
     terminal.submit(`/goal ${OBJECTIVE}`);
     await runtime.waitForScreenText(/Fresh thread goal e2e acknowledged\./i, terminal, 20_000);

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -79,6 +79,7 @@ import { modelSearchScenario } from './model-search.js';
 import { modelSelectionApiKeyPromptScenario } from './model-selection-api-key-prompt.js';
 import { modelSelectionCancelEnvScenario } from './model-selection-cancel-env.js';
 import { modelsPackActivationPersistenceScenario } from './models-pack-activation-persistence.js';
+import { newThreadRestartScenario } from './new-thread-restart.js';
 import { notificationInboxCrudFlowScenario } from './notification-inbox-crud-flow.js';
 import { notificationInboxReloadScenario } from './notification-inbox-reload.js';
 import { notificationInboxToolFlowScenario } from './notification-inbox-tool-flow.js';
@@ -355,6 +356,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'task-prompt-context-next-turn': taskPromptContextNextTurnScenario,
   'terminal-resize-reflow': terminalResizeReflowScenario,
   'thread-history': threadHistoryScenario,
+  'new-thread-restart': newThreadRestartScenario,
   'tool-history-reload': toolHistoryReloadScenario,
   'tool-schema-compat': toolSchemaCompatScenario,
   'tool-suspension-same-run-resume': toolSuspensionSameRunResumeScenario,

--- a/mastracode/tui/e2e/tui/new-thread-restart.ts
+++ b/mastracode/tui/e2e/tui/new-thread-restart.ts
@@ -1,0 +1,71 @@
+import { DatabaseSync } from 'node:sqlite';
+import { detectProject } from '@mastra/code-sdk/utils/project';
+import type { Session } from '@mastra/core/agent-controller';
+import type { McE2eScenario } from './types.js';
+
+export const newThreadRestartScenario: McE2eScenario = {
+  name: 'new-thread-restart',
+  description: 'Keep an explicit blank /new thread selected after restarting Mastra Code.',
+  testName: 'resumes an explicit blank /new thread after restart',
+  prepare({ dbPath, projectDir }) {
+    const project = detectProject(projectDir);
+    const timestamp = '2026-06-06T14:30:00.000Z';
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.prepare(
+        'insert into mastra_threads (id, resourceId, title, metadata, createdAt, updatedAt) values (?, ?, ?, ?, ?, ?)',
+      ).run(
+        'thread-mc-e2e-older',
+        project.resourceId,
+        'Older persisted thread',
+        JSON.stringify({ projectPath: project.rootPath }),
+        timestamp,
+        timestamp,
+      );
+    } finally {
+      db.close();
+    }
+  },
+  async run({ terminal, runtime, dbPath }) {
+    runtime.startLiveOutput(terminal);
+    await runtime.waitForScreenText(/Older persisted thread/i, terminal);
+
+    terminal.submit('/new');
+    await runtime.waitForScreenText(/Ready for new conversation/i, terminal);
+    terminal.submit('/thread');
+    await runtime.waitForScreenText(/Title: \(untitled\)/i, terminal);
+
+    const db = new DatabaseSync(dbPath);
+    let newThreadId: string;
+    try {
+      const row = db
+        .prepare("select id, metadata from mastra_threads where title = '' order by updatedAt desc limit 1")
+        .get() as { id?: string; metadata?: Uint8Array } | undefined;
+      if (!row?.id || !row.metadata || !Buffer.from(row.metadata).includes('explicitNewThread')) {
+        throw new Error('Expected /new to persist a thread marked explicitNewThread');
+      }
+      newThreadId = row.id;
+    } finally {
+      db.close();
+    }
+
+    if (!runtime.restartApp) throw new Error('The TUI E2E backend does not support restarting the app');
+    let restartedSession: Session | undefined;
+    await runtime.restartApp({
+      onCreated(result) {
+        restartedSession = result.session;
+      },
+    });
+    await runtime.waitForScreenText(/Project:\s+mastra/i, terminal);
+
+    terminal.submit('/thread');
+    await runtime.waitForScreenText(/Title: \(untitled\)/i, terminal);
+    const restartedThreadId = restartedSession?.thread.getId();
+    if (restartedThreadId !== newThreadId) {
+      throw new Error(`Expected restart to resume ${newThreadId}, received ${String(restartedThreadId)}`);
+    }
+    runtime.printScreen('explicit /new thread after restart', terminal);
+
+    terminal.keyCtrlC();
+  },
+};

--- a/mastracode/tui/e2e/tui/new-thread-restart.ts
+++ b/mastracode/tui/e2e/tui/new-thread-restart.ts
@@ -35,6 +35,11 @@ export const newThreadRestartScenario: McE2eScenario = {
     terminal.submit('/thread');
     await runtime.waitForScreenText(/Title: \(untitled\)/i, terminal);
 
+    if (!runtime.stopApp || !runtime.restartApp) {
+      throw new Error('The TUI E2E backend does not support restarting the app');
+    }
+    await runtime.stopApp();
+
     const db = new DatabaseSync(dbPath);
     let newThreadId: string;
     try {
@@ -49,7 +54,6 @@ export const newThreadRestartScenario: McE2eScenario = {
       db.close();
     }
 
-    if (!runtime.restartApp) throw new Error('The TUI E2E backend does not support restarting the app');
     let restartedSession: Session | undefined;
     await runtime.restartApp({
       onCreated(result) {

--- a/mastracode/tui/e2e/tui/new-thread-restart.ts
+++ b/mastracode/tui/e2e/tui/new-thread-restart.ts
@@ -26,7 +26,7 @@ export const newThreadRestartScenario: McE2eScenario = {
       db.close();
     }
   },
-  async run({ terminal, runtime, dbPath }) {
+  async run({ terminal, runtime }) {
     runtime.startLiveOutput(terminal);
     await runtime.waitForScreenText(/Older persisted thread/i, terminal);
 
@@ -35,25 +35,10 @@ export const newThreadRestartScenario: McE2eScenario = {
     terminal.submit('/thread');
     await runtime.waitForScreenText(/Title: \(untitled\)/i, terminal);
 
-    if (!runtime.stopApp || !runtime.restartApp) {
-      throw new Error('The TUI E2E backend does not support restarting the app');
-    }
-    await runtime.stopApp();
+    const newThreadId = terminal.serialize().view.match(/^\s*ID:\s+(\S+)\s*$/m)?.[1];
+    if (!newThreadId) throw new Error('Expected /thread to display the new thread ID');
 
-    const db = new DatabaseSync(dbPath);
-    let newThreadId: string;
-    try {
-      const row = db
-        .prepare("select id, metadata from mastra_threads where title = '' order by updatedAt desc limit 1")
-        .get() as { id?: string; metadata?: Uint8Array } | undefined;
-      if (!row?.id || !row.metadata || !Buffer.from(row.metadata).includes('explicitNewThread')) {
-        throw new Error('Expected /new to persist a thread marked explicitNewThread');
-      }
-      newThreadId = row.id;
-    } finally {
-      db.close();
-    }
-
+    if (!runtime.restartApp) throw new Error('The TUI E2E backend does not support restarting the app');
     let restartedSession: Session | undefined;
     await runtime.restartApp({
       onCreated(result) {

--- a/mastracode/tui/e2e/tui/resourceid-drift-prompt-decline.ts
+++ b/mastracode/tui/e2e/tui/resourceid-drift-prompt-decline.ts
@@ -70,9 +70,14 @@ export const resourceidDriftPromptDeclineScenario: McE2eScenario = {
     await runtime.waitForScreenText(/Project:/i, terminal, 10_000);
 
     terminal.submit('/thread');
-    await runtime.waitForScreenText(/Title: \(untitled\)/i, terminal, 10_000);
+    await runtime.waitForScreenText(/No active thread/i, terminal, 10_000);
     await runtime.waitForScreenText(/Pending new thread: yes/i, terminal, 5_000);
     runtime.printScreen('after declining clone', terminal);
+
+    const threadCount = Number(queryValue(scenarioDbPath, 'select count(*) from mastra_threads;'));
+    if (threadCount !== 1) {
+      throw new Error(`Expected only the old-resource thread to remain, found ${threadCount} threads`);
+    }
 
     const oldThreadResourceId = queryValue(
       scenarioDbPath,

--- a/mastracode/tui/e2e/tui/thread-history.ts
+++ b/mastracode/tui/e2e/tui/thread-history.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { detectProject } from '@mastra/code-sdk/utils/project';
 import type { McE2eScenario } from './types.js';
 
 function quoteSql(value: string): string {
@@ -7,12 +8,16 @@ function quoteSql(value: string): string {
 
 export const threadHistoryScenario: McE2eScenario = {
   name: 'thread-history',
-  description: 'Switch to a seeded persisted thread and render loaded history through the real TUI.',
-  testName: 'switches to a seeded persisted thread from the real TUI',
+  description: 'Resume a persisted thread, then fork and rename it through the real TUI.',
+  testName: 'supports /resume, /fork, and /rename',
+  inProcessApp({ startMastraCodeApp }) {
+    return startMastraCodeApp({ tui: { resumeThreadId: 'thread-mc-e2e-seeded-history' } });
+  },
   prepare({ dbPath, projectDir }) {
     const now = new Date('2026-06-06T14:30:00.000Z');
     const nowMs = now.getTime();
-    const resourceId = 'mc-e2e-seeded-resource';
+    const project = detectProject(projectDir);
+    const resourceId = project.resourceId;
     const threadId = 'thread-mc-e2e-seeded-history';
     const title = 'E2E seeded history fixture';
     const userText = 'Recovered prior user request from a sanitized fixture.';
@@ -21,7 +26,7 @@ export const threadHistoryScenario: McE2eScenario = {
     const assistantContent = JSON.stringify({ format: 2, parts: [{ type: 'text', text: assistantText }] });
     const sql = `
 insert into mastra_threads (id, resourceId, title, metadata, createdAt, updatedAt)
-values (${quoteSql(threadId)}, ${quoteSql(resourceId)}, ${quoteSql(title)}, ${quoteSql(JSON.stringify({ projectPath: projectDir }))}, ${quoteSql(now.toISOString())}, ${quoteSql(now.toISOString())});
+values (${quoteSql(threadId)}, ${quoteSql(resourceId)}, ${quoteSql(title)}, ${quoteSql(JSON.stringify({ projectPath: project.rootPath }))}, ${quoteSql(now.toISOString())}, ${quoteSql(now.toISOString())});
 insert into mastra_messages (id, thread_id, content, role, type, createdAt, resourceId)
 values
   ('msg-mc-e2e-seeded-user', ${quoteSql(threadId)}, ${quoteSql(userContent)}, 'user', 'v2', ${quoteSql(now.toISOString())}, ${quoteSql(resourceId)}),
@@ -32,10 +37,11 @@ values
   async run({ terminal, runtime }) {
     runtime.startLiveOutput(terminal);
     await runtime.waitForScreenText(/Mastra Code|Project:/i, terminal);
-
-    terminal.submit('/threads');
     await runtime.waitForScreenText(/E2E seeded history fixture/i, terminal);
-    runtime.printScreen('after /threads', terminal);
+
+    terminal.submit('/resume');
+    await runtime.waitForScreenText(/E2E seeded history fixture/i, terminal);
+    runtime.printScreen('after /resume', terminal);
 
     terminal.write('seeded history');
     await runtime.waitForScreenText(/E2E seeded history fixture/i, terminal);
@@ -45,5 +51,19 @@ values
     await runtime.waitForScreenText(/Recovered prior user request from a sanitized fixture/i, terminal);
     await runtime.waitForScreenText(/Recovered assistant answer from sanitized history/i, terminal);
     runtime.printScreen('after seeded thread switch', terminal);
+
+    terminal.submit('/fork');
+    await runtime.waitForScreenText(/Fork the current thread\?/i, terminal);
+    terminal.write('\r');
+    await runtime.waitForScreenText(/Give the forked thread a name\?/i, terminal);
+    terminal.write('\x1b');
+    await runtime.waitForScreenText(/Forked thread: Clone of E2E seeded history fixture/i, terminal);
+
+    terminal.submit('/rename Forked demo thread');
+    await runtime.waitForScreenText(/Thread renamed to: Forked demo thread/i, terminal);
+    terminal.submit('/resume');
+    await runtime.waitForScreenText(/Forked demo thread/i, terminal);
+    terminal.write('\x1b');
+    runtime.printScreen('after /fork and /rename', terminal);
   },
 };

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -232,7 +232,10 @@ export type McE2eStartMastraCodeAppOptions = {
   setupDebugLogging?: boolean;
   startupWarnings?: string[];
   tui?: Partial<
-    Pick<MastraTUIOptions, 'appName' | 'initialMessage' | 'inlineQuestions' | 'processMemoryDiagnostics' | 'verbose'>
+    Pick<
+      MastraTUIOptions,
+      'appName' | 'initialMessage' | 'inlineQuestions' | 'processMemoryDiagnostics' | 'resumeThreadId' | 'verbose'
+    >
   >;
 };
 

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -166,6 +166,7 @@ export type ScenarioName =
   | 'terminal-resize-reflow'
   | 'task-prompt-context-next-turn'
   | 'thread-history'
+  | 'new-thread-restart'
   | 'tool-history-reload'
   | 'plugins-streaming-tool-output'
   | 'tool-schema-compat'
@@ -209,6 +210,8 @@ export type McE2eScenarioRuntime = {
    * need to inspect on-disk database state after shutdown call this first.
    */
   stopApp?: () => Promise<void>;
+  /** Stop and relaunch the default app against the same terminal and on-disk storage. */
+  restartApp?: (options?: McE2eStartMastraCodeAppOptions) => Promise<void>;
 };
 
 export type McE2ePrepareContext = {

--- a/mastracode/tui/src/main.ts
+++ b/mastracode/tui/src/main.ts
@@ -23,6 +23,7 @@ import {
   createShutdownCoordinator,
   startTuiProcessMemoryDiagnostics,
 } from './process-memory-diagnostics-lifecycle.js';
+import { formatResumeHint, parseResumeThreadId, shouldRunHeadless } from './resume-command.js';
 import { resolveTuiSubagents } from './subagent-settings.js';
 import { detectTerminalTheme } from './tui/detect-theme.js';
 import { MastraTUI } from './tui/index.js';
@@ -41,6 +42,7 @@ let tui: MastraTUI | undefined;
 let processMemoryDiagnostics: ProcessMemoryDiagnostics | undefined;
 let storageClosed = false;
 let cleanupPromise: Promise<void> | null = null;
+let getResumeThreadId: (() => string | null) | undefined;
 
 const CRASH_LOG_PATH = '/tmp/mastra-crash.log';
 
@@ -68,7 +70,7 @@ process.on('unhandledRejection', reason => {
   handleFatalError(reason instanceof Error ? reason : new Error(String(reason)));
 });
 
-async function tuiMain(pipedInput?: string | null) {
+async function tuiMain(pipedInput?: string | null, resumeThreadId?: string) {
   const settings = loadSettings();
   processMemoryDiagnostics = await startTuiProcessMemoryDiagnostics(process.env, warning => {
     console.info(`⚠ ${warning}`);
@@ -133,6 +135,7 @@ async function tuiMain(pipedInput?: string | null) {
   // createMastraCode() brought up shared resources and minted the single
   // session that all work runs through. The AgentController owns no session of its own.
   const session = result.session;
+  getResumeThreadId = () => session.thread.getId();
 
   analytics = createMastraCodeAnalytics({ version: getCurrentVersion() });
   analytics.capture('mastracode_session_started', {
@@ -157,6 +160,7 @@ async function tuiMain(pipedInput?: string | null) {
     appName: 'Mastra Code',
     version: getCurrentVersion(),
     inlineQuestions: true,
+    ...(resumeThreadId ? { resumeThreadId } : {}),
     githubSignals: result.githubSignals,
     exit: exitCode => void shutdownAndExit(exitCode),
     ...(pipedInput ? { initialMessage: `The following was piped via stdin:\n\n${pipedInput}` } : {}),
@@ -246,6 +250,14 @@ process.on('exit', () => {
   }
   restoreTerminalForeground();
   releaseAllThreadLocks();
+  try {
+    const threadId = getResumeThreadId?.();
+    if (threadId) {
+      process.stdout.write(`\n${formatResumeHint(threadId)}\n`);
+    }
+  } catch {
+    // session state or stdout may already be closed during exit
+  }
 });
 
 // Start durable diagnostics shutdown before synchronous TUI teardown so a stalled
@@ -352,7 +364,16 @@ async function main() {
     return pluginMain(process.argv.slice(3));
   }
 
-  if (hasHeadlessFlag(process.argv) || process.argv.includes('--help') || process.argv.includes('-h')) {
+  let resumeThreadId: string | undefined;
+  try {
+    resumeThreadId = parseResumeThreadId(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (shouldRunHeadless(process.argv, resumeThreadId, hasHeadlessFlag(process.argv))) {
     return runMCCli(undefined, { coAuthor: TUI_CO_AUTHOR });
   }
 
@@ -376,12 +397,17 @@ async function main() {
     // stdin is consumed/closed and the TUI needs a live TTY for keyboard input.
     const reopenedStdin = reopenStdinFromTTY();
     if (!reopenedStdin) {
+      if (resumeThreadId) {
+        process.stderr.write('mastracode resume requires an interactive terminal.\n');
+        process.exitCode = 1;
+        return;
+      }
       process.stderr.write('No TTY available — falling back to headless mode.\n');
       return runMCCli(pipedInput, { coAuthor: TUI_CO_AUTHOR });
     }
   }
 
-  return tuiMain(pipedInput);
+  return tuiMain(pipedInput, resumeThreadId);
 }
 
 main().catch(error => {

--- a/mastracode/tui/src/resume-command.test.ts
+++ b/mastracode/tui/src/resume-command.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatResumeHint, parseResumeThreadId, shouldRunHeadless } from './resume-command.js';
+
+describe('resume command', () => {
+  it('reads an explicit thread ID', () => {
+    expect(parseResumeThreadId(['resume', 'thread-123'])).toBe('thread-123');
+  });
+
+  it('rejects an incomplete command', () => {
+    expect(() => parseResumeThreadId(['resume'])).toThrow('Usage: mastracode resume <thread-id>');
+  });
+
+  it('keeps resume commands out of headless mode', () => {
+    const argv = ['node', 'mastracode', 'resume', 'thread-123'];
+    expect(shouldRunHeadless(argv, 'thread-123', true)).toBe(false);
+    expect(shouldRunHeadless(['node', 'mastracode', '--prompt', 'hello'], undefined, true)).toBe(true);
+  });
+
+  it('formats the exit hint', () => {
+    expect(formatResumeHint('thread-123')).toBe('To continue this session, run mastracode resume thread-123');
+    expect(formatResumeHint("thread 'quoted'")).toBe(
+      "To continue this session, run mastracode resume 'thread '\\''quoted'\\'''",
+    );
+  });
+});

--- a/mastracode/tui/src/resume-command.ts
+++ b/mastracode/tui/src/resume-command.ts
@@ -8,7 +8,11 @@ export function parseResumeThreadId(args: string[]): string | undefined {
   return threadId;
 }
 
-export function shouldRunHeadless(argv: string[], resumeThreadId: string | undefined, hasHeadlessFlag: boolean): boolean {
+export function shouldRunHeadless(
+  argv: string[],
+  resumeThreadId: string | undefined,
+  hasHeadlessFlag: boolean,
+): boolean {
   return !resumeThreadId && (hasHeadlessFlag || argv.includes('--help') || argv.includes('-h'));
 }
 

--- a/mastracode/tui/src/resume-command.ts
+++ b/mastracode/tui/src/resume-command.ts
@@ -1,0 +1,18 @@
+export function parseResumeThreadId(args: string[]): string | undefined {
+  if (args[0] !== 'resume') return undefined;
+
+  const threadId = args[1]?.trim();
+  if (!threadId || args.length !== 2) {
+    throw new Error('Usage: mastracode resume <thread-id>');
+  }
+  return threadId;
+}
+
+export function shouldRunHeadless(argv: string[], resumeThreadId: string | undefined, hasHeadlessFlag: boolean): boolean {
+  return !resumeThreadId && (hasHeadlessFlag || argv.includes('--help') || argv.includes('-h'));
+}
+
+export function formatResumeHint(threadId: string): string {
+  const argument = /^[a-zA-Z0-9_-]+$/.test(threadId) ? threadId : `'${threadId.replaceAll("'", "'\\''")}'`;
+  return `To continue this session, run mastracode resume ${argument}`;
+}

--- a/mastracode/tui/src/tui/__tests__/command-dispatch.test.ts
+++ b/mastracode/tui/src/tui/__tests__/command-dispatch.test.ts
@@ -21,6 +21,9 @@ const mocks = vi.hoisted(() => ({
   handleMastraGatewayCommand: vi.fn().mockResolvedValue(undefined),
   handlePluginsCommand: vi.fn().mockResolvedValue(undefined),
   handleProfileCommand: vi.fn().mockResolvedValue(undefined),
+  handleCloneCommand: vi.fn().mockResolvedValue(undefined),
+  handleThreadsCommand: vi.fn().mockResolvedValue(undefined),
+  handleNameCommand: vi.fn().mockResolvedValue(undefined),
   processSlashCommand: vi.fn().mockResolvedValue('custom output'),
   startGoalWithDefaults: vi.fn().mockResolvedValue(undefined),
   showError: vi.fn(),
@@ -34,7 +37,7 @@ vi.mock('../commands/index.js', () => ({
   handleYoloCommand: vi.fn(),
   handleThinkCommand: vi.fn(),
   handlePermissionsCommand: vi.fn(),
-  handleNameCommand: vi.fn(),
+  handleNameCommand: mocks.handleNameCommand,
   handleExitCommand: vi.fn(),
   handleHooksCommand: vi.fn(),
   handleMcpCommand: mocks.handleMcpCommand,
@@ -42,9 +45,10 @@ vi.mock('../commands/index.js', () => ({
   handleSkillCommand: mocks.handleSkillCommand,
   handleSkillsCommand: vi.fn(),
   handleNewCommand: vi.fn(),
+  handleCloneCommand: mocks.handleCloneCommand,
   handleResourceCommand: vi.fn(),
   handleDiffCommand: vi.fn(),
-  handleThreadsCommand: vi.fn(),
+  handleThreadsCommand: mocks.handleThreadsCommand,
   handleThreadTagDirCommand: vi.fn(),
   handleSandboxCommand: vi.fn(),
   handleModelCommand: mocks.handleModelCommand,
@@ -93,7 +97,7 @@ import { SlashCommandComponent } from '../components/slash-command.js';
 import { GOAL_JUDGE_INPUT_LOCK_MESSAGE } from '../goal-input-lock.js';
 import { createMockState } from './agent-controller-mock.js';
 
-describe('dispatchSlashCommand models routing', () => {
+describe('dispatchSlashCommand routing', () => {
   beforeEach(() => {
     mocks.handleModelCommand.mockClear();
     mocks.handleConnectCommand.mockClear();
@@ -112,6 +116,9 @@ describe('dispatchSlashCommand models routing', () => {
     mocks.handleMastraGatewayCommand.mockClear();
     mocks.handlePluginsCommand.mockClear();
     mocks.handleProfileCommand.mockClear();
+    mocks.handleCloneCommand.mockClear();
+    mocks.handleThreadsCommand.mockClear();
+    mocks.handleNameCommand.mockClear();
     mocks.processSlashCommand.mockClear();
     mocks.startGoalWithDefaults.mockClear();
     mocks.showError.mockClear();
@@ -169,6 +176,59 @@ describe('dispatchSlashCommand models routing', () => {
     expect(await dispatchSlashCommand('/packs', state, () => ctx)).toBe(true);
     expect(mocks.handleModelsPackCommand).toHaveBeenCalledTimes(2);
     expect(mocks.handleModelCommand).not.toHaveBeenCalled();
+  });
+
+  it('routes /fork and /clone to the thread clone handler', async () => {
+    const state = {
+      customSlashCommands: [],
+      session: {
+        identity: { getResourceId: vi.fn(() => 'resource-1') },
+        thread: { getId: vi.fn(() => 'thread-1') },
+        mode: { get: vi.fn(() => 'build') },
+      },
+    } as any;
+    const ctx = { analytics: { trackCommand: mocks.trackCommand } } as any;
+
+    expect(await dispatchSlashCommand('/fork', state, () => ctx)).toBe(true);
+    expect(await dispatchSlashCommand('/clone', state, () => ctx)).toBe(true);
+    expect(mocks.handleCloneCommand).toHaveBeenCalledTimes(2);
+    expect(mocks.handleCloneCommand).toHaveBeenNthCalledWith(1, ctx);
+    expect(mocks.handleCloneCommand).toHaveBeenNthCalledWith(2, ctx);
+  });
+
+  it('routes /resume and /threads to the thread selector', async () => {
+    const state = {
+      customSlashCommands: [],
+      session: {
+        identity: { getResourceId: vi.fn(() => 'resource-1') },
+        thread: { getId: vi.fn(() => 'thread-1') },
+        mode: { get: vi.fn(() => 'build') },
+      },
+    } as any;
+    const ctx = { analytics: { trackCommand: mocks.trackCommand } } as any;
+
+    expect(await dispatchSlashCommand('/resume', state, () => ctx)).toBe(true);
+    expect(await dispatchSlashCommand('/threads', state, () => ctx)).toBe(true);
+    expect(mocks.handleThreadsCommand).toHaveBeenCalledTimes(2);
+    expect(mocks.handleThreadsCommand).toHaveBeenNthCalledWith(1, ctx);
+    expect(mocks.handleThreadsCommand).toHaveBeenNthCalledWith(2, ctx);
+  });
+
+  it('routes /rename and /name to the thread name handler', async () => {
+    const state = {
+      customSlashCommands: [],
+      session: {
+        identity: { getResourceId: vi.fn(() => 'resource-1') },
+        thread: { getId: vi.fn(() => 'thread-1') },
+        mode: { get: vi.fn(() => 'build') },
+      },
+    } as any;
+    const ctx = { analytics: { trackCommand: mocks.trackCommand } } as any;
+
+    expect(await dispatchSlashCommand('/rename Demo thread', state, () => ctx)).toBe(true);
+    expect(await dispatchSlashCommand('/name Legacy title', state, () => ctx)).toBe(true);
+    expect(mocks.handleNameCommand).toHaveBeenNthCalledWith(1, ctx, ['Demo', 'thread']);
+    expect(mocks.handleNameCommand).toHaveBeenNthCalledWith(2, ctx, ['Legacy', 'title']);
   });
 
   it('routes /profile subcommands to handleProfileCommand', async () => {

--- a/mastracode/tui/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/tui/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -59,12 +59,7 @@ vi.mock('../status-line.js', () => ({
 
 import { showError, showInfo } from '../display.js';
 import { GOAL_JUDGE_INPUT_LOCK_MESSAGE } from '../goal-input-lock.js';
-import {
-  refreshSkillsAutocomplete,
-  setupAutocomplete,
-  setupKeyHandlers,
-  setupKeyboardShortcuts,
-} from '../setup.js';
+import { refreshSkillsAutocomplete, setupAutocomplete, setupKeyHandlers, setupKeyboardShortcuts } from '../setup.js';
 import { createMockState } from './agent-controller-mock.js';
 
 const originalPlatform = process.platform;

--- a/mastracode/tui/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/tui/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -59,7 +59,12 @@ vi.mock('../status-line.js', () => ({
 
 import { showError, showInfo } from '../display.js';
 import { GOAL_JUDGE_INPUT_LOCK_MESSAGE } from '../goal-input-lock.js';
-import { refreshSkillsAutocomplete, setupAutocomplete, setupKeyHandlers, setupKeyboardShortcuts } from '../setup.js';
+import {
+  refreshSkillsAutocomplete,
+  setupAutocomplete,
+  setupKeyHandlers,
+  setupKeyboardShortcuts,
+} from '../setup.js';
 import { createMockState } from './agent-controller-mock.js';
 
 const originalPlatform = process.platform;
@@ -252,6 +257,18 @@ describe('setupKeyboardShortcuts', () => {
     const commandNames = autocompleteProviders[0]?.commands.map(command => command.name) ?? [];
     expect(commandNames[0]).toBe('new');
     expect(commandNames).toContain('thread');
+    expect(commandNames).toContain('fork');
+    expect(commandNames).toContain('resume');
+    expect(commandNames).toContain('rename');
+    expect(autocompleteProviders[0]?.commands.find(command => command.name === 'name')?.description).toBe(
+      'Alias for /rename',
+    );
+    expect(autocompleteProviders[0]?.commands.find(command => command.name === 'clone')?.description).toBe(
+      'Alias for /fork',
+    );
+    expect(autocompleteProviders[0]?.commands.find(command => command.name === 'threads')?.description).toBe(
+      'Alias for /resume',
+    );
     expect(commandNames).not.toContain('judge');
     expect(commandNames).not.toContain('notify');
     const goalCommand = autocompleteProviders[0]?.commands.find(command => command.name === 'goal') as

--- a/mastracode/tui/src/tui/__tests__/terminal-backend.test.ts
+++ b/mastracode/tui/src/tui/__tests__/terminal-backend.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { EmulatedTerminal } from '../../../e2e/terminal-backend.js';
+
+describe('EmulatedTerminal input lifecycle', () => {
+  it('discards input queued before a restart', async () => {
+    const terminal = new EmulatedTerminal(80, 24);
+    const firstInput = vi.fn();
+    terminal.start(firstInput, vi.fn());
+
+    terminal.sendInput('stale-a');
+    terminal.sendInput('stale-b');
+    terminal.stop();
+
+    const restartedInput = vi.fn();
+    terminal.start(restartedInput, vi.fn());
+    await terminal.flushInput();
+
+    expect(firstInput).not.toHaveBeenCalled();
+    expect(restartedInput).not.toHaveBeenCalled();
+
+    terminal.sendInput('current');
+    await terminal.flushInput();
+
+    expect(restartedInput.mock.calls.flat().join('')).toBe('current');
+    terminal.stop();
+  });
+});

--- a/mastracode/tui/src/tui/command-dispatch.ts
+++ b/mastracode/tui/src/tui/command-dispatch.ts
@@ -75,6 +75,9 @@ const TRACKED_COMMANDS = new Set([
   'memory-gateway',
   'custom-providers',
   'threads',
+  'resume',
+  'clone',
+  'fork',
   'new',
 ]);
 
@@ -163,9 +166,11 @@ export async function dispatchSlashCommand(
       await handleNewCommand(ctx);
       return true;
     case 'clone':
+    case 'fork':
       await handleCloneCommand(ctx);
       return true;
     case 'threads':
+    case 'resume':
       await handleThreadsCommand(ctx);
       return true;
     case 'thread':
@@ -247,6 +252,7 @@ export async function dispatchSlashCommand(
     case 'diff':
       await handleDiffCommand(ctx, args[0]);
       return true;
+    case 'rename':
     case 'name':
       await handleNameCommand(ctx, args);
       return true;

--- a/mastracode/tui/src/tui/commands/__tests__/name.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/name.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { handleNameCommand } from '../name.js';
+
+describe('handleNameCommand', () => {
+  it('renames the active thread', async () => {
+    const rename = vi.fn().mockResolvedValue(undefined);
+    const ctx = {
+      state: { session: { thread: { getId: vi.fn(() => 'thread-1'), rename } } },
+      showInfo: vi.fn(),
+    } as any;
+
+    await handleNameCommand(ctx, ['Demo', 'thread']);
+
+    expect(rename).toHaveBeenCalledWith({ title: 'Demo thread' });
+    expect(ctx.showInfo).toHaveBeenCalledWith('Thread renamed to: Demo thread');
+  });
+
+  it('shows /rename usage when the title is empty', async () => {
+    const ctx = { showInfo: vi.fn() } as any;
+
+    await handleNameCommand(ctx, []);
+
+    expect(ctx.showInfo).toHaveBeenCalledWith('Usage: /rename <title>');
+  });
+
+  it('does not save a title before the first prompt creates a thread', async () => {
+    const rename = vi.fn();
+    const ctx = {
+      state: { session: { thread: { getId: vi.fn(() => null), rename } } },
+      showInfo: vi.fn(),
+    } as any;
+
+    await handleNameCommand(ctx, ['Unsaved']);
+
+    expect(rename).not.toHaveBeenCalled();
+    expect(ctx.showInfo).toHaveBeenCalledWith('No active thread. Send a message first.');
+  });
+});

--- a/mastracode/tui/src/tui/commands/__tests__/new.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/new.test.ts
@@ -34,8 +34,11 @@ function createMockState() {
     session: {
       state: { set: vi.fn(async () => {}) },
       thread: {
+        getId: vi.fn(() => 'old-thread'),
         detachFromCurrent: vi.fn(),
         create: vi.fn(async () => ({ id: 'new-thread' })),
+        switch: vi.fn(async () => {}),
+        clearAndReleaseLock: vi.fn(async () => {}),
         ensureCurrentSubscription: vi.fn(async () => {}),
       },
       displayState: { get: vi.fn(() => ({ modifiedFiles: new Map([['f', true]]) })) },
@@ -93,6 +96,22 @@ describe('handleNewCommand', () => {
 
     expect(state.session.thread.detachFromCurrent).toHaveBeenCalledOnce();
     expect(state.session.thread.ensureCurrentSubscription).toHaveBeenCalledOnce();
+    expect(ctx.showInfo).not.toHaveBeenCalled();
+  });
+
+  it('restores the previous thread binding when creation fails after rebinding', async () => {
+    const state = createMockState();
+    const ctx = createCtx(state);
+    const error = new Error('subscription failed');
+    state.session.thread.create.mockImplementation(async () => {
+      state.session.thread.getId.mockReturnValue('new-thread');
+      throw error;
+    });
+
+    await expect(handleNewCommand(ctx)).rejects.toBe(error);
+
+    expect(state.session.thread.switch).toHaveBeenCalledWith({ threadId: 'old-thread' });
+    expect(state.session.thread.ensureCurrentSubscription).not.toHaveBeenCalled();
     expect(ctx.showInfo).not.toHaveBeenCalled();
   });
 

--- a/mastracode/tui/src/tui/commands/__tests__/new.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/new.test.ts
@@ -33,7 +33,11 @@ function createMockState() {
     taskToolInsertIndex: 5,
     session: {
       state: { set: vi.fn(async () => {}) },
-      thread: { detachFromCurrent: vi.fn() },
+      thread: {
+        detachFromCurrent: vi.fn(),
+        create: vi.fn(async () => ({ id: 'new-thread' })),
+        ensureCurrentSubscription: vi.fn(async () => {}),
+      },
       displayState: { get: vi.fn(() => ({ modifiedFiles: new Map([['f', true]]) })) },
     },
     controller: {
@@ -57,7 +61,7 @@ function createCtx(state: ReturnType<typeof createMockState>): SlashCommandConte
 }
 
 describe('handleNewCommand', () => {
-  it('detaches from current thread before setting pendingNewThread', async () => {
+  it('creates and marks a durable thread before reporting the new conversation ready', async () => {
     const state = createMockState();
     const ctx = createCtx(state);
     const callOrder: string[] = [];
@@ -65,22 +69,31 @@ describe('handleNewCommand', () => {
     state.session.thread.detachFromCurrent.mockImplementation(() => {
       callOrder.push('detach');
     });
-    const origPendingNewThread = Object.getOwnPropertyDescriptor(state, 'pendingNewThread');
-    Object.defineProperty(state, 'pendingNewThread', {
-      set(v: boolean) {
-        if (v) callOrder.push('pendingNewThread');
-        Object.defineProperty(state, 'pendingNewThread', { value: v, writable: true, configurable: true });
-      },
-      get() {
-        return origPendingNewThread?.value ?? false;
-      },
-      configurable: true,
+    state.session.thread.create.mockImplementation(async () => {
+      callOrder.push('create');
+      return { id: 'new-thread' };
     });
+    ctx.showInfo = vi.fn(() => callOrder.push('ready'));
 
     await handleNewCommand(ctx);
 
     expect(state.session.thread.detachFromCurrent).toHaveBeenCalledOnce();
-    expect(callOrder).toEqual(['detach', 'pendingNewThread']);
+    expect(state.session.thread.create).toHaveBeenCalledWith({ metadata: { explicitNewThread: true } });
+    expect(state.pendingNewThread).toBe(false);
+    expect(callOrder).toEqual(['detach', 'create', 'ready']);
+  });
+
+  it('restores the previous thread subscription when durable thread creation fails', async () => {
+    const state = createMockState();
+    const ctx = createCtx(state);
+    const error = new Error('create failed');
+    state.session.thread.create.mockRejectedValue(error);
+
+    await expect(handleNewCommand(ctx)).rejects.toBe(error);
+
+    expect(state.session.thread.detachFromCurrent).toHaveBeenCalledOnce();
+    expect(state.session.thread.ensureCurrentSubscription).toHaveBeenCalledOnce();
+    expect(ctx.showInfo).not.toHaveBeenCalled();
   });
 
   it('clears UI state and ephemeral thread state', async () => {

--- a/mastracode/tui/src/tui/commands/clone.ts
+++ b/mastracode/tui/src/tui/commands/clone.ts
@@ -17,11 +17,11 @@ interface CloneResetContext {
  * confirmed, false on cancel or "No".
  */
 export async function confirmClone(state: TUIState, threadLabel?: string): Promise<boolean> {
-  const label = threadLabel ? `Clone thread "${threadLabel}"?` : 'Clone the current thread?';
+  const label = threadLabel ? `Fork thread "${threadLabel}"?` : 'Fork the current thread?';
   const answer = await askModalQuestion(state.ui, {
     question: label,
     options: [
-      { label: 'Yes', description: 'Clone this thread' },
+      { label: 'Yes', description: 'Fork this thread' },
       { label: 'No', description: 'Cancel' },
     ],
   });
@@ -33,7 +33,7 @@ export async function confirmClone(state: TUIState, threadLabel?: string): Promi
  * if the user presses Esc or submits an empty string.
  */
 export async function askCloneName(state: TUIState): Promise<string | null> {
-  const answer = await askModalQuestion(state.ui, { question: 'Give the cloned thread a name? (Esc to skip)' });
+  const answer = await askModalQuestion(state.ui, { question: 'Give the forked thread a name? (Esc to skip)' });
   const trimmed = answer?.trim() ?? '';
   return trimmed.length > 0 ? trimmed : null;
 }
@@ -65,7 +65,7 @@ export async function resetUIAfterClone(ctx: CloneResetContext, clonedTitle: str
   ctx.updateStatusLine();
   await ctx.renderExistingMessages();
   state.ui.requestRender();
-  ctx.showInfo(`Cloned thread: ${clonedTitle}`);
+  ctx.showInfo(`Forked thread: ${clonedTitle}`);
 }
 
 export async function handleCloneCommand(ctx: SlashCommandContext): Promise<void> {
@@ -73,7 +73,7 @@ export async function handleCloneCommand(ctx: SlashCommandContext): Promise<void
 
   const currentThreadId = state.session.thread.getId();
   if (!currentThreadId) {
-    ctx.showInfo('No active thread to clone');
+    ctx.showInfo('No active thread to fork');
     return;
   }
 
@@ -91,6 +91,6 @@ export async function handleCloneCommand(ctx: SlashCommandContext): Promise<void
 
     await resetUIAfterClone(ctx, clonedThread.title || clonedThread.id);
   } catch (error) {
-    ctx.showError(`Failed to clone thread: ${error instanceof Error ? error.message : String(error)}`);
+    ctx.showError(`Failed to fork thread: ${error instanceof Error ? error.message : String(error)}`);
   }
 }

--- a/mastracode/tui/src/tui/commands/name.ts
+++ b/mastracode/tui/src/tui/commands/name.ts
@@ -3,7 +3,7 @@ import type { SlashCommandContext } from './types.js';
 export async function handleNameCommand(ctx: SlashCommandContext, args: string[]): Promise<void> {
   const title = args.join(' ').trim();
   if (!title) {
-    ctx.showInfo('Usage: /name <title>');
+    ctx.showInfo('Usage: /rename <title>');
     return;
   }
   if (!ctx.state.session.thread.getId()) {

--- a/mastracode/tui/src/tui/commands/new.ts
+++ b/mastracode/tui/src/tui/commands/new.ts
@@ -1,4 +1,5 @@
 import { disposeAssistantRenderState } from '../assistant-render-registry.js';
+import { EXPLICIT_NEW_THREAD_SETTING } from '../thread-startup.js';
 import { setCurrentThreadTitle } from '../thread-title.js';
 import type { SlashCommandContext } from './types.js';
 
@@ -11,7 +12,20 @@ export async function handleNewCommand(ctx: SlashCommandContext): Promise<void> 
   // on the same thread from pushing output into this TUI.
   state.session.thread.detachFromCurrent();
 
-  state.pendingNewThread = true;
+  // `/new` is an explicit request for a durable thread, even if the user exits
+  // before sending its first message. Mark it so startup cleanup can distinguish
+  // it from the disposable blank thread created during controller bootstrap.
+  try {
+    await state.session.thread.create({ metadata: { [EXPLICIT_NEW_THREAD_SETTING]: true } });
+  } catch (error) {
+    try {
+      await state.session.thread.ensureCurrentSubscription();
+    } catch {
+      // Preserve the thread creation error if restoring the old subscription fails.
+    }
+    throw error;
+  }
+  state.pendingNewThread = false;
   setCurrentThreadTitle(state, undefined);
   disposeAssistantRenderState(state);
   state.chatContainer.clear();

--- a/mastracode/tui/src/tui/commands/new.ts
+++ b/mastracode/tui/src/tui/commands/new.ts
@@ -5,6 +5,7 @@ import type { SlashCommandContext } from './types.js';
 
 export async function handleNewCommand(ctx: SlashCommandContext): Promise<void> {
   const { state } = ctx;
+  const previousThreadId = state.session.thread.getId();
 
   // Detach from the old thread's event stream so cross-process events
   // don't leak into the new conversation. Unlike bare abort(), this also
@@ -19,9 +20,18 @@ export async function handleNewCommand(ctx: SlashCommandContext): Promise<void> 
     await state.session.thread.create({ metadata: { [EXPLICIT_NEW_THREAD_SETTING]: true } });
   } catch (error) {
     try {
-      await state.session.thread.ensureCurrentSubscription();
+      const currentThreadId = state.session.thread.getId();
+      if (currentThreadId !== previousThreadId) {
+        if (previousThreadId) {
+          await state.session.thread.switch({ threadId: previousThreadId });
+        } else {
+          await state.session.thread.clearAndReleaseLock();
+        }
+      } else {
+        await state.session.thread.ensureCurrentSubscription();
+      }
     } catch {
-      // Preserve the thread creation error if restoring the old subscription fails.
+      // Preserve the thread creation error if restoring the old binding fails.
     }
     throw error;
   }

--- a/mastracode/tui/src/tui/commands/threads.ts
+++ b/mastracode/tui/src/tui/commands/threads.ts
@@ -24,14 +24,14 @@ export function showThreadLockPrompt(
       options: [
         { label: 'Switch thread', description: 'Pick a different thread' },
         { label: 'New thread', description: 'Start a fresh thread' },
-        ...(lockedThreadId ? [{ label: 'Clone thread', description: 'Fork from this thread' }] : []),
+        ...(lockedThreadId ? [{ label: 'Fork thread', description: 'Fork from this thread' }] : []),
         { label: 'Exit', description: 'Exit' },
       ],
     });
 
     if (answer === 'Switch thread') {
       await handleThreadsCommand(ctx);
-    } else if (answer === 'Clone thread' && lockedThreadId) {
+    } else if (answer === 'Fork thread' && lockedThreadId) {
       try {
         const customTitle = await askCloneName(ctx.state);
         const clonedThread = await ctx.state.session.thread.clone({
@@ -41,7 +41,7 @@ export function showThreadLockPrompt(
         ctx.state.pendingNewThread = false;
         await resetUIAfterClone(ctx, clonedThread.title || clonedThread.id);
       } catch (error) {
-        ctx.showError(`Failed to clone thread: ${error instanceof Error ? error.message : String(error)}`);
+        ctx.showError(`Failed to fork thread: ${error instanceof Error ? error.message : String(error)}`);
       }
     } else if (answer === 'New thread') {
       // pendingNewThread is already true from the caller
@@ -162,7 +162,7 @@ export async function handleThreadsCommand(ctx: SlashCommandContext): Promise<vo
           state.pendingNewThread = false;
           await resetUIAfterClone(ctx, clonedThread.title || clonedThread.id);
         } catch (error) {
-          ctx.showError(`Failed to clone thread: ${error instanceof Error ? error.message : String(error)}`);
+          ctx.showError(`Failed to fork thread: ${error instanceof Error ? error.message : String(error)}`);
         }
         resolve();
       },

--- a/mastracode/tui/src/tui/components/__tests__/help-overlay.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/help-overlay.test.ts
@@ -12,7 +12,12 @@ describe('buildHelpText', () => {
     process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS = '1';
     const text = buildHelpText(baseOpts);
     expect(text).toContain('/new');
-    expect(text).toContain('/threads');
+    expect(text).toMatch(/\/fork\s+Fork the current thread/);
+    expect(text).toMatch(/\/clone\s+Alias for \/fork/);
+    expect(text).toMatch(/\/resume\s+Resume an existing thread/);
+    expect(text).toMatch(/\/threads\s+Alias for \/resume/);
+    expect(text).toMatch(/\/rename\s+Rename current thread/);
+    expect(text).toMatch(/\/name\s+Alias for \/rename/);
     expect(text).toContain('/settings');
     expect(text).toMatch(/\/model\s+Change the current mode model/);
     expect(text).toMatch(/\/models\s+Switch model pack/);

--- a/mastracode/tui/src/tui/components/help-overlay.ts
+++ b/mastracode/tui/src/tui/components/help-overlay.ts
@@ -26,10 +26,14 @@ interface HelpEntry {
 function getCommands(modes: number): HelpEntry[] {
   const cmds: HelpEntry[] = [
     { key: '/new', description: 'Start a new thread' },
-    { key: '/threads', description: 'Switch between threads' },
+    { key: '/fork', description: 'Fork the current thread' },
+    { key: '/clone', description: 'Alias for /fork' },
+    { key: '/resume', description: 'Resume an existing thread' },
+    { key: '/threads', description: 'Alias for /resume' },
     { key: '/thread', description: 'Show current thread info' },
     { key: '/thread:tag-dir', description: 'Tag thread with current directory' },
-    { key: '/name', description: 'Rename current thread' },
+    { key: '/rename', description: 'Rename current thread' },
+    { key: '/name', description: 'Alias for /rename' },
     { key: '/resource', description: 'Show/switch resource ID' },
     { key: '/skills', description: 'List available skills' },
     { key: '/skill/<name>', description: 'Activate a skill' },

--- a/mastracode/tui/src/tui/mastra-tui.ts
+++ b/mastracode/tui/src/tui/mastra-tui.ts
@@ -74,13 +74,13 @@ import {
   refreshSkillsAutocomplete,
   setupKeyHandlers,
   subscribeToAgentController,
-  promptForThreadSelection,
   renderExistingTasks,
 } from './setup.js';
 import { handleShellPassthrough } from './shell.js';
 import type { MastraTUIOptions, TUIState } from './state.js';
 import { createTUIState, getGithubPrSubscriptionsFromMetadata } from './state.js';
 import { updateStatusLine } from './status-line.js';
+import { resumeThreadOnStartup } from './thread-startup.js';
 import { setCurrentThreadTitle } from './thread-title.js';
 
 // =============================================================================
@@ -645,8 +645,8 @@ export class MastraTUI {
     // Start the UI before thread selection so resource-drift prompts can render.
     this.state.ui.start();
 
-    // Check for existing threads and prompt for resume
-    await promptForThreadSelection(this.state);
+    // Resume the latest unlocked thread for this directory.
+    await resumeThreadOnStartup(this.state, this.state.options.resumeThreadId);
 
     // Subscribe to controller events
     subscribeToAgentController(this.state, event => this.handleEvent(event));
@@ -662,7 +662,7 @@ export class MastraTUI {
     await this.state.controller.loadOMProgress(this.state.session);
 
     // Sync current thread metadata — the thread_changed event from
-    // promptForThreadSelection fired before we subscribed above.
+    // Initial thread setup ran before we subscribed above.
     await syncInitialThreadState(this.state);
 
     this.state.isInitialized = true;

--- a/mastracode/tui/src/tui/setup.ts
+++ b/mastracode/tui/src/tui/setup.ts
@@ -7,17 +7,13 @@ import { CombinedAutocompleteProvider, Spacer, Text } from '@earendil-works/pi-t
 import type { SlashCommand } from '@earendil-works/pi-tui';
 import { THINK_COMMAND_DESCRIPTOR } from '@mastra/code-sdk/thinking';
 import { loadCustomCommands } from '@mastra/code-sdk/utils/slash-command-loader';
-import { ThreadLockError } from '@mastra/code-sdk/utils/thread-lock';
 import type { AgentControllerEventListener } from '@mastra/core/agent-controller';
 import { isUserInvocable } from './commands/skill-filters.js';
 import { renderBanner } from './components/banner.js';
 import { IdleCounterComponent } from './components/idle-counter.js';
-import { SimpleProgressComponent } from './components/simple-progress.js';
 import { TaskProgressComponent } from './components/task-progress.js';
 import { notifyForInputRequest, runPermissionHooksForEvent, showError, showInfo } from './display.js';
 import { isGoalJudgeInputLocked, showGoalJudgeInputLockInfo } from './goal-input-lock.js';
-import { askModalQuestion } from './modal-question.js';
-import { showModalOverlay } from './overlay.js';
 import type { TUIState } from './state.js';
 import { updateStatusLine } from './status-line.js';
 import { theme } from './theme.js';
@@ -360,9 +356,11 @@ function detectFdPath(): string | null {
 export function setupAutocomplete(state: TUIState): void {
   const slashCommands: SlashCommand[] = [
     { name: 'new', description: 'Start a new thread' },
-    { name: 'clone', description: 'Clone the current thread' },
+    { name: 'fork', description: 'Fork the current thread' },
+    { name: 'clone', description: 'Alias for /fork' },
     { name: 'thread', description: 'Show current thread info' },
-    { name: 'threads', description: 'Switch between threads' },
+    { name: 'resume', description: 'Resume an existing thread' },
+    { name: 'threads', description: 'Alias for /resume' },
     { name: 'models', description: 'Switch model pack' },
     { name: 'packs', description: 'Alias for /models' },
     { name: 'model', description: 'Change the current mode model' },
@@ -380,7 +378,8 @@ export function setupAutocomplete(state: TUIState): void {
     { name: 'context', description: 'Audit what is using the context window' },
     { name: 'ctx', description: 'Alias for /context' },
     { name: 'diff', description: 'Show modified files or git diff' },
-    { name: 'name', description: 'Rename current thread' },
+    { name: 'rename', description: 'Rename current thread' },
+    { name: 'name', description: 'Alias for /rename' },
     {
       name: 'resource',
       description: 'Show/switch resource ID (tag for sharing)',
@@ -677,110 +676,6 @@ export function subscribeToAgentController(state: TUIState, handleEvent: (event:
     return eventQueue;
   };
   state.unsubscribe = state.session.subscribe(listener);
-}
-
-// =============================================================================
-// Thread Selection
-// =============================================================================
-
-export async function promptForThreadSelection(state: TUIState): Promise<void> {
-  const currentPath = state.projectInfo.rootPath;
-  const currentResourceId = state.session.identity.getResourceId();
-
-  const allThreads = await state.session.thread.list();
-  const activeThreadId = state.session.thread.getId();
-
-  // Filter to threads explicitly tagged for the current working directory.
-  const taggedThreads = allThreads.filter(t => {
-    const threadPath = t.metadata?.projectPath as string | undefined;
-    return !!threadPath && threadPath === currentPath;
-  });
-  const threads: typeof taggedThreads = [];
-  for (const thread of taggedThreads) {
-    const isActiveBlankThread = thread.id === activeThreadId && !thread.title;
-    if (isActiveBlankThread) {
-      const messages = await state.session.thread.listMessages({ threadId: thread.id, limit: 1 });
-      if (messages.length === 0) continue;
-    }
-    threads.push(thread);
-  }
-
-  if (threads.length === 0) {
-    const driftCandidates = (
-      await state.session.thread.list({
-        allResources: true,
-        metadata: { projectPath: currentPath },
-      })
-    ).filter(t => t.resourceId !== currentResourceId);
-    const [thread] = [...driftCandidates].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
-
-    if (thread) {
-      const answer = await askModalQuestion(state.ui, {
-        question: [
-          'This directory is tagged on a different resource.',
-          '',
-          `Project: ${currentPath}`,
-          `Thread: ${thread.title || thread.id}`,
-          `Old resource: ${thread.resourceId}`,
-          `Current resource: ${currentResourceId}`,
-          '',
-          'Clone this thread into the current resource and resume the clone?',
-        ].join('\n'),
-        options: [{ label: 'Clone and resume' }, { label: 'Start fresh' }],
-        selectedOptionLabel: 'Clone and resume',
-        allowCustomResponse: false,
-        overlay: { widthPercent: 80, maxHeight: '70%' },
-      });
-
-      if (answer === 'Clone and resume') {
-        const progress = new SimpleProgressComponent({ showElapsed: false, showPercentage: false });
-        progress.start('Cloning thread into the current resource...');
-        showModalOverlay(state.ui, progress, { widthPercent: 70, maxHeight: '40%', minHeightPercent: 0.35 });
-        state.ui.requestRender();
-
-        try {
-          await new Promise(resolve => setTimeout(resolve, 50));
-          progress.updateStatus('Loading cloned thread...');
-          state.ui.requestRender();
-          await state.session.thread.cloneToCurrentResource({
-            threadId: thread.id,
-            expectedResourceId: thread.resourceId,
-            expectedProjectPath: currentPath,
-          });
-        } finally {
-          state.ui.hideOverlay();
-          state.ui.requestRender();
-        }
-        return;
-      }
-    }
-
-    // No existing threads for this path - defer creation until first message
-    state.pendingNewThread = true;
-    return;
-  }
-
-  // Sort by most recent
-  const sortedThreads = [...threads].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
-
-  // Try each in order until one is unlocked
-  for (const thread of sortedThreads) {
-    try {
-      await state.session.thread.switch({ threadId: thread.id });
-      if (!thread.metadata?.projectPath) {
-        await state.session.thread.setSetting({ key: 'projectPath', value: currentPath });
-      }
-      return;
-    } catch (error) {
-      if (error instanceof ThreadLockError) {
-        continue; // Try the next one
-      }
-      throw error;
-    }
-  }
-
-  // All directory threads are locked — silently start a new thread
-  state.pendingNewThread = true;
 }
 
 // =============================================================================

--- a/mastracode/tui/src/tui/state.ts
+++ b/mastracode/tui/src/tui/state.ts
@@ -132,6 +132,9 @@ export interface MastraTUIOptions {
   /** Initial message to send on startup */
   initialMessage?: string;
 
+  /** Thread ID requested by `mastracode resume`. */
+  resumeThreadId?: string;
+
   /** Whether to show verbose startup info */
   verbose?: boolean;
 

--- a/mastracode/tui/src/tui/thread-startup.test.ts
+++ b/mastracode/tui/src/tui/thread-startup.test.ts
@@ -14,7 +14,10 @@ function createThread(id: string, title: string, updatedAt: string) {
 
 describe('resumeThreadOnStartup', () => {
   it('resumes the requested thread instead of the latest thread', async () => {
-    const requested = { ...createThread('thread-requested', 'Requested', '2026-08-28T10:00:00Z'), resourceId: 'resource-2' };
+    const requested = {
+      ...createThread('thread-requested', 'Requested', '2026-08-28T10:00:00Z'),
+      resourceId: 'resource-2',
+    };
     const latest = createThread('thread-latest', 'Latest', '2026-08-28T11:00:00Z');
     const setResourceId = vi.fn().mockResolvedValue(undefined);
     const switchThread = vi.fn().mockResolvedValue(undefined);

--- a/mastracode/tui/src/tui/thread-startup.test.ts
+++ b/mastracode/tui/src/tui/thread-startup.test.ts
@@ -1,0 +1,209 @@
+import { ThreadLockError } from '@mastra/code-sdk/utils/thread-lock';
+import { describe, expect, it, vi } from 'vitest';
+import { resumeThreadOnStartup } from './thread-startup.js';
+
+function createThread(id: string, title: string, updatedAt: string) {
+  return {
+    id,
+    title,
+    resourceId: 'resource-1',
+    metadata: { projectPath: '/tmp/project' },
+    updatedAt: new Date(updatedAt),
+  };
+}
+
+describe('resumeThreadOnStartup', () => {
+  it('resumes the requested thread instead of the latest thread', async () => {
+    const requested = { ...createThread('thread-requested', 'Requested', '2026-08-28T10:00:00Z'), resourceId: 'resource-2' };
+    const latest = createThread('thread-latest', 'Latest', '2026-08-28T11:00:00Z');
+    const setResourceId = vi.fn().mockResolvedValue(undefined);
+    const switchThread = vi.fn().mockResolvedValue(undefined);
+    const state = {
+      projectInfo: { rootPath: '/tmp/project' },
+      pendingNewThread: true,
+      controller: { setResourceId },
+      session: {
+        identity: { getResourceId: vi.fn(() => 'resource-1') },
+        thread: {
+          getId: vi.fn(() => 'thread-latest'),
+          list: vi.fn().mockResolvedValue([latest, requested]),
+          switch: switchThread,
+        },
+      },
+    } as any;
+
+    await resumeThreadOnStartup(state, 'thread-requested');
+
+    expect(setResourceId).toHaveBeenCalledWith(state.session, { resourceId: 'resource-2' });
+    expect(switchThread).toHaveBeenCalledWith({ threadId: 'thread-requested' });
+    expect(state.pendingNewThread).toBe(false);
+  });
+
+  it('reports an unknown requested thread', async () => {
+    const state = {
+      projectInfo: { rootPath: '/tmp/project' },
+      session: {
+        thread: {
+          getId: vi.fn(() => null),
+          list: vi.fn().mockResolvedValue([]),
+        },
+      },
+    } as any;
+
+    await expect(resumeThreadOnStartup(state, 'missing-thread')).rejects.toThrow('Thread not found: missing-thread');
+  });
+
+  it('deletes an unsent startup thread before resuming saved work', async () => {
+    const blank = createThread('thread-blank', '', '2026-08-28T11:01:00Z');
+    const saved = createThread('thread-saved', 'Saved thread', '2026-08-28T11:00:00Z');
+    const deleteThread = vi.fn().mockResolvedValue(undefined);
+    const switchThread = vi.fn().mockResolvedValue(undefined);
+    const state = {
+      projectInfo: { rootPath: '/tmp/project' },
+      pendingNewThread: false,
+      session: {
+        identity: { getResourceId: vi.fn(() => 'resource-1') },
+        thread: {
+          getId: vi.fn(() => 'thread-blank'),
+          list: vi.fn().mockResolvedValue([blank, saved]),
+          listMessages: vi.fn().mockResolvedValue([]),
+          delete: deleteThread,
+          switch: switchThread,
+          setSetting: vi.fn(),
+        },
+      },
+    } as any;
+
+    await resumeThreadOnStartup(state);
+
+    expect(deleteThread).toHaveBeenCalledWith({ threadId: 'thread-blank' });
+    expect(switchThread).toHaveBeenCalledWith({ threadId: 'thread-saved' });
+  });
+
+  it('resumes the latest unlocked thread for the current directory', async () => {
+    const latest = createThread('thread-latest', 'Latest thread', '2026-08-28T11:00:00Z');
+    const older = createThread('thread-older', 'Older thread', '2026-08-28T10:00:00Z');
+    const switchThread = vi.fn().mockResolvedValue(undefined);
+    const state = {
+      projectInfo: { rootPath: '/tmp/project' },
+      pendingNewThread: false,
+      session: {
+        identity: { getResourceId: vi.fn(() => 'resource-1') },
+        thread: {
+          getId: vi.fn(() => null),
+          list: vi.fn().mockResolvedValue([older, latest]),
+          listMessages: vi.fn(),
+          switch: switchThread,
+          setSetting: vi.fn(),
+        },
+      },
+    } as any;
+
+    await resumeThreadOnStartup(state);
+
+    expect(switchThread).toHaveBeenCalledOnce();
+    expect(switchThread).toHaveBeenCalledWith({ threadId: 'thread-latest' });
+    expect(state.pendingNewThread).toBe(false);
+  });
+
+  it('keeps the controller lock when the latest thread is already active', async () => {
+    const latest = createThread('thread-latest', 'Latest thread', '2026-08-28T11:00:00Z');
+    const switchThread = vi.fn();
+    const state = {
+      projectInfo: { rootPath: '/tmp/project' },
+      pendingNewThread: false,
+      session: {
+        thread: {
+          getId: vi.fn(() => 'thread-latest'),
+          list: vi.fn().mockResolvedValue([latest]),
+          listMessages: vi.fn(),
+          switch: switchThread,
+        },
+      },
+    } as any;
+
+    await resumeThreadOnStartup(state);
+
+    expect(switchThread).not.toHaveBeenCalled();
+    expect(state.pendingNewThread).toBe(false);
+  });
+
+  it('ignores leftover empty threads when resuming saved work', async () => {
+    const activeBlank = createThread('thread-active-blank', '', '2026-08-28T11:02:00Z');
+    const leftoverBlank = createThread('thread-leftover-blank', '', '2026-08-28T11:01:00Z');
+    const saved = createThread('thread-saved', 'Saved thread', '2026-08-28T11:00:00Z');
+    const deleteThread = vi.fn().mockResolvedValue(undefined);
+    const switchThread = vi.fn().mockResolvedValue(undefined);
+    const state = {
+      projectInfo: { rootPath: '/tmp/project' },
+      pendingNewThread: false,
+      session: {
+        thread: {
+          getId: vi.fn(() => 'thread-active-blank'),
+          list: vi.fn().mockResolvedValue([saved, leftoverBlank, activeBlank]),
+          listMessages: vi.fn().mockResolvedValue([]),
+          delete: deleteThread,
+          switch: switchThread,
+        },
+      },
+    } as any;
+
+    await resumeThreadOnStartup(state);
+
+    expect(deleteThread).toHaveBeenCalledWith({ threadId: 'thread-active-blank' });
+    expect(switchThread).toHaveBeenCalledWith({ threadId: 'thread-saved' });
+  });
+
+  it('resumes the next thread when the latest is locked', async () => {
+    const latest = createThread('thread-latest', 'Latest thread', '2026-08-28T11:00:00Z');
+    const older = createThread('thread-older', 'Older thread', '2026-08-28T10:00:00Z');
+    const switchThread = vi
+      .fn()
+      .mockRejectedValueOnce(new ThreadLockError('thread-latest', 1234))
+      .mockResolvedValueOnce(undefined);
+    const state = {
+      projectInfo: { rootPath: '/tmp/project' },
+      pendingNewThread: false,
+      session: {
+        thread: {
+          getId: vi.fn(() => null),
+          list: vi.fn().mockResolvedValue([older, latest]),
+          listMessages: vi.fn(),
+          switch: switchThread,
+        },
+      },
+    } as any;
+
+    await resumeThreadOnStartup(state);
+
+    expect(switchThread).toHaveBeenNthCalledWith(1, { threadId: 'thread-latest' });
+    expect(switchThread).toHaveBeenNthCalledWith(2, { threadId: 'thread-older' });
+    expect(state.pendingNewThread).toBe(false);
+  });
+
+  it('starts a new thread when every saved thread is locked', async () => {
+    const latest = createThread('thread-latest', 'Latest thread', '2026-08-28T11:00:00Z');
+    const older = createThread('thread-older', 'Older thread', '2026-08-28T10:00:00Z');
+    const switchThread = vi
+      .fn()
+      .mockRejectedValueOnce(new ThreadLockError('thread-latest', 1234))
+      .mockRejectedValueOnce(new ThreadLockError('thread-older', 5678));
+    const state = {
+      projectInfo: { rootPath: '/tmp/project' },
+      pendingNewThread: false,
+      session: {
+        thread: {
+          getId: vi.fn(() => null),
+          list: vi.fn().mockResolvedValue([older, latest]),
+          listMessages: vi.fn(),
+          switch: switchThread,
+        },
+      },
+    } as any;
+
+    await resumeThreadOnStartup(state);
+
+    expect(switchThread).toHaveBeenCalledTimes(2);
+    expect(state.pendingNewThread).toBe(true);
+  });
+});

--- a/mastracode/tui/src/tui/thread-startup.test.ts
+++ b/mastracode/tui/src/tui/thread-startup.test.ts
@@ -111,6 +111,36 @@ describe('resumeThreadOnStartup', () => {
     expect(switchThread).toHaveBeenCalledWith({ threadId: 'thread-saved' });
   });
 
+  it('keeps an explicit blank /new thread active across restart', async () => {
+    const explicitBlank = {
+      ...createThread('thread-new', '', '2026-08-28T11:01:00Z'),
+      metadata: { projectPath: '/tmp/project', explicitNewThread: true },
+    };
+    const saved = createThread('thread-saved', 'Saved thread', '2026-08-28T11:00:00Z');
+    const deleteThread = vi.fn().mockResolvedValue(undefined);
+    const switchThread = vi.fn().mockResolvedValue(undefined);
+    const state = {
+      projectInfo: { rootPath: '/tmp/project' },
+      pendingNewThread: false,
+      session: {
+        identity: { getResourceId: vi.fn(() => 'resource-1') },
+        thread: {
+          getId: vi.fn(() => 'thread-new'),
+          list: vi.fn().mockResolvedValue([saved, explicitBlank]),
+          listMessages: vi.fn().mockResolvedValue([]),
+          delete: deleteThread,
+          switch: switchThread,
+        },
+      },
+    } as any;
+
+    await resumeThreadOnStartup(state);
+
+    expect(deleteThread).not.toHaveBeenCalled();
+    expect(switchThread).not.toHaveBeenCalled();
+    expect(state.pendingNewThread).toBe(false);
+  });
+
   it('resumes the latest unlocked thread for the current directory', async () => {
     const latest = createThread('thread-latest', 'Latest thread', '2026-08-28T11:00:00Z');
     const older = createThread('thread-older', 'Older thread', '2026-08-28T10:00:00Z');

--- a/mastracode/tui/src/tui/thread-startup.test.ts
+++ b/mastracode/tui/src/tui/thread-startup.test.ts
@@ -37,6 +37,7 @@ describe('resumeThreadOnStartup', () => {
 
     await resumeThreadOnStartup(state, 'thread-requested');
 
+    expect(state.session.thread.list).toHaveBeenCalledWith({ allResources: true });
     expect(setResourceId).toHaveBeenCalledWith(state.session, { resourceId: 'resource-2' });
     expect(switchThread).toHaveBeenCalledWith({ threadId: 'thread-requested' });
     expect(state.pendingNewThread).toBe(false);

--- a/mastracode/tui/src/tui/thread-startup.test.ts
+++ b/mastracode/tui/src/tui/thread-startup.test.ts
@@ -57,6 +57,33 @@ describe('resumeThreadOnStartup', () => {
     await expect(resumeThreadOnStartup(state, 'missing-thread')).rejects.toThrow('Thread not found: missing-thread');
   });
 
+  it('does not resume a requested thread from another project', async () => {
+    const requested = {
+      ...createThread('thread-requested', 'Requested', '2026-08-28T10:00:00Z'),
+      resourceId: 'resource-2',
+      metadata: { projectPath: '/tmp/other-project' },
+    };
+    const setResourceId = vi.fn().mockResolvedValue(undefined);
+    const switchThread = vi.fn().mockResolvedValue(undefined);
+    const state = {
+      projectInfo: { rootPath: '/tmp/project' },
+      controller: { setResourceId },
+      session: {
+        thread: {
+          getId: vi.fn(() => null),
+          list: vi.fn().mockResolvedValue([requested]),
+          switch: switchThread,
+        },
+      },
+    } as any;
+
+    await expect(resumeThreadOnStartup(state, 'thread-requested')).rejects.toThrow(
+      'Thread not found: thread-requested',
+    );
+    expect(setResourceId).not.toHaveBeenCalled();
+    expect(switchThread).not.toHaveBeenCalled();
+  });
+
   it('deletes an unsent startup thread before resuming saved work', async () => {
     const blank = createThread('thread-blank', '', '2026-08-28T11:01:00Z');
     const saved = createThread('thread-saved', 'Saved thread', '2026-08-28T11:00:00Z');

--- a/mastracode/tui/src/tui/thread-startup.ts
+++ b/mastracode/tui/src/tui/thread-startup.ts
@@ -4,6 +4,8 @@ import { askModalQuestion } from './modal-question.js';
 import { showModalOverlay } from './overlay.js';
 import type { TUIState } from './state.js';
 
+export const EXPLICIT_NEW_THREAD_SETTING = 'explicitNewThread';
+
 export async function resumeThreadOnStartup(state: TUIState, requestedThreadId?: string): Promise<void> {
   const currentPath = state.projectInfo.rootPath;
   const allThreads = await state.session.thread.list(requestedThreadId ? { allResources: true } : undefined);
@@ -25,7 +27,9 @@ export async function resumeThreadOnStartup(state: TUIState, requestedThreadId?:
   }
 
   const projectThreads = allThreads.filter(thread => thread.metadata?.projectPath === currentPath);
-  const untitledThreads = projectThreads.filter(thread => !thread.title);
+  const untitledThreads = projectThreads.filter(
+    thread => !thread.title && thread.metadata?.[EXPLICIT_NEW_THREAD_SETTING] !== true,
+  );
   const emptyThreadIds = new Set(
     (
       await Promise.all(

--- a/mastracode/tui/src/tui/thread-startup.ts
+++ b/mastracode/tui/src/tui/thread-startup.ts
@@ -10,7 +10,9 @@ export async function resumeThreadOnStartup(state: TUIState, requestedThreadId?:
   const activeThreadId = state.session.thread.getId();
 
   if (requestedThreadId) {
-    const thread = allThreads.find(candidate => candidate.id === requestedThreadId);
+    const thread = allThreads.find(
+      candidate => candidate.id === requestedThreadId && candidate.metadata?.projectPath === currentPath,
+    );
     if (!thread) throw new Error(`Thread not found: ${requestedThreadId}`);
     if (thread.resourceId !== state.session.identity.getResourceId()) {
       await state.controller.setResourceId(state.session, { resourceId: thread.resourceId });

--- a/mastracode/tui/src/tui/thread-startup.ts
+++ b/mastracode/tui/src/tui/thread-startup.ts
@@ -1,0 +1,113 @@
+import { ThreadLockError } from '@mastra/code-sdk/utils/thread-lock';
+import { SimpleProgressComponent } from './components/simple-progress.js';
+import { askModalQuestion } from './modal-question.js';
+import { showModalOverlay } from './overlay.js';
+import type { TUIState } from './state.js';
+
+export async function resumeThreadOnStartup(state: TUIState, requestedThreadId?: string): Promise<void> {
+  const currentPath = state.projectInfo.rootPath;
+  const allThreads = await state.session.thread.list(requestedThreadId ? { allResources: true } : undefined);
+  const activeThreadId = state.session.thread.getId();
+
+  if (requestedThreadId) {
+    const thread = allThreads.find(candidate => candidate.id === requestedThreadId);
+    if (!thread) throw new Error(`Thread not found: ${requestedThreadId}`);
+    if (thread.resourceId !== state.session.identity.getResourceId()) {
+      await state.controller.setResourceId(state.session, { resourceId: thread.resourceId });
+    }
+    if (requestedThreadId !== activeThreadId) {
+      await state.session.thread.switch({ threadId: requestedThreadId });
+    }
+    state.pendingNewThread = false;
+    return;
+  }
+
+  const projectThreads = allThreads.filter(thread => thread.metadata?.projectPath === currentPath);
+  const untitledThreads = projectThreads.filter(thread => !thread.title);
+  const emptyThreadIds = new Set(
+    (
+      await Promise.all(
+        untitledThreads.map(async thread => {
+          const messages = await state.session.thread.listMessages({ threadId: thread.id, limit: 1 });
+          return messages.length === 0 ? thread.id : undefined;
+        }),
+      )
+    ).filter((threadId): threadId is string => threadId !== undefined),
+  );
+
+  if (activeThreadId && emptyThreadIds.has(activeThreadId)) {
+    await state.session.thread.delete({ threadId: activeThreadId });
+  }
+
+  const threads = projectThreads.filter(thread => !emptyThreadIds.has(thread.id));
+
+  if (threads.length === 0) {
+    if (await cloneDriftedThread(state)) return;
+    state.pendingNewThread = true;
+    return;
+  }
+
+  for (const thread of [...threads].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())) {
+    if (thread.id === state.session.thread.getId()) return;
+    try {
+      await state.session.thread.switch({ threadId: thread.id });
+      return;
+    } catch (error) {
+      if (error instanceof ThreadLockError) continue;
+      throw error;
+    }
+  }
+
+  state.pendingNewThread = true;
+}
+
+async function cloneDriftedThread(state: TUIState): Promise<boolean> {
+  const currentPath = state.projectInfo.rootPath;
+  const currentResourceId = state.session.identity.getResourceId();
+  const driftCandidates = (
+    await state.session.thread.list({
+      allResources: true,
+      metadata: { projectPath: currentPath },
+    })
+  ).filter(thread => thread.resourceId !== currentResourceId);
+  const thread = [...driftCandidates].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0];
+  if (!thread) return false;
+
+  const answer = await askModalQuestion(state.ui, {
+    question: [
+      'This directory is tagged on a different resource.',
+      '',
+      `Project: ${currentPath}`,
+      `Thread: ${thread.title || thread.id}`,
+      `Old resource: ${thread.resourceId}`,
+      `Current resource: ${currentResourceId}`,
+      '',
+      'Clone this thread into the current resource and resume the clone?',
+    ].join('\n'),
+    options: [{ label: 'Clone and resume' }, { label: 'Start fresh' }],
+    selectedOptionLabel: 'Clone and resume',
+    allowCustomResponse: false,
+    overlay: { widthPercent: 80, maxHeight: '70%' },
+  });
+  if (answer !== 'Clone and resume') return false;
+
+  const progress = new SimpleProgressComponent({ showElapsed: false, showPercentage: false });
+  progress.start('Cloning thread into the current resource...');
+  showModalOverlay(state.ui, progress, { widthPercent: 70, maxHeight: '40%', minHeightPercent: 0.35 });
+  state.ui.requestRender();
+
+  try {
+    await new Promise(resolve => setTimeout(resolve, 50));
+    progress.updateStatus('Loading cloned thread...');
+    state.ui.requestRender();
+    await state.session.thread.cloneToCurrentResource({
+      threadId: thread.id,
+      expectedResourceId: thread.resourceId,
+      expectedProjectPath: currentPath,
+    });
+  } finally {
+    state.ui.hideOverlay();
+    state.ui.requestRender();
+  }
+  return true;
+}

--- a/mastracode/tui/src/tui/thread-startup.ts
+++ b/mastracode/tui/src/tui/thread-startup.ts
@@ -87,13 +87,13 @@ async function cloneDriftedThread(state: TUIState): Promise<boolean> {
     options: [{ label: 'Clone and resume' }, { label: 'Start fresh' }],
     selectedOptionLabel: 'Clone and resume',
     allowCustomResponse: false,
-    overlay: { widthPercent: 80, maxHeight: '70%' },
+    overlay: { widthPercent: 0.8, maxHeight: '70%' },
   });
   if (answer !== 'Clone and resume') return false;
 
   const progress = new SimpleProgressComponent({ showElapsed: false, showPercentage: false });
   progress.start('Cloning thread into the current resource...');
-  showModalOverlay(state.ui, progress, { widthPercent: 70, maxHeight: '40%', minHeightPercent: 0.35 });
+  showModalOverlay(state.ui, progress, { widthPercent: 0.7, maxHeight: '40%', minHeightPercent: 0.35 });
   state.ui.requestRender();
 
   try {

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -575,7 +575,15 @@ export class SessionThread {
   }
 
   /** Create a new thread, bind the session to it, and rebind the agent stream. */
-  async create({ title, id }: { title?: string; id?: string } = {}): Promise<AgentControllerThread> {
+  async create({
+    title,
+    id,
+    metadata: initialMetadata,
+  }: {
+    title?: string;
+    id?: string;
+    metadata?: Record<string, unknown>;
+  } = {}): Promise<AgentControllerThread> {
     const session = this.#owner;
     const store = this.#store;
     this.cleanupSubscription();
@@ -592,7 +600,9 @@ export class SessionThread {
     const currentMode = session.mode.resolve();
     const modelId = currentStateModel || currentMode.defaultModelId;
 
-    const metadata: Record<string, unknown> = {};
+    const metadata: Record<string, unknown> = Object.fromEntries(
+      Object.entries(initialMetadata ?? {}).filter(([key]) => !isReservedThreadMetadataKey(key)),
+    );
     if (modelId) {
       metadata.currentModelId = modelId;
       metadata[`modeModelId_${session.mode.get()}`] = modelId;
@@ -601,6 +611,7 @@ export class SessionThread {
     // Stamp the session's scope so thread selection can filter listings back to
     // it (e.g. a `projectPath` per git worktree).
     Object.assign(metadata, session.getThreadScope());
+    if (Object.keys(metadata).length > 0) thread.metadata = metadata;
 
     // Acquire lock on new thread before releasing old one.
     // If acquire fails, attempt to re-acquire the old lock before rethrowing.
@@ -636,7 +647,7 @@ export class SessionThread {
             title: thread.title!,
             createdAt: thread.createdAt,
             updatedAt: thread.updatedAt,
-            metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+            metadata: thread.metadata,
           },
         });
       } catch (err) {

--- a/packages/core/src/agent-controller/thread-locking.test.ts
+++ b/packages/core/src/agent-controller/thread-locking.test.ts
@@ -330,6 +330,36 @@ describe('AgentController thread locking', () => {
       expect(metadata.projectPath).toBe('/repo/wt');
       expect(metadata.branch).toBe('feat/x');
     });
+
+    it('persists caller metadata atomically while keeping session scope authoritative', async () => {
+      const store = new InMemoryStore();
+      const controller = freshController(store);
+      await controller.init();
+      const session = await controller.createSession({
+        id: 'metadata',
+        ownerId: 'test-owner',
+        resourceId: 'repo',
+        tags: { projectPath: '/repo/current' },
+      });
+
+      const created = await session.thread.create({
+        metadata: {
+          explicitNewThread: true,
+          projectPath: '/repo/wrong',
+          currentModeId: 'caller-mode',
+          tokenUsage: { total: 10_000 },
+          modeModelId_caller: 'caller-model',
+        },
+      });
+      const persisted = await session.thread.getById({ threadId: created.id });
+
+      expect(created.metadata?.explicitNewThread).toBe(true);
+      expect(persisted?.metadata?.explicitNewThread).toBe(true);
+      expect(persisted?.metadata?.projectPath).toBe('/repo/current');
+      expect(persisted?.metadata?.currentModeId).toBeUndefined();
+      expect(persisted?.metadata?.tokenUsage).toBeUndefined();
+      expect(persisted?.metadata?.modeModelId_caller).toBeUndefined();
+    });
   });
 
   describe('deleteThread', () => {


### PR DESCRIPTION
Adds `/resume`, `/fork`, and `/rename`, including their existing aliases, plus `mastracode resume <thread-id>` for continuing a specific conversation.

Mastra Code now resumes the latest unlocked thread for the current project, enables first-message title generation across clients, and avoids duplicate status rows after responses.

Includes documentation, changesets, focused unit tests, and TUI coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Mastra Code can now reopen, copy, and rename conversations. It remembers the correct conversation after a restart and avoids duplicate status messages.

## Changes

- Added `/resume`, `/fork`, and `/rename` commands.
- Preserved `/threads`, `/clone`, and `/name` as aliases.
- Added `mastracode resume <thread-id>`.
- Resumes the latest unlocked thread for the current project.
- Preserves explicit blank threads created with `/new` across restarts.
- Added first-message title generation for all Mastra Code clients.
- Added resume hints when the application exits.
- Added thread metadata support to `session.thread.create()`.
- Prevented duplicate status rows after responses.
- Updated documentation and help text.
- Added unit tests, SQLite restart coverage, and TUI end-to-end coverage.
- Added release changesets for `mastracode`, `@mastra/code-sdk`, and `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->