### PR TITLE
fix(schema-compat): reduce Zod schema type instantiation

### DIFF
--- a/.changeset/loose-facts-float.md
+++ b/.changeset/loose-facts-float.md
@@ -1,0 +1,6 @@
+---
+'@mastra/schema-compat': patch
+'@mastra/core': patch
+---
+
+Reduced TypeScript memory usage for applications that define many tools with Zod schemas.

--- a/packages/core/src/tools/createtool-input-types.test-d.ts
+++ b/packages/core/src/tools/createtool-input-types.test-d.ts
@@ -112,6 +112,28 @@ describe('createTool execute inputData type inference (issue #16528)', () => {
   });
 });
 
+describe('createTool structural Zod schema inference (issue #23658)', () => {
+  it('accepts the minimal structural shape used to identify Zod schemas', () => {
+    const structuralZodSchema = {
+      _output: {} as { name: string },
+      _input: {} as { name: string },
+      _def: {},
+      parse: (_data: unknown) => ({ name: 'Grace' }),
+      safeParse: (_data: unknown): unknown => ({ success: true, data: { name: 'Grace' } }),
+    };
+
+    createTool({
+      id: 'structural-zod-schema',
+      description: 'Test',
+      inputSchema: structuralZodSchema,
+      execute: async inputData => {
+        expectTypeOf(inputData).toEqualTypeOf<{ name: string }>();
+        return undefined;
+      },
+    });
+  });
+});
+
 describe('createTool accepts jsonSchema() without cast (issue #16384)', () => {
   it('accepts a jsonSchema() schema without requiring "as never" cast', () => {
     createTool({

--- a/packages/core/src/tools/createtool-input-types.test-d.ts
+++ b/packages/core/src/tools/createtool-input-types.test-d.ts
@@ -1,6 +1,7 @@
 import { jsonSchema } from '@mastra/schema-compat';
 import { describe, it, expectTypeOf } from 'vitest';
 import zDefault from 'zod';
+import z3 from 'zod/v3';
 import { z } from 'zod/v4';
 
 import { createTool } from './tool';
@@ -54,6 +55,48 @@ describe('createTool execute inputData type inference (issue #16528)', () => {
         expectTypeOf(inputData).toEqualTypeOf<{ name: string; email?: string | undefined }>();
         return undefined;
       },
+    });
+  });
+
+  it('preserves Zod v3 input and output inference', () => {
+    createTool({
+      id: 'zod-v3',
+      description: 'Test',
+      inputSchema: z3.object({ name: z3.string() }),
+      outputSchema: z3.object({ greeting: z3.string() }),
+      execute: async inputData => {
+        expectTypeOf(inputData).toEqualTypeOf<{ name: string }>();
+        return { greeting: `Hello ${inputData.name}` };
+      },
+    });
+
+    createTool({
+      id: 'zod-v3-invalid-output',
+      description: 'Test',
+      outputSchema: z3.object({ greeting: z3.string() }),
+      // @ts-expect-error - outputSchema requires greeting to be a string
+      execute: async () => ({ greeting: 42 }),
+    });
+  });
+
+  it('infers the parsed output from a transformed Zod v4 input schema', () => {
+    createTool({
+      id: 'transformed-input',
+      description: 'Test',
+      inputSchema: z.object({ name: z.string() }).transform(({ name }) => ({ nameLength: name.length })),
+      execute: async inputData => {
+        expectTypeOf(inputData).toEqualTypeOf<{ nameLength: number }>();
+        return undefined;
+      },
+    });
+  });
+
+  it('rejects objects that do not match a supported schema shape', () => {
+    createTool({
+      id: 'invalid-schema',
+      description: 'Test',
+      // @ts-expect-error - arbitrary objects are not supported schemas
+      inputSchema: { unsupported: true },
     });
   });
 

--- a/packages/schema-compat/src/schema.types.ts
+++ b/packages/schema-compat/src/schema.types.ts
@@ -18,9 +18,23 @@ export type ZodDefault = z4.ZodDefault<any> | z3.ZodDefault<any>;
 
 export type AISdkSchemaLike<Output = unknown> = { _type: Output };
 
+/**
+ * A shallow structural boundary for Zod schemas.
+ *
+ * Using the full Zod v3 and v4 types in `PublicSchema` forces TypeScript to
+ * deeply compare both type trees whenever a concrete schema is inferred. The
+ * properties below are shared by supported Zod versions and mirror the shape
+ * checked by the runtime Zod guard.
+ */
+type StructuralZodSchema<Output = unknown, Input = Output> = {
+  readonly _output: Output;
+  readonly _input: Input;
+  parse(data: unknown): Output;
+  safeParse(data: unknown): unknown;
+} & ({ readonly _def: unknown } | { readonly _zod: unknown });
+
 export type PublicSchema<Output = unknown, Input = Output> =
-  | z4.ZodType<Output, Input>
-  | z3.Schema<Output, z3.ZodTypeDef, Input>
+  | StructuralZodSchema<Output, Input>
   | SchemaV4<Output>
   | SchemaV5<Output>
   | SchemaV6<Output>


### PR DESCRIPTION
## Description

Replaces the nominal Zod 3 and Zod 4 members in `PublicSchema` with a shallow structural boundary that preserves schema inference without repeatedly comparing both full type trees. In the 220-tool reproduction, TypeScript instantiations drop from 880,428 to 186,056; focused coverage verifies Zod 3 input/output inference, transformed Zod 4 inputs, and invalid schema rejection.

## Related Issue(s)

Fixes #23658

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes TypeScript inspect a small schema shape instead of comparing every Zod schema in full. This reduces memory use and prevents type-checking failures in applications with many tools.

## Summary

- Replaced nominal Zod 3 and Zod 4 members in `PublicSchema` with a shallow structural boundary.
- Preserved support for AI SDK schemas, JSON Schema, Standard Schema, and existing schema inference.
- Added type tests for:
  - Zod 3 input and output inference.
  - Transformed Zod 4 output inference.
  - Rejection of unsupported schema objects.
- Added a changeset for patch releases of `@mastra/schema-compat` and `@mastra/core`.
- Reduced TypeScript instantiations in the 220-tool reproduction from `880,428` to `186,056`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->