### PR TITLE
Make `diagnosis` the primary deploy-diagnosis CLI command and document `mastra env diagnosis`

### DIFF
--- a/.changeset/slow-radios-attend.md
+++ b/.changeset/slow-radios-attend.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Renamed the deploy diagnosis commands so `diagnosis` is the primary name and `suggestions` is the alias. Run `mastra env diagnosis`, `mastra studio deploy diagnosis`, or `mastra server deploy diagnosis` to debug a failed deploy; the previous `suggestions` names still work.

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -621,6 +621,30 @@ Omit `[environment]` to show deploys across all environments; pass an environmen
 
 Emit machine-readable JSON.
 
+### `mastra env diagnosis`
+
+Diagnoses a failed deploy and prints suggestions for fixing it. Each suggestion includes a description, a recommended action, and a documentation link when one applies, followed by a link to the deploy logs in the dashboard. `mastra env suggestions` is an alias.
+
+```bash
+mastra env diagnosis
+mastra env diagnosis <deploy-id>
+mastra env diagnosis --environment staging
+```
+
+Omit `<deploy-id>` to diagnose the environment's latest deploy. The environment comes from `--environment`, or from the project when it has exactly one environment. Projects with several environments require `--environment` or a deploy ID. A deploy ID passed on its own works without a linked project.
+
+If the deploy is running successfully, the command reports that no suggestions are required and exits. Otherwise it starts a diagnosis when one doesn't already exist and polls until the result is ready, for up to five minutes. Rerunning the command is safe: an in-progress diagnosis is reused rather than restarted. The command exits with a non-zero code when the diagnosis itself fails.
+
+After a failed `mastra deploy`, the CLI prints the exact `mastra env diagnosis <deploy-id>` command to run.
+
+#### `--project`
+
+Project name, slug, or ID. Defaults to the linked project, as described in [`mastra env`](#mastra-env).
+
+#### `--environment`
+
+Environment name, slug, or ID. Defaults to the project's only environment; required when the project has more than one and no deploy ID is passed.
+
 ## `mastra studio deploy`
 
 :::note

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -633,7 +633,7 @@ mastra env diagnosis --environment staging
 
 Omit `<deploy-id>` to diagnose the environment's latest deploy. The environment comes from `--environment`, or from the project when it has exactly one environment. Projects with several environments require `--environment` or a deploy ID. A deploy ID passed on its own works without a linked project.
 
-If the deploy is running successfully, the command reports that no suggestions are required and exits. Otherwise it starts a diagnosis when one doesn't already exist and polls until the result is ready, for up to five minutes. Rerunning the command is safe: an in-progress diagnosis is reused rather than restarted. The command exits with a non-zero code when the diagnosis itself fails.
+If the deploy is running successfully, the command reports that no suggestions are required and exits. Otherwise it starts a diagnosis when one doesn't already exist and polls until the result is ready, for up to five minutes. Rerunning the command reuses an in-progress diagnosis instead of restarting it. The command exits with a non-zero code when the diagnosis itself fails.
 
 After a failed `mastra deploy`, the CLI prints the exact `mastra env diagnosis <deploy-id>` command to run.
 
@@ -643,7 +643,7 @@ Project name, slug, or ID. Defaults to the linked project, as described in [`mas
 
 #### `--environment`
 
-Environment name, slug, or ID. Defaults to the project's only environment; required when the project has more than one and no deploy ID is passed.
+Environment name, slug, or ID. Defaults to the project's only environment. Required when the project has more than one and no deploy ID is passed.
 
 ## `mastra studio deploy`
 

--- a/packages/cli/src/commands/env/deploy-suggestions.ts
+++ b/packages/cli/src/commands/env/deploy-suggestions.ts
@@ -67,7 +67,7 @@ async function resolveTarget(
   const environments = await fetchEnvironments(token, orgId, project.id);
   if (environments.length === 0) {
     throw new Error(
-      `No environments found for project ${project.name}. Deploy first with \`mastra deploy\`, then rerun \`mastra env suggestions\`.`,
+      `No environments found for project ${project.name}. Deploy first with \`mastra deploy\`, then rerun \`mastra env diagnosis\`.`,
     );
   }
 
