### PR TITLE
feat(mastracode): add Firecrawl as a web search provider

### DIFF
--- a/.changeset/firecrawl-web-search-provider.md
+++ b/.changeset/firecrawl-web-search-provider.md
@@ -1,0 +1,6 @@
+---
+'@mastra/code-sdk': patch
+'mastracode': patch
+---
+
+Added Firecrawl as a web search and extract provider for Mastra Code. Set `FIRECRAWL_API_KEY` to enable it, and pick it under `/settings` → **Web search provider**. In the default `auto` mode it is used when no Tavily or Parallel key is configured.

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -745,6 +745,7 @@ MASTRACODE_DISABLE_CAFFEINATE=1 mastracode
 | `KIMI_API_KEY` | Kimi For Coding API key |
 | `PARALLEL_API_KEY` | Enable Parallel-powered web search and extract tools (selectable as the default web provider in `/settings`) |
 | `TAVILY_API_KEY` | Enable Tavily-powered web search and extract tools |
+| `FIRECRAWL_API_KEY` | Enable Firecrawl-powered web search and extract tools (selectable as the default web provider in `/settings`) |
 
 ## Resource ID override
 

--- a/docs/src/mastra-code/tools.mdx
+++ b/docs/src/mastra-code/tools.mdx
@@ -151,12 +151,13 @@ Request access to directories outside the project root. The user is prompted to 
 
 Search the web for documentation, error messages, package APIs, and other information.
 
-Mastra Code supports two configured providers, Tavily and Parallel. Choose a default in the TUI under `/settings` → **Web search provider**; a provider can only be selected while its API key is configured. With the default **Auto** setting, Mastra Code selects the first available provider in this order:
+Mastra Code supports three configured providers, Tavily, Parallel, and Firecrawl. Choose a default in the TUI under `/settings` → **Web search provider**; a provider can only be selected while its API key is configured. With the default **Auto** setting, Mastra Code selects the first available provider in this order:
 
 - **Tavily**: Used when `TAVILY_API_KEY` is set.
 - **Parallel**: Used when `PARALLEL_API_KEY` is set and no Tavily key is configured.
+- **Firecrawl**: Used when `FIRECRAWL_API_KEY` is set and no Tavily or Parallel key is configured.
 
-When neither key is configured, agents running on Anthropic or OpenAI models fall back to that model's built-in web search. This model-native fallback applies only to agents on those models — other models, and Mastra Code workflows, have no `web_search` tool without a configured provider key.
+When no provider key is configured, agents running on Anthropic or OpenAI models fall back to that model's built-in web search. This model-native fallback applies only to agents on those models — other models, and Mastra Code workflows, have no `web_search` tool without a configured provider key.
 
 Provider-backed versions of `web_search` accept a single `query`. Optional parameters vary by provider.
 
@@ -173,7 +174,7 @@ Tavily parameters:
 
 Extract content from one or more web pages. Mastra Code uses the same provider selected for `web_search` (the `/settings` **Web search provider** choice, or the first configured key in Auto mode).
 
-Parallel extract accepts `urls` plus optional controls such as `objective`, `searchQueries`, `fullContent`, and character limits. Tavily accepts `urls`, `extractDepth`, and `includeImages`.
+Parallel extract accepts `urls` plus optional controls such as `objective`, `searchQueries`, `fullContent`, and character limits. Tavily accepts `urls`, `extractDepth`, and `includeImages`. Firecrawl accepts `urls` (1-10) and returns each page as markdown.
 
 Tavily parameters:
 

--- a/mastracode/sdk/package.json
+++ b/mastracode/sdk/package.json
@@ -69,6 +69,7 @@
     "@mastra/tavily": "workspace:*",
     "ai": "^6.0.236",
     "execa": "^9.6.1",
+    "firecrawl": "^4.18.4",
     "libsql": "^0.5.29",
     "posthog-node": "^5.46.1",
     "smol-toml": "1.7.0",

