### PR TITLE
fix(core): trust the gateway's capability answer over the nested provider

### DIFF
--- a/.changeset/quiet-gateways-decide.md
+++ b/.changeset/quiet-gateways-decide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the model capability registry trusting a nested provider's capabilities over the gateway actually serving the request. When a gateway such as OpenRouter lists a routed model (e.g. `openrouter/deepseek/deepseek-v4-flash`) without attachment support, that answer is now authoritative instead of falling back to the upstream provider's file, which caused Observational Memory to forward images to endpoints that reject them ("No endpoints found that support image input").

--- a/packages/core/src/llm/model/provider-registry.test.ts
+++ b/packages/core/src/llm/model/provider-registry.test.ts
@@ -42,6 +42,45 @@ describe('modelSupportsAttachments', () => {
     expect(modelSupportsAttachments('openrouter/openai/gpt-4o')).toBe(true);
     expect(modelSupportsAttachments('mastra/openrouter/openai/gpt-4o')).toBe(true);
   });
+
+  it('does not fall back to the nested provider when the gateway lists the model without support', () => {
+    const originalReadFileSync = fs.readFileSync;
+    vi.spyOn(fs, 'readFileSync').mockImplementation((filePath, ...rest) => {
+      const content = originalReadFileSync(filePath as any, ...(rest as [any]));
+      if (typeof filePath === 'string' && path.basename(filePath) === 'deepseek.json' && typeof content === 'string') {
+        // Simulate a gateway-synced DeepSeek file where the direct API gained vision.
+        const data = JSON.parse(content);
+        data.attachment = [...(data.attachment ?? []), 'deepseek-v4-flash'];
+        return JSON.stringify(data);
+      }
+      return content;
+    });
+
+    // DeepSeek direct supports it, but OpenRouter lists the model without attachment support.
+    expect(modelSupportsAttachments('deepseek/deepseek-v4-flash')).toBe(true);
+    expect(modelSupportsAttachments('openrouter/deepseek/deepseek-v4-flash')).toBe(false);
+  });
+
+  it('falls back to the nested provider only when the gateway does not list the model at all', () => {
+    const originalReadFileSync = fs.readFileSync;
+    vi.spyOn(fs, 'readFileSync').mockImplementation((filePath, ...rest) => {
+      const content = originalReadFileSync(filePath as any, ...(rest as [any]));
+      if (
+        typeof filePath === 'string' &&
+        path.basename(filePath) === 'openrouter.json' &&
+        typeof content === 'string'
+      ) {
+        const data = JSON.parse(content);
+        for (const key of Object.keys(data)) {
+          if (Array.isArray(data[key])) data[key] = data[key].filter((id: string) => id !== 'openai/gpt-4o');
+        }
+        return JSON.stringify(data);
+      }
+      return content;
+    });
+
+    expect(modelSupportsAttachments('openrouter/openai/gpt-4o')).toBe(true);
+  });
 });
 
 describe('modelSupportsTemperature', () => {

--- a/packages/core/src/llm/model/provider-registry.ts
+++ b/packages/core/src/llm/model/provider-registry.ts
@@ -609,6 +609,15 @@ function getProviderCapabilitySupport(
   return models.includes(modelId);
 }
 
+/** Whether the provider's capability file enumerates this model under any dimension. */
+function providerListsModel(provider: string, modelId: string, useDynamicLoading: boolean): boolean {
+  const file = loadProviderCapabilityFile(provider, useDynamicLoading);
+  if (!file) return false;
+  return (Object.keys(providerCapCaches) as CapabilityDimension[]).some(dimension =>
+    file[dimension]?.includes(modelId),
+  );
+}
+
 function modelSupportsCapability(modelRouterId: string, dimension: CapabilityDimension): boolean | undefined {
   const parsed = parseModelString(modelRouterId);
   const provider = parsed.provider ? (PROVIDER_ALIASES[parsed.provider] ?? parsed.provider) : parsed.provider;
@@ -638,12 +647,16 @@ function modelSupportsCapability(modelRouterId: string, dimension: CapabilityDim
   // Positive direct match wins immediately.
   if (directSupport === true) return true;
 
-  // For nested model IDs (e.g. `openrouter/anthropic/claude-sonnet-4-6`), the
-  // outer gateway's capability list may not enumerate every nested model. Fall
-  // back to the underlying provider's authoritative capability file before
-  // trusting a `false` from the gateway.
+  // The provider actually serving the request is authoritative. If it lists the
+  // model at all, its `false` stands — a gateway can lack capabilities the
+  // upstream provider offers directly (OpenRouter has no image-capable endpoint
+  // for `deepseek/deepseek-v4-flash` even though DeepSeek's own API does).
+  //
+  // Only when the gateway doesn't enumerate the nested model anywhere (e.g.
+  // `openrouter/anthropic/claude-sonnet-4-6` missing from OpenRouter's data) do
+  // we fall back to the underlying provider's capability file.
   const nestedProviderDelimiter = modelId.indexOf('/');
-  if (nestedProviderDelimiter !== -1) {
+  if (nestedProviderDelimiter !== -1 && !providerListsModel(provider, modelId, useDynamicLoading)) {
     const nestedProvider = modelId.substring(0, nestedProviderDelimiter);
     const nestedModelId = modelId.substring(nestedProviderDelimiter + 1);
     if (nestedProvider && nestedModelId) {


### PR DESCRIPTION
## Summary

When a model is routed through a gateway (e.g. `openrouter/deepseek/deepseek-v4-flash`), the capability registry consulted the nested provider's capability file whenever the gateway reported `false`. That let DeepSeek's direct-provider entry on models.dev (which currently marks `deepseek-v4-flash` as image-capable) override OpenRouter's explicit "no attachment support".

With Observational Memory's `observeAttachments: 'auto'`, this forwarded screenshots to OpenRouter and every observation failed:

```
Observational memory observation buffering failed: No endpoints found that support image input
```

This change makes the gateway authoritative when it lists the model at all — it is the endpoint actually serving the request, and it can lack capabilities the upstream provider offers directly. The nested-provider fallback is kept only for models the gateway doesn't enumerate under any dimension (models.dev's gateway data is incomplete, e.g. `openrouter/anthropic/claude-sonnet-4-6` isn't listed by OpenRouter, so temperature support must come from `anthropic.json`).

## Test plan

- [x] New test: gateway `false` beats nested provider `true` when the gateway lists the model (red before the fix, green after)
- [x] New test: nested-provider fallback still applies when the gateway doesn't list the model
- [x] Existing `modelSupportsAttachments` / `modelSupportsTemperature` / `modelSupportsStructuredOutput` tests pass
- [x] `tsc --noEmit` and oxlint clean for `@mastra/core`

## Note

`provider-registry.test.ts`'s `GatewayRegistry Auto-Refresh` block runs the real registry generator against `~/.cache/mastra` with mocked gateways that return no capability data, which wipes the developer's `~/.cache/mastra/capabilities` directory (`registry-generator.ts:337`). Pre-existing; not addressed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Mastra now trusts a gateway when it says a routed model lacks a capability. It uses the underlying provider only when the gateway has not answered.

## Changes

- Made gateway capability results authoritative when the gateway lists the model and provides data for that capability.
- Prevented nested-provider capabilities from overriding gateway limitations for attachments, temperature, and structured output.
- Preserved fallback for catalog-only gateways and models that the gateway does not list.
- Added tests for OpenRouter precedence and Netlify fallback behavior.
- Added a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->