### PR TITLE
fix(core): time out UnixSocketPubSub membership acks so new clients do not hang on legacy brokers

### DIFF
--- a/.changeset/long-parents-clean.md
+++ b/.changeset/long-parents-clean.md
@@ -2,4 +2,10 @@
 '@mastra/core': patch
 ---
 
-Fixed Unix socket pubsub clients hanging forever on startup when connecting to a broker from an older build that never acknowledges subscribe requests. Subscriptions now proceed best-effort after a configurable timeout (default 5 seconds, via the new membershipAckTimeoutMs option).
+Fixed Unix socket pubsub clients hanging forever on startup when connecting to a broker from an older build that never acknowledges membership requests. Both `subscribe` and `unsubscribe` now proceed best-effort after a configurable timeout when no acknowledgement arrives, so newer clients no longer deadlock against legacy brokers.
+
+Configure the timeout via the new `membershipAckTimeoutMs` option (default 5000ms):
+
+```ts
+const pubsub = new UnixSocketPubSub(socketPath, { membershipAckTimeoutMs: 5000 });
+```

--- a/.changeset/long-parents-clean.md
+++ b/.changeset/long-parents-clean.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Unix socket pubsub clients hanging forever on startup when connecting to a broker from an older build that never acknowledges subscribe requests. Subscriptions now proceed best-effort after a configurable timeout (default 5 seconds, via the new membershipAckTimeoutMs option).

--- a/packages/core/src/events/unix-socket-pubsub.test.ts
+++ b/packages/core/src/events/unix-socket-pubsub.test.ts
@@ -506,6 +506,78 @@ describe('UnixSocketPubSub', () => {
     expect(goodCb).toHaveBeenCalledTimes(1);
   });
 
