### PR TITLE
fix(core): preserve unknown AgentController token usage

### DIFF
--- a/.changeset/acp-unknown-usage.md
+++ b/.changeset/acp-unknown-usage.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Stopped ACP and headless responses from reporting incomplete token usage as a complete measurement. ACP omits its optional usage report when required counts are unknown, and `runMC()` preserves unknown counts across multi-step runs.

--- a/.changeset/four-tigers-help.md
+++ b/.changeset/four-tigers-help.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Updated the Factory Cost command to show unreported token counts as unknown while preserving measured zero.

--- a/.changeset/good-bars-repeat.md
+++ b/.changeset/good-bars-repeat.md
@@ -1,0 +1,21 @@
+---
+'@mastra/core': minor
+'@mastra/server': minor
+'@mastra/client-js': minor
+---
+
+Preserved unknown AgentController token usage instead of reporting missing provider counts as zero.
+
+The primary `TokenUsage` fields are now optional across Core, the server response schema, and the generated JavaScript client contract. Aggregates remain unknown when any contributing step omits that count, while an explicitly measured zero remains `0`.
+
+**Before**
+
+```ts
+formatTokens(usage.totalTokens);
+```
+
+**After**
+
+```ts
+const total = usage.totalTokens === undefined ? 'unknown' : formatTokens(usage.totalTokens);
+```

