### PR TITLE
fix(mastracode): persist new threads across restarts

### DIFF
--- a/.changeset/blue-heads-train.md
+++ b/.changeset/blue-heads-train.md
@@ -3,3 +3,9 @@
 ---
 
 Added initial metadata support when creating agent controller threads.
+
+```ts
+const thread = await session.thread.create({
+  metadata: { source: 'migration' },
+});
+```

--- a/.changeset/blue-heads-train.md
+++ b/.changeset/blue-heads-train.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added initial metadata support when creating agent controller threads.

--- a/.changeset/floppy-ants-lie.md
+++ b/.changeset/floppy-ants-lie.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed explicit /new threads being replaced by older threads after restarting Mastra Code.

--- a/docs/src/content/en/docs/harness/agent-controller.mdx
+++ b/docs/src/content/en/docs/harness/agent-controller.mdx
@@ -139,7 +139,7 @@ const session = await controller.createSession({
 })
 ```
 
-Use [`session.thread.create()`](/reference/agent-controller/session#sessionthreadcreate-title-id-) and [`session.thread.switch()`](/reference/agent-controller/session#sessionthreadswitch-threadid-emitevent-) to move one live Session between conversations.
+Use [`session.thread.create()`](/reference/agent-controller/session#sessionthreadcreate-title-id-metadata-) and [`session.thread.switch()`](/reference/agent-controller/session#sessionthreadswitch-threadid-emitevent-) to move one live Session between conversations.
 
 ### List stored messages from the client
 

--- a/docs/src/content/en/reference/agent-controller/session.mdx
+++ b/docs/src/content/en/reference/agent-controller/session.mdx
@@ -353,14 +353,15 @@ To change the resource ID, use [`controller.setResourceId()`](/reference/agent-c
 
 `session.thread` owns the active thread binding and resource-scoped thread operations. Stored threads and messages can survive controller recreation when storage is configured. The live session and its event bus don't.
 
-### `session.thread.create({ title?, id? })`
+### `session.thread.create({ title?, id?, metadata? })`
 
-Create a thread, bind the session to it, and open its event stream.
+Create a thread, bind the session to it, and open its event stream. Pass `metadata` to persist values as part of the initial thread record. Session scope metadata takes precedence over matching keys supplied by the caller.
 
 ```typescript
 const thread = await session.thread.create({
   id: 'thread-7',
   title: 'Investigate login failure',
+  metadata: { source: 'support-queue' },
 })
 ```
 

--- a/mastracode/tui/e2e/terminal-backend.ts
+++ b/mastracode/tui/e2e/terminal-backend.ts
@@ -475,6 +475,12 @@ export async function runTerminalScenario(
       runtime.stopApp = async () => {
         await stopApp?.();
       };
+      runtime.restartApp = async options => {
+        await stopApp?.();
+        releaseAllThreadLocks();
+        const app = await startMastraCodeApp(runConfig, terminal, options);
+        stopApp = app.stop;
+      };
 
       await withTerminalProcessOutput(terminal, () =>
         scenario.run({ terminal: scenarioTerminal, runtime, dbPath: runConfig.context.dbPath }),

--- a/mastracode/tui/e2e/tui/goal-fresh-thread-persistence.ts
+++ b/mastracode/tui/e2e/tui/goal-fresh-thread-persistence.ts
@@ -31,7 +31,7 @@ export const goalFreshThreadPersistenceScenario: McE2eScenario = {
 
     // Create a durable blank thread before starting the goal.
     terminal.submit('/new');
-    await runtime.sleep(500);
+    await runtime.waitForScreenText(/Ready for new conversation/i, terminal);
 
     terminal.submit(`/goal ${OBJECTIVE}`);
     await runtime.waitForScreenText(/Fresh thread goal e2e acknowledged\./i, terminal, 20_000);

--- a/mastracode/tui/e2e/tui/goal-fresh-thread-persistence.ts
+++ b/mastracode/tui/e2e/tui/goal-fresh-thread-persistence.ts
@@ -6,20 +6,8 @@ import type { McE2eScenario } from './types.js';
 const OBJECTIVE = 'Keep the fresh thread goal e2e objective alive.';
 
 /**
- * End-to-end coverage for goals started on a thread that does not exist yet:
- * the TUI creates the thread as part of starting the goal, and the goal must
- * still be on that created thread once the app shuts down.
- *
- * This is NOT a discriminating regression test for the persist-flag ordering
- * defect. That defect needs the deferred `thread_created` handler to land
- * between the create and a later save, and this harness does not reproduce
- * that ordering — the scenario was verified green with
- * `src/tui/commands/goal.ts` reverted to its pre-fix version. The deterministic
- * pin for the ordering lives in the unit tests
- * (`src/tui/commands/__tests__/goal.test.ts`), which assert the flag is armed
- * before `thread.create()` and that the condition holds in both directions.
- * What this scenario buys is the real end-to-end path: `/new`, a real goal
- * start, and the goal record actually landing in SQLite on the new thread.
+ * End-to-end coverage for goals started on an explicit new thread. The goal
+ * must still be on the thread created by `/new` once the app shuts down.
  */
 export const goalFreshThreadPersistenceScenario: McE2eScenario = {
   name: 'goal-fresh-thread-persistence',
@@ -41,7 +29,7 @@ export const goalFreshThreadPersistenceScenario: McE2eScenario = {
     runtime.startLiveOutput(terminal);
     await runtime.waitForScreenText(/Mastra Code|Project:/i, terminal);
 
-    // Queue a brand-new thread so the goal start is the thing that creates it.
+    // Create a durable blank thread before starting the goal.
     terminal.submit('/new');
     await runtime.sleep(500);
 

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -79,6 +79,7 @@ import { modelSearchScenario } from './model-search.js';
 import { modelSelectionApiKeyPromptScenario } from './model-selection-api-key-prompt.js';
 import { modelSelectionCancelEnvScenario } from './model-selection-cancel-env.js';
 import { modelsPackActivationPersistenceScenario } from './models-pack-activation-persistence.js';
+import { newThreadRestartScenario } from './new-thread-restart.js';
 import { notificationInboxCrudFlowScenario } from './notification-inbox-crud-flow.js';
 import { notificationInboxReloadScenario } from './notification-inbox-reload.js';
 import { notificationInboxToolFlowScenario } from './notification-inbox-tool-flow.js';
@@ -355,6 +356,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'task-prompt-context-next-turn': taskPromptContextNextTurnScenario,
   'terminal-resize-reflow': terminalResizeReflowScenario,
   'thread-history': threadHistoryScenario,
+  'new-thread-restart': newThreadRestartScenario,
   'tool-history-reload': toolHistoryReloadScenario,
   'tool-schema-compat': toolSchemaCompatScenario,
   'tool-suspension-same-run-resume': toolSuspensionSameRunResumeScenario,

--- a/mastracode/tui/e2e/tui/new-thread-restart.ts
+++ b/mastracode/tui/e2e/tui/new-thread-restart.ts
@@ -1,0 +1,71 @@
+import { DatabaseSync } from 'node:sqlite';
+import { detectProject } from '@mastra/code-sdk/utils/project';
+import type { Session } from '@mastra/core/agent-controller';
+import type { McE2eScenario } from './types.js';
+
+export const newThreadRestartScenario: McE2eScenario = {
+  name: 'new-thread-restart',
+  description: 'Keep an explicit blank /new thread selected after restarting Mastra Code.',
+  testName: 'resumes an explicit blank /new thread after restart',
+  prepare({ dbPath, projectDir }) {
+    const project = detectProject(projectDir);
+    const timestamp = '2026-06-06T14:30:00.000Z';
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.prepare(
+        'insert into mastra_threads (id, resourceId, title, metadata, createdAt, updatedAt) values (?, ?, ?, ?, ?, ?)',
+      ).run(
+        'thread-mc-e2e-older',
+        project.resourceId,
+        'Older persisted thread',
+        JSON.stringify({ projectPath: project.rootPath }),
+        timestamp,
+        timestamp,
+      );
+    } finally {
+      db.close();
+    }
+  },
+  async run({ terminal, runtime, dbPath }) {
+    runtime.startLiveOutput(terminal);
+    await runtime.waitForScreenText(/Older persisted thread/i, terminal);
+
+    terminal.submit('/new');
+    await runtime.waitForScreenText(/Ready for new conversation/i, terminal);
+    terminal.submit('/thread');
+    await runtime.waitForScreenText(/Title: \(untitled\)/i, terminal);
+
+    const db = new DatabaseSync(dbPath);
+    let newThreadId: string;
+    try {
+      const row = db
+        .prepare("select id, metadata from mastra_threads where title = '' order by updatedAt desc limit 1")
+        .get() as { id?: string; metadata?: Uint8Array } | undefined;
+      if (!row?.id || !row.metadata || !Buffer.from(row.metadata).includes('explicitNewThread')) {
+        throw new Error('Expected /new to persist a thread marked explicitNewThread');
+      }
+      newThreadId = row.id;
+    } finally {
+      db.close();
+    }
+
+    if (!runtime.restartApp) throw new Error('The TUI E2E backend does not support restarting the app');
+    let restartedSession: Session | undefined;
+    await runtime.restartApp({
+      onCreated(result) {
+        restartedSession = result.session;
+      },
+    });
+    await runtime.waitForScreenText(/Project:\s+mastra/i, terminal);
+
+    terminal.submit('/thread');
+    await runtime.waitForScreenText(/Title: \(untitled\)/i, terminal);
+    const restartedThreadId = restartedSession?.thread.getId();
+    if (restartedThreadId !== newThreadId) {
+      throw new Error(`Expected restart to resume ${newThreadId}, received ${String(restartedThreadId)}`);
+    }
+    runtime.printScreen('explicit /new thread after restart', terminal);
+
+    terminal.keyCtrlC();
+  },
+};

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -166,6 +166,7 @@ export type ScenarioName =
   | 'terminal-resize-reflow'
   | 'task-prompt-context-next-turn'
   | 'thread-history'
+  | 'new-thread-restart'
   | 'tool-history-reload'
   | 'plugins-streaming-tool-output'
   | 'tool-schema-compat'
@@ -209,6 +210,8 @@ export type McE2eScenarioRuntime = {
    * need to inspect on-disk database state after shutdown call this first.
    */
   stopApp?: () => Promise<void>;
+  /** Stop and relaunch the default app against the same terminal and on-disk storage. */
+  restartApp?: (options?: McE2eStartMastraCodeAppOptions) => Promise<void>;
 };
 
 export type McE2ePrepareContext = {

--- a/mastracode/tui/src/tui/commands/__tests__/new.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/new.test.ts
@@ -36,6 +36,7 @@ function createMockState() {
       thread: {
         detachFromCurrent: vi.fn(),
         create: vi.fn(async () => ({ id: 'new-thread' })),
+        ensureCurrentSubscription: vi.fn(async () => {}),
       },
       displayState: { get: vi.fn(() => ({ modifiedFiles: new Map([['f', true]]) })) },
     },
@@ -80,6 +81,19 @@ describe('handleNewCommand', () => {
     expect(state.session.thread.create).toHaveBeenCalledWith({ metadata: { explicitNewThread: true } });
     expect(state.pendingNewThread).toBe(false);
     expect(callOrder).toEqual(['detach', 'create', 'ready']);
+  });
+
+  it('restores the previous thread subscription when durable thread creation fails', async () => {
+    const state = createMockState();
+    const ctx = createCtx(state);
+    const error = new Error('create failed');
+    state.session.thread.create.mockRejectedValue(error);
+
+    await expect(handleNewCommand(ctx)).rejects.toBe(error);
+
+    expect(state.session.thread.detachFromCurrent).toHaveBeenCalledOnce();
+    expect(state.session.thread.ensureCurrentSubscription).toHaveBeenCalledOnce();
+    expect(ctx.showInfo).not.toHaveBeenCalled();
   });
 
   it('clears UI state and ephemeral thread state', async () => {

--- a/mastracode/tui/src/tui/commands/__tests__/new.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/new.test.ts
@@ -33,7 +33,10 @@ function createMockState() {
     taskToolInsertIndex: 5,
     session: {
       state: { set: vi.fn(async () => {}) },
-      thread: { detachFromCurrent: vi.fn() },
+      thread: {
+        detachFromCurrent: vi.fn(),
+        create: vi.fn(async () => ({ id: 'new-thread' })),
+      },
       displayState: { get: vi.fn(() => ({ modifiedFiles: new Map([['f', true]]) })) },
     },
     controller: {
@@ -57,7 +60,7 @@ function createCtx(state: ReturnType<typeof createMockState>): SlashCommandConte
 }
 
 describe('handleNewCommand', () => {
-  it('detaches from current thread before setting pendingNewThread', async () => {
+  it('creates and marks a durable thread before reporting the new conversation ready', async () => {
     const state = createMockState();
     const ctx = createCtx(state);
     const callOrder: string[] = [];
@@ -65,22 +68,18 @@ describe('handleNewCommand', () => {
     state.session.thread.detachFromCurrent.mockImplementation(() => {
       callOrder.push('detach');
     });
-    const origPendingNewThread = Object.getOwnPropertyDescriptor(state, 'pendingNewThread');
-    Object.defineProperty(state, 'pendingNewThread', {
-      set(v: boolean) {
-        if (v) callOrder.push('pendingNewThread');
-        Object.defineProperty(state, 'pendingNewThread', { value: v, writable: true, configurable: true });
-      },
-      get() {
-        return origPendingNewThread?.value ?? false;
-      },
-      configurable: true,
+    state.session.thread.create.mockImplementation(async () => {
+      callOrder.push('create');
+      return { id: 'new-thread' };
     });
+    ctx.showInfo = vi.fn(() => callOrder.push('ready'));
 
     await handleNewCommand(ctx);
 
     expect(state.session.thread.detachFromCurrent).toHaveBeenCalledOnce();
-    expect(callOrder).toEqual(['detach', 'pendingNewThread']);
+    expect(state.session.thread.create).toHaveBeenCalledWith({ metadata: { explicitNewThread: true } });
+    expect(state.pendingNewThread).toBe(false);
+    expect(callOrder).toEqual(['detach', 'create', 'ready']);
   });
 
   it('clears UI state and ephemeral thread state', async () => {

--- a/mastracode/tui/src/tui/commands/new.ts
+++ b/mastracode/tui/src/tui/commands/new.ts
@@ -1,4 +1,5 @@
 import { disposeAssistantRenderState } from '../assistant-render-registry.js';
+import { EXPLICIT_NEW_THREAD_SETTING } from '../thread-startup.js';
 import { setCurrentThreadTitle } from '../thread-title.js';
 import type { SlashCommandContext } from './types.js';
 
@@ -11,7 +12,11 @@ export async function handleNewCommand(ctx: SlashCommandContext): Promise<void> 
   // on the same thread from pushing output into this TUI.
   state.session.thread.detachFromCurrent();
 
-  state.pendingNewThread = true;
+  // `/new` is an explicit request for a durable thread, even if the user exits
+  // before sending its first message. Mark it so startup cleanup can distinguish
+  // it from the disposable blank thread created during controller bootstrap.
+  await state.session.thread.create({ metadata: { [EXPLICIT_NEW_THREAD_SETTING]: true } });
+  state.pendingNewThread = false;
   setCurrentThreadTitle(state, undefined);
   disposeAssistantRenderState(state);
   state.chatContainer.clear();

--- a/mastracode/tui/src/tui/commands/new.ts
+++ b/mastracode/tui/src/tui/commands/new.ts
@@ -15,7 +15,16 @@ export async function handleNewCommand(ctx: SlashCommandContext): Promise<void> 
   // `/new` is an explicit request for a durable thread, even if the user exits
   // before sending its first message. Mark it so startup cleanup can distinguish
   // it from the disposable blank thread created during controller bootstrap.
-  await state.session.thread.create({ metadata: { [EXPLICIT_NEW_THREAD_SETTING]: true } });
+  try {
+    await state.session.thread.create({ metadata: { [EXPLICIT_NEW_THREAD_SETTING]: true } });
+  } catch (error) {
+    try {
+      await state.session.thread.ensureCurrentSubscription();
+    } catch {
+      // Preserve the thread creation error if restoring the old subscription fails.
+    }
+    throw error;
+  }
   state.pendingNewThread = false;
   setCurrentThreadTitle(state, undefined);
   disposeAssistantRenderState(state);

--- a/mastracode/tui/src/tui/thread-startup.test.ts
+++ b/mastracode/tui/src/tui/thread-startup.test.ts
@@ -14,7 +14,10 @@ function createThread(id: string, title: string, updatedAt: string) {
 
 describe('resumeThreadOnStartup', () => {
   it('resumes the requested thread instead of the latest thread', async () => {
-    const requested = { ...createThread('thread-requested', 'Requested', '2026-08-28T10:00:00Z'), resourceId: 'resource-2' };
+    const requested = {
+      ...createThread('thread-requested', 'Requested', '2026-08-28T10:00:00Z'),
+      resourceId: 'resource-2',
+    };
     const latest = createThread('thread-latest', 'Latest', '2026-08-28T11:00:00Z');
     const setResourceId = vi.fn().mockResolvedValue(undefined);
     const switchThread = vi.fn().mockResolvedValue(undefined);
@@ -78,6 +81,36 @@ describe('resumeThreadOnStartup', () => {
 
     expect(deleteThread).toHaveBeenCalledWith({ threadId: 'thread-blank' });
     expect(switchThread).toHaveBeenCalledWith({ threadId: 'thread-saved' });
+  });
+
+  it('keeps an explicit blank /new thread active across restart', async () => {
+    const explicitBlank = {
+      ...createThread('thread-new', '', '2026-08-28T11:01:00Z'),
+      metadata: { projectPath: '/tmp/project', explicitNewThread: true },
+    };
+    const saved = createThread('thread-saved', 'Saved thread', '2026-08-28T11:00:00Z');
+    const deleteThread = vi.fn().mockResolvedValue(undefined);
+    const switchThread = vi.fn().mockResolvedValue(undefined);
+    const state = {
+      projectInfo: { rootPath: '/tmp/project' },
+      pendingNewThread: false,
+      session: {
+        identity: { getResourceId: vi.fn(() => 'resource-1') },
+        thread: {
+          getId: vi.fn(() => 'thread-new'),
+          list: vi.fn().mockResolvedValue([saved, explicitBlank]),
+          listMessages: vi.fn().mockResolvedValue([]),
+          delete: deleteThread,
+          switch: switchThread,
+        },
+      },
+    } as any;
+
+    await resumeThreadOnStartup(state);
+
+    expect(deleteThread).not.toHaveBeenCalled();
+    expect(switchThread).not.toHaveBeenCalled();
+    expect(state.pendingNewThread).toBe(false);
   });
 
   it('resumes the latest unlocked thread for the current directory', async () => {

--- a/mastracode/tui/src/tui/thread-startup.ts
+++ b/mastracode/tui/src/tui/thread-startup.ts
@@ -4,6 +4,8 @@ import { askModalQuestion } from './modal-question.js';
 import { showModalOverlay } from './overlay.js';
 import type { TUIState } from './state.js';
 
+export const EXPLICIT_NEW_THREAD_SETTING = 'explicitNewThread';
+
 export async function resumeThreadOnStartup(state: TUIState, requestedThreadId?: string): Promise<void> {
   const currentPath = state.projectInfo.rootPath;
   const allThreads = await state.session.thread.list(requestedThreadId ? { allResources: true } : undefined);
@@ -23,7 +25,9 @@ export async function resumeThreadOnStartup(state: TUIState, requestedThreadId?:
   }
 
   const projectThreads = allThreads.filter(thread => thread.metadata?.projectPath === currentPath);
-  const untitledThreads = projectThreads.filter(thread => !thread.title);
+  const untitledThreads = projectThreads.filter(
+    thread => !thread.title && thread.metadata?.[EXPLICIT_NEW_THREAD_SETTING] !== true,
+  );
   const emptyThreadIds = new Set(
     (
       await Promise.all(

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -575,7 +575,15 @@ export class SessionThread {
   }
 
   /** Create a new thread, bind the session to it, and rebind the agent stream. */
-  async create({ title, id }: { title?: string; id?: string } = {}): Promise<AgentControllerThread> {
+  async create({
+    title,
+    id,
+    metadata: initialMetadata,
+  }: {
+    title?: string;
+    id?: string;
+    metadata?: Record<string, unknown>;
+  } = {}): Promise<AgentControllerThread> {
     const session = this.#owner;
     const store = this.#store;
     this.cleanupSubscription();
@@ -592,7 +600,7 @@ export class SessionThread {
     const currentMode = session.mode.resolve();
     const modelId = currentStateModel || currentMode.defaultModelId;
 
-    const metadata: Record<string, unknown> = {};
+    const metadata: Record<string, unknown> = { ...initialMetadata };
     if (modelId) {
       metadata.currentModelId = modelId;
       metadata[`modeModelId_${session.mode.get()}`] = modelId;
@@ -601,6 +609,7 @@ export class SessionThread {
     // Stamp the session's scope so thread selection can filter listings back to
     // it (e.g. a `projectPath` per git worktree).
     Object.assign(metadata, session.getThreadScope());
+    if (Object.keys(metadata).length > 0) thread.metadata = metadata;
 
     // Acquire lock on new thread before releasing old one.
     // If acquire fails, attempt to re-acquire the old lock before rethrowing.
@@ -636,7 +645,7 @@ export class SessionThread {
             title: thread.title!,
             createdAt: thread.createdAt,
             updatedAt: thread.updatedAt,
-            metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+            metadata: thread.metadata,
           },
         });
       } catch (err) {

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -600,7 +600,9 @@ export class SessionThread {
     const currentMode = session.mode.resolve();
     const modelId = currentStateModel || currentMode.defaultModelId;
 
-    const metadata: Record<string, unknown> = { ...initialMetadata };
+    const metadata: Record<string, unknown> = Object.fromEntries(
+      Object.entries(initialMetadata ?? {}).filter(([key]) => !isReservedThreadMetadataKey(key)),
+    );
     if (modelId) {
       metadata.currentModelId = modelId;
       metadata[`modeModelId_${session.mode.get()}`] = modelId;

--- a/packages/core/src/agent-controller/thread-locking.test.ts
+++ b/packages/core/src/agent-controller/thread-locking.test.ts
@@ -330,6 +330,27 @@ describe('AgentController thread locking', () => {
       expect(metadata.projectPath).toBe('/repo/wt');
       expect(metadata.branch).toBe('feat/x');
     });
+
+    it('persists caller metadata atomically while keeping session scope authoritative', async () => {
+      const store = new InMemoryStore();
+      const controller = freshController(store);
+      await controller.init();
+      const session = await controller.createSession({
+        id: 'metadata',
+        ownerId: 'test-owner',
+        resourceId: 'repo',
+        tags: { projectPath: '/repo/current' },
+      });
+
+      const created = await session.thread.create({
+        metadata: { explicitNewThread: true, projectPath: '/repo/wrong' },
+      });
+      const persisted = await session.thread.getById({ threadId: created.id });
+
+      expect(created.metadata?.explicitNewThread).toBe(true);
+      expect(persisted?.metadata?.explicitNewThread).toBe(true);
+      expect(persisted?.metadata?.projectPath).toBe('/repo/current');
+    });
   });
 
   describe('deleteThread', () => {

--- a/packages/core/src/agent-controller/thread-locking.test.ts
+++ b/packages/core/src/agent-controller/thread-locking.test.ts
@@ -343,13 +343,22 @@ describe('AgentController thread locking', () => {
       });
 
       const created = await session.thread.create({
-        metadata: { explicitNewThread: true, projectPath: '/repo/wrong' },
+        metadata: {
+          explicitNewThread: true,
+          projectPath: '/repo/wrong',
+          currentModeId: 'caller-mode',
+          tokenUsage: { total: 10_000 },
+          modeModelId_caller: 'caller-model',
+        },
       });
       const persisted = await session.thread.getById({ threadId: created.id });
 
       expect(created.metadata?.explicitNewThread).toBe(true);
       expect(persisted?.metadata?.explicitNewThread).toBe(true);
       expect(persisted?.metadata?.projectPath).toBe('/repo/current');
+      expect(persisted?.metadata?.currentModeId).toBeUndefined();
+      expect(persisted?.metadata?.tokenUsage).toBeUndefined();
+      expect(persisted?.metadata?.modeModelId_caller).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Fixes #21836.

`/new` now creates its thread immediately instead of waiting for the first prompt. The thread is marked atomically so startup cleanup can distinguish an intentionally blank conversation from a disposable bootstrap thread and resume the same thread ID after relaunch.

Adds initial metadata support to `session.thread.create()`, documents the API, and covers the behavior with unit tests and an in-process SQLite restart test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

`/new` now creates a real saved thread instead of a temporary blank screen. When Mastra Code restarts, it resumes that same thread instead of restoring an older one.

## Changes

- Create `/new` threads immediately with `explicitNewThread` metadata.
- Preserve intentionally blank threads during startup cleanup.
- Add initial metadata support to `session.thread.create()`.
- Document the new `metadata` parameter and precedence rules.
- Add unit tests for metadata persistence and thread startup behavior.
- Add an in-process SQLite restart test and a TUI end-to-end scenario for `/new` thread persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->