### PR TITLE
fix(notifications): mark viewed notifications seen and bound inbox listings

### DIFF
--- a/.changeset/gentle-dingos-jump.md
+++ b/.changeset/gentle-dingos-jump.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed the notification inbox tool so notifications are marked seen when the agent views them by listing, reading, or searching, instead of staying pending forever. Listing now defaults to unread notifications and to 20 records per call (use the `limit` option or a `status` filter to change that), reports `hasMore` when more remain and `markedSeen` for how many were transitioned, and drops internal metadata and payload bookkeeping from each record to keep responses small.
+Fixed the notification inbox tool leaving notifications pending forever after the agent viewed them. Listing, reading, or searching now marks the returned unread notifications as seen. `list` defaults to unread notifications in pages of 20 and reports `hasMore` and `markedSeen`; pass `status: 'seen'` to list already-viewed notifications or `limit` to change the page size. Internal `metadata` and `payload` fields are no longer included in list and search results.

--- a/.changeset/gentle-dingos-jump.md
+++ b/.changeset/gentle-dingos-jump.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the notification inbox tool so notifications are marked seen when the agent views them by listing, reading, or searching, instead of staying pending forever. Listing now defaults to unread notifications and to 20 records per call (use the `limit` option or a `status` filter to change that), reports `hasMore` when more remain and `markedSeen` for how many were transitioned, and drops internal metadata and payload bookkeeping from each record to keep responses small.

--- a/.changeset/old-frogs-deny.md
+++ b/.changeset/old-frogs-deny.md
@@ -1,0 +1,5 @@
+---
+'@mastra/github-signals': patch
+---
+
+Slimmed GitHub pull request notification records by keeping agent-facing details (title, state, CI state, comment fields, check names) in attributes only. Internal sync bookkeeping in metadata no longer duplicates those fields, so stored notifications are several KB smaller each. Failing CI checks now also include a `failingCheckUrls` attribute so agents can link directly to a failing run.

--- a/.changeset/old-frogs-deny.md
+++ b/.changeset/old-frogs-deny.md
@@ -2,4 +2,4 @@
 '@mastra/github-signals': patch
 ---
 
-Slimmed GitHub pull request notification records by keeping agent-facing details (title, state, CI state, comment fields, check names) in attributes only. Internal sync bookkeeping in metadata no longer duplicates those fields, so stored notifications are several KB smaller each. Failing CI checks now also include a `failingCheckUrls` attribute so agents can link directly to a failing run.
+Reduced the size of GitHub pull request notification records and added a `failingCheckUrls` attribute linking directly to failing CI checks.

--- a/.changeset/old-frogs-deny.md
+++ b/.changeset/old-frogs-deny.md
@@ -3,3 +3,10 @@
 ---
 
 Reduced the size of GitHub pull request notification records and added a `failingCheckUrls` attribute linking directly to failing CI checks.
+
+```ts
+// A pull-request-ci-failure notification now exposes check names and run links as attributes
+const { attributes } = notification;
+attributes.failingChecks; // 'Quality assurance, Lint'
+attributes.failingCheckUrls; // 'Quality assurance: https://github.com/…/runs/1; Lint: https://github.com/…/runs/2'
+```

--- a/mastracode/sdk/src/agents/extra-tools.test.ts
+++ b/mastracode/sdk/src/agents/extra-tools.test.ts
@@ -250,10 +250,10 @@ describe('createDynamicTools – extraTools', () => {
     ).resolves.toMatchObject({ notifications: [{ id: 'n1' }] });
     expect(notificationStore.listNotifications).toHaveBeenCalledWith({
       threadId: 'thread-1',
-      status: undefined,
+      status: ['pending', 'delivered'],
       priority: undefined,
       source: undefined,
-      limit: undefined,
+      limit: 21,
     });
   });
 

--- a/packages/core/src/notifications/notifications.test.ts
+++ b/packages/core/src/notifications/notifications.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { z } from 'zod/v4';
 import { Mastra } from '../mastra';
 import { MastraCompositeStore } from '../storage/base';
 import { InMemoryNotificationsStorage } from './storage';
