### PR TITLE
fix(core): preserve unknown usage counts

### DIFF
--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -962,7 +962,17 @@ describe('MastraModelOutput', () => {
         },
       });
 
-      await output.consumeStream();
+      const chunks: ChunkType[] = [];
+      for await (const chunk of output.fullStream) {
+        chunks.push(chunk);
+      }
+
+      const finalChunk = chunks.filter(c => c.type === 'finish').pop();
+      expect((finalChunk as any)?.payload?.output?.usage).toMatchObject({
+        cacheCreationInputTokens: 5268,
+        cacheCreationInputTokens5m: 4100,
+        cacheCreationInputTokens1h: 1168,
+      });
 
       expect(finishPayload?.totalUsage?.inputTokens).toBe(17962);
       expect(finishPayload?.totalUsage?.outputTokens).toBe(1500);

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -540,6 +540,104 @@ describe('MastraModelOutput', () => {
   });
 
   describe('usage raw passthrough', () => {
+    it('keeps missing usage counts unknown across multiple steps', async () => {
+      const runId = 'test-run';
+      const messageList = new MessageList({ threadId: 'test-thread' });
+      let finishPayload: any;
+
+      const stream = createChunkStream([
+        createStepFinishChunk(runId, undefined, { inputTokens: 10, outputTokens: 20, totalTokens: 30 }),
+        createStepFinishChunk(runId, undefined, { outputTokens: 5 }),
+        createFinishChunk(runId, undefined, { outputTokens: 5 }),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: {
+          runId,
+          onFinish: async payload => {
+            finishPayload = payload;
+          },
+        },
+      });
+
+      await output.consumeStream();
+
+      expect(finishPayload?.totalUsage).toMatchObject({
+        inputTokens: undefined,
+        outputTokens: 25,
+        totalTokens: undefined,
+      });
+    });
+
+    it('keeps all usage counts unknown when every step omits them', async () => {
+      const runId = 'test-run';
+      const messageList = new MessageList({ threadId: 'test-thread' });
+      let finishPayload: any;
+
+      const stream = createChunkStream([
+        createStepFinishChunk(runId, undefined, {}),
+        createFinishChunk(runId, undefined, {}),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: {
+          runId,
+          onFinish: async payload => {
+            finishPayload = payload;
+          },
+        },
+      });
+
+      await output.consumeStream();
+
+      expect(finishPayload?.usage).toMatchObject({
+        inputTokens: undefined,
+        outputTokens: undefined,
+        totalTokens: undefined,
+      });
+      expect(finishPayload?.totalUsage).toMatchObject({
+        inputTokens: undefined,
+        outputTokens: undefined,
+        totalTokens: undefined,
+      });
+    });
+
+    it('preserves measured zero usage as known', async () => {
+      const runId = 'test-run';
+      const messageList = new MessageList({ threadId: 'test-thread' });
+      let finishPayload: any;
+
+      const stream = createChunkStream([
+        createStepFinishChunk(runId, undefined, { inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+        createFinishChunk(runId, undefined, { inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: {
+          runId,
+          onFinish: async payload => {
+            finishPayload = payload;
+          },
+        },
+      });
+
+      await output.consumeStream();
+
+      expect(finishPayload?.totalUsage).toMatchObject({ inputTokens: 0, outputTokens: 0, totalTokens: 0 });
+    });
+
     it('should expose raw usage in onStepFinish callback', async () => {
       const runId = 'test-run';
       const rawUsage = {

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -1029,6 +1029,12 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 ...(self.#usageCount.cacheCreationInputTokens !== undefined && {
                   cacheCreationInputTokens: self.#usageCount.cacheCreationInputTokens,
                 }),
+                ...(self.#usageCount.cacheCreationInputTokens5m !== undefined && {
+                  cacheCreationInputTokens5m: self.#usageCount.cacheCreationInputTokens5m,
+                }),
+                ...(self.#usageCount.cacheCreationInputTokens1h !== undefined && {
+                  cacheCreationInputTokens1h: self.#usageCount.cacheCreationInputTokens1h,
+                }),
                 ...(self.#usageCount.raw !== undefined && {
                   raw: self.#usageCount.raw,
                 }),

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -275,6 +275,8 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
     outputTokens: undefined,
     totalTokens: undefined,
   };
+  #usageCountInitialized = false;
+  #usageCountMissing = new Set<keyof LanguageModelUsage>();
   #tripwire: StepTripwireData | undefined = undefined;
   #wasSuspended = false;
   #transportRef: MastraModelOutputOptions<OUTPUT>['transportRef'] | undefined;
@@ -1015,9 +1017,9 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               this.populateUsageCount(chunk.payload.output.usage as Record<string, number>);
 
               chunk.payload.output.usage = {
-                inputTokens: self.#usageCount.inputTokens ?? 0,
-                outputTokens: self.#usageCount.outputTokens ?? 0,
-                totalTokens: self.#usageCount.totalTokens ?? 0,
+                inputTokens: self.#usageCount.inputTokens,
+                outputTokens: self.#usageCount.outputTokens,
+                totalTokens: self.#getTotalUsage().totalTokens,
                 ...(self.#usageCount.reasoningTokens !== undefined && {
                   reasoningTokens: self.#usageCount.reasoningTokens,
                 }),
@@ -1573,33 +1575,25 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
     }
 
     // Use AI SDK v5 format only (MastraModelOutput is only used in VNext paths)
-    if (usage.inputTokens !== undefined) {
-      this.#usageCount.inputTokens = (this.#usageCount.inputTokens ?? 0) + usage.inputTokens;
+    for (const key of [
+      'inputTokens',
+      'outputTokens',
+      'totalTokens',
+      'reasoningTokens',
+      'cachedInputTokens',
+      'cacheCreationInputTokens',
+      'cacheCreationInputTokens5m',
+      'cacheCreationInputTokens1h',
+    ] as const) {
+      const value = usage[key];
+      if (value === undefined) {
+        this.#usageCountMissing.add(key);
+        this.#usageCount[key] = undefined;
+      } else if (!this.#usageCountMissing.has(key)) {
+        this.#usageCount[key] = (this.#usageCount[key] ?? 0) + value;
+      }
     }
-    if (usage.outputTokens !== undefined) {
-      this.#usageCount.outputTokens = (this.#usageCount.outputTokens ?? 0) + usage.outputTokens;
-    }
-    if (usage.totalTokens !== undefined) {
-      this.#usageCount.totalTokens = (this.#usageCount.totalTokens ?? 0) + usage.totalTokens;
-    }
-    if (usage.reasoningTokens !== undefined) {
-      this.#usageCount.reasoningTokens = (this.#usageCount.reasoningTokens ?? 0) + usage.reasoningTokens;
-    }
-    if (usage.cachedInputTokens !== undefined) {
-      this.#usageCount.cachedInputTokens = (this.#usageCount.cachedInputTokens ?? 0) + usage.cachedInputTokens;
-    }
-    if (usage.cacheCreationInputTokens !== undefined) {
-      this.#usageCount.cacheCreationInputTokens =
-        (this.#usageCount.cacheCreationInputTokens ?? 0) + usage.cacheCreationInputTokens;
-    }
-    if (usage.cacheCreationInputTokens5m !== undefined) {
-      this.#usageCount.cacheCreationInputTokens5m =
-        (this.#usageCount.cacheCreationInputTokens5m ?? 0) + usage.cacheCreationInputTokens5m;
-    }
-    if (usage.cacheCreationInputTokens1h !== undefined) {
-      this.#usageCount.cacheCreationInputTokens1h =
-        (this.#usageCount.cacheCreationInputTokens1h ?? 0) + usage.cacheCreationInputTokens1h;
-    }
+    this.#usageCountInitialized = true;
     // raw is provider-specific and not summable; keep the latest step's raw
     if (usage.raw !== undefined) {
       this.#usageCount.raw = usage.raw;
@@ -1612,28 +1606,60 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
     }
 
     // Use AI SDK v5 format only (MastraModelOutput is only used in VNext paths)
-    if (usage.inputTokens !== undefined && this.#usageCount.inputTokens === undefined) {
+    if (
+      usage.inputTokens !== undefined &&
+      this.#usageCount.inputTokens === undefined &&
+      !this.#usageCountMissing.has('inputTokens')
+    ) {
       this.#usageCount.inputTokens = usage.inputTokens;
     }
-    if (usage.outputTokens !== undefined && this.#usageCount.outputTokens === undefined) {
+    if (
+      usage.outputTokens !== undefined &&
+      this.#usageCount.outputTokens === undefined &&
+      !this.#usageCountMissing.has('outputTokens')
+    ) {
       this.#usageCount.outputTokens = usage.outputTokens;
     }
-    if (usage.totalTokens !== undefined && this.#usageCount.totalTokens === undefined) {
+    if (
+      usage.totalTokens !== undefined &&
+      this.#usageCount.totalTokens === undefined &&
+      !this.#usageCountMissing.has('totalTokens')
+    ) {
       this.#usageCount.totalTokens = usage.totalTokens;
     }
-    if (usage.reasoningTokens !== undefined && this.#usageCount.reasoningTokens === undefined) {
+    if (
+      usage.reasoningTokens !== undefined &&
+      this.#usageCount.reasoningTokens === undefined &&
+      !this.#usageCountMissing.has('reasoningTokens')
+    ) {
       this.#usageCount.reasoningTokens = usage.reasoningTokens;
     }
-    if (usage.cachedInputTokens !== undefined && this.#usageCount.cachedInputTokens === undefined) {
+    if (
+      usage.cachedInputTokens !== undefined &&
+      this.#usageCount.cachedInputTokens === undefined &&
+      !this.#usageCountMissing.has('cachedInputTokens')
+    ) {
       this.#usageCount.cachedInputTokens = usage.cachedInputTokens;
     }
-    if (usage.cacheCreationInputTokens !== undefined && this.#usageCount.cacheCreationInputTokens === undefined) {
+    if (
+      usage.cacheCreationInputTokens !== undefined &&
+      this.#usageCount.cacheCreationInputTokens === undefined &&
+      !this.#usageCountMissing.has('cacheCreationInputTokens')
+    ) {
       this.#usageCount.cacheCreationInputTokens = usage.cacheCreationInputTokens;
     }
-    if (usage.cacheCreationInputTokens5m !== undefined && this.#usageCount.cacheCreationInputTokens5m === undefined) {
+    if (
+      usage.cacheCreationInputTokens5m !== undefined &&
+      this.#usageCount.cacheCreationInputTokens5m === undefined &&
+      !this.#usageCountMissing.has('cacheCreationInputTokens5m')
+    ) {
       this.#usageCount.cacheCreationInputTokens5m = usage.cacheCreationInputTokens5m;
     }
-    if (usage.cacheCreationInputTokens1h !== undefined && this.#usageCount.cacheCreationInputTokens1h === undefined) {
+    if (
+      usage.cacheCreationInputTokens1h !== undefined &&
+      this.#usageCount.cacheCreationInputTokens1h === undefined &&
+      !this.#usageCountMissing.has('cacheCreationInputTokens1h')
+    ) {
       this.#usageCount.cacheCreationInputTokens1h = usage.cacheCreationInputTokens1h;
     }
     if (usage.raw !== undefined && this.#usageCount.raw === undefined) {
@@ -1920,11 +1946,12 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
   #getTotalUsage(): LanguageModelUsage {
     let total = this.#usageCount.totalTokens;
 
-    if (total === undefined) {
-      const input = this.#usageCount.inputTokens ?? 0;
-      const output = this.#usageCount.outputTokens ?? 0;
-      const reasoning = this.#usageCount.reasoningTokens ?? 0;
-      total = input + output + reasoning;
+    if (
+      total === undefined &&
+      this.#usageCount.inputTokens !== undefined &&
+      this.#usageCount.outputTokens !== undefined
+    ) {
+      total = this.#usageCount.inputTokens + this.#usageCount.outputTokens;
     }
 
     return {
@@ -2121,6 +2148,8 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
       finishReason: this.#finishReason,
       request: this.#request,
       usageCount: this.#usageCount,
+      usageCountInitialized: this.#usageCountInitialized,
+      usageCountMissing: [...this.#usageCountMissing],
       tripwire: this.#tripwire,
       wasSuspended: this.#wasSuspended,
       messageList: this.messageList.serialize(),
@@ -2146,6 +2175,11 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
     this.#finishReason = state.finishReason;
     this.#request = state.request;
     this.#usageCount = state.usageCount;
+    this.#usageCountInitialized = state.usageCountInitialized ?? false;
+    this.#usageCountMissing = new Set(
+      state.usageCountMissing ??
+        (state.usageCountInitialized === undefined ? ['inputTokens', 'outputTokens', 'totalTokens'] : []),
+    );
     this.#tripwire = state.tripwire;
     this.#wasSuspended = state.wasSuspended ?? state.status === 'suspended';
     this.messageList = this.messageList.deserialize(state.messageList);


### PR DESCRIPTION
## Description

Native multi-step usage aggregation treated omitted provider counts as zero, so partial provider data produced complete-looking totals. Missing counts are now tracked as unknown, measured zero values are preserved, and derived totals are computed only when the contributing input/output counts are complete. Usage completeness state is persisted and restored with backward-compatible defaults.

## Related issue(s)

Closes #23469

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a model step does not report token usage, the system now keeps that value unknown instead of guessing zero. It preserves real zero values and calculates totals only when all required counts are available.

## Changes

- Track missing input and output usage fields during multi-step aggregation.
- Preserve measured zero values.
- Derive totals only from complete input and output counts.
- Avoid double-counting reasoning tokens.
- Preserve cache-creation token counts.
- Persist and restore usage completeness state.
- Use backward-compatible defaults for legacy snapshots.
- Add coverage for ordinary and durable native agents, missing counts, measured zero, late metadata, serialization, and total derivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->