### PR TITLE
docs(memory): document lastMessages prompt cache invalidation

### DIFF
--- a/docs/src/content/en/docs/guides/context-engineering.mdx
+++ b/docs/src/content/en/docs/guides/context-engineering.mdx
@@ -195,7 +195,7 @@ await assistant.generate('Help me plan the next project milestone.', {
 
 The example assumes storage is configured on the registered Mastra instance or directly on `Memory`. `lastMessages` controls how many recent messages Mastra loads from the thread. The default is 10.
 
-Message history works well for shorter conversations where recent turns contain the context the agent needs. For long-running conversations, Mastra recommends [Observational Memory](/docs/memory/observational-memory), which keeps recent conversation available and turns older history into a dense observation log.
+Message history works well for shorter conversations where recent turns contain the context the agent needs. Because the `lastMessages` window slides forward on every request, each turn past the limit removes the oldest message from the start of the prompt and invalidates the provider prompt cache. For long-running conversations, Mastra recommends [Observational Memory](/docs/memory/observational-memory), which keeps recent conversation available and turns older history into a dense observation log while keeping the prompt prefix stable for caching.
 
 ## Observational Memory
 

--- a/docs/src/content/en/docs/memory/message-history.mdx
+++ b/docs/src/content/en/docs/memory/message-history.mdx
@@ -118,6 +118,12 @@ You can use this history in two ways:
 - **Automatic inclusion**: Mastra automatically includes recent messages in the context window. The default of 10 messages keeps agents grounded in the conversation. Adjust it with `lastMessages` when needed.
 - [**Manual querying**](#querying): For more control, query threads and messages directly with `recall()`. Use the results to choose which memories enter the context window or to render conversation history in your UI.
 
+:::note
+
+`lastMessages` counts every stored message, including tool calls, tool results, and [signals](/docs/harness/signals) of any kind, so a single turn can add several messages to the count. The window also slides forward on every request: once a thread grows past the limit, the oldest message leaves context on each turn, which changes the start of the prompt and invalidates the provider prompt cache. For long-running conversations, use [Observational Memory](/docs/memory/observational-memory), which keeps the prompt prefix stable.
+
+:::
+
 :::tip
 
 When memory is enabled, [Studio](/docs/studio/overview) uses message history to display past conversations in the chat sidebar.

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -74,7 +74,7 @@ To enable `workingMemory` on an agent, you’ll need a storage provider configur
             name: 'lastMessages',
             type: 'number | false',
             description:
-              'Number of most recent messages to include in context. Set to `false` to disable the message history feature entirely (messages are not loaded into context or saved). Use `Number.MAX_SAFE_INTEGER` to retrieve all messages with no limit. To load messages without saving new ones, use the `readOnly` option.',
+              'Number of most recent messages to include in context. Set to `false` to disable the message history feature entirely (messages are not loaded into context or saved). Use `Number.MAX_SAFE_INTEGER` to retrieve all messages with no limit. To load messages without saving new ones, use the `readOnly` option. The window slides forward on every request, so once a thread exceeds the limit, each turn invalidates the provider prompt cache. For long-running conversations, use [Observational Memory](/docs/memory/observational-memory) instead.',
             isOptional: true,
             defaultValue: '10',
           },


### PR DESCRIPTION
`lastMessages` slides forward on every request, so once a thread grows past the limit, each turn drops the oldest message from the front of the prompt and invalidates the provider prompt cache. None of the docs mentioned this, which led to the confusion in #23231 — with signals enabled, one turn can persist several rows, so small `lastMessages` values silently evicted the previous turn's tool results.

This updates the memory class reference, the message history page, and the context engineering guide to explain the sliding-window cache behavior, note that signals of any kind count toward the limit, and point long-running conversations at Observational Memory, which keeps the prompt prefix stable.

Code-side deprecation of `lastMessages` is hopefully happening separately in #23238, so this PR is docs-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This update explains how `lastMessages` removes old messages as conversations grow. It also recommends Observational Memory for long conversations because it keeps the prompt cache stable.

## Changes

- Documented that `lastMessages` uses a sliding window.
- Explained that all signal types count toward the message limit.
- Documented that removing the oldest message invalidates the provider prompt cache.
- Noted that persistent signals can remove earlier tool results when the limit is small.
- Updated the memory reference, message history page, and context engineering guide.
- Recommended Observational Memory for long-running conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->