@@ -90,7 +90,7 @@ async function resolveTarget(
   const latest = pickLatestDeployForEnv(deploys, environment.id);
   if (!latest) {
     throw new Error(
-      `No deploys found for environment ${environment.slug} in project ${project.name}. The suggestions command helps debug failed deployments; run it after a deployment fails with \`mastra env suggestions <deploy-id>\` or \`mastra env suggestions --environment ${environment.slug}\`.`,
+      `No deploys found for environment ${environment.slug} in project ${project.name}. The diagnosis command helps debug failed deployments; run it after a deployment fails with \`mastra env diagnosis <deploy-id>\` or \`mastra env diagnosis --environment ${environment.slug}\`.`,
     );
   }
 
@@ -124,7 +124,7 @@ export async function envSuggestionsAction(deployId: string | undefined, opts: S
     return;
   }
 
-  p.intro('mastra env suggestions');
+  p.intro('mastra env diagnosis');
   try {
     const token = await getToken();
     const { orgId } = await resolveCurrentOrg(token);

--- a/packages/cli/src/commands/server/deploy-suggestions.test.ts
+++ b/packages/cli/src/commands/server/deploy-suggestions.test.ts
@@ -175,7 +175,7 @@ describe('serverSuggestionsAction', () => {
     await expect(serverSuggestionsAction(undefined, {})).rejects.toThrow('exit:1');
 
     expect(mockLogError).toHaveBeenCalledWith(
-      'No deploys found for linked Server project Server App. The suggestions command helps debug failed deployments, and you can run it after a deployment fails with `mastra server deploy suggestions <deploy-id>` or `mastra server deploy suggestions`.',
+      'No deploys found for linked Server project Server App. The diagnosis command helps debug failed deployments, and you can run it after a deployment fails with `mastra server deploy diagnosis <deploy-id>` or `mastra server deploy diagnosis`.',
     );
     expect(mockFetchServerDeployDiagnosis).not.toHaveBeenCalled();
     mockExit.mockRestore();

--- a/packages/cli/src/commands/server/deploy-suggestions.ts
+++ b/packages/cli/src/commands/server/deploy-suggestions.ts
@@ -18,7 +18,7 @@ async function resolveDeployId(
   const { project } = await fetchServerProjectDetail(token, orgId, projectId);
   if (!project.latestDeployId) {
     throw new Error(
-      `No deploys found for linked Server project ${project.name}. The suggestions command helps debug failed deployments, and you can run it after a deployment fails with \`mastra server deploy suggestions <deploy-id>\` or \`mastra server deploy suggestions\`.`,
+      `No deploys found for linked Server project ${project.name}. The diagnosis command helps debug failed deployments, and you can run it after a deployment fails with \`mastra server deploy diagnosis <deploy-id>\` or \`mastra server deploy diagnosis\`.`,
     );
   }
 
@@ -32,7 +32,7 @@ function buildLogsUrl(orgId: string, projectId: string | undefined, deployId: st
 }
 
 export async function serverSuggestionsAction(deployId: string | undefined, opts: { org?: string }) {
-  p.intro('mastra server deploy suggestions');
+  p.intro('mastra server deploy diagnosis');
   try {
     const { token, orgId } = await resolveAuth(opts.org);
     const resolved = await resolveDeployId(token, orgId, deployId);

--- a/packages/cli/src/commands/studio/deploy-commands.test.ts
+++ b/packages/cli/src/commands/studio/deploy-commands.test.ts
@@ -366,7 +366,7 @@ describe('suggestionsAction', () => {
     await expect(suggestionsAction()).rejects.toThrow('process.exit');
 
     expect(mockClackLogError).toHaveBeenCalledWith(
-      'No deploys found for linked Studio project App 2. The suggestions command helps debug failed deployments, and you can run it after a deployment fails with `mastra studio deploy suggestions <deploy-id>` or `mastra studio deploy suggestions`.',
+      'No deploys found for linked Studio project App 2. The diagnosis command helps debug failed deployments, and you can run it after a deployment fails with `mastra studio deploy diagnosis <deploy-id>` or `mastra studio deploy diagnosis`.',
     );
     expect(mockFetchDeployDiagnosis).not.toHaveBeenCalled();
     mockExit.mockRestore();

--- a/packages/cli/src/commands/studio/deploy-suggestions.ts
+++ b/packages/cli/src/commands/studio/deploy-suggestions.ts
@@ -15,7 +15,7 @@ function getLatestProjectDeploy(projects: Project[], linkedProjectId?: string) {
     }
 
     throw new Error(
-      `No deploys found for linked Studio project ${linkedProject.name}. The suggestions command helps debug failed deployments, and you can run it after a deployment fails with \`mastra studio deploy suggestions <deploy-id>\` or \`mastra studio deploy suggestions\`.`,
+      `No deploys found for linked Studio project ${linkedProject.name}. The diagnosis command helps debug failed deployments, and you can run it after a deployment fails with \`mastra studio deploy diagnosis <deploy-id>\` or \`mastra studio deploy diagnosis\`.`,
     );
   }
 
@@ -66,7 +66,7 @@ async function resolveDeployId(
 }
 
 export async function suggestionsAction(deployId?: string) {
-  p.intro('mastra studio deploy suggestions');
+  p.intro('mastra studio deploy diagnosis');
 
   try {
     const token = await getToken();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -314,9 +314,9 @@ deployCommand
 
 if (coreFeatures.has('deploy-diagnosis')) {
   deployCommand
-    .command('suggestions [deploy-id]')
-    .alias('diagnosis')
-    .description('Show deploy suggestions for a failed deploy')
+    .command('diagnosis [deploy-id]')
+    .alias('suggestions')
+    .description('Diagnose a failed deploy and show fix suggestions')
     .action(wrapAction(suggestionsAction));
 }
 
@@ -376,9 +376,9 @@ registerEnvDbCommands(envCommand);
 
 if (coreFeatures.has('deploy-diagnosis')) {
   envCommand
-    .command('suggestions [deploy-id]')
-    .alias('diagnosis')
-    .description('Show deploy suggestions for a failed environment deploy')
+    .command('diagnosis [deploy-id]')
+    .alias('suggestions')
+    .description('Diagnose a failed environment deploy and show fix suggestions')
     .option('--project <project>', 'Project name, slug, or ID (default: linked project)')
     .option('--environment <name>', 'Environment name, slug, or ID (default: only env, or required when >1)')
     .action(wrapAction(envSuggestionsAction));
@@ -403,9 +403,9 @@ const serverDeployCommand = serverCommand
 
 if (coreFeatures.has('deploy-diagnosis')) {
   serverDeployCommand
-    .command('suggestions [deploy-id]')
-    .alias('diagnosis')
-    .description('Show deploy suggestions for a failed deploy')
+    .command('diagnosis [deploy-id]')
+    .alias('suggestions')
+    .description('Diagnose a failed deploy and show fix suggestions')
     .option('--org <id>', 'Organization ID')
     .action(wrapAction(serverSuggestionsAction));
 }


### PR DESCRIPTION
## Summary

The CLI's deploy-diagnosis commands were registered as `suggestions` with a `diagnosis` alias. "Diagnosis" is the stronger, more accurate term for what the command does — it diagnoses a failed deploy and then shows fix suggestions — so this PR makes `diagnosis` the primary name and keeps `suggestions` as an alias for compatibility.

- `mastra env diagnosis`, `mastra studio deploy diagnosis`, and `mastra server deploy diagnosis` are now the primary commands (`suggestions` still works everywhere)
- Command descriptions, intros, and error-message hints now use the `diagnosis` name
- Adds a `mastra env diagnosis` section to the CLI reference docs covering target resolution (`--project`, `--environment`, bare deploy ID), the healthy-deploy short-circuit, polling behavior, and exit codes
- Adds a patch changeset for `mastra`

## Test plan

- `pnpm --filter ./packages/cli typecheck` passes
- `vitest run` on `env/deploy-suggestions.test.ts`, `server/deploy-suggestions.test.ts`, and `studio/deploy-commands.test.ts` — 25/25 passing
- Docs page verified locally with the docs dev server; file passes prettier


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The CLI now uses `diagnosis` as the main command for investigating failed deployments. The old `suggestions` command still works as an alias.

## Changes

- Renamed deploy-diagnosis commands:
  - `mastra env diagnosis`
  - `mastra studio deploy diagnosis`
  - `mastra server deploy diagnosis`
- Updated command descriptions, intros, and error-message hints.
- Added CLI documentation for target resolution, polling, healthy deployments, and exit codes.
- Added a patch changeset for `mastra`.
- Updated related test expectations.

Typechecking, targeted tests, and documentation formatting checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->