### PR TITLE
fix(core): preserve sealed reasoning on workflow resume

### DIFF
--- a/.changeset/huge-pets-sip.md
+++ b/.changeset/huge-pets-sip.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed observational memory workflow resumes duplicating Anthropic thinking blocks when approved tools complete. Sealed assistant messages now update the existing tool invocation while preserving provider-signed reasoning.

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1860,7 +1860,54 @@ export class MessageList {
 
           let newParts: typeof incomingParts;
 
-          if (incomingParts.length <= sealedPartCount) {
+          const existingToolCallIds = new Set(
+            existingParts.flatMap(part =>
+              part.type === 'tool-invocation' && part.toolInvocation ? [part.toolInvocation.toolCallId] : [],
+            ),
+          );
+          const resumedToolInvocations = incomingParts.filter(
+            part =>
+              part.type === 'tool-invocation' &&
+              part.toolInvocation &&
+              existingToolCallIds.has(part.toolInvocation.toolCallId),
+          );
+
+          if (resumedToolInvocations.length > 0) {
+            // A workflow resume returns the accumulated assistant message with the
+            // pending tool invocation updated to approval-responded/result. Update
+            // only those invocations on the sealed message so provider-signed
+            // reasoning remains in its original assistant message and is not copied
+            // into a second one.
+            MessageMerger.merge(existingMessage, {
+              ...messageV2,
+              content: {
+                format: 2,
+                parts: resumedToolInvocations,
+              },
+            });
+            this.pushMessageToSource(existingMessage, messageSource);
+
+            const isCompleteSnapshot =
+              incomingParts.length >= sealedPartCount &&
+              incomingParts.slice(0, sealedPartCount).every((part, index) => {
+                const existingPart = existingParts[index];
+                if (!existingPart) return false;
+                if (part.type === 'tool-invocation' && existingPart.type === 'tool-invocation') {
+                  return part.toolInvocation?.toolCallId === existingPart.toolInvocation?.toolCallId;
+                }
+                return CacheKeyGenerator.fromDBParts([part]) === CacheKeyGenerator.fromDBParts([existingPart]);
+              });
+
+            // Accumulated snapshots contain all parts through the seal boundary;
+            // partial stream flushes do not. In either case, the resumed tool
+            // invocation was merged above and must not be appended again.
+            newParts = isCompleteSnapshot
+              ? incomingParts.slice(sealedPartCount)
+              : incomingParts.filter(part => !resumedToolInvocations.includes(part));
+            if (newParts.length === 0) {
+              return this;
+            }
+          } else if (incomingParts.length <= sealedPartCount) {
             // Incoming message has fewer or equal parts than the sealed boundary.
             // Check if these are truly stale (same content as the sealed message) or
             // new content flushed independently (e.g., text deltas flushed with the

--- a/packages/core/src/agent/message-list/tests/message-list-sealed.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-sealed.test.ts
@@ -360,6 +360,129 @@ describe('MessageList sealed message handling', () => {
     expect((newMessage?.content.parts[0] as { text?: string })?.text).toBe('New content after observation');
   });
 
+  it('should update a resumed tool invocation without duplicating sealed Anthropic reasoning', () => {
+    const messageList = new MessageList({ threadId: 'test-thread' });
+
+    messageList.add({ role: 'user', content: 'Run the workflow' }, 'input');
+
+    const assistantMessageId = 'assistant-msg-1';
+    const reasoningPart = {
+      type: 'reasoning',
+      reasoning: 'I should request approval before running this tool.',
+      details: [
+        {
+          type: 'text',
+          text: 'I should request approval before running this tool.',
+          signature: 'sig-anthropic-thinking',
+        },
+      ],
+      providerMetadata: { anthropic: { signature: 'sig-anthropic-thinking' } },
+    } as MastraMessagePart;
+    const pendingToolPart = {
+      type: 'tool-invocation',
+      toolInvocation: {
+        toolCallId: 'call-1',
+        toolName: 'runWorkflow',
+        args: { input: 'test' },
+        state: 'approval-requested',
+        approval: { id: 'approval-1' },
+      },
+      metadata: { mastra: { sealedAt: Date.now() } },
+    } as MastraMessagePart;
+
+    messageList.add(
+      {
+        id: assistantMessageId,
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [reasoningPart, { type: 'text', text: 'May I run the workflow?' }, pendingToolPart],
+          metadata: { mastra: { sealed: true } },
+        },
+        createdAt: new Date(),
+      } as MastraDBMessage,
+      'response',
+    );
+
+    messageList.add(
+      {
+        id: assistantMessageId,
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [
+            reasoningPart,
+            { type: 'text', text: 'May I run the workflow?' },
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                toolCallId: 'call-1',
+                toolName: 'runWorkflow',
+                args: { input: 'test' },
+                state: 'result',
+                result: 'complete',
+              },
+            } as MastraMessagePart,
+          ],
+        },
+        createdAt: new Date(),
+      } as MastraDBMessage,
+      'response',
+    );
+
+    const assistantMessages = messageList.get.all.db().filter(message => message.role === 'assistant');
+    expect(assistantMessages).toHaveLength(1);
+    expect(assistantMessages[0]?.content.parts.filter(part => part.type === 'reasoning')).toHaveLength(1);
+    expect(messageList.get.response.db().filter(message => message.role === 'assistant')).toEqual(assistantMessages);
+
+    const toolPart = assistantMessages[0]?.content.parts.find(part => part.type === 'tool-invocation');
+    expect(toolPart?.type === 'tool-invocation' && toolPart.toolInvocation).toMatchObject({
+      toolCallId: 'call-1',
+      state: 'result',
+      result: 'complete',
+    });
+    expect(assistantMessages[0]?.content.metadata).toMatchObject({ mastra: { sealed: true } });
+    expect(toolPart).toMatchObject({ metadata: { mastra: { sealedAt: expect.any(Number) } } });
+
+    // Streaming may later flush only the resumed invocation and new text,
+    // rather than another complete accumulated assistant snapshot.
+    messageList.add(
+      {
+        id: assistantMessageId,
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                toolCallId: 'call-1',
+                toolName: 'runWorkflow',
+                args: { input: 'test' },
+                state: 'result',
+                result: 'complete',
+              },
+            } as MastraMessagePart,
+            { type: 'text', text: 'The workflow completed.' },
+          ],
+        },
+        createdAt: new Date(),
+      } as MastraDBMessage,
+      'response',
+    );
+
+    const messagesAfterPartialFlush = messageList.get.all.db().filter(message => message.role === 'assistant');
+    expect(messagesAfterPartialFlush).toHaveLength(2);
+    expect(
+      messagesAfterPartialFlush.flatMap(message => message.content.parts).filter(part => part.type === 'reasoning'),
+    ).toHaveLength(1);
+
+    const continuation = messagesAfterPartialFlush.find(message => message.id !== assistantMessageId);
+    expect(continuation?.content.parts).toEqual([
+      expect.objectContaining({ type: 'text', text: 'The workflow completed.' }),
+    ]);
+  });
+
   it('should not merge into messages at or before the latest sealed boundary', () => {
     const messageList = new MessageList({ threadId: 'test-thread' });
 


### PR DESCRIPTION
## Description

Preserves sealed Anthropic reasoning when observational memory buffers during a workflow tool approval. Resumed tool states are merged into the existing assistant message while post-seal output remains separate, including partial stream flushes.

## Related Issue(s)

Fixes #22802

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a workflow pauses for tool approval, the system keeps the original sealed reasoning instead of adding it again. New output after approval remains separate.

## Changes

- Merge resumed tool invocations into sealed assistant messages.
- Preserve Anthropic `thinking` and `redacted_thinking` blocks.
- Ignore stale tool-state updates.
- Keep post-seal text and partial stream flushes in a separate continuation.
- Add regression tests for delayed approvals, sealed reasoning, and partial output.
- Add a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->