### PR TITLE
fix(editor): gate conditional fallback branches

### DIFF
--- a/.changeset/quiet-defaults-wait.md
+++ b/.changeset/quiet-defaults-wait.md
@@ -1,0 +1,5 @@
+---
+'@mastra/editor': patch
+---
+
+Fixed conditional processor defaults so they run only when no explicit rule matches. Fixes #23712.

--- a/packages/editor/src/conditional-branch.test.ts
+++ b/packages/editor/src/conditional-branch.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { matchesAnyConditionRule } from './conditional-branch';
+
+const conditions = [
+  {
+    rules: {
+      operator: 'AND' as const,
+      conditions: [{ field: 'state.route', operator: 'equals' as const, value: 'matched' }],
+    },
+    steps: [],
+  },
+  { steps: [] },
+];
+
+describe('matchesAnyConditionRule', () => {
+  it('returns true when an explicit rule matches', () => {
+    expect(matchesAnyConditionRule(conditions, { state: { route: 'matched' } })).toBe(true);
+  });
+
+  it('ignores the default condition when no explicit rule matches', () => {
+    expect(matchesAnyConditionRule(conditions, { state: { route: 'fallback' } })).toBe(false);
+  });
+
+  it('returns false when a graph contains only a default condition', () => {
+    expect(matchesAnyConditionRule([{ steps: [] }], { state: { route: 'matched' } })).toBe(false);
+  });
+});

--- a/packages/editor/src/conditional-branch.ts
+++ b/packages/editor/src/conditional-branch.ts
@@ -1,0 +1,10 @@
+import type { ProcessorGraphCondition } from '@mastra/core/storage';
+
+import { evaluateRuleGroup } from './rule-evaluator';
+
+export function matchesAnyConditionRule(
+  conditions: ProcessorGraphCondition[],
+  inputData: Record<string, unknown>,
+): boolean {
+  return conditions.some(condition => condition.rules && evaluateRuleGroup(condition.rules, inputData));
+}

--- a/packages/editor/src/processor-graph-hydrator.test.ts
+++ b/packages/editor/src/processor-graph-hydrator.test.ts
@@ -709,6 +709,80 @@ describe('hydrateProcessorGraph', () => {
       expect(branchACalled).toHaveBeenCalled();
     }, 10000);
 
