### PR TITLE
docs: fix missing 'to' in agent quickstart tool sentence

### DIFF
--- a/docs/src/content/en/docs/getting-started/_partial-agent-quickstart.mdx
+++ b/docs/src/content/en/docs/getting-started/_partial-agent-quickstart.mdx
@@ -66,7 +66,7 @@ Short list of known model IDs are:
 
 Go to [https://mastra.ai/models](https://mastra.ai/models) for a full list of supported models.
 
-Add a tool an agent by importing the tool and passing it to the agent constructor as a tools object.
+Add a tool to an agent by importing the tool and passing it to the agent constructor as a tools object.
 
 Example:
 


### PR DESCRIPTION
## Summary
- Fix grammar in the agent quickstart: "Add a tool an agent" → "Add a tool to an agent".

Tiny unsolicited docs grammar fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a grammar mistake in the agent quickstart documentation. It changes the text to clearly say how to add a tool to an agent.

## Changes

- Corrected “Add a tool an agent” to “Add a tool to an agent.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->