### PR TITLE
refactor(studio): remove redundant interaction casts

### DIFF
--- a/packages/playground/src/domains/agent-builder/hooks/use-stored-agent-favorite.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-stored-agent-favorite.ts
@@ -48,7 +48,7 @@ export const useToggleStoredAgentFavorite = (agentId?: string) => {
       for (const [key, value] of listQueries) {
         previousLists.push([key, value]);
         if (!value?.agents) continue;
-        queryClient.setQueryData<ListStoredAgentsResponse>(key as readonly unknown[], {
+        queryClient.setQueryData<ListStoredAgentsResponse>(key, {
           ...value,
           agents: value.agents.map(a => (a.id === agentId ? applyFavoriteToAgent(a, favorited) : a)),
         });

--- a/packages/playground/src/domains/agent-builder/hooks/use-stored-skill-favorite.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-stored-skill-favorite.ts
@@ -45,7 +45,7 @@ export const useToggleStoredSkillFavorite = (skillId?: string) => {
       for (const [key, value] of listQueries) {
         previousLists.push([key, value]);
         if (!value?.skills) continue;
-        queryClient.setQueryData<ListStoredSkillsResponse>(key as readonly unknown[], {
+        queryClient.setQueryData<ListStoredSkillsResponse>(key, {
           ...value,
           skills: value.skills.map(s => (s.id === skillId ? applyFavoriteToSkill(s, favorited) : s)),
         });

--- a/packages/playground/src/domains/agents/components/composer-model-settings.tsx
+++ b/packages/playground/src/domains/agents/components/composer-model-settings.tsx
@@ -276,7 +276,7 @@ export const ComposerModelSettings = ({ agentId }: ComposerModelSettingsProps) =
                     canEditSettings &&
                     setSettings({
                       ...settings,
-                      modelSettings: { ...settings?.modelSettings, requireToolApproval: value as boolean },
+                      modelSettings: { ...settings?.modelSettings, requireToolApproval: value },
                     })
                   }
                 />

--- a/packages/playground/src/domains/mcps/components/MCPDetail.tsx
+++ b/packages/playground/src/domains/mcps/components/MCPDetail.tsx
@@ -178,7 +178,7 @@ function hasAppUi(meta?: Record<string, unknown>): boolean {
   if (!meta) return false;
   const ui = meta.ui as { resourceUri?: string } | undefined;
   if (typeof ui?.resourceUri === 'string' && ui.resourceUri.startsWith('ui://')) return true;
-  if (typeof meta['ui/resourceUri'] === 'string' && (meta['ui/resourceUri'] as string).startsWith('ui://')) return true;
+  if (typeof meta['ui/resourceUri'] === 'string' && meta['ui/resourceUri'].startsWith('ui://')) return true;
   return false;
 }
 

--- a/packages/playground/src/domains/workflows/workflow/workflow-run-options.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-run-options.tsx
@@ -11,7 +11,7 @@ export const WorkflowRunOptions = () => {
         Debug Mode
       </Txt>
 
-      <Checkbox checked={debugMode} onCheckedChange={value => setDebugMode(value as boolean)} />
+      <Checkbox checked={debugMode} onCheckedChange={value => setDebugMode(value)} />
     </>
   );
 };


### PR DESCRIPTION
## Description

Remove five assertions from favorite query keys, checkbox values, and the guarded MCP resource URI. React Query, the checkbox callback, and the existing string guard already provide those types.

Favorite updates, settings changes, and MCP app detection behave the same. The emitted JavaScript matches after ignoring comments and formatting.

## Related issue(s)

Internal type cleanup; no linked issue.

## Type of change

- [x] Code refactoring

## Checklist

- [x] Existing coverage checked; no new behavior requires a new test.
- [x] Documentation unchanged because usage is unchanged.
- [x] Review feedback addressed.

---

> ██████████████████ **source** `+5 −5`