+    it('should run a default branch only when no explicit rule matches', async () => {
+      const matchingCalled = vi.fn();
+      const defaultCalled = vi.fn();
+      const makeProvider = (id: string, onRun: () => void): ProcessorProvider => ({
+        info: { id, name: id },
+        configSchema: z.object({}),
+        availablePhases: ['processInput'] as ProcessorPhase[],
+        createProcessor: () => ({
+          id: `${id}-instance`,
+          name: id,
+          processInput: async ({ messages }) => {
+            onRun();
+            return messages;
+          },
+        }),
+      });
+
+      const graph: StoredProcessorGraph = {
+        steps: [
+          {
+            type: 'conditional',
+            conditions: [
+              {
+                rules: {
+                  operator: 'AND',
+                  conditions: [{ field: 'state.route', operator: 'equals', value: 'matched' }],
+                },
+                steps: [
+                  {
+                    type: 'step',
+                    step: { id: 'matching', providerId: 'matching', config: {}, enabledPhases: ['processInput'] },
+                  },
+                ],
+              },
+              {
+                steps: [
+                  {
+                    type: 'step',
+                    step: { id: 'default', providerId: 'default', config: {}, enabledPhases: ['processInput'] },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const [workflow] = hydrateProcessorGraph(graph, 'input', {
+        providers: {
+          matching: makeProvider('matching', matchingCalled),
+          default: makeProvider('default', defaultCalled),
+        },
+      }) as ProcessorWorkflow[];
+      const messages = [makeMsg('Hello')];
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+
+      const matchingRun = await workflow!.createRun();
+      await matchingRun.start({
+        inputData: { phase: 'input', messages, messageList, state: { route: 'matched' } },
+      });
+
+      expect(matchingCalled).toHaveBeenCalledOnce();
+      expect(defaultCalled).not.toHaveBeenCalled();
+
+      const defaultRun = await workflow!.createRun();
+      await defaultRun.start({
+        inputData: { phase: 'input', messages, messageList, state: { route: 'fallback' } },
+      });
+
+      expect(matchingCalled).toHaveBeenCalledOnce();
+      expect(defaultCalled).toHaveBeenCalledOnce();
+    }, 10000);
+
     it('should produce valid ProcessorStepOutput from a conditional workflow with default branch', async () => {
       const defaultCalled = vi.fn();
 

--- a/packages/editor/src/processor-graph-hydrator.ts
+++ b/packages/editor/src/processor-graph-hydrator.ts
@@ -19,6 +19,7 @@ import { createWorkflow, createStep } from '@mastra/core/workflows';
 import type { IMastraLogger } from '@mastra/core/logger';
 import type { Mastra } from '@mastra/core';
 
+import { matchesAnyConditionRule } from './conditional-branch';
 import { evaluateRuleGroup } from './rule-evaluator';
 
 const PASSTHROUGH_STEP_PREFIX = 'passthrough-';
@@ -187,6 +188,9 @@ function buildWorkflow(
       // Build conditional branches using .branch()
       // branch() takes Array<[ConditionFunction, Step]> tuples
       const branchTuples: Array<[any, any]> = [];
+      const hasDefaultBranch = entry.conditions.some(condition => !condition.rules);
+      const noRulesMatch = (inputData: Record<string, unknown>) =>
+        !matchesAnyConditionRule(entry.conditions, inputData);
 
       for (const [i, condition] of entry.conditions.entries()) {
         // Each condition branch is an array of entries
@@ -208,22 +212,27 @@ function buildWorkflow(
           };
           branchTuples.push([conditionFn, branchStep]);
         } else {
-          // Default branch (no rules = always matches, acts as fallback)
-          branchTuples.push([async () => true, branchStep]);
+          // Default branch: run only when no explicit rule matches.
+          branchTuples.push([
+            async ({ inputData }: { inputData: Record<string, unknown> }) => noRulesMatch(inputData),
+            branchStep,
+          ]);
         }
       }
 
       if (branchTuples.length > 0) {
-        // Always add a pass-through fallback so the workflow returns input unchanged
-        // when no user-defined condition matches (e.g. during inputStep/outputStep phases
-        // where conditions only target 'input' or 'outputResult' phase).
+        // Add a pass-through fallback so the workflow returns input unchanged when no
+        // explicit rule matches and the graph has no user-defined default branch.
         const passthroughStep = createStep({
           id: `${PASSTHROUGH_STEP_PREFIX}${workflowId}`,
           inputSchema: ProcessorStepSchema,
           outputSchema: ProcessorStepSchema,
           execute: async ({ inputData }) => inputData,
         });
-        branchTuples.push([async () => true, passthroughStep]);
+        branchTuples.push([
+          async ({ inputData }: { inputData: Record<string, unknown> }) => !hasDefaultBranch && noRulesMatch(inputData),
+          passthroughStep,
+        ]);
 
         workflow = (workflow as any).branch(branchTuples);
         // After branch, outputs are keyed by step ID: { [stepId]: ProcessorStepOutput }


### PR DESCRIPTION
## Description

Conditional processor graphs previously treated both user defaults and the internal pass-through as unconditional branches. A matching explicit rule could therefore run alongside fallback behavior.

This change detects whether any explicit condition matches the current workflow input. User defaults now run only when none match, and the internal pass-through runs only when no rule matches and no user default exists. It adds focused predicate coverage and a workflow regression that executes both the matched and default paths.

## Related issue(s)

Fixes #23712.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Validation

- `pnpm --filter @mastra/editor exec vitest run src/conditional-branch.test.ts` (3 tests passed)
- `oxfmt --check` on all changed source and test files
- `git diff --check`

The full hydrator test file requires built `@mastra/core` outputs that are not present in the isolated worktree, so it was not rebuilt or run locally. This keeps validation scoped and avoids a broad dependency build.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The processor now chooses the correct fallback. A default branch runs only when no specific rule matches, and the internal pass-through runs only when no default exists.

## Changes

- Added `matchesAnyConditionRule` to share explicit-rule matching logic.
- Gated user-defined default branches on the absence of a matching explicit rule.
- Gated the internal pass-through on the absence of both a matching rule and a user default.
- Added regression tests for matching, default fallback, and pass-through behavior.
- Added a patch changeset for `@mastra/editor`.

## Validation

- Ran three focused Vitest tests.
- Ran formatting checks.
- Ran `git diff --check`.
- Full hydrator tests were not run because built `@mastra/core` outputs were unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->