### PR TITLE
refactor(core): remove redundant type assertions

### DIFF
--- a/.changeset/public-ducks-warn.md
+++ b/.changeset/public-ducks-warn.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Removed redundant type assertions from core guards and callbacks without changing runtime behavior.
+Simplified core maintenance without changing schema validation, event serialization, or callback behavior.

--- a/.changeset/public-ducks-warn.md
+++ b/.changeset/public-ducks-warn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Removed redundant type assertions from core guards and callbacks without changing runtime behavior.

--- a/observability/datadog/vitest.config.ts
+++ b/observability/datadog/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     name: 'unit:observability/datadog',
-    isolate: false,
     environment: 'node',
     include: ['src/**/*.test.ts'],
   },

--- a/packages/core/src/events/codec/codec.ts
+++ b/packages/core/src/events/codec/codec.ts
@@ -174,7 +174,7 @@ export function decode(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(decode);
 
   if (CODEC_TAG in value && isEnvelope(value)) {
-    const env = value as Envelope;
+    const env = value;
     switch (env[CODEC_TAG]) {
       case 'Undefined':
         return undefined;

--- a/packages/core/src/events/codec/error.ts
+++ b/packages/core/src/events/codec/error.ts
@@ -39,7 +39,7 @@ export function serializeError(err: Error, depth = 0): SerializedError {
 export function rehydrateError(s: SerializedError): Error {
   const cause =
     s.cause !== undefined
-      ? s.cause && typeof s.cause === 'object' && 'message' in (s.cause as object) && 'name' in (s.cause as object)
+      ? s.cause && typeof s.cause === 'object' && 'message' in s.cause && 'name' in s.cause
         ? rehydrateError(s.cause as SerializedError)
         : s.cause
       : undefined;

--- a/packages/core/src/events/event-emitter/ack-handle-buffer.ts
+++ b/packages/core/src/events/event-emitter/ack-handle-buffer.ts
@@ -114,10 +114,7 @@ export class AckHandleBuffer {
           if (this.disposed) break;
           const entry = byEvent.get(ev);
           try {
-            // The declared EventCallback return type is `void`, but real
-            // implementations frequently return a Promise. Await both kinds
-            // so per-event isolation actually waits for the cb to settle.
-            await (this.cb(ev, entry?.ack, entry?.nack) as void | Promise<void>);
+            await this.cb(ev, entry?.ack, entry?.nack);
           } catch (err) {
             this.onError?.(err, { phase: 'cb' });
           }

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -658,10 +658,10 @@ function isV3Usage(usage: unknown): usage is LanguageModelV3Usage {
   return (
     typeof u.inputTokens === 'object' &&
     u.inputTokens !== null &&
-    'total' in (u.inputTokens as object) &&
+    'total' in u.inputTokens &&
     typeof u.outputTokens === 'object' &&
     u.outputTokens !== null &&
-    'total' in (u.outputTokens as object)
+    'total' in u.outputTokens
   );
 }
 

--- a/packages/core/src/utils/zod-utils.ts
+++ b/packages/core/src/utils/zod-utils.ts
@@ -60,7 +60,7 @@ export function getZodTypeName(schema: ZodTypeAny): string | undefined {
  */
 export function isZodArray(value: unknown): value is ZodArrayAny {
   if (!isZodType(value)) return false;
-  return getZodTypeName(value as ZodTypeAny) === 'ZodArray';
+  return getZodTypeName(value) === 'ZodArray';
 }
 
 /**
@@ -70,7 +70,7 @@ export function isZodArray(value: unknown): value is ZodArrayAny {
  */
 export function isZodObject(value: unknown): value is ZodObjectAny {
   if (!isZodType(value)) return false;
-  return getZodTypeName(value as ZodTypeAny) === 'ZodObject';
+  return getZodTypeName(value) === 'ZodObject';
 }
 
 /**

--- a/packages/core/src/workflows/utils.ts
+++ b/packages/core/src/workflows/utils.ts
@@ -43,7 +43,7 @@ async function validateWithStandardSchema<T>(
     };
   }
 
-  return { success: true, data: resolvedResult.value as T };
+  return { success: true, data: resolvedResult.value };
 }
 
 export async function validateStepInput({


### PR DESCRIPTION
## Description

Remove nine assertions where existing guards, schema results, and callback signatures already provide the type. Keep the same validation and awaited callback handling, and remove the obsolete comment claiming callbacks only return void.

No production behavior changes. The emitted production JavaScript matches after ignoring comments and formatting.

## Related issue(s)

Separated from #23858, now merged.

## Type of change

- [x] Code refactoring

## Checklist

- [x] Existing coverage checked; no new production behavior requires a new test.
- [x] Documentation unchanged because usage is unchanged.
- [x] Review feedback addressed.

---

> ██████████████████ **source** `+8 −11`
> ███████████ **changeset** `+5`

