### PR TITLE
refactor(studio): remove redundant dataset and experiment casts

### DIFF
--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-eval.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-eval.tsx
@@ -330,7 +330,7 @@ export function ExperimentResultsPanel({
   onCreateScorer?: (items: Array<{ input: unknown; output: unknown }>) => void;
 }) {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const experimentStatus = experiment.status as 'running' | 'pending' | 'completed' | 'failed';
+  const experimentStatus = experiment.status;
   const {
     data: results,
     isLoading,

--- a/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
@@ -68,7 +68,7 @@ export function DatasetsList({
         experimentFilter === 'all' ||
         (experimentFilter === 'with' && ds.experimentCount > 0) ||
         (experimentFilter === 'without' && ds.experimentCount === 0);
-      const matchesTag = tagFilter === 'all' || (Array.isArray(ds.tags) && (ds.tags as string[]).includes(tagFilter));
+      const matchesTag = tagFilter === 'all' || (Array.isArray(ds.tags) && ds.tags.includes(tagFilter));
       return matchesSearch && matchesExperiment && matchesTag;
     });
   }, [enrichedDatasets, search, experimentFilter, tagFilter]);

--- a/packages/playground/src/domains/datasets/components/datasets-list/helpers.ts
+++ b/packages/playground/src/domains/datasets/components/datasets-list/helpers.ts
@@ -13,7 +13,7 @@ export function getAllDatasetTags(datasets: DatasetRecord[]): string[] {
   for (const dataset of datasets) {
     if (!Array.isArray(dataset.tags)) continue;
 
-    for (const tag of dataset.tags as string[]) {
+    for (const tag of dataset.tags) {
       tagSet.add(tag);
     }
   }

--- a/packages/playground/src/domains/experiments/components/experiment-status-card.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-status-card.tsx
@@ -44,7 +44,7 @@ export function ExperimentStatusCard({ experiments, datasets, isLoading, isError
         byDataset.set(key, { completed: 0, running: 0, pending: 0, failed: 0 });
       }
       const counts = byDataset.get(key)!;
-      const status = exp.status as keyof typeof counts;
+      const status = exp.status;
       if (status in counts) {
         counts[status]++;
       }

--- a/packages/playground/src/domains/shared/components/review-item-card.tsx
+++ b/packages/playground/src/domains/shared/components/review-item-card.tsx
@@ -61,9 +61,7 @@ export function ReviewItemCard({
     }
   })();
 
-  const scoresEntries: Array<[string, number]> = item.scores
-    ? (Object.entries(item.scores) as Array<[string, number]>)
-    : [];
+  const scoresEntries: Array<[string, number]> = item.scores ? Object.entries(item.scores) : [];
 
   return (
     <div


### PR DESCRIPTION
## Description

Use the existing types for dataset tags, experiment statuses, and review score entries. This removes five assertions across the dataset list and experiment views.

Filtering, status counts, and score rendering behave the same. The emitted JavaScript matches after ignoring comments and formatting.

## Related issue(s)

Internal type cleanup; no linked issue.

## Type of change

- [x] Code refactoring

## Checklist

- [x] Existing coverage checked; no new behavior requires a new test.
- [x] Documentation unchanged because usage is unchanged.
- [x] Review feedback addressed.

---

> ██████████████████ **source** `+5 −7`