### PR TITLE
feat(studio): make nested workflow panels resizable

### DIFF
--- a/.changeset/nested-workflow-panel.md
+++ b/.changeset/nested-workflow-panel.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Improved nested workflow graphs in Studio with a resizable desktop panel and a full-width layout on smaller screens.

--- a/packages/playground/e2e/tests/workflows/$workflowId/nested-graph.spec.ts
+++ b/packages/playground/e2e/tests/workflows/$workflowId/nested-graph.spec.ts
@@ -17,16 +17,44 @@ test.describe('Workflow nested graph', () => {
   });
 
   test.describe('when "View nested graph" is selected on a nested step', () => {
-    test('opens the nested graph view in the step detail panel', async ({ page }) => {
+    test.beforeEach(async ({ page }) => {
       const nestedNode = page.locator('[data-workflow-node]').filter({ hasText: 'nested-text-processor' });
       await expect(nestedNode).toBeVisible();
 
       await nestedNode.getByRole('button', { name: 'Step actions' }).click();
       await page.getByRole('menuitem', { name: 'View nested graph' }).click();
+    });
 
+    test('opens the nested graph view in the step detail panel', async ({ page }) => {
       const panel = page.getByTestId('workflow-step-detail-panel');
       await expect(panel).toBeVisible({ timeout: 15000 });
       await expect(panel).toContainText('Workflow');
+    });
+
+    test('gives the nested graph more room when the panel is resized', async ({ page }) => {
+      const panel = page.getByTestId('workflow-step-detail-panel');
+      await expect(panel).toBeVisible({ timeout: 15000 });
+
+      const initialWidth = await panel.evaluate(element => element.getBoundingClientRect().width);
+      const separator = page.locator('[role="separator"][aria-controls="workflow-graph"]');
+      const separatorBox = await separator.boundingBox();
+      if (!separatorBox) throw new Error('Nested graph resize handle is not visible');
+
+      await page.mouse.move(separatorBox.x, separatorBox.y + separatorBox.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(separatorBox.x - 180, separatorBox.y + separatorBox.height / 2, { steps: 5 });
+      await page.mouse.up();
+
+      await expect
+        .poll(() => panel.evaluate(element => element.getBoundingClientRect().width))
+        .toBeGreaterThan(initialWidth + 100);
+    });
+
+    test('uses the available width on smaller screens', async ({ page }) => {
+      await page.setViewportSize({ width: 768, height: 900 });
+
+      const panel = page.getByTestId('workflow-step-detail-panel');
+      await expect.poll(() => panel.evaluate(element => element.getBoundingClientRect().width)).toBeGreaterThan(700);
     });
   });
 });

--- a/packages/playground/src/domains/workflows/workflow/workflow-nested-graph.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-nested-graph.tsx
@@ -50,7 +50,7 @@ export function WorkflowNestedGraph({ stepGraph, open, workflowName }: WorkflowN
           onNodesChange={onNodesChange}
         >
           <ZoomSlider position="bottom-left" />
-          <Background variant={BackgroundVariant.Lines} gap={12} size={0.5} />
+          <Background variant={BackgroundVariant.Lines} gap={12} size={0.5} color="var(--border1)" />
         </ReactFlow>
       ) : (
         <div className="flex h-full w-full items-center justify-center">

--- a/packages/playground/src/pages/workflows/workflow/index.tsx
+++ b/packages/playground/src/pages/workflows/workflow/index.tsx
@@ -1,7 +1,11 @@
 import type { GetWorkflowResponse } from '@mastra/client-js';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { useIsMobile } from '@mastra/playground-ui/hooks/use-is-mobile';
+import { PanelGroup } from '@mastra/playground-ui/resize/panel-group';
+import { PanelSeparator } from '@mastra/playground-ui/resize/separator';
 import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
+import { Panel } from 'react-resizable-panels';
 import { useParams } from 'react-router';
 import { WorkflowStepDetailContent } from '@/domains/workflows/components/workflow-step-detail';
 import { useWorkflowStepDetail } from '@/domains/workflows/context/workflow-step-detail-context';
@@ -19,22 +23,43 @@ interface WorkflowContentProps {
 
 const WorkflowContent = ({ workflowId, workflow, isLoading }: WorkflowContentProps) => {
   const { stepDetail } = useWorkflowStepDetail();
+  const isMobile = useIsMobile();
+  const graph = (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="relative min-h-0 flex-1 p-2 pb-0">
+        <WorkflowGraph workflowId={workflowId} workflow={workflow} isLoading={isLoading} />
+        <WorkflowSuspendedOverlay />
+        <WorkflowTimeline />
+      </div>
+    </div>
+  );
+
+  if (isMobile) {
+    return stepDetail ? (
+      <div className="h-full min-h-0 overflow-hidden">
+        <WorkflowStepDetailContent />
+      </div>
+    ) : (
+      graph
+    );
+  }
 
   return (
-    <div className="flex h-full min-h-0">
-      <div className="flex h-full min-h-0 flex-1 flex-col">
-        <div className="relative min-h-0 flex-1 p-2 pb-0">
-          <WorkflowGraph workflowId={workflowId} workflow={workflow} isLoading={isLoading} />
-          <WorkflowSuspendedOverlay />
-          <WorkflowTimeline />
-        </div>
-      </div>
-      {stepDetail && (
-        <div className="border-border1 min-h-0 w-[420px] overflow-hidden border-l">
-          <WorkflowStepDetailContent />
-        </div>
-      )}
-    </div>
+    <PanelGroup className="h-full min-h-0 w-full min-w-0">
+      <Panel id="workflow-graph" className="min-w-0">
+        {graph}
+      </Panel>
+      {stepDetail ? (
+        <>
+          <PanelSeparator />
+          <Panel id="workflow-step-detail" minSize={300} maxSize="60%" defaultSize={420} className="min-w-0">
+            <div className="border-border1 h-full min-h-0 overflow-hidden border-l">
+              <WorkflowStepDetailContent />
+            </div>
+          </Panel>
+        </>
+      ) : null}
+    </PanelGroup>
   );
 };
 


### PR DESCRIPTION
## Description

Makes the nested workflow detail panel resizable on desktop so larger graphs stay readable. Smaller screens use the full content width, and the line grid keeps its intended contrast while resizing.

## Related issue(s)

Fixes #22443

| | Light | Dark |
| --- | --- | --- |
| Before | ![Nested workflow constrained to the fixed panel in light mode](https://github.com/user-attachments/assets/5466e7ea-ca05-462b-a32c-53041beab6c9) | ![Nested workflow constrained to the fixed panel in dark mode](https://github.com/user-attachments/assets/bb3ff802-7210-4474-a5bb-18425053f5c2) |
| After | ![Nested workflow shown in the widened resizable panel in light mode](https://github.com/user-attachments/assets/b8b12d3b-9288-4717-9d0b-6522636d7771) | ![Nested workflow shown in the widened resizable panel in dark mode](https://github.com/user-attachments/assets/c26fae3d-dbd3-4f01-921f-20b872442501) |

Verified: playground typecheck and lint; full playground Vitest suite (2,374 passed, 2 skipped); focused Playwright coverage (3 passed); `pnpm build:cli`; desktop, tablet, and mobile browser checks; localhost review.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Nested workflow graphs now have more room to display their steps clearly. You can resize the panel on desktop, while smaller screens use the available content width.

## Changes

- Added resizable nested workflow panels on desktop.
- Added responsive layouts for tablet and mobile screens.
- Updated the graph grid to preserve contrast in both themes.
- Added end-to-end tests for panel resizing and responsive width.
- Added a patch changeset for `mastra`.

## Validation

- Typecheck, lint, Vitest, focused Playwright, and CLI build passed.
- Desktop, tablet, and mobile browser checks passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->