### PR TITLE
fix(core): preserve stderr for successful execute_command calls

### DIFF
--- a/.changeset/honest-pens-enjoy.md
+++ b/.changeset/honest-pens-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed execute_command to include stderr when commands exit successfully. (#23679)

--- a/packages/core/src/workspace/tools/__tests__/execute-command.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/execute-command.test.ts
@@ -321,6 +321,30 @@ describe('executeCommandTool data chunks', () => {
 
       expect(result).toBe('hello world\n');
     });
+
+    it('returns stderr for successful command with no stdout', async () => {
+      const { context } = createMockContext({
+        executeCommand: async () => {
+          return { success: true, exitCode: 0, stdout: '', stderr: 'warning', executionTimeMs: 5 };
+        },
+      });
+
+      const result = await execute({ command: 'warn', args: [], timeout: null, cwd: null }, context);
+
+      expect(result).toBe('stderr:\nwarning');
+    });
+
+    it('labels stdout and stderr for successful command with both streams', async () => {
+      const { context } = createMockContext({
+        executeCommand: async () => {
+          return { success: true, exitCode: 0, stdout: 'completed', stderr: 'warning', executionTimeMs: 5 };
+        },
+      });
+
+      const result = await execute({ command: 'build', args: [], timeout: null, cwd: null }, context);
+
+      expect(result).toBe('stdout:\ncompleted\n\nstderr:\nwarning');
+    });
   });
 
   describe('streaming chunks match return value', () => {

--- a/packages/core/src/workspace/tools/execute-command.ts
+++ b/packages/core/src/workspace/tools/execute-command.ts
@@ -264,7 +264,12 @@ async function executeCommand(input: Record<string, any>, context: any) {
       return appendTerminalLine(parts, `Exit code: ${result.exitCode}`);
     }
 
-    return (await truncateOutput(result.stdout, tail, tokenLimit, tokenFrom)) || '(no output)';
+    return (
+      formatCommandOutput(
+        await truncateOutput(result.stdout, tail, tokenLimit, tokenFrom),
+        await truncateOutput(result.stderr, tail, tokenLimit, tokenFrom),
+      ).join('\n') || '(no output)'
+    );
   } catch (error) {
     await context?.writer?.custom({
       type: 'data-sandbox-exit',


### PR DESCRIPTION
## Description

Preserves `stderr` in successful `execute_command` results and labels both streams when stdout and stderr are present. Before this change, a successful command with only stderr returned `(no output)`; after this change, it returns the stderr diagnostic. Adds regression coverage and a patch changeset for `@mastra/core`.

## Related Issue(s)

Fixes #23679

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Commands can write messages to `stderr` even when they succeed. This change keeps those messages instead of showing `(no output)`.

## Changes

- Updated `execute_command` to preserve successful command output from both `stdout` and `stderr`.
- Added labeled `stdout:` and `stderr:` sections when both streams contain output.
- Kept `(no output)` when neither stream contains output.
- Added regression tests for `stderr`-only and mixed output.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->