--- a/mastracode/sdk/src/agents/__tests__/instructions.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/instructions.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 vi.mock('../../tools/index.js', () => ({
   hasParallelKey: () => false,
   hasTavilyKey: () => false,
+  hasFirecrawlKey: () => false,
 }));
 
 vi.mock('../../utils/project.js', () => ({

--- a/mastracode/sdk/src/agents/__tests__/prompt-sections.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/prompt-sections.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('../../tools/index.js', () => ({
   hasParallelKey: () => false,
   hasTavilyKey: () => false,
+  hasFirecrawlKey: () => false,
 }));
 
 import { getDynamicInstructions, getDynamicInstructionSections } from '../instructions.js';

--- a/mastracode/sdk/src/agents/__tests__/prompts-lsp.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/prompts-lsp.test.ts
@@ -5,7 +5,11 @@ import type { GlobalSettings } from '../../onboarding/settings.js';
 async function buildPromptWithLspSetting(lsp: GlobalSettings['lsp']) {
   vi.resetModules();
   // Keep prompt tests independent from optional web-search package artifacts.
-  vi.doMock('../../tools/index.js', () => ({ hasParallelKey: () => false, hasTavilyKey: () => false }));
+  vi.doMock('../../tools/index.js', () => ({
+    hasParallelKey: () => false,
+    hasTavilyKey: () => false,
+    hasFirecrawlKey: () => false,
+  }));
   const settings = await vi.importActual<typeof import('../../onboarding/settings.js')>('../../onboarding/settings.js');
   vi.doMock('../../onboarding/settings.js', () => ({
     ...settings,

--- a/mastracode/sdk/src/agents/__tests__/prompts.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/prompts.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 vi.mock('../../tools/index.js', () => ({
   hasParallelKey: () => false,
   hasTavilyKey: () => false,
+  hasFirecrawlKey: () => false,
 }));
 
 import { buildFullPrompt } from '../prompts/index.js';

--- a/mastracode/sdk/src/agents/extra-tools.test.ts
+++ b/mastracode/sdk/src/agents/extra-tools.test.ts
@@ -9,6 +9,7 @@ vi.mock('../tools/index.js', () => ({
   createConfiguredWebTools: () => undefined,
   hasParallelKey: () => false,
   hasTavilyKey: () => false,
+  hasFirecrawlKey: () => false,
   requestSandboxAccessTool: { description: 'request sandbox access' },
 }));
 

--- a/mastracode/sdk/src/agents/prompts/index.test.ts
+++ b/mastracode/sdk/src/agents/prompts/index.test.ts
@@ -8,6 +8,7 @@ import { afterAll, describe, expect, it, vi } from 'vitest';
 vi.mock('../../tools/index.js', () => ({
   hasParallelKey: () => false,
   hasTavilyKey: () => false,
+  hasFirecrawlKey: () => false,
 }));
 
 const mocks = vi.hoisted(() => ({ home: '' }));

--- a/mastracode/sdk/src/agents/prompts/index.ts
+++ b/mastracode/sdk/src/agents/prompts/index.ts
@@ -10,7 +10,7 @@ import { buildBasePrompt } from '@mastra/core/coding-agent';
 import type { PromptContext as BasePromptContext } from '@mastra/core/coding-agent';
 import { loadSettings, resolveLspSetting } from '../../onboarding/settings.js';
 import { MC_TOOLS } from '../../tool-names.js';
-import { hasParallelKey, hasTavilyKey } from '../../tools/index.js';
+import { hasFirecrawlKey, hasParallelKey, hasTavilyKey } from '../../tools/index.js';
 import { getLocalPlansRelativeDir } from '../../utils/plans.js';
 import {
   loadAgentInstructions,
@@ -89,6 +89,7 @@ export function buildFullPromptSections(ctx: PromptContext): PromptSection[] {
   const hasWebSearch =
     hasParallelKey() ||
     hasTavilyKey() ||
+    hasFirecrawlKey() ||
     (!!modelId && (modelId.startsWith('anthropic/') || modelId.startsWith('openai/')));
 
   // Collect per-tool deny rules so guidance omits denied tools

--- a/mastracode/sdk/src/agents/tools.test.ts
+++ b/mastracode/sdk/src/agents/tools.test.ts
@@ -15,6 +15,7 @@ vi.mock('../tools/index.js', () => ({
   createConfiguredWebTools: () => webToolMocks.configuredTools,
   hasParallelKey: () => false,
   hasTavilyKey: () => false,
+  hasFirecrawlKey: () => false,
   requestSandboxAccessTool: { description: 'request sandbox access' },
 }));
 

--- a/mastracode/sdk/src/onboarding/settings.ts
+++ b/mastracode/sdk/src/onboarding/settings.ts
@@ -81,7 +81,7 @@ export const MEMORY_GATEWAY_PROVIDER = MASTRA_GATEWAY_PROVIDER;
 export const MEMORY_GATEWAY_DEFAULT_URL = MASTRA_GATEWAY_DEFAULT_URL;
 
 /** Preferred model-independent web search/extract provider. */
-export type WebSearchProviderSetting = 'auto' | 'tavily' | 'parallel';
+export type WebSearchProviderSetting = 'auto' | 'tavily' | 'parallel' | 'firecrawl';
 
 /** Browser provider type. */
 export type BrowserProvider = 'stagehand' | 'agent-browser';
@@ -303,7 +303,7 @@ export interface GlobalSettings {
     quietModeMaxToolPreviewLines: number;
     /**
      * Default web search/extract provider. `auto` picks the first configured
-     * provider key (Tavily, then Parallel). An explicit provider is only
+     * provider key (Tavily, then Parallel, then Firecrawl). An explicit provider is only
      * honored while its API key is configured.
      */
     webSearchProvider: WebSearchProviderSetting;
@@ -445,7 +445,7 @@ const DEFAULTS: GlobalSettings = {
   observability: { resources: {}, localTracing: false },
 };
 
-export const WEB_SEARCH_PROVIDER_VALUES: WebSearchProviderSetting[] = ['auto', 'tavily', 'parallel'];
+export const WEB_SEARCH_PROVIDER_VALUES: WebSearchProviderSetting[] = ['auto', 'tavily', 'parallel', 'firecrawl'];
 const QUIET_MODE_MAX_TOOL_PREVIEW_LINES_MAX = 8;
 const loadedSignalSettings = new WeakMap<GlobalSettings, SignalSettings>();
 

--- a/mastracode/sdk/src/tools/index.ts
+++ b/mastracode/sdk/src/tools/index.ts
@@ -4,10 +4,13 @@
 
 export {
   createConfiguredWebTools,
+  createFirecrawlWebExtractTool,
+  createFirecrawlWebSearchTool,
   createParallelWebExtractTool,
   createParallelWebSearchTool,
   createWebExtractTool,
   createWebSearchTool,
+  hasFirecrawlKey,
   hasParallelKey,
   hasTavilyKey,
   resolveWebSearchProvider,

--- a/mastracode/sdk/src/tools/web-search.test.ts
+++ b/mastracode/sdk/src/tools/web-search.test.ts
@@ -4,6 +4,15 @@ import { z } from 'zod';
 const providerMocks = vi.hoisted(() => ({
   parallelSearchExecute: vi.fn(),
   parallelExtractExecute: vi.fn(),
+  firecrawlSearch: vi.fn(),
+  firecrawlScrape: vi.fn(),
+}));
+
+vi.mock('firecrawl', () => ({
+  Firecrawl: class {
+    search = providerMocks.firecrawlSearch;
+    scrape = providerMocks.firecrawlScrape;
+  },
 }));
 
 vi.mock('@mastra/parallel', () => ({
@@ -40,6 +49,8 @@ vi.mock('../onboarding/settings.js', () => ({
 
 import {
   createConfiguredWebTools,
+  createFirecrawlWebExtractTool,
+  createFirecrawlWebSearchTool,
   createParallelWebExtractTool,
   createParallelWebSearchTool,
   resolveWebSearchProvider,
@@ -48,10 +59,12 @@ import {
 describe('createConfiguredWebTools', () => {
   const originalParallelKey = process.env.PARALLEL_API_KEY;
   const originalTavilyKey = process.env.TAVILY_API_KEY;
+  const originalFirecrawlKey = process.env.FIRECRAWL_API_KEY;
 
   beforeEach(() => {
     delete process.env.PARALLEL_API_KEY;
     delete process.env.TAVILY_API_KEY;
+    delete process.env.FIRECRAWL_API_KEY;
     settingsMock.webSearchProvider = 'auto';
   });
 
@@ -61,6 +74,9 @@ describe('createConfiguredWebTools', () => {
 
     if (originalTavilyKey === undefined) delete process.env.TAVILY_API_KEY;
     else process.env.TAVILY_API_KEY = originalTavilyKey;
+
+    if (originalFirecrawlKey === undefined) delete process.env.FIRECRAWL_API_KEY;
+    else process.env.FIRECRAWL_API_KEY = originalFirecrawlKey;
   });
 
   it('selects Tavily in auto mode when both provider keys are configured', () => {
@@ -102,7 +118,17 @@ describe('createConfiguredWebTools', () => {
     expect(tools?.web_extract.description).toBe('parallel extract');
   });
 
-  it('returns no model-independent tools when neither key is configured', () => {
+  it('selects Firecrawl in auto mode when only its key is configured', () => {
+    process.env.FIRECRAWL_API_KEY = 'firecrawl-key';
+
+    const tools = createConfiguredWebTools();
+
+    expect(tools?.web_search.id).toBe('web-search');
+    expect(tools?.web_extract.id).toBe('web-extract');
+    expect(resolveWebSearchProvider('auto')).toBe('firecrawl');
+  });
+
+  it('returns no model-independent tools when no key is configured', () => {
     expect(createConfiguredWebTools()).toBeUndefined();
   });
 
@@ -118,6 +144,53 @@ describe('createConfiguredWebTools', () => {
 
     delete process.env.TAVILY_API_KEY;
     expect(resolveWebSearchProvider('tavily')).toBeUndefined();
+
+    process.env.FIRECRAWL_API_KEY = 'firecrawl-key';
+    expect(resolveWebSearchProvider('firecrawl')).toBe('firecrawl');
+    delete process.env.FIRECRAWL_API_KEY;
+    expect(resolveWebSearchProvider('firecrawl')).toBeUndefined();
+  });
+});
+
+describe('Firecrawl web tool adapters', () => {
+  it('formats Firecrawl search results for Mastra Code', async () => {
+    providerMocks.firecrawlSearch.mockResolvedValueOnce({
+      web: [
+        { url: 'https://example.com/result', title: 'Example result', description: 'A relevant description.' },
+        { url: 'https://example.com/untitled' },
+      ],
+    });
+    const tool = createFirecrawlWebSearchTool();
+
+    const output = await tool.execute!({ query: 'example query' }, {} as never);
+
+    expect(output).toBe(
+      '## Example result\nhttps://example.com/result\nA relevant description.\n\n## https://example.com/untitled\nhttps://example.com/untitled',
+    );
+    expect(providerMocks.firecrawlSearch).toHaveBeenCalledWith('example query', { sources: ['web'] });
+  });
+
+  it('returns empty output when Firecrawl reports no web results', async () => {
+    providerMocks.firecrawlSearch.mockResolvedValueOnce({});
+    const tool = createFirecrawlWebSearchTool();
+
+    expect(await tool.execute!({ query: 'example query' }, {} as never)).toBe('');
+  });
+
+  it('reports failed URLs inline instead of failing the whole extraction', async () => {
+    providerMocks.firecrawlScrape
+      .mockResolvedValueOnce({ markdown: 'Page content.' })
+      .mockRejectedValueOnce(new Error('DNS resolution failed'));
+    const tool = createFirecrawlWebExtractTool();
+
+    const output = await tool.execute!(
+      { urls: ['https://example.com/page', 'https://example.com/missing'] },
+      {} as never,
+    );
+
+    expect(output).toBe(
+      '## https://example.com/page\nPage content.\n\n## https://example.com/missing\nError: DNS resolution failed',
+    );
   });
 });
 

--- a/mastracode/sdk/src/tools/web-search.ts
+++ b/mastracode/sdk/src/tools/web-search.ts
@@ -1,6 +1,7 @@
 import { createTool, isValidationError, type ValidationError } from '@mastra/core/tools';
 import { createParallelSearchTool, createParallelExtractTool } from '@mastra/parallel';
 import { createTavilySearchTool, createTavilyExtractTool } from '@mastra/tavily';
+import { Firecrawl, type SearchResultWeb } from 'firecrawl';
 import { z } from 'zod';
 
 import { loadSettings, type WebSearchProviderSetting } from '../onboarding/settings.js';
@@ -13,6 +14,14 @@ const MIN_RELEVANCE_SCORE = 0.25;
 
 const parallelWebSearchInputSchema = z.object({
   query: z.string().min(1).describe('The search query'),
+});
+
+const firecrawlWebSearchInputSchema = z.object({
+  query: z.string().min(1).describe('The search query'),
+});
+
+const firecrawlWebExtractInputSchema = z.object({
+  urls: z.array(z.string().url()).min(1).max(10).describe('URLs to extract content from (1-10).'),
 });
 
 function requireParallelOutput<T>(output: T | ValidationError | void, operation: 'search' | 'extract'): T {
@@ -39,6 +48,20 @@ export function hasTavilyKey(): boolean {
 /** Check whether a Parallel API key is available in the environment. */
 export function hasParallelKey(): boolean {
   return !!process.env.PARALLEL_API_KEY;
+}
+
+/** Check whether a Firecrawl API key is available in the environment. */
+export function hasFirecrawlKey(): boolean {
+  return !!process.env.FIRECRAWL_API_KEY;
+}
+
+function createLazyFirecrawlClient(): () => Firecrawl {
+  let client: Firecrawl | undefined;
+
+  return () => {
+    client ??= new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+    return client;
+  };
 }
 
 /**
@@ -168,19 +191,76 @@ export function createParallelWebExtractTool() {
 }
 
 /**
+ * Firecrawl web search with Mastra Code's standard tool id, markdown string
+ * output, and token truncation.
+ */
+export function createFirecrawlWebSearchTool() {
+  const getClient = createLazyFirecrawlClient();
+
+  return createTool({
+    id: 'web-search',
+    description: 'Search the web with Firecrawl. Returns ranked results with titles, URLs, and descriptions.',
+    inputSchema: firecrawlWebSearchInputSchema,
+    execute: async ({ query }) => {
+      const { web } = await getClient().search(query, { sources: ['web'] });
+
+      // Without `scrapeOptions` Firecrawl returns search results, never scraped documents.
+      const results = (web ?? []) as SearchResultWeb[];
+      const parts = results.map(result =>
+        [`## ${result.title || result.url}`, result.url, result.description].filter(Boolean).join('\n'),
+      );
+
+      return truncateStringForTokenEstimate(parts.join('\n\n'), MAX_WEB_SEARCH_TOKENS);
+    },
+  });
+}
+
+/**
+ * Firecrawl page extraction with Mastra Code's standard tool id, markdown
+ * string output, and token truncation. Failed URLs are reported inline so one
+ * bad URL does not fail the whole call.
+ */
+export function createFirecrawlWebExtractTool() {
+  const getClient = createLazyFirecrawlClient();
+
+  return createTool({
+    id: 'web-extract',
+    description: 'Extract the content of web pages as markdown with Firecrawl.',
+    inputSchema: firecrawlWebExtractInputSchema,
+    execute: async ({ urls }) => {
+      const client = getClient();
+      const parts = await Promise.all(
+        urls.map(async url => {
+          try {
+            const { markdown } = await client.scrape(url, { formats: ['markdown'] });
+            return `## ${url}\n${markdown ?? ''}`;
+          } catch (error) {
+            return `## ${url}\nError: ${error instanceof Error ? error.message : String(error)}`;
+          }
+        }),
+      );
+
+      return truncateStringForTokenEstimate(parts.join('\n\n'), MAX_WEB_EXTRACT_TOKENS);
+    },
+  });
+}
+
+/**
  * Resolve which model-independent web provider to use. An explicit user
  * preference wins while its API key is configured; otherwise `auto` picks the
- * first configured provider key (Tavily, then Parallel).
+ * first configured provider key (Tavily, then Parallel, then Firecrawl).
  */
 export function resolveWebSearchProvider(
   preference: WebSearchProviderSetting = 'auto',
-): 'tavily' | 'parallel' | undefined {
+): 'tavily' | 'parallel' | 'firecrawl' | undefined {
   if (preference === 'tavily' && hasTavilyKey()) return 'tavily';
   if (preference === 'parallel' && hasParallelKey()) return 'parallel';
+  if (preference === 'firecrawl' && hasFirecrawlKey()) return 'firecrawl';
 
   // `auto`, or an explicit choice whose key is no longer configured.
   if (hasTavilyKey()) return 'tavily';
   if (hasParallelKey()) return 'parallel';
+  if (hasFirecrawlKey()) return 'firecrawl';
   return undefined;
 }
 
@@ -202,6 +282,13 @@ export function createConfiguredWebTools() {
     return {
       web_search: createWebSearchTool(),
       web_extract: createWebExtractTool(),
+    };
+  }
+
+  if (provider === 'firecrawl') {
+    return {
+      web_search: createFirecrawlWebSearchTool(),
+      web_extract: createFirecrawlWebExtractTool(),
     };
   }
 

--- a/mastracode/tui/e2e/tui/web-search-provider-settings.ts
+++ b/mastracode/tui/e2e/tui/web-search-provider-settings.ts
@@ -10,6 +10,7 @@ export const webSearchProviderSettingsScenario = {
     return {
       TAVILY_API_KEY: 'mc-e2e-tavily-key',
       PARALLEL_API_KEY: '',
+      FIRECRAWL_API_KEY: '',
     };
   },
   prepare({ appDataDir }) {

--- a/mastracode/tui/src/tui/commands/settings.ts
+++ b/mastracode/tui/src/tui/commands/settings.ts
@@ -209,11 +209,13 @@ export async function handleSettingsCommand(ctx: SlashCommandContext): Promise<v
     // the choice comes back when the key does.
     webSearchProvider:
       (globalSettings.preferences.webSearchProvider === 'tavily' && !process.env.TAVILY_API_KEY) ||
-      (globalSettings.preferences.webSearchProvider === 'parallel' && !process.env.PARALLEL_API_KEY)
+      (globalSettings.preferences.webSearchProvider === 'parallel' && !process.env.PARALLEL_API_KEY) ||
+      (globalSettings.preferences.webSearchProvider === 'firecrawl' && !process.env.FIRECRAWL_API_KEY)
         ? 'auto'
         : globalSettings.preferences.webSearchProvider,
     tavilyKeyAvailable: !!process.env.TAVILY_API_KEY,
     parallelKeyAvailable: !!process.env.PARALLEL_API_KEY,
+    firecrawlKeyAvailable: !!process.env.FIRECRAWL_API_KEY,
   };
 
   return new Promise<void>(resolve => {

--- a/mastracode/tui/src/tui/components/__tests__/settings.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/settings.test.ts
@@ -109,6 +109,7 @@ function createConfig(overrides: Partial<SettingsConfig> = {}): SettingsConfig {
     webSearchProvider: 'auto',
     tavilyKeyAvailable: false,
     parallelKeyAvailable: false,
+    firecrawlKeyAvailable: false,
     ...overrides,
   };
 }
@@ -219,10 +220,12 @@ describe('SettingsComponent web search provider submenu', () => {
 
   it('always lists all providers, marking those missing their API key', () => {
     const { select } = openWebSearchSubmenu(createConfig({ tavilyKeyAvailable: true }));
-    expect(select.items.map((i: { value: string }) => i.value)).toEqual(['auto', 'tavily', 'parallel']);
+    expect(select.items.map((i: { value: string }) => i.value)).toEqual(['auto', 'tavily', 'parallel', 'firecrawl']);
     expect(select.items[1].label).toBe('  Tavily');
     expect(select.items[2].label).toBe('  Parallel (unavailable)');
     expect(select.items[2].description).toContain('PARALLEL_API_KEY');
+    expect(select.items[3].label).toBe('  Firecrawl (unavailable)');
+    expect(select.items[3].description).toContain('FIRECRAWL_API_KEY');
   });
 
   it('persists the choice when the provider key is configured', () => {

--- a/mastracode/tui/src/tui/components/settings.ts
+++ b/mastracode/tui/src/tui/components/settings.ts
@@ -32,6 +32,7 @@ export interface SettingsConfig {
   webSearchProvider: WebSearchProviderSetting;
   tavilyKeyAvailable: boolean;
   parallelKeyAvailable: boolean;
+  firecrawlKeyAvailable: boolean;
 }
 
 export interface SettingsCallbacks {
@@ -196,6 +197,7 @@ function quietPreviewLinesLabel(lines: number): string {
 function webSearchProviderLabel(provider: WebSearchProviderSetting): string {
   if (provider === 'tavily') return 'Tavily';
   if (provider === 'parallel') return 'Parallel';
+  if (provider === 'firecrawl') return 'Firecrawl';
   return 'Auto';
 }
 
@@ -415,7 +417,7 @@ export class SettingsComponent extends Box implements Focusable {
               {
                 value: 'auto',
                 label: '  Auto',
-                description: 'First configured provider key (Tavily, then Parallel)',
+                description: 'First configured provider key (Tavily, then Parallel, then Firecrawl)',
               },
               {
                 value: 'tavily',
@@ -431,12 +433,20 @@ export class SettingsComponent extends Box implements Focusable {
                   ? 'Always use Parallel'
                   : 'Missing PARALLEL_API_KEY — set it to use Parallel',
               },
+              {
+                value: 'firecrawl',
+                label: config.firecrawlKeyAvailable ? '  Firecrawl' : '  Firecrawl (unavailable)',
+                description: config.firecrawlKeyAvailable
+                  ? 'Always use Firecrawl'
+                  : 'Missing FIRECRAWL_API_KEY — set it to use Firecrawl',
+              },
             ],
             config.webSearchProvider,
             value => {
               // Providers without their API key are shown but not selectable.
               if (value === 'tavily' && !config.tavilyKeyAvailable) return;
               if (value === 'parallel' && !config.parallelKeyAvailable) return;
+              if (value === 'firecrawl' && !config.firecrawlKeyAvailable) return;
               config.webSearchProvider = value as WebSearchProviderSetting;
               callbacks.onWebSearchProviderChange(config.webSearchProvider);
               done(webSearchProviderLabel(config.webSearchProvider));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2652,6 +2652,9 @@ importers:
       execa:
         specifier: ^9.6.1
         version: 9.6.1
+      firecrawl:
+        specifier: ^4.18.4
+        version: 4.25.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       libsql:
         specifier: ^0.5.29
         version: 0.5.29


### PR DESCRIPTION
## Description

Adds Firecrawl as a third model-independent `web_search` / `web_extract` provider for Mastra Code, alongside Tavily and Parallel.

- `FIRECRAWL_API_KEY` enables it, gated the same way as the other two providers.
- `web_search` uses Firecrawl `search()`; `web_extract` uses `scrape()` with the markdown format, reporting per-URL failures inline so one bad URL does not fail the whole call.
- Selectable under `/settings` → **Web search provider**, shown as unavailable while its key is missing.
- In the default `auto` mode it is appended last (Tavily → Parallel → Firecrawl), so existing behaviour is unchanged for anyone with a Tavily or Parallel key.

Implementation notes:

- No new workspace package. It calls the official `firecrawl` v4 SDK, which the monorepo already depends on via `browser/firecrawl`, directly from `mastracode/sdk/src/tools/web-search.ts` next to the existing Tavily and Parallel wrappers. The only new dependency edge is `@mastra/code-sdk` → `firecrawl`, and the lockfile change is three lines.
- The client is created lazily per tool via `createLazyFirecrawlClient()`, mirroring `createLazyParallelClient` in `@mastra/parallel`.
- Output goes through the same `truncateStringForTokenEstimate` token budgets as the other providers.

Verified locally: new and existing unit tests pass for `mastracode/sdk` and `mastracode/tui`, `tsc --noEmit` is clean for both, oxlint and oxfmt are clean, and the tools were smoke-tested against the live Firecrawl API (including a failing URL).

## Related issue(s)

Fixes #23663

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Mastra Code can now use Firecrawl to search the web and extract page content. Users can enable it with `FIRECRAWL_API_KEY` and select it in `/settings`.

## Changes

- Added Firecrawl `search()` and markdown `scrape()` support.
- Added `FIRECRAWL_API_KEY` detection and lazy client creation.
- Added Firecrawl to automatic provider selection after Tavily and Parallel.
- Added Firecrawl to `/settings`, with unavailable-state handling when the key is missing.
- Reported extraction failures per URL without failing the full request.
- Added documentation, tests, and the `firecrawl` SDK dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->