+  describe('membership ack timeout', () => {
+    /**
+     * Simulates a broker running an older protocol version: it accepts
+     * connections and subscribe/unsubscribe frames but never sends
+     * `subscribed`/`unsubscribed` acks.
+     */
+    async function startLegacyBroker(path: string): Promise<{ close: () => Promise<void> }> {
+      const sockets = new Set<net.Socket>();
+      const server = net.createServer(socket => {
+        sockets.add(socket);
+        socket.on('close', () => sockets.delete(socket));
+        socket.on('error', () => {});
+        socket.on('data', () => {}); // swallow frames, never ack
+      });
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(path, resolve);
+      });
+      return {
+        close: () => {
+          sockets.forEach(socket => socket.destroy());
+          return new Promise(resolve => server.close(() => resolve()));
+        },
+      };
+    }
+
+    it('rejects an invalid membershipAckTimeoutMs option', async () => {
+      const path = await socketPath();
+      for (const value of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+        expect(() => new UnixSocketPubSub(path, { membershipAckTimeoutMs: value })).toThrow(
+          'membershipAckTimeoutMs must be a positive finite number',
+        );
+      }
+    });
+
+    it('subscribe resolves best-effort when the broker never acks', async () => {
+      const path = await socketPath('legacy.sock');
+      const legacyBroker = await startLegacyBroker(path);
+      try {
+        const client = new UnixSocketPubSub(path, { membershipAckTimeoutMs: 100 });
+        pubsubs.push(client);
+        await expect(
+          Promise.race([
+            client.subscribe('topic-a', vi.fn()),
+            new Promise((_, reject) => setTimeout(() => reject(new Error('subscribe hung past ack timeout')), 2000)),
+          ]),
+        ).resolves.toBeUndefined();
+      } finally {
+        await legacyBroker.close();
+      }
+    });
+
+    it('unsubscribe resolves best-effort when the broker never acks', async () => {
+      const path = await socketPath('legacy-unsub.sock');
+      const legacyBroker = await startLegacyBroker(path);
+      try {
+        const client = new UnixSocketPubSub(path, { membershipAckTimeoutMs: 100 });
+        pubsubs.push(client);
+        const cb = vi.fn();
+        await client.subscribe('topic-a', cb);
+        await expect(
+          Promise.race([
+            client.unsubscribe('topic-a', cb),
+            new Promise((_, reject) => setTimeout(() => reject(new Error('unsubscribe hung past ack timeout')), 2000)),
+          ]),
+        ).resolves.toBeUndefined();
+      } finally {
+        await legacyBroker.close();
+      }
+    });
+  });
+
   describe('inbound frame size limit', () => {
     const LIMIT = 64 * 1024;
 

--- a/packages/core/src/events/unix-socket-pubsub.ts
+++ b/packages/core/src/events/unix-socket-pubsub.ts
@@ -35,6 +35,15 @@ type UnixSocketPubSubOptions = {
    * memory without bound.
    */
   maxInboundFrameBytes?: number;
+  /**
+   * How long (ms) a client waits for the broker to acknowledge a
+   * subscribe/unsubscribe frame before proceeding best-effort. Brokers running
+   * an older protocol version never send `subscribed`/`unsubscribed` acks, so
+   * an unbounded wait would deadlock startup of any newer client that connects
+   * to them. On timeout the membership change is assumed applied — old brokers
+   * do honor the frames, they just never acknowledge them.
+   */
+  membershipAckTimeoutMs?: number;
 };
 
 type BrokerClient = {
@@ -51,6 +60,7 @@ type MembershipWaiter = {
 
 const DEFAULT_MAX_REMOTE_CLIENT_QUEUED_BYTES = 64 * 1024 * 1024;
 const DEFAULT_MAX_INBOUND_FRAME_BYTES = 64 * 1024 * 1024;
+const DEFAULT_MEMBERSHIP_ACK_TIMEOUT_MS = 5_000;
 const NEWLINE_BYTE = 0x0a;
 
 /**
@@ -226,6 +236,7 @@ export class UnixSocketPubSub extends PubSub {
   #recovering?: Promise<void>;
   #maxRemoteClientQueuedBytes: number;
   #maxInboundFrameBytes: number;
+  #membershipAckTimeoutMs: number;
 
   constructor(socketPath: string, options: UnixSocketPubSubOptions = {}) {
     super();
@@ -237,6 +248,12 @@ export class UnixSocketPubSub extends PubSub {
       throw new Error('UnixSocketPubSub maxInboundFrameBytes must be a positive finite number');
     }
     this.#maxInboundFrameBytes = maxInboundFrameBytes;
+
+    const membershipAckTimeoutMs = options.membershipAckTimeoutMs ?? DEFAULT_MEMBERSHIP_ACK_TIMEOUT_MS;
+    if (!Number.isFinite(membershipAckTimeoutMs) || membershipAckTimeoutMs <= 0) {
+      throw new Error('UnixSocketPubSub membershipAckTimeoutMs must be a positive finite number');
+    }
+    this.#membershipAckTimeoutMs = membershipAckTimeoutMs;
   }
 
   override get supportedModes(): ReadonlyArray<PubSubDeliveryMode> {
@@ -644,7 +661,21 @@ export class UnixSocketPubSub extends PubSub {
     } catch (error) {
       this.#settleMembershipWaiters(waiterMap, key, error instanceof Error ? error : new Error(String(error)));
     }
-    await acknowledged;
+    // Brokers on an older protocol version accept subscribe/unsubscribe frames
+    // but never acknowledge them. Waiting unboundedly would deadlock every
+    // newer client that connects to such a broker, so after the timeout we
+    // resolve best-effort: the membership change was applied broker-side, only
+    // the ack is missing. Settling clears the waiter map, so a late ack (or
+    // this timer firing after a real ack) is a no-op.
+    const ackTimeout = setTimeout(() => {
+      this.#settleMembershipWaiters(waiterMap, key);
+    }, this.#membershipAckTimeoutMs);
+    ackTimeout.unref?.();
+    try {
+      await acknowledged;
+    } finally {
+      clearTimeout(ackTimeout);
+    }
   }
 
   #waitForPendingMembershipAcknowledgement(waiterMap: Map<string, MembershipWaiter[]>, key: string): Promise<void> {


### PR DESCRIPTION
## Summary

Processes using the Unix socket pubsub could hang forever on startup when connecting to a broker owned by a process running an older build. New clients send `subscribe`/`unsubscribe` frames and wait for an acknowledgement frame (`subscribed`/`unsubscribed`) — but brokers built before consumer-group support never send those acks, so the waiter promise stayed pending indefinitely. In practice this deadlocked `mastracode` TUI startup whenever a stale instance still owned the broker socket.

This adds a `membershipAckTimeoutMs` option to `UnixSocketPubSub` (default 5000ms). If no ack arrives within the timeout, pending membership waiters resolve best-effort so startup can proceed. The timer is unref'd and is cleared when the ack arrives or the client closes, so behavior with up-to-date brokers is unchanged.

## Changes

- `packages/core/src/events/unix-socket-pubsub.ts`: new `membershipAckTimeoutMs` option with validation; best-effort timeout on membership ack waiters
- `packages/core/src/events/unix-socket-pubsub.test.ts`: tests for a legacy broker that accepts connections but never acks (subscribe + unsubscribe), plus option validation
- Changeset (patch, `@mastra/core`)

## Test plan

- [x] `vitest run src/events/unix-socket-pubsub.test.ts` — 35/35 pass
- [x] `pnpm --filter ./packages/core check` — clean
- [x] Manually reproduced the TUI startup hang against a stale broker; startup proceeds after the timeout with this fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Older brokers may not confirm subscription requests, which can make clients wait forever. This change lets clients continue after a configurable timeout.

## Changes

- Added `membershipAckTimeoutMs` to `UnixSocketPubSub`.
- Set the default timeout to 5 seconds.
- Validate that the timeout is a positive, finite number.
- Resolve pending `subscribe` and `unsubscribe` operations best-effort after the timeout.
- Clear and unreference timers when acknowledgements arrive or the client closes.
- Added tests for legacy brokers and timeout validation.
- Added a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->