### PR TITLE
fix(redis-streams): make the inFlightTimeoutMs settlement atomic

### DIFF
--- a/.changeset/redis-streams-atomic-timeout-nack.md
+++ b/.changeset/redis-streams-atomic-timeout-nack.md
@@ -1,0 +1,5 @@
+---
+'@mastra/redis-streams': patch
+---
+
+`inFlightTimeoutMs` now settles a timed-out entry atomically. The ownership check and the republish + `XACK` run in a single Redis script, so a sibling consumer claiming the entry between the two can no longer cause a duplicate republish or an `XACK` of the sibling's pending entry.

--- a/pubsub/redis-streams/src/index.ts
+++ b/pubsub/redis-streams/src/index.ts
@@ -8,6 +8,31 @@ import type { RedisClientOptions, RedisClientType } from 'redis';
 const RECLAIM_PAGE_SIZE = 100;
 
 /**
+ * Atomically nack a pending entry only if it is still owned by the given
+ * consumer. Returns 1 if this consumer owned it and it was settled, 0 if the
+ * entry was not pending for this consumer (acked, or claimed by a sibling).
+ *
+ * KEYS[1] stream key
+ * ARGV[1] group, ARGV[2] consumer, ARGV[3] stream entry id,
+ * ARGV[4] republish payload ('' = drop without republish),
+ * ARGV[5] stream idle TTL in ms (0 = none)
+ */
+const NACK_IF_OWNED_SCRIPT = `
+  local pending = redis.call("XPENDING", KEYS[1], ARGV[1], ARGV[3], ARGV[3], 1)
+  if #pending == 0 or pending[1][2] ~= ARGV[2] then
+    return 0
+  end
+  if ARGV[4] ~= "" then
+    redis.call("XADD", KEYS[1], "*", "event", ARGV[4])
+    if tonumber(ARGV[5]) > 0 then
+      redis.call("PEXPIRE", KEYS[1], ARGV[5])
+    end
+  end
+  redis.call("XACK", KEYS[1], ARGV[1], ARGV[3])
+  return 1
+`;
+
+/**
  * Flatten an error into searchable text. node-redis MULTI failures throw a
  * `MultiErrorReply` whose own message is just "N commands failed…" — the real
  * per-command errors (e.g. BUSYGROUP) live in `err.replies`, so those are
@@ -486,39 +511,18 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
     const cutoff = Date.now() - this.#inFlightTimeoutMs;
     for (const [streamId, entry] of sub.inFlight) {
       if (entry.since > cutoff) continue;
-      // The local marker is not proof of ownership: if the entry has already
-      // been idle >= reclaimIdleMs a sibling may have claimed it (and may be
-      // processing it right now), or it may have been acked outright. Nacking
-      // in that state would republish a duplicate and xAck the sibling's
-      // pending entry out from under it. So check the PEL first and, if we no
-      // longer own the entry, just disown it locally — that also flips
-      // `settled` so a late ack/nack from the hung handler becomes a no-op.
-      // XCLAIM by a sibling between this check and the nack's xAck is still
-      // possible but requires the claim to land inside a single round-trip.
-      const [pendingEntry] = await this.#writeClient.xPendingRange(sub.streamKey, sub.group, streamId, streamId, 1);
-      if (!pendingEntry || pendingEntry.consumer !== sub.consumer) {
-        this.#logger?.warn?.(
-          'redis-streams: handler exceeded inFlightTimeoutMs but entry is no longer owned; disowning',
-          {
-            topic: sub.topic,
-            group: sub.group,
-            streamId,
-            owner: pendingEntry?.consumer ?? null,
-          },
-        );
-        entry.disown();
-        continue;
-      }
       this.#logger?.warn?.('redis-streams: handler exceeded inFlightTimeoutMs; nacking on its behalf', {
         topic: sub.topic,
         group: sub.group,
         streamId,
         inFlightMs: Date.now() - entry.since,
       });
-      // nack() is idempotent via its `settled` flag, republishes with
-      // deliveryAttempt + 1 (so maxDeliveryAttempts still applies), and
-      // removes the entry from `inFlight` once Redis has settled it.
-      await entry.nack();
+      // The local marker is not proof of ownership: once the entry has been
+      // idle >= reclaimIdleMs a sibling may have claimed it, or it may have
+      // been acked outright. `expire` verifies ownership and settles in one
+      // atomic Redis step, honours maxDeliveryAttempts, and removes the entry
+      // from `inFlight` either way.
+      await entry.expire();
     }
   }
 
@@ -981,13 +985,60 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
       }
     };
 
+    // Timeout-driven nack, used by #expireInFlight. Unlike `nack` above this
+    // can run while a sibling may have reclaimed the entry, so the ownership
+    // check and the republish+xAck must be one atomic Redis step: a
+    // read-then-nack would let a sibling XCLAIM land in between, and we'd
+    // republish a duplicate and xAck the sibling's entry out from under it.
+    // Either way the local marker is settled afterwards so a late ack/nack
+    // from the hung handler is a no-op.
+    const expire = async () => {
+      if (settled) return;
+      settled = true;
+      const attempt = event.deliveryAttempt ?? 1;
+      const drop = attempt >= this.#maxDeliveryAttempts;
+      const payload = drop ? '' : JSON.stringify({ ...event, deliveryAttempt: attempt + 1 } satisfies Event);
+      let owned: unknown;
+      try {
+        owned = await this.#writeClient.eval(NACK_IF_OWNED_SCRIPT, {
+          keys: [sub.streamKey],
+          arguments: [sub.group, sub.consumer, streamId, payload, String(this.#streamIdleTtlMs)],
+        });
+      } catch (err) {
+        this.#logger?.warn?.('redis-streams: timeout nack failed; leaving original pending for reclaim', {
+          topic: sub.topic,
+          eventId: event.id,
+          err: err instanceof Error ? err.message : err,
+        });
+        // Same recovery as a failed nack republish: the entry is still
+        // pending, so let a future reclaim (or the next timeout pass, if the
+        // handler is still hung) retry it.
+        settled = false;
+        sub.inFlight.delete(streamId);
+        return;
+      }
+      sub.inFlight.delete(streamId);
+      if (owned !== 1) {
+        this.#logger?.warn?.(
+          'redis-streams: handler exceeded inFlightTimeoutMs but entry is no longer owned; disowning',
+          { topic: sub.topic, group: sub.group, streamId },
+        );
+        return;
+      }
+      if (drop) {
+        this.#logger?.warn?.('redis-streams: dropping event after max delivery attempts', {
+          topic: sub.topic,
+          eventType: event.type,
+          eventId: event.id,
+          attempt,
+          max: this.#maxDeliveryAttempts,
+        });
+      }
+    };
+
     // Mark this entry in-flight for the reclaim loop's benefit for exactly the
     // window between invoking the handler and the delivery settling (ack/nack).
-    const disown = () => {
-      settled = true;
-      sub.inFlight.delete(streamId);
-    };
-    sub.inFlight.set(streamId, { since: Date.now(), nack, disown });
+    sub.inFlight.set(streamId, { since: Date.now(), expire });
     try {
       // EventCallback is typed `=> void` but handlers commonly return a
       // promise (TS allows Promise<void> to satisfy void). If we get one
@@ -1062,7 +1113,6 @@ interface Subscription {
   // Stream entry IDs currently being processed locally by this subscription.
   // The reclaim loop consults this to avoid re-invoking the handler for a
   // message whose original delivery is still in flight (self-redelivery).
-  // `disown` marks the delivery settled locally without touching Redis, for
-  // when the timeout path finds the entry is no longer owned by this consumer.
-  inFlight: Map<string, { since: number; nack: () => Promise<void>; disown: () => void }>;
+  // `expire` is the timeout path's atomic nack-if-still-owned.
+  inFlight: Map<string, { since: number; expire: () => Promise<void> }>;
 }

--- a/pubsub/redis-streams/src/reclaim.test.ts
+++ b/pubsub/redis-streams/src/reclaim.test.ts
@@ -294,4 +294,61 @@ describe('RedisStreamsPubSub reclaim loop', () => {
       await raw.quit();
     }
   });
+
+  it('does not republish or xAck when a sibling claims the entry inside the timeout settlement', async () => {
+    // The tightest possible race: the sibling's XCLAIM lands after the timeout
+    // path has decided to nack but before the nack reaches Redis. A separate
+    // ownership check followed by republish+xAck would still lose here; the
+    // settlement must verify ownership and settle in one atomic Redis step.
+    //
+    // Simulate it by intercepting the write client's script call and moving
+    // the entry to a sibling immediately before it is sent.
+    const topic = `t-${randomUUID()}`;
+    const group = `atomic-${randomUUID()}`;
+    const streamKey = `mastra:topic:${topic}`;
+
+    const raw = createClient({ url: REDIS_URL }) as RedisClientType;
+    await raw.connect();
+
+    let claimedInWindow = 0;
+    const realCreate = createClient;
+    vi.spyOn(await import('redis'), 'createClient').mockImplementation(((opts: any) => {
+      const client = realCreate(opts) as RedisClientType;
+      const origEval = client.eval.bind(client);
+      (client as any).eval = async (...args: Parameters<typeof origEval>) => {
+        const [pending] = await raw.xPendingRange(streamKey, group, '-', '+', 1);
+        if (pending) {
+          await raw.xClaim(streamKey, group, 'sibling', 0, [pending.id], { FORCE: true });
+          claimedInWindow++;
+        }
+        return origEval(...args);
+      };
+      return client;
+    }) as any);
+
+    const ps = createPubSub({ inFlightTimeoutMs: 300, reclaimIdleMs: 60_000 });
+    const attempts: number[] = [];
+    const cb: EventCallback = event => {
+      attempts.push(event.deliveryAttempt ?? 1);
+      // intentionally never ack/nack
+    };
+    await ps.subscribe(topic, cb, { group });
+    await ps.publish(topic, makeEvent({ type: 'atomic' }));
+    await waitFor(() => attempts.length === 1, 5000);
+
+    try {
+      // Cover the timeout (t≈300ms) and its settlement with margin.
+      await sleep(1000);
+
+      expect(attempts).toEqual([1]);
+      // Nothing republished, and the sibling still owns the untouched entry.
+      expect(await raw.xLen(streamKey)).toBe(1);
+      const pending = await raw.xPendingRange(streamKey, group, '-', '+', 10);
+      expect(pending).toHaveLength(1);
+      expect(pending[0]!.consumer).toBe('sibling');
+      expect(claimedInWindow).toBe(1);
+    } finally {
+      await raw.quit();
+    }
+  });
 });


### PR DESCRIPTION
Follow-up to #23656.

## Summary

When `inFlightTimeoutMs` fires, the reclaim loop nacks a hung handler's entry on its behalf. It first checked the pending entry's owner with `XPENDING`, then called the regular `nack()`, which republishes and `XACK`s in separate round-trips. A sibling consumer's `XCLAIM` landing between the check and the `XACK` meant we republished a duplicate **and** acked the sibling's newly-owned entry out from under it — the exact duplicate-execution failure the option exists to bound.

This moves the ownership check and the republish + `XACK` into a single Lua script (same pattern as the existing lease-refresh script), so settlement is atomic: if the entry is no longer pending for this consumer, the script is a no-op and the local in-flight marker is dropped. `maxDeliveryAttempts` is still honoured (drop = `XACK` only, no republish).

## Test plan

- New regression test intercepts the write client's script call and moves the entry to a sibling via `XCLAIM FORCE` immediately before it is sent. On the previous implementation the handler is invoked `[1, 2, 3, 4]` times (duplicate republish loop); with this change it stays `[1]`, the stream has no republished entry, and the sibling still owns the untouched pending entry.
- Full redis-streams suite (`pubsub`, `reclaim`, `unsubscribe`): 55/55, run 3x against an isolated Redis 8.
- Lint, typecheck, build, prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a timed-out message is recovered, Redis now checks ownership, republishes, and marks the original as done in one safe operation. This prevents duplicate messages or changes to messages claimed by another consumer.

## Changes

- Added an atomic Lua script for Redis Streams timeout recovery.
- Prevented duplicate republishing when a sibling consumer claims an entry first.
- Preserved `maxDeliveryAttempts` behavior for exhausted entries.
- Added a regression test for the consumer-claim race.
- Added a changeset for `@mastra/redis-streams`.

## Validation

- Redis Streams tests passed.
- Lint, typecheck, build, and formatting checks passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->