@@ -351,14 +352,27 @@ describe('notification inbox', () => {
     const tool = createNotificationInboxTool({ storage });
 
     const page = (await tool.execute?.({ action: 'list' }, { agent: { threadId: 'thread-1' } } as any)) as {
-      notifications: { id: string }[];
+      notifications: { id: string; status: string }[];
       markedSeen: number;
     };
     expect(page.notifications).toHaveLength(2);
     expect(page.markedSeen).toBe(1);
+    // The returned status reflects what storage actually holds for each record.
+    const byId = Object.fromEntries(page.notifications.map(notification => [notification.id, notification]));
+    expect(byId.ok!.status).toBe('seen');
+    expect(byId.bad!.status).toBe('pending');
     await expect(storage.getNotification({ threadId: 'thread-1', id: 'bad' })).resolves.toMatchObject({
       status: 'pending',
     });
+  });
+
+  it('rejects search without a query at the schema level', () => {
+    const tool = createNotificationInboxTool({ storage: new InMemoryNotificationsStorage() });
+    const schema = tool.inputSchema as z.ZodType;
+    expect(schema.safeParse({ action: 'search' }).success).toBe(false);
+    expect(schema.safeParse({ action: 'search', query: '  ' }).success).toBe(false);
+    expect(schema.safeParse({ action: 'search', query: 'launch' }).success).toBe(true);
+    expect(schema.safeParse({ action: 'list' }).success).toBe(true);
   });
 
   it('resolves priority-aware default delivery decisions', async () => {

--- a/packages/core/src/notifications/notifications.test.ts
+++ b/packages/core/src/notifications/notifications.test.ts
@@ -376,6 +376,7 @@ describe('notification inbox', () => {
     for (const action of ['markSeen', 'dismiss', 'archive']) {
       expect(schema.safeParse({ action }).success).toBe(false);
       expect(schema.safeParse({ action, id: '' }).success).toBe(false);
+      expect(schema.safeParse({ action, id: '   ' }).success).toBe(false);
       expect(schema.safeParse({ action, id: 'n1' }).success).toBe(true);
     }
     // read supports both a single id and a bulk unread read.

--- a/packages/core/src/notifications/notifications.test.ts
+++ b/packages/core/src/notifications/notifications.test.ts
@@ -366,13 +366,20 @@ describe('notification inbox', () => {
     });
   });
 
-  it('rejects search without a query at the schema level', () => {
+  it('rejects search without a query and id-scoped actions without an id at the schema level', () => {
     const tool = createNotificationInboxTool({ storage: new InMemoryNotificationsStorage() });
     const schema = tool.inputSchema as z.ZodType;
     expect(schema.safeParse({ action: 'search' }).success).toBe(false);
     expect(schema.safeParse({ action: 'search', query: '  ' }).success).toBe(false);
     expect(schema.safeParse({ action: 'search', query: 'launch' }).success).toBe(true);
     expect(schema.safeParse({ action: 'list' }).success).toBe(true);
+    for (const action of ['markSeen', 'dismiss', 'archive']) {
+      expect(schema.safeParse({ action }).success).toBe(false);
+      expect(schema.safeParse({ action, id: '' }).success).toBe(false);
+      expect(schema.safeParse({ action, id: 'n1' }).success).toBe(true);
+    }
+    // read supports both a single id and a bulk unread read.
+    expect(schema.safeParse({ action: 'read' }).success).toBe(true);
   });
 
   it('resolves priority-aware default delivery decisions', async () => {

--- a/packages/core/src/notifications/notifications.test.ts
+++ b/packages/core/src/notifications/notifications.test.ts
@@ -214,6 +214,7 @@ describe('notification inbox', () => {
       kind: 'direct-message',
       summary: 'Jane sent a launch update',
       payload: { body: 'Launch moved to Friday' },
+      metadata: { internal: 'bookkeeping' },
       resourceId: 'resource-1',
       agentId: 'agent-1',
     });
@@ -233,24 +234,45 @@ describe('notification inbox', () => {
     }));
     const tool = createNotificationInboxTool({ storage });
 
-    await expect(tool.execute?.({ action: 'list' }, { agent: { threadId: 'thread-1' } } as any)).resolves.toMatchObject(
-      {
-        notifications: expect.arrayContaining([
-          expect.objectContaining({ id: 'n1', status: 'pending' }),
-          expect.objectContaining({ id: 'n2', status: 'pending' }),
-        ]),
-      },
-    );
+    // Listing views the notifications: returned records are marked seen and internal
+    // metadata/payload bookkeeping is stripped from the agent-facing projection.
+    const listResult = (await tool.execute?.({ action: 'list' }, { agent: { threadId: 'thread-1' } } as any)) as {
+      notifications: Record<string, unknown>[];
+      hasMore: boolean;
+    };
+    expect(listResult.hasMore).toBe(false);
+    expect(listResult.notifications).toHaveLength(2);
+    const listed = Object.fromEntries(listResult.notifications.map(notification => [notification.id, notification]));
+    expect(listed.n1).toMatchObject({ id: 'n1', status: 'seen', summary: 'Jane sent a launch update' });
+    expect(listed.n2).toMatchObject({ id: 'n2', status: 'seen' });
+    expect('payload' in listed.n1!).toBe(false);
+    expect('metadata' in listed.n1!).toBe(false);
+    await expect(storage.getNotification({ threadId: 'thread-1', id: 'n2' })).resolves.toMatchObject({
+      status: 'seen',
+    });
+
+    // Search still finds viewed records and marks fresh matches seen too.
     await expect(
       tool.execute?.({ action: 'search', query: 'launch' }, { agent: { threadId: 'thread-1' } } as any),
-    ).resolves.toMatchObject({ notifications: [{ id: 'n1' }] });
+    ).resolves.toMatchObject({ notifications: [{ id: 'n1' }], hasMore: false });
+
+    // The pending backlog is drained because viewing marked everything seen.
     await expect(
-      tool.execute?.({ action: 'search', query: 'github', status: 'pending', source: 'github' }, {
-        agent: { threadId: 'thread-1' },
-      } as any),
-    ).resolves.toMatchObject({ notifications: [{ id: 'n2' }] });
+      tool.execute?.({ action: 'search', query: 'CI', status: 'pending' }, { agent: { threadId: 'thread-1' } } as any),
+    ).resolves.toMatchObject({ notifications: [] });
+
+    // Reading a not-yet-viewed notification still delivers it through the agent.
+    await storage.createNotification({
+      id: 'n3',
+      threadId: 'thread-1',
+      source: 'email',
+      kind: 'direct-message',
+      summary: 'Fresh pending update',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+    });
     await expect(
-      tool.execute?.({ action: 'read', id: 'n1' }, {
+      tool.execute?.({ action: 'read', id: 'n3' }, {
         agent: { agentId: 'agent-1', threadId: 'thread-1', resourceId: 'resource-1' },
         mastra: { getAgentById: vi.fn(async () => ({ sendSignal })) },
       } as any),
@@ -259,16 +281,83 @@ describe('notification inbox', () => {
       delivered: 1,
     });
     expect(sendSignal).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'notification', tagName: 'notification', contents: 'Jane sent a launch update' }),
+      expect.objectContaining({ type: 'notification', tagName: 'notification', contents: 'Fresh pending update' }),
       { resourceId: 'resource-1', threadId: 'thread-1' },
     );
-    await expect(storage.getNotification({ threadId: 'thread-1', id: 'n1' })).resolves.toMatchObject({
+    await expect(storage.getNotification({ threadId: 'thread-1', id: 'n3' })).resolves.toMatchObject({
       status: 'seen',
     });
     await expect(
       tool.execute?.({ action: 'archive', id: 'n1' }, { agent: { threadId: 'thread-1' } } as any),
     ).resolves.toMatchObject({
       notification: { id: 'n1', status: 'archived' },
+    });
+  });
+
+  it('bounds list results, drains unread pages without repeating them, and reports hasMore', async () => {
+    const storage = new InMemoryNotificationsStorage();
+    for (let index = 0; index < 25; index += 1) {
+      await storage.createNotification({
+        id: `n${index}`,
+        threadId: 'thread-1',
+        source: 'github',
+        kind: 'pull-request-activity',
+        summary: `Notification ${index}`,
+        createdAt: new Date(Date.UTC(2026, 0, 1, 0, index)),
+      });
+    }
+    const tool = createNotificationInboxTool({ storage });
+    const context = { agent: { threadId: 'thread-1' } } as any;
+    type Page = { notifications: { id: string; status: string }[]; hasMore: boolean; markedSeen: number };
+
+    // Listing defaults to unread notifications and marks the returned page seen, so repeated
+    // lists page through the backlog even though marking seen bumps the updatedAt sort key.
+    const firstPage = (await tool.execute?.({ action: 'list' }, context)) as Page;
+    expect(firstPage.notifications).toHaveLength(20);
+    expect(firstPage.hasMore).toBe(true);
+    expect(firstPage.markedSeen).toBe(20);
+
+    const secondPage = (await tool.execute?.({ action: 'list' }, context)) as Page;
+    expect(secondPage.notifications).toHaveLength(5);
+    expect(secondPage.hasMore).toBe(false);
+    expect(secondPage.markedSeen).toBe(5);
+    const firstIds = new Set(firstPage.notifications.map(notification => notification.id));
+    expect(secondPage.notifications.some(notification => firstIds.has(notification.id))).toBe(false);
+
+    const drained = (await tool.execute?.({ action: 'list' }, context)) as Page;
+    expect(drained.notifications).toHaveLength(0);
+    expect(drained.markedSeen).toBe(0);
+
+    // An explicit status lists already-viewed records; explicit limit is honored.
+    const seenPage = (await tool.execute?.({ action: 'list', status: 'seen', limit: 3 }, context)) as Page;
+    expect(seenPage.notifications).toHaveLength(3);
+    expect(seenPage.hasMore).toBe(true);
+    expect(seenPage.markedSeen).toBe(0);
+
+    const allSeen = (await tool.execute?.({ action: 'list', status: 'seen', limit: 25 }, context)) as Page;
+    expect(allSeen.notifications).toHaveLength(25);
+    expect(allSeen.hasMore).toBe(false);
+  });
+
+  it('reports how many viewed notifications were actually marked seen when a status write fails', async () => {
+    const storage = new InMemoryNotificationsStorage();
+    await storage.createNotification({ id: 'ok', threadId: 'thread-1', source: 'email', kind: 'dm', summary: 'ok' });
+    await storage.createNotification({ id: 'bad', threadId: 'thread-1', source: 'email', kind: 'dm', summary: 'bad' });
+    const update = storage.updateNotification.bind(storage);
+    vi.spyOn(storage, 'updateNotification').mockImplementation(async input => {
+      if (input.id === 'bad') throw new Error('write failed');
+      return update(input);
+    });
+    const tool = createNotificationInboxTool({ storage });
+
+    const page = (await tool.execute?.({ action: 'list' }, { agent: { threadId: 'thread-1' } } as any)) as {
+      notifications: { id: string }[];
+      markedSeen: number;
+    };
+    expect(page.notifications).toHaveLength(2);
+    expect(page.markedSeen).toBe(1);
+    await expect(storage.getNotification({ threadId: 'thread-1', id: 'bad' })).resolves.toMatchObject({
+      status: 'pending',
     });
   });
 

--- a/packages/core/src/notifications/tool.ts
+++ b/packages/core/src/notifications/tool.ts
@@ -3,7 +3,7 @@ import { createTool } from '../tools';
 import type { ToolExecutionContext } from '../tools';
 import { createNotificationSignal } from './signals';
 import type { NotificationsStorage } from './storage';
-import type { ListNotificationsInput, NotificationRecord, NotificationStatus } from './types';
+import type { NotificationRecord, NotificationStatus } from './types';
 
 const notificationActionSchema = z.object({
   action: z.enum(['list', 'read', 'markSeen', 'dismiss', 'archive', 'search']),
@@ -13,7 +13,12 @@ const notificationActionSchema = z.object({
   priority: z.enum(['low', 'medium', 'high', 'urgent']).optional(),
   source: z.string().optional(),
   query: z.string().optional(),
-  limit: z.number().int().positive().optional(),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Maximum records to return. Defaults to 20; the response reports hasMore when more remain.'),
 });
 
 type NotificationInboxAction = z.infer<typeof notificationActionSchema>;
@@ -27,6 +32,42 @@ type NotificationToolAgent = {
 
 const isReadable = (notification: NotificationRecord) =>
   notification.status === 'pending' || notification.status === 'delivered';
+
+const DEFAULT_LIST_LIMIT = 20;
+
+/**
+ * Agent-facing projection for list/search results. `metadata` and `payload` are internal
+ * bookkeeping (content hashes, raw source payloads) that can be several KB per record and
+ * dominate the token cost of an inbox listing.
+ */
+const toInboxProjection = (notification: NotificationRecord) => {
+  const { metadata: _metadata, payload: _payload, ...projection } = notification;
+  return projection;
+};
+
+/**
+ * Viewing a notification marks it as seen: any pending/delivered notification returned to
+ * the agent transitions to 'seen' so the pending backlog drains as the agent triages it.
+ * Without this, summarized notifications stayed 'pending' forever (the summary digest is
+ * consumed without any per-record transition) and every list returned the full backlog.
+ * Returns the number of records whose status write succeeded.
+ */
+async function markViewedNotificationsSeen({
+  notifications,
+  storage,
+}: {
+  notifications: NotificationRecord[];
+  storage: NotificationsStorage;
+}): Promise<number> {
+  const results = await Promise.allSettled(
+    notifications
+      .filter(isReadable)
+      .map(notification =>
+        storage.updateNotification({ threadId: notification.threadId, id: notification.id, status: 'seen' }),
+      ),
+  );
+  return results.filter(result => result.status === 'fulfilled').length;
+}
 
 async function deliverNotifications({
   notifications,
@@ -75,6 +116,8 @@ async function deliverNotifications({
       await storage.updateNotification({ threadId: notification.threadId, id: notification.id, status: 'seen' });
       markedSeen += 1;
     } else {
+      // No agent/resourceId to deliver through and no prior signal: the content never reached
+      // the agent, so leave it pending rather than silently consuming it.
       unavailable += 1;
     }
   }
@@ -91,7 +134,7 @@ export function createNotificationInboxTool({ storage }: { storage: Notification
   return createTool({
     id: 'notification-inbox',
     description:
-      'Inspect and manage the current thread notification inbox. Use this to list pending notifications, read full details after a summary, mark notifications seen, dismiss, archive, or search old notifications.',
+      'Inspect and manage the current thread notification inbox. Use this to list unread notifications, read full details after a summary, mark notifications seen, dismiss, archive, or search old notifications. Listing, reading, or searching automatically marks the returned unread notifications as seen; list defaults to unread notifications unless a status is given.',
     inputSchema: notificationActionSchema,
     execute: async (input: NotificationInboxAction, context) => {
       const threadId = input.threadId ?? context?.agent?.threadId;
@@ -99,28 +142,30 @@ export function createNotificationInboxTool({ storage }: { storage: Notification
         throw new Error('notification-inbox requires a threadId');
       }
 
-      if (input.action === 'list') {
-        const listInput: ListNotificationsInput = {
+      if (input.action === 'list' || input.action === 'search') {
+        if (input.action === 'search' && !input.query) throw new Error('notification-inbox search requires query');
+        // Fetch one past the page so the response can report whether the inbox has more.
+        const limit = input.limit ?? DEFAULT_LIST_LIMIT;
+        const notifications = await storage.listNotifications({
           threadId,
-          status: input.status,
+          // Default list to unread: auto-seen bumps updatedAt (the sort key), so listing every
+          // status would keep returning the page just viewed. Search spans all statuses.
+          status: input.status ?? (input.action === 'list' ? ['pending', 'delivered'] : undefined),
           priority: input.priority,
           source: input.source,
-          limit: input.limit,
-        };
-        return { notifications: await storage.listNotifications(listInput) };
-      }
-
-      if (input.action === 'search') {
-        if (!input.query) throw new Error('notification-inbox search requires query');
+          ...(input.action === 'search' ? { search: input.query! } : {}),
+          limit: limit + 1,
+        });
+        const page = notifications.slice(0, limit);
+        const markedSeen = await markViewedNotificationsSeen({ notifications: page, storage });
         return {
-          notifications: await storage.listNotifications({
-            threadId,
-            search: input.query,
-            status: input.status,
-            priority: input.priority,
-            source: input.source,
-            limit: input.limit,
-          }),
+          notifications: page.map(notification =>
+            isReadable(notification)
+              ? { ...toInboxProjection(notification), status: 'seen' as const }
+              : toInboxProjection(notification),
+          ),
+          hasMore: notifications.length > limit,
+          markedSeen,
         };
       }
 
@@ -132,7 +177,7 @@ export function createNotificationInboxTool({ storage }: { storage: Notification
               status: input.status ?? ['pending', 'delivered'],
               priority: input.priority,
               source: input.source,
-              limit: input.limit,
+              limit: input.limit ?? DEFAULT_LIST_LIMIT,
             });
         if (input.id && !notifications[0])
           throw new Error(`Notification ${input.id} was not found for thread ${threadId}`);

--- a/packages/core/src/notifications/tool.ts
+++ b/packages/core/src/notifications/tool.ts
@@ -5,21 +5,27 @@ import { createNotificationSignal } from './signals';
 import type { NotificationsStorage } from './storage';
 import type { NotificationRecord, NotificationStatus } from './types';
 
-const notificationActionSchema = z.object({
-  action: z.enum(['list', 'read', 'markSeen', 'dismiss', 'archive', 'search']),
-  threadId: z.string().optional(),
-  id: z.string().optional(),
-  status: z.enum(['pending', 'delivered', 'seen', 'dismissed', 'archived', 'discarded', 'failed']).optional(),
-  priority: z.enum(['low', 'medium', 'high', 'urgent']).optional(),
-  source: z.string().optional(),
-  query: z.string().optional(),
-  limit: z
-    .number()
-    .int()
-    .positive()
-    .optional()
-    .describe('Maximum records to return. Defaults to 20; the response reports hasMore when more remain.'),
-});
+const notificationActionSchema = z
+  .object({
+    action: z.enum(['list', 'read', 'markSeen', 'dismiss', 'archive', 'search']),
+    threadId: z.string().optional(),
+    id: z.string().optional(),
+    status: z.enum(['pending', 'delivered', 'seen', 'dismissed', 'archived', 'discarded', 'failed']).optional(),
+    priority: z.enum(['low', 'medium', 'high', 'urgent']).optional(),
+    source: z.string().optional(),
+    query: z.string().optional(),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe('Maximum records to return. Defaults to 20; the response reports hasMore when more remain.'),
+  })
+  .superRefine((input, ctx) => {
+    if (input.action === 'search' && !input.query?.trim()) {
+      ctx.addIssue({ code: 'custom', path: ['query'], message: 'notification-inbox search requires query' });
+    }
+  });
 
 type NotificationInboxAction = z.infer<typeof notificationActionSchema>;
 
@@ -50,7 +56,7 @@ const toInboxProjection = (notification: NotificationRecord) => {
  * the agent transitions to 'seen' so the pending backlog drains as the agent triages it.
  * Without this, summarized notifications stayed 'pending' forever (the summary digest is
  * consumed without any per-record transition) and every list returned the full backlog.
- * Returns the number of records whose status write succeeded.
+ * Returns the ids of the records whose status write succeeded.
  */
 async function markViewedNotificationsSeen({
   notifications,
@@ -58,15 +64,14 @@ async function markViewedNotificationsSeen({
 }: {
   notifications: NotificationRecord[];
   storage: NotificationsStorage;
-}): Promise<number> {
+}): Promise<Set<string>> {
+  const readable = notifications.filter(isReadable);
   const results = await Promise.allSettled(
-    notifications
-      .filter(isReadable)
-      .map(notification =>
-        storage.updateNotification({ threadId: notification.threadId, id: notification.id, status: 'seen' }),
-      ),
+    readable.map(notification =>
+      storage.updateNotification({ threadId: notification.threadId, id: notification.id, status: 'seen' }),
+    ),
   );
-  return results.filter(result => result.status === 'fulfilled').length;
+  return new Set(readable.filter((_, index) => results[index]!.status === 'fulfilled').map(n => n.id));
 }
 
 async function deliverNotifications({
@@ -143,7 +148,6 @@ export function createNotificationInboxTool({ storage }: { storage: Notification
       }
 
       if (input.action === 'list' || input.action === 'search') {
-        if (input.action === 'search' && !input.query) throw new Error('notification-inbox search requires query');
         // Fetch one past the page so the response can report whether the inbox has more.
         const limit = input.limit ?? DEFAULT_LIST_LIMIT;
         const notifications = await storage.listNotifications({
@@ -157,15 +161,15 @@ export function createNotificationInboxTool({ storage }: { storage: Notification
           limit: limit + 1,
         });
         const page = notifications.slice(0, limit);
-        const markedSeen = await markViewedNotificationsSeen({ notifications: page, storage });
+        const seenIds = await markViewedNotificationsSeen({ notifications: page, storage });
         return {
           notifications: page.map(notification =>
-            isReadable(notification)
+            seenIds.has(notification.id)
               ? { ...toInboxProjection(notification), status: 'seen' as const }
               : toInboxProjection(notification),
           ),
           hasMore: notifications.length > limit,
-          markedSeen,
+          markedSeen: seenIds.size,
         };
       }
 

--- a/packages/core/src/notifications/tool.ts
+++ b/packages/core/src/notifications/tool.ts
@@ -25,6 +25,12 @@ const notificationActionSchema = z
     if (input.action === 'search' && !input.query?.trim()) {
       ctx.addIssue({ code: 'custom', path: ['query'], message: 'notification-inbox search requires query' });
     }
+    if (
+      (input.action === 'markSeen' || input.action === 'dismiss' || input.action === 'archive') &&
+      !input.id?.trim()
+    ) {
+      ctx.addIssue({ code: 'custom', path: ['id'], message: `notification-inbox ${input.action} requires id` });
+    }
   });
 
 type NotificationInboxAction = z.infer<typeof notificationActionSchema>;
@@ -194,7 +200,6 @@ export function createNotificationInboxTool({ storage }: { storage: Notification
         });
       }
 
-      if (!input.id) throw new Error(`notification-inbox ${input.action} requires id`);
       const statusByAction = {
         markSeen: 'seen',
         dismiss: 'dismissed',
@@ -204,7 +209,8 @@ export function createNotificationInboxTool({ storage }: { storage: Notification
       return {
         notification: await storage.updateNotification({
           threadId,
-          id: input.id,
+          // The schema refine guarantees id for these actions; superRefine does not narrow the type.
+          id: input.id!,
           status: statusByAction[input.action],
         }),
       };

--- a/signals/github/src/index.test.ts
+++ b/signals/github/src/index.test.ts
@@ -2347,13 +2347,8 @@ describe('GithubSignals', () => {
             latestCommentUpdatedAt: '2026-06-05T22:05:00.000Z',
           }),
           metadata: expect.objectContaining({
-            github: expect.objectContaining({
-              latestCommentAuthor: 'devin-ai-integration',
-              // Full comment body is no longer persisted in notification metadata; only the excerpt.
-              latestCommentExcerpt: 'Acknowledged! The authorized comment should still be delivered.',
-              latestCommentUrl: 'https://github.com/mastra-ai/mastra/pull/17590#issuecomment-devin',
-              latestCommentUpdatedAt: '2026-06-05T22:05:00.000Z',
-            }),
+            // Agent-facing comment fields live in attributes only; metadata keeps sync bookkeeping.
+            github: expect.not.objectContaining({ latestCommentAuthor: expect.anything() }),
           }),
         }),
       ],
@@ -2637,14 +2632,8 @@ describe('GithubSignals', () => {
             latestCommentUpdatedAt: '2026-01-01T00:05:00.000Z',
           }),
           metadata: expect.objectContaining({
-            github: expect.objectContaining({
-              latestCommentAuthor: 'devin-ai-integration[bot]',
-              // Full comment body is no longer persisted in notification metadata; only the excerpt.
-              latestCommentExcerpt:
-                'Acknowledged! Third test comment received. Bot notification delivery is working after the rebuild/reload.',
-              latestCommentUrl: 'https://github.com/mastra-ai/mastra/pull/123#issuecomment-1',
-              latestCommentUpdatedAt: '2026-01-01T00:05:00.000Z',
-            }),
+            // Agent-facing comment fields live in attributes only; metadata keeps sync bookkeeping.
+            github: expect.not.objectContaining({ latestCommentAuthor: expect.anything() }),
           }),
         }),
       ],
@@ -3147,11 +3136,24 @@ describe('GithubSignals', () => {
           attributes: expect.objectContaining({
             ciState: 'failure',
             failingChecks: 'Quality assurance',
+            failingCheckUrls: 'Quality assurance: https://github.com/mastra-ai/mastra/actions/runs/1',
           }),
+          metadata: {
+            github: expect.not.objectContaining({
+              failingChecks: expect.anything(),
+              pendingChecks: expect.anything(),
+            }),
+          },
         }),
       ],
       expect.objectContaining({ resourceId: thread.resourceId, threadId: thread.id }),
     );
+    // Signal attributes are rendered with String(value), so every attribute must be a scalar —
+    // an object or array here would surface to the agent as "[object Object]".
+    const [sent] = sendNotificationSignal.mock.calls[0]![0] as Array<{ attributes: Record<string, unknown> }>;
+    for (const [key, value] of Object.entries(sent!.attributes)) {
+      expect(value === null || typeof value !== 'object', `attributes.${key} must be scalar`).toBe(true);
+    }
   });
 
   it('classifies CI recovery, review activity, terminal states, and bot-only noise', async () => {
@@ -4756,7 +4758,9 @@ describe('GithubSignals', () => {
           kind: 'pull-request-code-activity',
           summary: 'New head revision for mastra-ai/mastra#207: Review dedicated changes.',
           attributes: expect.objectContaining({ mode: 'review' }),
-          metadata: expect.objectContaining({ github: expect.objectContaining({ mode: 'review' }) }),
+          metadata: expect.objectContaining({
+            github: expect.objectContaining({ headSha: 'new-head', reviewStateHash: 'review-2' }),
+          }),
         }),
       ]),
     );

--- a/signals/github/src/index.ts
+++ b/signals/github/src/index.ts
@@ -8,6 +8,7 @@ import type { AgentSignalInput, Agent, AgentSignalIfIdleOptions } from '@mastra/
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
 import type { Mastra } from '@mastra/core/mastra';
 import type { StorageThreadType } from '@mastra/core/memory';
+import type { SendNotificationSignalInput } from '@mastra/core/notifications';
 import type {
   InputProcessorOrWorkflow,
   OutputProcessorOrWorkflow,
@@ -226,7 +227,7 @@ type GithubPRSignal = {
 type GithubSignalAgent = {
   sendSignal(signal: AgentSignalInput, target: unknown): { accepted: unknown };
   sendNotificationSignal?(
-    notification: unknown | unknown[],
+    notification: SendNotificationSignalInput | SendNotificationSignalInput[],
     target: unknown,
   ): { accepted?: unknown } | Promise<unknown>;
 };
@@ -2071,43 +2072,37 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
         ...(input.snapshot.latestCommentUpdatedAt
           ? { latestCommentUpdatedAt: input.snapshot.latestCommentUpdatedAt }
           : {}),
-        ...(failingChecks.length > 0 ? { failingChecks: failingChecks.map(check => check.name).join(', ') } : {}),
-        ...(pendingChecks.length > 0 ? { pendingChecks: pendingChecks.map(check => check.name).join(', ') } : {}),
+        ...(failingChecks.length
+          ? {
+              failingChecks: failingChecks.map(check => check.name).join(', '),
+              failingCheckUrls: failingChecks
+                .filter(check => check.detailsUrl)
+                .map(check => `${check.name}: ${check.detailsUrl}`)
+                .join('; '),
+            }
+          : {}),
+        ...(pendingChecks.length ? { pendingChecks: pendingChecks.map(check => check.name).join(', ') } : {}),
       },
       metadata: {
         github: {
-          owner: input.subscription.owner,
-          repo: input.subscription.repo,
-          number: input.subscription.number,
-          mode: input.subscription.mode,
-          title: input.snapshot.title,
-          state: input.snapshot.state,
-          htmlUrl: input.snapshot.htmlUrl,
-          githubUpdatedAt: input.snapshot.githubUpdatedAt,
+          // Agent-facing fields (title, state, URL, CI state, comment fields, PR identity) live in
+          // attributes only — they were previously mirrored here, doubling every record's size.
+          // This object keeps just the internal bookkeeping the sync loop needs for change detection.
           previousGithubUpdatedAt: input.previousGithubUpdatedAt,
-          contentHash: input.snapshot.contentHash,
           previousContentHash: input.previousContentHash,
+          contentHash: input.snapshot.contentHash,
           threadContentHash: input.snapshot.threadContentHash,
           headSha: input.snapshot.headSha,
           headRef: input.snapshot.headRef,
-          mergeableState: input.snapshot.mergeableState,
-          ciState: input.snapshot.ciState,
-          closedAt: input.snapshot.closedAt,
-          mergedAt: input.snapshot.mergedAt,
-          unresolvedReviewThreads: input.snapshot.unresolvedReviewThreads,
           reviewStateHash: input.snapshot.reviewStateHash,
           latestReviewThreadAt: input.snapshot.latestReviewThreadAt,
-          latestCommentAuthor: input.snapshot.latestCommentAuthor,
-          latestCommentAuthorType: input.snapshot.latestCommentAuthorType,
-          latestCommentIsBot: input.snapshot.latestCommentIsBot,
+          closedAt: input.snapshot.closedAt,
+          mergedAt: input.snapshot.mergedAt,
           // Intentionally omit the full latestCommentBody here: persisting it verbatim bloats
           // notification payloads (a single CodeRabbit comment can exceed 100KB) and can overflow
           // agent context windows when listed. The 240-char latestCommentExcerpt is stored instead.
-          latestCommentExcerpt,
-          latestCommentUrl: input.snapshot.latestCommentUrl,
-          latestCommentUpdatedAt: input.snapshot.latestCommentUpdatedAt,
-          failingChecks,
-          pendingChecks,
+          // Check names and failing-check URLs live in attributes as flat strings (signal attributes
+          // must be scalars); full check snapshots ballooned every record by several KB.
         },
       },
     };


### PR DESCRIPTION
The `notification_inbox` tool had no way for notifications to leave `pending` unless the agent called `markSeen`/`dismiss` one id at a time. Notifications that were only surfaced through a summary digest stayed pending forever, so every `list` returned the whole backlog. In one live session that was 96 GitHub records (~360KB of JSON) in a single tool result, which pushed the thread straight past the observational-memory threshold and forced a synchronous observation every turn.

Now viewing a notification counts as reading it. `list`, `read`, and `search` mark the returned unread records seen, `list` defaults to unread records and a page of 20, and the response reports `hasMore` and `markedSeen`. Internal `metadata` / `payload` bookkeeping is dropped from the agent-facing records.

Before, every call returned everything, forever:

```ts
await tool.execute({ action: 'list' });
// { notifications: [ /* all 96, full metadata, still pending */ ] }
await tool.execute({ action: 'list' });
// same 96 again
```

After, repeated lists drain the backlog:

```ts
await tool.execute({ action: 'list' });
// { notifications: [ /* 20, status: 'seen', no metadata/payload */ ], hasMore: true, markedSeen: 20 }
await tool.execute({ action: 'list' });
// { notifications: [ /* next 20 */ ], hasMore: true, markedSeen: 20 }
```

On the GitHub side, PR notification records were mirroring every agent-facing field (title, state, comment excerpt, full check objects) into `metadata.github` on top of `attributes`, roughly doubling each record. `metadata.github` now only keeps the sync bookkeeping the change detector needs. Check names live in `attributes` as flat strings since signal attributes are rendered with `String(value)`, and failing checks get a `failingCheckUrls` attribute so the agent can link to the run. `GithubSignalAgent.sendNotificationSignal` is now typed with `SendNotificationSignalInput` instead of `unknown` so a non-scalar attribute fails typecheck.

```ts
attributes: {
  ciState: 'failure',
  failingChecks: 'Quality assurance',
  failingCheckUrls: 'Quality assurance: https://github.com/mastra-ai/mastra/actions/runs/1',
}
```

Tests cover the drain (25 pending → 20 + 5 disjoint pages → empty), the `markedSeen` count when a status write fails, the stripped projection, and that every GitHub notification attribute is a scalar. Verified with `packages/core` notifications + agent-signals suites, `signals/github`, and `mastracode/sdk` extra-tools, plus typecheck and lint on the touched packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When an agent views notifications, the tool marks them as seen. It shows unread notifications first, supports paging, and hides internal data from agent responses.

## Changes

- Updated `notification_inbox`:
  - Defaults `list` to unread notifications.
  - Returns pages of 20 notifications.
  - Reports `hasMore` and `markedSeen`.
  - Marks returned unread notifications as seen for `list`, `read`, and `search`.
  - Requires a search query for `search`.
  - Requires a non-empty `id` for `markSeen`, `dismiss`, and `archive`.
  - Omits internal `metadata` and `payload` fields.
  - Reports only successfully updated notifications as seen.
- Updated GitHub notifications:
  - Stores agent-facing fields as scalar attributes.
  - Removes duplicated fields from `metadata.github`.
  - Adds `failingCheckUrls` for failed checks.
  - Preserves review-mode change-detection fields.
  - Uses the typed `SendNotificationSignalInput`.
- Added patch changesets for `@mastra/core` and `@mastra/github-signals`.
- Expanded tests for pagination, backlog draining, status-write failures, response projections, whitespace-only IDs, schema validation, and GitHub attributes.
- Updated related SDK expectations and package test, typecheck, and lint coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->