### PR TITLE
fix(schema-compat): type optional scalar enum and const schemas

### DIFF
--- a/.changeset/easy-aliens-reply.md
+++ b/.changeset/easy-aliens-reply.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed OpenAI structured output rejecting optional scalar properties whose schema was declared with `enum` or `const`. The compatibility layer now infers the scalar `type` from those values before nullable wrapping, so an optional property accepts `null` and its permitted values instead of failing schema conversion.

--- a/packages/schema-compat/src/provider-compats/openai.test.ts
+++ b/packages/schema-compat/src/provider-compats/openai.test.ts
@@ -620,6 +620,31 @@ describe('OpenAISchemaCompatLayer', () => {
     });
   });
 
+  describe('optional scalar enum and const properties', () => {
+    it('accepts null while retaining enum and const validation', () => {
+      const result = compat.processToJSONSchema({
+        type: 'object',
+        properties: {
+          format: { enum: ['image', 'text'] },
+          kind: { const: 'input' },
+        },
+        required: [],
+      } as any) as Record<string, any>;
+
+      expect(result.properties.format).toEqual({
+        anyOf: [{ type: 'string', enum: ['image', 'text'] }, { type: 'null' }],
+      });
+      expect(result.properties.kind).toEqual({
+        anyOf: [{ type: 'string', const: 'input' }, { type: 'null' }],
+      });
+
+      const validate = new Ajv({ strict: false }).compile(result);
+      expect(validate({ format: null, kind: null })).toBe(true);
+      expect(validate({ format: 'image', kind: 'input' })).toBe(true);
+      expect(validate({ format: 'audio', kind: 'output' })).toBe(false);
+    });
+  });
+
   // OpenAI strict mode rejects `propertyNames`, which z.record() emits for its key type.
   // See https://github.com/mastra-ai/mastra/issues/19273
   describe('z.record() under strict mode', () => {

--- a/packages/schema-compat/src/provider-compats/openai.ts
+++ b/packages/schema-compat/src/provider-compats/openai.ts
@@ -102,6 +102,23 @@ function schemaValuesEqual(left: unknown, right: unknown, keyword?: string): boo
   );
 }
 
+function scalarTypeForValue(value: unknown): JSONSchema7['type'] | undefined {
+  if (typeof value === 'string') return 'string';
+  if (typeof value === 'boolean') return 'boolean';
+  if (typeof value === 'number') return 'number';
+  return undefined;
+}
+
+function inferScalarType(schema: JSONSchema7): JSONSchema7['type'] | undefined {
+  const values = 'const' in schema ? [schema.const] : Array.isArray(schema.enum) ? schema.enum : [];
+  const inferredTypes = values.map(scalarTypeForValue);
+  if (inferredTypes.some(type => type === undefined)) return undefined;
+
+  const types = [...new Set(inferredTypes)] as string[];
+  if (types.length === 0) return undefined;
+  return types.length === 1 ? (types[0] as JSONSchema7['type']) : (types as JSONSchema7['type']);
+}
+
 export class OpenAISchemaCompatLayer extends SchemaCompatLayer {
   getSchemaTarget(): Targets | undefined {
     return `jsonSchema7`;
@@ -293,7 +310,27 @@ export class OpenAISchemaCompatLayer extends SchemaCompatLayer {
       this.defaultUnionHandler(schema);
     }
 
+    if (Array.isArray(schema.anyOf)) {
+      for (const branch of schema.anyOf) {
+        if (typeof branch === 'object' && branch !== null && branch.type === undefined) {
+          const inferredType = inferScalarType(branch);
+          if (inferredType) {
+            branch.type = inferredType;
+          }
+        }
+      }
+    }
+
     if (schema.type === undefined && !schema.anyOf) {
+      const inferredType = inferScalarType(schema);
+      if (inferredType) {
+        schema.type = inferredType;
+      }
+
+      if (schema.type !== undefined) {
+        return;
+      }
+
       let subSchema: typeof schema = {};
       for (const key of Object.keys(schema)) {
         // @ts-expect-error - key is a valid property for JSON Schema


### PR DESCRIPTION
## Description

Optional scalar `enum` and `const` properties were emitted without a type on their non-null branch in OpenAI strict schemas, so a nullable property could not accept `null` while keeping its constraint. Infer the scalar type from the `enum` / `const` values during normalization, so `{ enum: ['image', 'text'] }` becomes `anyOf: [{ type: 'string', enum: ['image', 'text'] }, { type: 'null' }]`. Required scalar constraints remain non-nullable.

## Related issue(s)

Fixes #23173

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Optional settings such as `encoding` can now be left empty without breaking OpenAI schema validation. The fix still checks allowed values and preserves native image output when no encoding is provided.

## Changes

- Infer scalar JSON Schema types from `enum` and `const` values.
- Preserve `enum` and `const` validation for optional nullable properties.
- Keep required scalar constraints non-nullable.
- Add regression tests for optional scalar `enum` and `const` properties.
- Add a patch changeset for `@mastra/schema-compat`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->