### PR TITLE
chore(lint): use type-aware unused-vars and forbid focused tests

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -88,7 +88,7 @@ export default defineConfig({
       files: ['**/*.ts?(x)'],
       rules: {
         'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
-        'no-unused-vars': [
+        'typescript/no-unused-vars': [
           'error',
           {
             args: 'after-used',
@@ -209,7 +209,7 @@ export default defineConfig({
         'no-debugger': 'off',
         'no-restricted-globals': 'off',
         'no-restricted-imports': 'off',
-        'vitest/no-focused-tests': 'warn',
+        'vitest/no-focused-tests': 'error',
       },
       plugins: ['vitest'],
     },


### PR DESCRIPTION
## Description

Two one-line hardening changes in `oxlint.config.ts`:

- TS override used base `no-unused-vars`, missing type-only dead code → now `typescript/no-unused-vars` with identical options.
- `vitest/no-focused-tests` warn → error, so a stray `.only` fails CI instead of silently narrowing the suite (verified zero `.only` in repo today).

## Related issue(s)

Fixes #23749

## Type of change

- [x] Code refactoring

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable) (not applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (config-only; `pnpm lint` to be confirmed by CI, not run locally)
- [ ] I have addressed all Coderabbit comments on this PR (none yet — will address on review)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes lint checks stricter. It catches unused TypeScript code and prevents focused tests from reaching `main`.

## Changes

- Replaces `no-unused-vars` with `typescript/no-unused-vars` in the TypeScript override.
- Changes `vitest/no-focused-tests` from `warn` to `error`.
- Keeps the existing rule options unchanged.
- No `.only` usages currently exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->