### PR TITLE
docs: fix onboarding quickstart, pnpm version, and template metadata

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,7 +5,7 @@ This guide provides instructions for developers who want to contribute to or wor
 ## Prerequisites
 
 - **Node.js** (v22.13.0 or later)
-- **pnpm** (v10.18.0 or later): Mastra uses pnpm for package management
+- **pnpm** (v11.x — repo pins `pnpm@11.21.0` in root `package.json:packageManager`, `engines` requires `>=11.0.0`; run `corepack enable && corepack prepare pnpm@11.21.0 --activate`): Mastra uses pnpm for package management
 - **Docker** (for local development services): Only needed for a subset of tests, not required for general development
 
 ## Getting started
@@ -148,7 +148,14 @@ Mastra uses Vitest for testing. You can run all tests or only specific packages.
   pnpm test:watch
   ```
 
-Some tests require environment variables to be set. If you're unsure about the required variables, ask for help in the pull request or wait for CI to run the tests.
+Some tests require environment variables to be set. Copy the block below to a `.env` file in the root directory; only fill what your test target needs. CI-only keys (Pinecone/Cloudflare) can stay empty for `test:core`.
+
+| Var | Needed for |
+| `OPENAI_API_KEY` | `pnpm test:core`, `test:memory`, agent evals |
+| `ANTHROPIC_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY` | Gateway/provider fallback tests |
+| `COHERE_API_KEY` / `PINECONE_API_KEY` | RAG/vector provider tests (CI-only, optional locally) |
+| `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN` | Cloudflare store tests (CI-only, optional locally) |
+| `DB_URL=postgresql://postgres:postgres@localhost:5432/mastra` | pg store tests (after `pnpm run dev:services:up`) |
 
 Create a `.env` file in the root directory with the following content:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The **recommended** way to get started with Mastra is by running the command bel
 npm create mastra@latest
 ```
 
-Follow the [Installation guide](https://mastra.ai/guides/getting-started/quickstart) for step-by-step setup with the CLI or a manual install.
+Follow the [Installation guide](https://mastra.ai/docs) for step-by-step setup with the CLI or a manual install.
 
 If you're new to AI agents, check out our [templates](https://mastra.ai/docs/getting-started/templates), [course](https://mastra.ai/course), and [YouTube videos](https://youtube.com/@mastra-ai) to start building with Mastra today.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,21 +3,21 @@
 Navigate to the example directory you want to run. For example:
 
 ```bash
-cd examples/ai-sdk-v5
+cd examples/agent
 ```
 
 Install the packages:
 
 ```bash
-npm install
+pnpm install --ignore-workspace
 ```
 
 > The examples have a separate `package.json` file and are not part of the Mastra workspace.
 > Most examples can use `npm install`.
 > If an example links local workspace packages, use `pnpm install --ignore-workspace` from that example directory instead.
 
-Run the appropriate CLI command in your terminal (may vary by example). For example for the `ai-sdk-v5` example:
+Run the appropriate CLI command in your terminal (may vary by example). For example for the `agent` example:
 
 ```bash
-npm run dev
+pnpm mastra:dev
 ```

--- a/templates/weather-agent/README.md
+++ b/templates/weather-agent/README.md
@@ -20,10 +20,12 @@ This demo runs in Mastra Studio, but you can connect this workflow to your React
 
 1. **Clone the template**
    - Run `npx create-mastra@latest --template weather-agent` to scaffold the project locally.
-2. **Add your API keys**
+2. **Install dependencies**
+   - Run `npm install` (or `pnpm install`).
+3. **Add your API keys**
    - Copy `.env.example` to `.env` and fill in your key.
-3. **Start the dev server**
-   - Run `npm run dev` and open [localhost:4111](http://localhost:4111) to try it out.
+4. **Start the dev server**
+   - Run `npm run dev` (runs `mastra dev`) and open [localhost:4111](http://localhost:4111) to try it out.
 
 ## About Mastra templates
 

--- a/templates/weather-agent/package.json
+++ b/templates/weather-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "weather-agent",
   "version": "1.0.0",
-  "description": "",
+  "description": "Minimal Mastra agent + workflow that fetches weather and suggests activities.",
   "main": "index.js",
   "scripts": {
     "dev": "mastra dev",


### PR DESCRIPTION
## Description

Fixes stale onboarding references that fail on a fresh clone:

- `examples/README.md`: `examples/ai-sdk-v5` does not exist → now uses `examples/agent` with `pnpm install --ignore-workspace` + `pnpm mastra:dev`.
- `README.md`: Installation guide URL had no counterpart in `docs/` → points to `https://mastra.ai/docs`.
- `DEVELOPMENT.md`: pnpm v10 → v11.x per root `packageManager` pin (`pnpm@11.21.0`, `engines >=11.0.0`).
- `DEVELOPMENT.md`: test-env block gains a var→test-target table instead of "ask in the PR or wait for CI".
- `templates/weather-agent`: fills empty `package.json` description, adds missing install step to README.

No versioned packages touched, so no changeset (docs/templates only).

## Related issue(s)

Fixes #23748

## Type of change

- [x] Documentation update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (docs-only; verified by reading, full docs build not run locally)
- [ ] I have addressed all Coderabbit comments on this PR (none yet — will address on review)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes outdated setup instructions so new contributors can start the project without following broken links or commands. It also adds missing setup details for tests and the weather-agent template.

## Changes

- Replaced the nonexistent `examples/ai-sdk-v5` reference with `examples/agent`.
- Updated example commands to use pnpm.
- Changed the README installation link to `https://mastra.ai/docs`.
- Updated the documented pnpm requirement to v11.x.
- Added a test environment variable and test target table to `DEVELOPMENT.md`.
- Added the missing weather-agent dependency installation step.
- Added a description to `templates/weather-agent/package.json`.
- Made documentation and template metadata changes only. No versioned packages or changeset were added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->