--- a/.changeset/tui-unknown-usage.md
+++ b/.changeset/tui-unknown-usage.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Updated `/cost` and token-rate reporting to show unreported token counts as unknown while keeping measured zero distinct.

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -21003,9 +21003,9 @@ export type GetAgentControllerControllerIdSessionsResourceId_Response = {
     | undefined;
   tokenUsage?:
     | {
-        promptTokens: number;
-        completionTokens: number;
-        totalTokens: number;
+        promptTokens?: number | undefined;
+        completionTokens?: number | undefined;
+        totalTokens?: number | undefined;
         reasoningTokens?: number | undefined;
         cachedInputTokens?: number | undefined;
         cacheCreationInputTokens?: number | undefined;

--- a/mastracode/factory-ui/src/ui/domains/chat/context/__tests__/ChatRuntime.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/__tests__/ChatRuntime.msw.test.tsx
@@ -129,6 +129,28 @@ describe('chat runtime consumers', () => {
     expect(await screen.findByText('Observational memory phase: buffering')).toBeInTheDocument();
   });
 
+  it('keeps unknown token counts distinct from a measured zero', async () => {
+    const session = renderRuntime();
+    const user = userEvent.setup();
+    await screen.findByRole('button', { name: /Memory budgets/ });
+
+    await session.emit({
+      type: 'display_state_changed',
+      displayState: { tokenUsage: {} },
+    });
+    await user.click(screen.getByRole('button', { name: 'Cost' }));
+    expect(
+      await screen.findByText('Tokens — prompt: unknown, completion: unknown, total: unknown'),
+    ).toBeInTheDocument();
+
+    await session.emit({
+      type: 'display_state_changed',
+      displayState: { tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 } },
+    });
+    await user.click(screen.getByRole('button', { name: 'Cost' }));
+    expect(await screen.findByText('Tokens — prompt: 0, completion: 0, total: 0')).toBeInTheDocument();
+  });
+
   it.each([
     { scenario: 'no snapshot', resetState: undefined, restoreSnapshot: false },
     { scenario: 'matching thread', resetState: { ...snapshot, threadId: 'next-thread' }, restoreSnapshot: true },

--- a/mastracode/factory-ui/src/ui/domains/chat/context/useChatCommandRegistry.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/useChatCommandRegistry.ts
@@ -47,6 +47,10 @@ function thinkingSourceLabel(source: ThinkingLevelSource, modeId: string | null)
   return source === 'mode-default' && modeId ? `${modeId} mode default` : 'global default';
 }
 
+function formatUsageCount(value: number | undefined): string {
+  return value === undefined ? 'unknown' : value.toLocaleString();
+}
+
 export function useChatCommandRegistry(prefillComposer: (draft: string) => void) {
   const { factoryId } = useParams<{ factoryId: string }>();
   const factoryQuery = useFactoryQuery(factoryId);
@@ -182,9 +186,9 @@ export function useChatCommandRegistry(prefillComposer: (draft: string) => void)
       requiresSession: false,
       execute: async () => {
         pushNotice(
-          !usage?.totalTokens
+          usage === undefined
             ? 'No token usage recorded yet.'
-            : `Tokens — prompt: ${usage.promptTokens ?? 0}, completion: ${usage.completionTokens ?? 0}, total: ${usage.totalTokens}`,
+            : `Tokens — prompt: ${formatUsageCount(usage.promptTokens)}, completion: ${formatUsageCount(usage.completionTokens)}, total: ${formatUsageCount(usage.totalTokens)}`,
         );
       },
     },

--- a/mastracode/factory-ui/src/ui/domains/chat/services/runtime.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/runtime.ts
@@ -57,9 +57,10 @@ export function runtimeReducer(state: ChatRuntimeState, action: RuntimeAction): 
       return { ...state, _decodeStartedAt: Date.now() };
     case 'usage_update': {
       const usage = event.usage;
-      const stepTokens = usage.completionTokens + (usage.reasoningTokens ?? 0);
+      const stepTokens =
+        usage.completionTokens === undefined ? undefined : usage.completionTokens + (usage.reasoningTokens ?? 0);
       let tokensPerSec = state.tokensPerSec;
-      if (state._decodeStartedAt > 0 && stepTokens > 0) {
+      if (state._decodeStartedAt > 0 && stepTokens !== undefined && stepTokens > 0) {
         const decodeSeconds = Math.max((Date.now() - state._decodeStartedAt) / 1000, 0.001);
         const instantaneous = stepTokens / decodeSeconds;
         tokensPerSec =

--- a/mastracode/sdk/src/acp/agent.test.ts
+++ b/mastracode/sdk/src/acp/agent.test.ts
@@ -96,6 +96,47 @@ describe('ACP Agent - StopReason Mapping', () => {
   });
 });
 
+describe('ACP Agent - Usage reporting', () => {
+  it.each([
+    {
+      name: 'complete usage',
+      usage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+      expected: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+    },
+    {
+      name: 'unknown usage',
+      usage: { promptTokens: undefined, completionTokens: undefined, totalTokens: undefined },
+      expected: undefined,
+    },
+  ])('reports $name honestly', async ({ usage, expected }) => {
+    let eventListener: ((event: AgentControllerEvent) => void) | undefined;
+    const session = {
+      subscribe: vi.fn(listener => {
+        eventListener = listener;
+        return vi.fn();
+      }),
+      thread: {
+        create: vi.fn().mockResolvedValue({ id: 'thread-1' }),
+        switch: vi.fn().mockResolvedValue(undefined),
+      },
+      mode: { get: vi.fn(() => 'default') },
+      model: { get: vi.fn(() => 'test-model') },
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Session;
+    const controller = { listAvailableModels: vi.fn().mockResolvedValue([]) } as unknown as AgentController;
+    const connection = { sessionUpdate: vi.fn().mockResolvedValue(undefined) } as unknown as AgentSideConnection;
+    const agent = new MastraCodeAcpAgent(connection, controller, session, [] satisfies AgentControllerMode[]);
+    const { sessionId } = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+
+    const prompt = agent.prompt({ sessionId, prompt: [{ type: 'text', text: 'hello' }] });
+    await vi.waitFor(() => expect(session.sendMessage).toHaveBeenCalledTimes(1));
+    eventListener?.({ type: 'usage_update', usage });
+    eventListener?.({ type: 'agent_end', reason: 'complete' });
+
+    await expect(prompt).resolves.toEqual({ stopReason: 'end_turn', ...(expected ? { usage: expected } : {}) });
+  });
+});
+
 describe('ACP Agent - Prompt concurrency', () => {
   it('serializes thread switching for concurrent prompts', async () => {
     let eventListener: ((event: AgentControllerEvent) => void) | undefined;

--- a/mastracode/sdk/src/acp/agent.ts
+++ b/mastracode/sdk/src/acp/agent.ts
@@ -11,9 +11,20 @@ import type {
   ContentBlock,
 } from '@agentclientprotocol/sdk';
 import { PROTOCOL_VERSION } from '@agentclientprotocol/sdk';
-import type { AgentController, AgentControllerMode, Session } from '@mastra/core/agent-controller';
+import type { AgentController, AgentControllerMode, Session, TokenUsage } from '@mastra/core/agent-controller';
 import { handleAgentControllerEvent } from './event-mapper.js';
 import type { PromptState } from './event-mapper.js';
+
+type CompleteTokenUsage = TokenUsage & Required<Pick<TokenUsage, 'promptTokens' | 'completionTokens' | 'totalTokens'>>;
+
+function hasCompleteTokenUsage(usage: TokenUsage | undefined): usage is CompleteTokenUsage {
+  return (
+    usage !== undefined &&
+    typeof usage.promptTokens === 'number' &&
+    typeof usage.completionTokens === 'number' &&
+    typeof usage.totalTokens === 'number'
+  );
+}
 
 /**
  * ACP Agent implementation that wraps a mastracode Controller.
@@ -144,21 +155,16 @@ export class MastraCodeAcpAgent implements Agent {
         reason: 'complete' | 'aborted' | 'error' | 'suspended';
         usage: PromptState['usage'];
       }>(resolve => {
-        const usage: PromptState['usage'] = {
-          promptTokens: 0,
-          completionTokens: 0,
-          totalTokens: 0,
-        };
-
-        this.currentPromptState = {
+        const promptState: PromptState = {
           sessionId,
           lastTextLength: 0,
-          usage,
+          usage: undefined,
           resolve: reason => {
-            resolve({ reason, usage });
+            resolve({ reason, usage: promptState.usage });
             this.currentPromptState = null;
           },
         };
+        this.currentPromptState = promptState;
       });
 
       // Send the message to the session
@@ -174,14 +180,18 @@ export class MastraCodeAcpAgent implements Agent {
 
       return {
         stopReason: mapStopReason(reason),
-        usage: {
-          inputTokens: usage.promptTokens,
-          outputTokens: usage.completionTokens,
-          totalTokens: usage.totalTokens,
-          thoughtTokens: usage.reasoningTokens,
-          cachedReadTokens: usage.cachedInputTokens,
-          cachedWriteTokens: usage.cacheCreationInputTokens,
-        },
+        ...(hasCompleteTokenUsage(usage)
+          ? {
+              usage: {
+                inputTokens: usage.promptTokens,
+                outputTokens: usage.completionTokens,
+                totalTokens: usage.totalTokens,
+                thoughtTokens: usage.reasoningTokens,
+                cachedReadTokens: usage.cachedInputTokens,
+                cachedWriteTokens: usage.cacheCreationInputTokens,
+              },
+            }
+          : {}),
       };
     } finally {
       resolveMutex!();

--- a/mastracode/sdk/src/acp/event-mapper.test.ts
+++ b/mastracode/sdk/src/acp/event-mapper.test.ts
@@ -579,6 +579,46 @@ describe('ACP Event Mapper', () => {
         reasoningTokens: 10,
       });
     });
+
+    it.each([
+      {
+        name: 'known then unknown',
+        usages: [
+          { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
+          { promptTokens: undefined, completionTokens: undefined, totalTokens: undefined },
+        ],
+      },
+      {
+        name: 'unknown then known',
+        usages: [
+          { promptTokens: undefined, completionTokens: undefined, totalTokens: undefined },
+          { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
+        ],
+      },
+    ])('keeps $name primary counts unknown', ({ usages }) => {
+      const state = createPromptState('session-1');
+      for (const usage of usages) {
+        handleAgentControllerEvent({ type: 'usage_update', usage }, state, mockConnection, mockSession);
+      }
+
+      expect(state.usage?.promptTokens).toBeUndefined();
+      expect(state.usage?.completionTokens).toBeUndefined();
+      expect(state.usage?.totalTokens).toBeUndefined();
+    });
+
+    it('adopts the first usage update when the prompt has no prior measurements', () => {
+      const state = createPromptState('session-1');
+      state.usage = undefined;
+
+      handleAgentControllerEvent(
+        { type: 'usage_update', usage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 } },
+        state,
+        mockConnection,
+        mockSession,
+      );
+
+      expect(state.usage).toEqual({ promptTokens: 10, completionTokens: 20, totalTokens: 30 });
+    });
   });
 
   describe('agent_end - stopReason mapping', () => {

--- a/mastracode/sdk/src/acp/event-mapper.ts
+++ b/mastracode/sdk/src/acp/event-mapper.ts
@@ -63,7 +63,7 @@ function mapToolKind(
 export interface PromptState {
   sessionId: string;
   lastTextLength: number;
-  usage: TokenUsage;
+  usage: TokenUsage | undefined;
   resolve: (reason: 'complete' | 'aborted' | 'error' | 'suspended') => void;
 }
 
@@ -148,7 +148,11 @@ export function handleAgentControllerEvent(
       break;
 
     case 'usage_update':
-      accumulateUsage(state.usage, event.usage);
+      if (state.usage) {
+        accumulateUsage(state.usage, event.usage);
+      } else {
+        state.usage = { ...event.usage };
+      }
       break;
 
     case 'agent_end':
@@ -254,12 +258,18 @@ async function handleToolSuspended(
 }
 
 function accumulateUsage(target: TokenUsage, usage: TokenUsage): void {
-  target.promptTokens += usage.promptTokens;
-  target.completionTokens += usage.completionTokens;
-  target.totalTokens += usage.totalTokens;
-  if (usage.reasoningTokens) target.reasoningTokens = (target.reasoningTokens ?? 0) + usage.reasoningTokens;
-  if (usage.cachedInputTokens) target.cachedInputTokens = (target.cachedInputTokens ?? 0) + usage.cachedInputTokens;
-  if (usage.cacheCreationInputTokens) {
+  for (const field of ['promptTokens', 'completionTokens', 'totalTokens'] as const) {
+    const current = target[field];
+    const next = usage[field];
+    target[field] = current !== undefined && next !== undefined ? current + next : undefined;
+  }
+  if (usage.reasoningTokens !== undefined) {
+    target.reasoningTokens = (target.reasoningTokens ?? 0) + usage.reasoningTokens;
+  }
+  if (usage.cachedInputTokens !== undefined) {
+    target.cachedInputTokens = (target.cachedInputTokens ?? 0) + usage.cachedInputTokens;
+  }
+  if (usage.cacheCreationInputTokens !== undefined) {
     target.cacheCreationInputTokens = (target.cacheCreationInputTokens ?? 0) + usage.cacheCreationInputTokens;
   }
 }

--- a/mastracode/sdk/src/headless/run-mc.test.ts
+++ b/mastracode/sdk/src/headless/run-mc.test.ts
@@ -13,7 +13,11 @@ import type { ResolutionPolicy } from './types.js';
 
 vi.setConfig({ testTimeout: 30_000 });
 
-function textStream(text: string, finishReason: 'stop' | 'tool-calls' = 'stop') {
+type TestUsage = { inputTokens?: unknown; outputTokens?: unknown; totalTokens?: unknown };
+
+const completeUsage = { inputTokens: 10, outputTokens: 20, totalTokens: 30 };
+
+function textStream(text: string, finishReason: 'stop' | 'tool-calls' = 'stop', usage: TestUsage = completeUsage) {
   return new ReadableStream({
     start(controller) {
       controller.enqueue({ type: 'stream-start', warnings: [] });
@@ -24,14 +28,14 @@ function textStream(text: string, finishReason: 'stop' | 'tool-calls' = 'stop') 
       controller.enqueue({
         type: 'finish',
         finishReason,
-        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        usage,
       });
       controller.close();
     },
   });
 }
 
-function toolCallStream() {
+function toolCallStream(usage: TestUsage = completeUsage) {
   return new ReadableStream({
     start(controller) {
       controller.enqueue({ type: 'stream-start', warnings: [] });
@@ -46,7 +50,7 @@ function toolCallStream() {
       controller.enqueue({
         type: 'finish',
         finishReason: 'tool-calls',
-        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        usage,
       });
       controller.close();
     },
@@ -123,6 +127,48 @@ describe('runMC', () => {
     expect(result.text).toBe('The answer is 4.');
     expect(result.usage).toEqual({ inputTokens: 10, outputTokens: 20, totalTokens: 30 });
     expect(result.threadId).toBeTruthy();
+  });
+
+  it.each([
+    {
+      name: 'two complete steps',
+      usages: [completeUsage, completeUsage],
+      expected: { inputTokens: 20, outputTokens: 40, totalTokens: 60 },
+    },
+    {
+      name: 'known then unknown',
+      usages: [completeUsage, { inputTokens: {}, outputTokens: {} }],
+      expected: { inputTokens: undefined, outputTokens: undefined, totalTokens: undefined },
+    },
+    {
+      name: 'unknown then known',
+      usages: [{ inputTokens: {}, outputTokens: {} }, completeUsage],
+      expected: { inputTokens: undefined, outputTokens: undefined, totalTokens: undefined },
+    },
+    {
+      name: 'independently incomplete fields',
+      usages: [{ inputTokens: 5, outputTokens: {} }, completeUsage],
+      expected: { inputTokens: 15, outputTokens: undefined, totalTokens: undefined },
+    },
+    {
+      name: 'measured zero then known',
+      usages: [{ inputTokens: 0, outputTokens: 0, totalTokens: 0 }, completeUsage],
+      expected: completeUsage,
+    },
+  ])('accumulates $name without inventing counts', async ({ usages, expected }) => {
+    let call = 0;
+    const { controller, session } = await makeHarness({
+      withReadFileTool: true,
+      doStream: async () => {
+        const usage = usages[call++]!;
+        return { stream: call === 1 ? toolCallStream(usage) : textStream('Done', 'stop', usage) };
+      },
+    });
+
+    const result = await runMC({ controller, session, prompt: 'Read then answer' }).result;
+
+    expect(result.status).toBe('completed');
+    expect(result.usage).toEqual(expected);
   });
 
   it('yields controller events while iterating, then resolves', async () => {

--- a/mastracode/sdk/src/headless/run-mc.ts
+++ b/mastracode/sdk/src/headless/run-mc.ts
@@ -47,6 +47,21 @@ interface MutableResult {
   threadId?: string;
 }
 
+function accumulateUsage(
+  current: RunMCResult['usage'],
+  next: NonNullable<RunMCResult['usage']>,
+): NonNullable<RunMCResult['usage']> {
+  if (!current) return { ...next };
+
+  const accumulated = { ...current };
+  for (const field of ['inputTokens', 'outputTokens', 'totalTokens'] as const) {
+    const currentValue = current[field];
+    const nextValue = next[field];
+    accumulated[field] = currentValue !== undefined && nextValue !== undefined ? currentValue + nextValue : undefined;
+  }
+  return accumulated;
+}
+
 function aggregate(event: AgentControllerEvent, acc: MutableResult): void {
   switch (event.type) {
     case 'message_end':
@@ -68,11 +83,11 @@ function aggregate(event: AgentControllerEvent, acc: MutableResult): void {
       break;
     }
     case 'usage_update':
-      acc.usage = {
+      acc.usage = accumulateUsage(acc.usage, {
         inputTokens: event.usage.promptTokens,
         outputTokens: event.usage.completionTokens,
         totalTokens: event.usage.totalTokens,
-      };
+      });
       break;
     case 'error':
       acc.error = {

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -171,6 +171,7 @@ import { toolHistoryReloadScenario } from './tool-history-reload.js';
 import { toolSchemaCompatScenario } from './tool-schema-compat.js';
 import { toolSuspensionSameRunResumeScenario } from './tool-suspension-same-run-resume.js';
 import type { McE2eScenario, ScenarioName } from './types.js';
+import { unknownTokenUsageScenario } from './unknown-token-usage.js';
 import { updateCommandPromptScenario } from './update-command-prompt.js';
 import { updateStartupPromptScenario } from './update-startup-prompt.js';
 import { visibleCommandsScenario } from './visible-commands.js';
@@ -358,6 +359,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'tool-history-reload': toolHistoryReloadScenario,
   'tool-schema-compat': toolSchemaCompatScenario,
   'tool-suspension-same-run-resume': toolSuspensionSameRunResumeScenario,
+  'unknown-token-usage': unknownTokenUsageScenario,
   'update-command-prompt': updateCommandPromptScenario,
   'update-startup-prompt': updateStartupPromptScenario,
   'web-search-rendering': webSearchRenderingScenario,

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -170,6 +170,7 @@ export type ScenarioName =
   | 'plugins-streaming-tool-output'
   | 'tool-schema-compat'
   | 'tool-suspension-same-run-resume'
+  | 'unknown-token-usage'
   | 'update-command-prompt'
   | 'update-startup-prompt'
   | 'web-search-rendering'

--- a/mastracode/tui/e2e/tui/unknown-token-usage.ts
+++ b/mastracode/tui/e2e/tui/unknown-token-usage.ts
@@ -1,0 +1,29 @@
+import { expect } from './expect.js';
+import type { McE2eScenario } from './types.js';
+
+export const unknownTokenUsageScenario: McE2eScenario = {
+  name: 'unknown-token-usage',
+  description: 'Show unknown token counts in the real TUI without confusing them with measured zero.',
+  testName: 'renders unknown token usage honestly',
+  env: () => ({ MASTRACODE_MODEL_ID: 'openai/gpt-5.6-codex' }),
+  inProcessApp: ({ startMastraCodeApp }) =>
+    startMastraCodeApp({
+      onCreated: ({ session }) => {
+        session.setTokenUsage({});
+        session.emit({ type: 'usage_update', usage: {} });
+      },
+    }),
+  async run({ terminal, runtime }) {
+    await (
+      expect(terminal.getByText(/Mastra Code|Build|Plan|Fast|Type|Press|>/gi, { full: true, strict: false })) as any
+    ).toBeVisible();
+
+    terminal.submit('/cost');
+    await runtime.waitForScreenText(/Input:\s+unknown tokens/i, terminal);
+    await runtime.waitForScreenText(/Output:\s+unknown tokens/i, terminal);
+    await runtime.waitForScreenText(/Total:\s+unknown tokens/i, terminal);
+    runtime.printScreen('unknown token usage', terminal);
+
+    terminal.keyCtrlC();
+  },
+};

--- a/mastracode/tui/src/tui/__tests__/tokens-per-sec.test.ts
+++ b/mastracode/tui/src/tui/__tests__/tokens-per-sec.test.ts
@@ -186,6 +186,25 @@ describe('tokens/sec decode-window calculation', () => {
     expect(state.latestRequestPromptTokens).toBe(90_000);
   });
 
+  it('does not invent request or rate measurements for unknown usage', async () => {
+    const state = createMinimalState({ decodeStartedAt: 1000, tokensPerSec: 25, latestRequestPromptTokens: 50 });
+    const ectx = createEctx();
+
+    vi.setSystemTime(2000);
+    await dispatchEvent(
+      {
+        type: 'usage_update',
+        usage: { promptTokens: undefined, completionTokens: undefined, totalTokens: undefined },
+      } as any,
+      ectx,
+      state,
+    );
+
+    expect(state.latestRequestPromptTokens).toBeUndefined();
+    expect(state.tokensPerSec).toBe(25);
+    expect(state.decodeStartedAt).toBe(0);
+  });
+
   it('records stream activity on assistant message updates', async () => {
     const state = createMinimalState({ agentRunStartedAt: 1000, agentRunLastStreamPartAt: 1000 });
     const ectx = createEctx();

--- a/mastracode/tui/src/tui/commands/cost.test.ts
+++ b/mastracode/tui/src/tui/commands/cost.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { handleCostCommand } from './cost.js';
+import type { SlashCommandContext } from './types.js';
+
+function createContext(tokenUsage: { promptTokens?: number; completionTokens?: number; totalTokens?: number }): {
+  ctx: SlashCommandContext;
+  showInfo: ReturnType<typeof vi.fn>;
+} {
+  const showInfo = vi.fn();
+  const ctx = {
+    state: {
+      session: {
+        displayState: {
+          get: () => ({
+            tokenUsage,
+            omProgress: { observationTokens: 0 },
+          }),
+        },
+      },
+    },
+    showInfo,
+  } as unknown as SlashCommandContext;
+  return { ctx, showInfo };
+}
+
+describe('handleCostCommand', () => {
+  it('renders unknown primary counts instead of zero', () => {
+    const { ctx, showInfo } = createContext({});
+
+    handleCostCommand(ctx);
+
+    expect(showInfo).toHaveBeenCalledWith(expect.stringContaining('Input:      unknown tokens'));
+    expect(showInfo).toHaveBeenCalledWith(expect.stringContaining('Output:     unknown tokens'));
+    expect(showInfo).toHaveBeenCalledWith(expect.stringContaining('Total:      unknown tokens'));
+  });
+
+  it('keeps a measured zero distinct from unknown', () => {
+    const { ctx, showInfo } = createContext({ promptTokens: 0, completionTokens: 0, totalTokens: 0 });
+
+    handleCostCommand(ctx);
+
+    expect(showInfo).toHaveBeenCalledWith(expect.stringContaining('Input:      0 tokens'));
+    expect(showInfo).toHaveBeenCalledWith(expect.stringContaining('Output:     0 tokens'));
+    expect(showInfo).toHaveBeenCalledWith(expect.stringContaining('Total:      0 tokens'));
+  });
+});

--- a/mastracode/tui/src/tui/commands/cost.ts
+++ b/mastracode/tui/src/tui/commands/cost.ts
@@ -1,7 +1,7 @@
 import type { SlashCommandContext } from './types.js';
 
 export function handleCostCommand(ctx: SlashCommandContext): void {
-  const formatNumber = (n: number) => n.toLocaleString();
+  const formatNumber = (n: number | undefined) => (n === undefined ? 'unknown' : n.toLocaleString());
 
   // Read from AgentController display state (canonical source)
   const ds = ctx.state.session.displayState.get();

--- a/mastracode/tui/src/tui/event-dispatch.ts
+++ b/mastracode/tui/src/tui/event-dispatch.ts
@@ -276,15 +276,18 @@ export async function dispatchEvent(
     case 'usage_update': {
       // Token accumulation handled by AgentController display state. Keep the
       // latest step separate for context auditing; cumulative usage is billing data.
-      state.latestRequestPromptTokens = event.usage.promptTokens ?? 0;
+      state.latestRequestPromptTokens = event.usage.promptTokens;
       // usage_update fires at step-finish and carries the completion (and any
       // reasoning) tokens generated during this step. Measure tokens/sec over the
       // decode window only — from this step's first content delta
       // (state.decodeStartedAt) to now — which excludes TTFT and inter-step
       // tool/scheduling time. Smooth with an exponential moving average (α=0.3).
       const now = Date.now();
-      const stepTokens = (event.usage.completionTokens ?? 0) + (event.usage.reasoningTokens ?? 0);
-      if (state.decodeStartedAt > 0 && stepTokens > 0) {
+      const stepTokens =
+        event.usage.completionTokens === undefined
+          ? undefined
+          : event.usage.completionTokens + (event.usage.reasoningTokens ?? 0);
+      if (state.decodeStartedAt > 0 && stepTokens !== undefined && stepTokens > 0) {
         const decodeSec = (now - state.decodeStartedAt) / 1000;
         if (decodeSec > 0) {
           const instantaneous = stepTokens / decodeSec;

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -698,6 +698,7 @@ export class AgentController<TState = {}> {
         }
         await this.config.threadLock?.acquire(existingThread.id);
         session.thread.set({ threadId: existingThread.id });
+        session.setTokenUsage({});
         await session.thread.loadMetadata();
         await session.thread.ensureCurrentSubscription();
       } else {
@@ -721,6 +722,7 @@ export class AgentController<TState = {}> {
         const mostRecent = [...candidates].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0]!;
         await this.config.threadLock?.acquire(mostRecent.id);
         session.thread.set({ threadId: mostRecent.id });
+        session.setTokenUsage({});
         await session.thread.loadMetadata();
         await session.thread.ensureCurrentSubscription();
       }
@@ -2336,6 +2338,7 @@ export class AgentController<TState = {}> {
   private async persistTokenUsage(session: Session<TState>): Promise<void> {
     const threadId = session.thread.getId();
     if (!threadId || !this.#resolveStorage()) return;
+    const tokenUsage = session.getTokenUsage();
 
     try {
       const memoryStorage = await this.getMemoryStorage();
@@ -2344,7 +2347,7 @@ export class AgentController<TState = {}> {
         await memoryStorage.saveThread({
           thread: {
             ...thread,
-            metadata: { ...thread.metadata, tokenUsage: session.getTokenUsage() },
+            metadata: { ...thread.metadata, tokenUsage },
             updatedAt: new Date(),
           },
         });

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -781,17 +781,22 @@ export class SessionRunEngine {
           );
         const usage = getRecord(getPayload(chunk).output)?.usage;
         const usageRecord = getRecord(usage);
+        const promptTokens = usageRecord
+          ? (getUsageNumber(usageRecord, 'promptTokens') ?? getUsageNumber(usageRecord, 'inputTokens'))
+          : undefined;
+        const completionTokens = usageRecord
+          ? (getUsageNumber(usageRecord, 'completionTokens') ?? getUsageNumber(usageRecord, 'outputTokens'))
+          : undefined;
+        const reportedTotalTokens = usageRecord ? getUsageNumber(usageRecord, 'totalTokens') : undefined;
+        const totalTokens =
+          reportedTotalTokens ??
+          (promptTokens !== undefined && completionTokens !== undefined ? promptTokens + completionTokens : undefined);
+        const stepUsage: TokenUsage = {
+          promptTokens,
+          completionTokens,
+          totalTokens,
+        };
         if (usageRecord) {
-          const promptTokens =
-            getUsageNumber(usageRecord, 'promptTokens') ?? getUsageNumber(usageRecord, 'inputTokens') ?? 0;
-          const completionTokens =
-            getUsageNumber(usageRecord, 'completionTokens') ?? getUsageNumber(usageRecord, 'outputTokens') ?? 0;
-          const totalTokens = getUsageNumber(usageRecord, 'totalTokens') ?? promptTokens + completionTokens;
-          const stepUsage: TokenUsage = {
-            promptTokens,
-            completionTokens,
-            totalTokens,
-          };
           addOptionalUsageField(stepUsage, 'reasoningTokens', getUsageNumber(usageRecord, 'reasoningTokens'));
           addOptionalUsageField(stepUsage, 'cachedInputTokens', getUsageNumber(usageRecord, 'cachedInputTokens'));
           addOptionalUsageField(
@@ -812,12 +817,12 @@ export class SessionRunEngine {
           if (usageRecord.raw !== undefined) {
             stepUsage.raw = usageRecord.raw;
           }
-
-          this.#session.addUsage(stepUsage);
-
-          this.#machinery.persistTokenUsage().catch(() => {});
-          this.#session.emit({ type: 'usage_update', usage: stepUsage });
         }
+
+        this.#session.addUsage(stepUsage);
+
+        this.#machinery.persistTokenUsage().catch(() => {});
+        this.#session.emit({ type: 'usage_update', usage: stepUsage });
         break;
       }
 

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -80,6 +80,14 @@ export type SessionSendNotificationSignalOptions = {
   requestContext?: RequestContext;
 };
 
+/** Primary usage fields remain unknown when any contributing step omits them. */
+type PrimaryUsageField = 'promptTokens' | 'completionTokens' | 'totalTokens';
+
+function addPrimaryUsageField(usage: TokenUsage, key: PrimaryUsageField, value: number | undefined): void {
+  const current = usage[key];
+  usage[key] = current !== undefined && value !== undefined ? current + value : undefined;
+}
+
 /** Usage fields that are summed across steps when present on a step's usage. */
 type OptionalUsageField =
   | 'reasoningTokens'
@@ -799,6 +807,9 @@ export class SessionThread {
     }
 
     this.set({ threadId });
+    if (previousThreadId !== threadId) {
+      session.setTokenUsage({});
+    }
 
     await this.loadMetadata();
 
@@ -838,8 +849,8 @@ export class SessionThread {
   /**
    * Hydrate the session's per-thread settings from the active thread's metadata:
    * token usage, the persisted mode (restored first), the per-mode model, and
-   * observer/reflector model ids + thresholds. Best-effort: on any failure the
-   * token tally is reset and the rest is left at defaults.
+   * observer/reflector model ids + thresholds. Best-effort: failures keep the
+   * caller-provided tally and leave the remaining settings at defaults.
    */
   async loadMetadata(): Promise<void> {
     const session = this.#owner;
@@ -857,16 +868,15 @@ export class SessionThread {
       const savedUsage = thread?.metadata?.tokenUsage as TokenUsage | undefined;
       if (savedUsage) {
         session.setTokenUsage({
-          ...createEmptyTokenUsage(),
           ...savedUsage,
-          promptTokens: savedUsage.promptTokens ?? 0,
-          completionTokens: savedUsage.completionTokens ?? 0,
-          totalTokens: savedUsage.totalTokens ?? 0,
+          promptTokens: savedUsage.promptTokens,
+          completionTokens: savedUsage.completionTokens,
+          totalTokens: savedUsage.totalTokens,
           cachedInputTokens: savedUsage.cachedInputTokens ?? 0,
           cacheCreationInputTokens: savedUsage.cacheCreationInputTokens ?? 0,
         });
       } else {
-        session.resetTokenUsage();
+        session.setTokenUsage({});
       }
 
       const meta = thread?.metadata as Record<string, unknown> | undefined;
@@ -960,7 +970,7 @@ export class SessionThread {
         }
       }
     } catch {
-      session.resetTokenUsage();
+      // Keep the current tally. Thread switches clear it to unknown before loading.
     }
   }
 }
@@ -4030,9 +4040,9 @@ export class Session<TState = unknown> {
 
   /** Fold a single step's usage into the running tally. */
   addUsage(stepUsage: TokenUsage): void {
-    this.#tokenUsage.promptTokens += stepUsage.promptTokens;
-    this.#tokenUsage.completionTokens += stepUsage.completionTokens;
-    this.#tokenUsage.totalTokens += stepUsage.totalTokens;
+    addPrimaryUsageField(this.#tokenUsage, 'promptTokens', stepUsage.promptTokens);
+    addPrimaryUsageField(this.#tokenUsage, 'completionTokens', stepUsage.completionTokens);
+    addPrimaryUsageField(this.#tokenUsage, 'totalTokens', stepUsage.totalTokens);
     addOptionalUsageField(this.#tokenUsage, 'reasoningTokens', stepUsage.reasoningTokens);
     addOptionalUsageField(this.#tokenUsage, 'cachedInputTokens', stepUsage.cachedInputTokens);
     addOptionalUsageField(this.#tokenUsage, 'cacheCreationInputTokens', stepUsage.cacheCreationInputTokens);

--- a/packages/core/src/agent-controller/token-usage.test.ts
+++ b/packages/core/src/agent-controller/token-usage.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { AgentController } from './agent-controller';
@@ -24,13 +24,14 @@ function createController(storage = new InMemoryStore()) {
  * Creates a mock async iterable simulating a fullStream with a step-finish chunk
  * containing the given usage data, followed by a finish chunk.
  */
-async function* mockStream(usage: Record<string, unknown>) {
+async function* mockStream(usage?: Record<string, unknown>) {
+  const output = usage === undefined ? {} : { usage };
   yield {
     type: 'step-finish',
     runId: 'run-1',
     from: 'AGENT',
     payload: {
-      output: { usage },
+      output,
       stepResult: { reason: 'stop' },
       metadata: {},
     },
@@ -41,7 +42,32 @@ async function* mockStream(usage: Record<string, unknown>) {
     from: 'AGENT',
     payload: {
       stepResult: { reason: 'stop' },
-      output: { usage },
+      output,
+      metadata: {},
+    },
+  };
+}
+
+async function* mockMultiStepStream(usages: Array<Record<string, unknown> | undefined>) {
+  for (const [index, usage] of usages.entries()) {
+    yield {
+      type: 'step-finish',
+      runId: 'run-1',
+      from: 'AGENT',
+      payload: {
+        output: usage === undefined ? {} : { usage },
+        stepResult: { reason: index === usages.length - 1 ? 'stop' : 'tool-calls' },
+        metadata: {},
+      },
+    };
+  }
+  yield {
+    type: 'finish',
+    runId: 'run-1',
+    from: 'AGENT',
+    payload: {
+      stepResult: { reason: 'stop' },
+      output: {},
       metadata: {},
     },
   };
@@ -144,6 +170,40 @@ describe('step-finish token usage extraction', () => {
         cacheCreationInputTokens: 5,
         raw: { provider: 'test-provider' },
       });
+  });
+
+  it('persists the usage snapshot for the thread that produced it', async () => {
+    const storage = new InMemoryStore();
+    controller = createController(storage);
+    await controller.init();
+    session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    const originalThreadId = session.thread.requireId();
+    const memory = await storage.getStore('memory');
+    const getThreadById = memory!.getThreadById.bind(memory);
+    let releaseRead: () => void = () => {};
+    const readGate = new Promise<void>(resolve => {
+      releaseRead = resolve;
+    });
+    const readStarted = vi.fn();
+    vi.spyOn(memory!, 'getThreadById').mockImplementationOnce(async input => {
+      readStarted();
+      await readGate;
+      return getThreadById(input);
+    });
+
+    await (session as any).processStream({
+      fullStream: mockStream({ inputTokens: 100, outputTokens: 50, totalTokens: 150 }),
+    });
+    await vi.waitFor(() => expect(readStarted).toHaveBeenCalled());
+    await session.thread.create({ title: 'Next thread' });
+    releaseRead();
+
+    await expect
+      .poll(async () => {
+        const thread = await getThreadById({ threadId: originalThreadId });
+        return thread?.metadata?.tokenUsage;
+      })
+      .toMatchObject({ promptTokens: 100, completionTokens: 50, totalTokens: 150 });
   });
 
   it('accumulates token usage across multiple step-finish chunks', async () => {
@@ -253,6 +313,205 @@ describe('step-finish token usage extraction', () => {
       cacheCreationInputTokens: 12,
       raw: { step: 2 },
     });
+  });
+
+  it.each([
+    { name: 'missing primary counts', usage: { inputTokens: {}, outputTokens: {} } },
+    { name: 'an omitted usage object', usage: undefined },
+  ])('keeps $name unknown in events, tallies, and display state', async ({ usage }) => {
+    const events: AgentControllerEvent[] = [];
+    session.subscribe(event => events.push(event));
+
+    await (session as any).processStream({ fullStream: mockStream(usage) });
+
+    const usageEvent = events.find(event => event.type === 'usage_update');
+    expect(usageEvent).toEqual({
+      type: 'usage_update',
+      usage: {
+        promptTokens: undefined,
+        completionTokens: undefined,
+        totalTokens: undefined,
+      },
+    });
+    expect(session.getTokenUsage()).toMatchObject({
+      promptTokens: undefined,
+      completionTokens: undefined,
+      totalTokens: undefined,
+    });
+    expect(session.displayState.get().tokenUsage).toMatchObject({
+      promptTokens: undefined,
+      completionTokens: undefined,
+      totalTokens: undefined,
+    });
+  });
+
+  it.each([
+    {
+      name: 'known then unknown',
+      usages: [
+        { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+        { inputTokens: {}, outputTokens: {} },
+      ],
+    },
+    {
+      name: 'unknown then known',
+      usages: [
+        { inputTokens: {}, outputTokens: {} },
+        { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      ],
+    },
+  ])('keeps a mixed $name tally unknown', async ({ usages }) => {
+    await (session as any).processStream({ fullStream: mockMultiStepStream(usages) });
+
+    expect(session.getTokenUsage()).toMatchObject({
+      promptTokens: undefined,
+      completionTokens: undefined,
+      totalTokens: undefined,
+    });
+  });
+
+  it('tracks completeness independently for each primary count', async () => {
+    await (session as any).processStream({
+      fullStream: mockMultiStepStream([{ inputTokens: 100, outputTokens: 50, totalTokens: 150 }, { inputTokens: 20 }]),
+    });
+
+    expect(session.getTokenUsage()).toMatchObject({
+      promptTokens: 120,
+      completionTokens: undefined,
+      totalTokens: undefined,
+    });
+  });
+
+  it('keeps an explicitly measured zero distinct from unknown', async () => {
+    await (session as any).processStream({
+      fullStream: mockStream({ inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+    });
+
+    expect(session.getTokenUsage()).toMatchObject({
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+    });
+    expect(JSON.parse(JSON.stringify(session.getTokenUsage()))).toMatchObject({
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+    });
+  });
+
+  it('persists and rehydrates unknown primary counts', async () => {
+    const storage = new InMemoryStore();
+    controller = createController(storage);
+    await controller.init();
+    session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    const thread = await session.thread.create();
+
+    await (session as any).processStream({
+      fullStream: mockStream({ inputTokens: {}, outputTokens: {} }),
+    });
+
+    const memory = await storage.getStore('memory');
+    await expect
+      .poll(async () => {
+        const savedThread = await memory?.getThreadById({ threadId: thread.id });
+        return savedThread?.metadata?.tokenUsage;
+      })
+      .toBeDefined();
+    const savedThread = await memory?.getThreadById({ threadId: thread.id });
+    const serializedUsage = JSON.parse(JSON.stringify(savedThread?.metadata?.tokenUsage));
+    expect(serializedUsage.promptTokens).toBeUndefined();
+    expect(serializedUsage.completionTokens).toBeUndefined();
+    expect(serializedUsage.totalTokens).toBeUndefined();
+    await memory?.saveThread({
+      thread: {
+        ...savedThread!,
+        metadata: { ...savedThread?.metadata, tokenUsage: serializedUsage },
+      },
+    });
+
+    const reopenedController = createController(storage);
+    await reopenedController.init();
+    const reopened = await reopenedController.createSession({
+      id: 'reopened-session',
+      ownerId: 'test-owner',
+      threadId: thread.id,
+    });
+    expect(reopened.getTokenUsage()).toMatchObject({
+      promptTokens: undefined,
+      completionTokens: undefined,
+      totalTokens: undefined,
+    });
+  });
+
+  it('does not invent primary counts when saved metadata is incomplete', async () => {
+    const storage = new InMemoryStore();
+    controller = createController(storage);
+    await controller.init();
+    session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    const thread = await session.thread.create();
+    const memory = await storage.getStore('memory');
+    const savedThread = await memory?.getThreadById({ threadId: thread.id });
+    await memory?.saveThread({
+      thread: {
+        ...savedThread!,
+        metadata: { ...savedThread?.metadata, tokenUsage: { totalTokens: 999 } },
+      },
+    });
+
+    const reopenedController = createController(storage);
+    await reopenedController.init();
+    const reopened = await reopenedController.createSession({
+      id: 'reopened-session',
+      ownerId: 'test-owner',
+      threadId: thread.id,
+    });
+    expect(reopened.getTokenUsage()).toMatchObject({
+      promptTokens: undefined,
+      completionTokens: undefined,
+      totalTokens: 999,
+    });
+  });
+
+  it('preserves a measured tally when refreshing metadata fails', async () => {
+    const storage = new InMemoryStore();
+    controller = createController(storage);
+    await controller.init();
+    session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    await session.thread.create();
+    session.setTokenUsage({ promptTokens: 500, completionTokens: 250, totalTokens: 750 });
+
+    const memory = await storage.getStore('memory');
+    vi.spyOn(memory!, 'getThreadById').mockRejectedValueOnce(new Error('temporary storage failure'));
+    await session.thread.loadMetadata();
+
+    expect(session.getTokenUsage()).toMatchObject({
+      promptTokens: 500,
+      completionTokens: 250,
+      totalTokens: 750,
+    });
+  });
+
+  it('starts an existing thread at unknown when metadata hydration fails', async () => {
+    const storage = new InMemoryStore();
+    controller = createController(storage);
+    await controller.init();
+    session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    const thread = await session.thread.create();
+    const memory = await storage.getStore('memory');
+    const savedThread = await memory?.getThreadById({ threadId: thread.id });
+
+    const reopenedController = createController(storage);
+    await reopenedController.init();
+    vi.spyOn(memory!, 'getThreadById').mockResolvedValueOnce(savedThread).mockRejectedValueOnce(new Error('temporary'));
+    const reopened = await reopenedController.createSession({
+      id: 'reopened-session',
+      ownerId: 'test-owner',
+      threadId: thread.id,
+    });
+
+    expect(reopened.getTokenUsage().promptTokens).toBeUndefined();
+    expect(reopened.getTokenUsage().completionTokens).toBeUndefined();
+    expect(reopened.getTokenUsage().totalTokens).toBeUndefined();
   });
 
   it('defaults cache usage fields to 0 when not present in usage', async () => {

--- a/packages/core/src/agent-controller/types.ts
+++ b/packages/core/src/agent-controller/types.ts
@@ -512,9 +512,9 @@ export interface AgentControllerThread {
  * Token usage statistics from the model.
  */
 export interface TokenUsage {
-  promptTokens: number;
-  completionTokens: number;
-  totalTokens: number;
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
   reasoningTokens?: number;
   cachedInputTokens?: number;
   cacheCreationInputTokens?: number;

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -647,6 +647,25 @@ describe('agent-controller routes', () => {
       expect(res.running).toBe(false);
     });
 
+    it('returns unknown token counts without replacing them with zero', async () => {
+      const controller = mastra.getAgentController('code')!;
+      await controller.init();
+      const session = await controller.createSession({ resourceId: 'user-1', id: 'user-1', ownerId: controller.id });
+      session.setTokenUsage({ totalTokens: 999 });
+      session.emit({ type: 'usage_update', usage: { totalTokens: 999 } });
+
+      const res = (await GET_AGENT_CONTROLLER_SESSION_STATE_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-1',
+      } as any)) as { tokenUsage?: { promptTokens?: number; completionTokens?: number; totalTokens?: number } };
+
+      expect(res.tokenUsage?.promptTokens).toBeUndefined();
+      expect(res.tokenUsage?.completionTokens).toBeUndefined();
+      expect(res.tokenUsage?.totalTokens).toBe(999);
+      expect(JSON.parse(JSON.stringify(res)).tokenUsage).toEqual({ totalTokens: 999 });
+    });
+
     it('reports running: true while a run is active', async () => {
       const controller = mastra.getAgentController('code')!;
       await controller.init();

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -306,9 +306,9 @@ const omProgressSummarySchema = z.object({
   projectedReflectionSavings: z.number(),
 });
 const tokenUsageSchema = z.object({
-  promptTokens: z.number(),
-  completionTokens: z.number(),
-  totalTokens: z.number(),
+  promptTokens: z.number().optional(),
+  completionTokens: z.number().optional(),
+  totalTokens: z.number().optional(),
   reasoningTokens: z.number().optional(),
   cachedInputTokens: z.number().optional(),
   cacheCreationInputTokens: z.number().optional(),


### PR DESCRIPTION
## Summary

Fixes AgentController token accounting so missing provider counts remain unknown instead of being reported as measured zero.

Closes #23471.

## Problem

The Session layer replaced missing input and output token counts with `0`. It then:

- emitted those zeros through `usage_update`
- added them to the cumulative tally
- saved them in thread metadata
- restored them when reopening the thread
- exposed them through the server, client, ACP, headless runner, and user interfaces

This made incomplete usage look accurate and made a provider-reported zero indistinguishable from an unreported value.

## Changes

- Make the primary `TokenUsage` fields optional:
  - `promptTokens`
  - `completionTokens`
  - `totalTokens`
- Preserve missing counts through Session extraction and accumulation.
- Derive `totalTokens` only when both component counts are known.
- Keep each aggregate unknown if any contributing step omits that count.
- Preserve an explicitly measured zero as `0`.
- Persist and rehydrate unknown counts without inventing zeros.
- Preserve measured in-memory usage when a metadata refresh fails.
- Snapshot usage before asynchronous persistence so switching threads cannot save the next thread’s tally into the previous thread.
- Update the server response schema and generated client types.
- Update ACP to omit its optional usage report when required counts are incomplete.
- Update `runMC()` to accumulate multi-step usage and propagate unknown counts.
- Render unknown counts honestly in the MastraCode TUI and Factory UI.
- Avoid calculating token rates when completion usage is unknown.

## Before and after

| Scenario | Before | After |
| --- | --- | --- |
| Provider omits usage | Reported `0` | Remains unknown |
| Known step plus unknown step | Looked complete | Aggregate remains unknown |
| Explicit measured zero | `0` | `0` |
| Reopened thread | Missing fields became `0` | Missing fields remain unknown |
| Metadata refresh failure | Reset tally to zero | Preserves the measured tally |
| ACP response | Complete-looking usage | Usage omitted when incomplete |
| `runMC()` multi-step result | Last step only | Correct accumulated usage |
| `/cost` | `0 tokens` | `unknown tokens` |

## Compatibility

The three primary `TokenUsage` fields are now optional. Consumers that perform arithmetic or formatting directly must handle `undefined`.

```ts
const total =
  usage.totalTokens === undefined
    ? 'unknown'
    : usage.totalTokens.toLocaleString();
```

This PR fixes the Session consumer path described in #23471. The separate producer-side aggregation problem in #23469 remains out of scope.

## Verification

- Core token-usage tests: 18 passed
- Server AgentController tests: 54 passed
- ACP tests: 39 passed
- Headless `runMC()` tests: 16 passed
- MastraCode TUI unit tests: 16 passed
- MastraCode TUI end-to-end scenario: 1 passed
- Factory UI MSW tests: 6 passed
- Core, Code SDK, TUI, and Factory UI typechecks passed
- Core, server, client, MastraCode, and Factory UI builds passed
- Browser-tested the Factory `/cost` flow with unknown and measured-zero usage at desktop and mobile viewport sizes
