### PR TITLE
refactor(server): remove redundant A2A type assertions

### DIFF
--- a/.changeset/hip-zebras-juggle.md
+++ b/.changeset/hip-zebras-juggle.md
@@ -2,4 +2,4 @@
 '@mastra/server': patch
 ---
 
-Removed redundant type assertions from A2A handlers without changing request handling.
+Simplified A2A handler maintenance without changing discovery, validation, or execution behavior.

--- a/.changeset/hip-zebras-juggle.md
+++ b/.changeset/hip-zebras-juggle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Removed redundant type assertions from A2A handlers without changing request handling.

--- a/packages/server/src/server/handlers/a2a.ts
+++ b/packages/server/src/server/handlers/a2a.ts
@@ -329,7 +329,7 @@ export async function getAgentCardByIdHandler({
   };
   pushNotifications?: boolean;
 }): Promise<AgentCard> {
-  const agent = await getAgentFromSystem({ mastra, agentId: agentId as string });
+  const agent = await getAgentFromSystem({ mastra, agentId: agentId });
 
   const [instructions, tools]: [
     Awaited<ReturnType<typeof agent.getInstructions>>,
@@ -338,7 +338,7 @@ export async function getAgentCardByIdHandler({
 
   // Extract agent information to create the AgentCard
   const agentCard: AgentCard = {
-    name: agent.id || (agentId as string),
+    name: agent.id || agentId,
     description: convertInstructionsToString(instructions),
     url: executionUrl,
     provider,
@@ -388,7 +388,7 @@ function validateMessageSendParams(params: MessageSendParams) {
     messageSendParamsSchema.parse(params);
   } catch (error) {
     if (error instanceof z.ZodError) {
-      throw MastraA2AError.invalidParams((error as z.ZodError).issues[0]!.message);
+      throw MastraA2AError.invalidParams(error.issues[0]!.message);
     }
 
     throw error;
@@ -2353,7 +2353,7 @@ export const GET_AGENT_CARD_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ctx => {
     const executionUrl = getA2AExecutionUrl({
-      agentId: ctx.agentId as string,
+      agentId: ctx.agentId,
       request: (ctx as typeof ctx & { request?: Request }).request,
       routePrefix: ctx.routePrefix,
     });
@@ -2393,7 +2393,7 @@ export const AGENT_EXECUTION_ROUTE = createRoute({
     const result = await getAgentExecutionHandler({
       requestId,
       mastra,
-      agentId: agentId as string,
+      agentId: agentId,
       requestContext,
       method,
       params,


### PR DESCRIPTION
## Description

Remove four string assertions on agent IDs already typed by the handler and route schemas, plus the ZodError assertion inside its existing instanceof guard.

A2A discovery, execution, and error handling behave the same. The emitted JavaScript matches after ignoring comments and formatting.

## Related issue(s)

Internal type cleanup; no linked issue.

## Type of change

- [x] Code refactoring

## Checklist

- [x] Existing coverage checked; no new behavior requires a new test.
- [x] Documentation unchanged because usage is unchanged.
- [x] Review feedback addressed.

---

> ██████████████████ **source** `+5 −5`
> ██████████████████ **changeset** `+5`