### PR TITLE
fix(ci): replace removed Docker Hub MinIO images in s3 workspace compose

### DIFF
--- a/workspaces/s3/docker-compose.yml
+++ b/workspaces/s3/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   minio:
-    image: minio/minio:latest
+    # MinIO's community images were pulled from Docker Hub/Quay (source-only
+    # since Oct 2025); Chainguard maintains free builds. Pinned by digest for
+    # reproducible CI — bump deliberately. Free tier publishes no version tags.
+    image: cgr.dev/chainguard/minio@sha256:039800e64ec7247d2fde7cff3697e964f6fe20b6d7d2c46aa7d82cc63355d512
     ports:
       - '9000:9000'
       - '9001:9001'
@@ -14,15 +17,18 @@ services:
       timeout: 5s
       retries: 5
 
-  # Create test bucket on MinIO startup
+  # Create test bucket on MinIO startup (distroless Chainguard images have no
+  # shell, so bucket creation uses aws-cli instead of minio/mc)
   minio-setup:
-    image: minio/mc:latest
+    image: amazon/aws-cli:2.36.44
     depends_on:
       minio:
         condition: service_healthy
+    environment:
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
     entrypoint: >
       /bin/sh -c "
-      mc alias set local http://minio:9000 minioadmin minioadmin;
-      mc mb local/test-bucket --ignore-existing;
-      exit 0;
+      aws --endpoint-url http://minio:9000 s3api head-bucket --bucket test-bucket ||
+      aws --endpoint-url http://minio:9000 s3 mb s3://test-bucket
       "

--- a/workspaces/s3/package.json
+++ b/workspaces/s3/package.json
@@ -24,7 +24,7 @@
     "build:watch": "pnpm build --watch",
     "test:unit": "vitest run --exclude '**/*.integration.test.ts'",
     "test:watch": "vitest watch",
-    "pretest": "docker compose up -d && sleep 3",
+    "pretest": "docker compose up -d --wait --wait-timeout 180 && n=0; until [ \"$(docker compose ps -a -q minio-setup | xargs docker inspect -f '{{.State.Status}}-{{.State.ExitCode}}' 2>/dev/null)\" = 'exited-0' ] || [ \"$n\" -ge 60 ]; do sleep 1; n=$((n+1)); done; [ \"$(docker compose ps -a -q minio-setup | xargs docker inspect -f '{{.State.Status}}-{{.State.ExitCode}}' 2>/dev/null)\" = 'exited-0' ]",
     "test": "S3_ENDPOINT=http://localhost:9000 S3_ACCESS_KEY_ID=minioadmin S3_SECRET_ACCESS_KEY=minioadmin S3_BUCKET=test-bucket S3_REGION=us-east-1 vitest run ./src/**/*.integration.test.ts",
     "posttest": "docker compose down -v",
     "test:cloud": "vitest run ./src/**/*.integration.test.ts",


### PR DESCRIPTION
## Summary

MinIO discontinued their pre-compiled community images — `minio/minio` and `minio/mc` were removed from Docker Hub (404 / pull access denied), failing `Workspace Tests / test-docker (s3)` at the compose pull step on every PR that runs it (verified failing today on unrelated branches too, e.g. `proto/background-dispositions-signals`). The remaining `quay.io/minio` tags still pull but are frozen and unpatched (MinIO went source-only / archived the community repo in Oct 2025).

Changes to `workspaces/s3/docker-compose.yml`:

- **Server**: `cgr.dev/chainguard/minio` pinned by digest — Chainguard's actively maintained, zero-CVE community build of the MinIO source. Verified drop-in: serves the S3 API on 9000 and still bundles `mc`, so the existing `mc ready local` healthcheck works unchanged (verified empirically — compose reaches healthy, and `test-docker (s3)` is green on this PR). Pinned by digest for reproducible CI because the Chainguard free tier publishes no version tags; bump deliberately.
- **Bucket setup**: pinned `amazon/aws-cli` instead of `minio/mc` — Chainguard's distroless `minio-client` has no shell, so the old `sh -c` entrypoint can't run there. Creation is idempotent (`head-bucket` then `mb`) and real failures propagate instead of being swallowed.

## Test plan

- Verified locally end-to-end: `docker compose up -d --wait` → minio healthy, setup container exits 0, `test-bucket` created (`s3 ls` confirms); rerun without volume removal also succeeds (idempotent path); S3 ready endpoint returns 200.
- CI: `Workspace Tests / test-docker (s3)` green on this PR.

Co-Authored-By: mastra-platform[bot] <284800079+mastra-platform[bot]@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The S3 workspace now uses available container images instead of removed Docker Hub images. The test setup waits for MinIO to be ready and creates the test bucket safely, so S3 tests avoid image and startup-timing failures.

## Changes

- Pinned MinIO from `cgr.dev/chainguard/minio` by digest.
- Preserved the `mc ready local` healthcheck.
- Replaced the MinIO client with `amazon/aws-cli:2.36.44`.
- Added idempotent bucket creation through the MinIO S3 endpoint.
- Kept genuine bucket-creation failures visible.
- Updated `pretest` to wait for MinIO health and successful setup-container completion for up to 60 seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->