### PR TITLE
docs: fix 'propmts' typo in Electron integration guide

### DIFF
--- a/docs/src/content/en/integrations/frameworks/electron.mdx
+++ b/docs/src/content/en/integrations/frameworks/electron.mdx
@@ -381,7 +381,7 @@ export default function App(): React.JSX.Element {
 }
 ```
 
-This connects [`useChat()`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat) to the `/chat/weather-agent` endpoint, sending propmts there and streaming the response back in chunks.
+This connects [`useChat()`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat) to the `/chat/weather-agent` endpoint, sending prompts there and streaming the response back in chunks.
 
 ## Test your agent
 


### PR DESCRIPTION
## Summary
- Fix typo in Electron integration docs: `propmts` → `prompts`

Tiny unsolicited docs fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR corrects a spelling mistake in the Electron integration guide. It changes “propmts” to “prompts.”

## Changes

- Fixed the typo in `docs/src/content/en/integrations/frameworks/electron.mdx`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->