### PR TITLE
fix(voice): pass tool arguments as the first parameter

### DIFF
--- a/.changeset/voice-tool-input-shape.md
+++ b/.changeset/voice-tool-input-shape.md
@@ -1,0 +1,6 @@
+---
+'@mastra/voice-openai-realtime': patch
+'@mastra/voice-aws-nova-sonic': patch
+---
+
+Voice tools built with `createTool` now receive their arguments as the first parameter, matching `ToolExecuteFunction`. The realtime adapters wrapped them in `{ context: args }`, so every field the tool read was undefined and a tool that validated its input failed the call. Fixes #23723.

--- a/voice/aws-nova-sonic/src/index.ts
+++ b/voice/aws-nova-sonic/src/index.ts
@@ -1512,13 +1512,13 @@ export class NovaSonicVoice extends MastraVoice<
 
     try {
       // Execute tool
-      const result = await tool.execute(
-        { context: args, requestContext: this.requestContext },
-        {
-          toolCallId: toolUseId,
-          messages: [],
-        },
-      );
+      // The arguments are the first parameter and the request context belongs to
+      // the execute context, per ToolExecuteFunction in @mastra/core.
+      const result = await tool.execute(args, {
+        toolCallId: toolUseId,
+        messages: [],
+        requestContext: this.requestContext,
+      });
 
       // Send tool result back to the model
       await this.sendClientEvent({

--- a/voice/openai-realtime-api/src/utils.test.ts
+++ b/voice/openai-realtime-api/src/utils.test.ts
@@ -46,6 +46,29 @@ describe('transformTools', () => {
       });
     });
 
+    it('should call a createTool tool with its arguments, not wrapped in context', async () => {
+      // createTool's execute is (inputData, context), so wrapping the arguments
+      // in { context: args } left every field undefined and failed the tool's
+      // own input validation (#23723).
+      let received: unknown;
+      const tool = createTool({
+        id: 'echoTool',
+        description: 'Echoes its input',
+        inputSchema: z.object({ message: z.string() }),
+        outputSchema: z.string(),
+        execute: async input => {
+          received = input;
+          return input.message;
+        },
+      });
+
+      const transformedTools = transformTools({ echoTool: tool });
+      const result = await transformedTools[0].execute({ message: 'Hello' });
+
+      expect(received).toEqual({ message: 'Hello' });
+      expect(result).toBe('Hello');
+    });
+
     it('should transform a tool with JSON schema parameters to OpenAI format', () => {
       // Create a test tool with direct JSON schema
       const tool = {

--- a/voice/openai-realtime-api/src/utils.ts
+++ b/voice/openai-realtime-api/src/utils.ts
@@ -41,25 +41,14 @@ export const transformTools = (tools?: TTools) => {
             throw new Error(`Tool ${name} has no execute function`);
           }
 
-          // For ToolAction, the first argument is a context object with the args in a 'context' property
-          if ('inputSchema' in tool) {
-            return await tool.execute(
-              { context: args },
-              {
-                toolCallId: 'unknown',
-                messages: [],
-              },
-            );
-          }
-          // For VercelTool, pass args directly
-          else {
-            // Create a minimal ToolExecutionOptions object with required properties
-            const options = {
-              toolCallId: 'unknown',
-              messages: [],
-            };
-            return await tool.execute(args, options);
-          }
+          // Both shapes take the arguments as the FIRST parameter: createTool's
+          // execute is (inputData, context), and a Vercel tool's is (args,
+          // options). Wrapping them in { context: args } left every field the
+          // tool reads undefined, or failed its input validation.
+          return await tool.execute(args, {
+            toolCallId: 'unknown',
+            messages: [],
+          });
         } catch (error) {
           console.error(`Error executing tool ${name}:`, error);
           throw error;


### PR DESCRIPTION
Fixes #23723.

`transformTools` wrapped a `createTool` tool's arguments in `{ context: args }` and passed that as the input data:

```ts
if ('inputSchema' in tool) {
  return await tool.execute({ context: args }, { toolCallId: 'unknown', messages: [] });
}
```

`ToolExecuteFunction` in `@mastra/core` takes `(inputData, context)` (`packages/core/src/tools/types.ts:620-628`), so the tool received `{ context: { ...actualArgs } }` as its input: every field it read was `undefined`, and a tool that validates its input failed the call outright. The `else` branch for tools without an `inputSchema` already passed `args` directly, which is the current shape for both, so the two branches collapse into one.

`voice/aws-nova-sonic` carried the same wrapper and additionally put `requestContext` in the first parameter. `ToolExecuteContext` is where the type keeps it (`types.ts:612-617`), so it moves to the second. That file is not named in the issue; it is two lines and the identical defect, so leaving it would only mean the next report. Happy to split it out if you would rather keep this PR to the reported package.

## Test

`voice/openai-realtime-api/src/utils.test.ts` gains a case that builds a `createTool` tool with an `inputSchema`, runs it through `transformTools`, invokes the adapter with `{ message: 'Hello' }` and asserts the tool saw exactly that object and returned from it. It follows the existing cases in that file, including the `transformedTools[0].execute(...)` call shape already used there.

## What I could not run here

I could not execute that suite locally: this workspace needs several internal packages built first, and two of them fail to build on my machine independently of this change.

```
pnpm --filter "@internal/voice" build
  src/voice/voice.ts(268,10): error TS2339: Property 'logger' does not exist on type 'MastraVoice<...>'
pnpm --filter "@internal/ai-sdk-v5" build   -> tsdown exit 1
pnpm --filter "@mastra/schema-compat" build -> tsdown exit 2
```

`pnpm --filter "@internal/voice..." build` succeeds, but `vitest` then stops at `Failed to resolve entry for package "@internal/ai-sdk-v5"`, and driving `transformTools` directly stops at `@mastra/schema-compat/schema`. So the change here rests on the contract in `packages/core/src/tools/types.ts` and on the issue's reproduction rather than on a local green run, and CI is the first place the new test will actually execute. Flagging that plainly rather than claiming a run I did not do.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Voice tools now receive their arguments in the expected format. This prevents missing fields and schema validation failures.

## Changes

- Pass tool arguments directly to `execute` in OpenAI Realtime.
- Pass `requestContext` through the execution context in AWS Nova Sonic.
- Add a regression test for `createTool` input handling.
- Add patch changesets for both voice packages.

The full test suite was not run because required internal package builds fail independently of this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->