### PR TITLE
fix(security): pin actions to SHAs, harden git exec, require WebCrypto IDs

### DIFF
--- a/.github/scripts/check-deleted-pages.js
+++ b/.github/scripts/check-deleted-pages.js
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 
 const matcherCache = new Map();
@@ -6,10 +6,17 @@ const BASE_REF = process.env.BASE_REF || 'origin/main';
 const DOCS_DIR = 'docs/src/content';
 const VERCEL_JSON_PATH = 'docs/vercel.json';
 
+// Allow only git refs (branch names, tags, SHAs); blocks shell metacharacters from BASE_REF env input.
+const SAFE_REF = /^[A-Za-z0-9._\/-]+$/;
+if (!SAFE_REF.test(BASE_REF)) {
+  console.error(`Refusing to run: unsafe BASE_REF value ${JSON.stringify(BASE_REF)}`);
+  process.exit(1);
+}
+
 // Get list of deleted MDX files
 function getDeletedMdxFiles() {
   try {
-    const diff = execSync(`git diff --name-status ${BASE_REF}...HEAD -- ${DOCS_DIR}`, {
+    const diff = execFileSync('git', ['diff', '--name-status', `${BASE_REF}...HEAD`, '--', DOCS_DIR], {
       encoding: 'utf-8',
     });
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,4 +19,4 @@ jobs:
           fetch-tags: false
           filter: 'blob:none'
           show-progress: false
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6

--- a/.github/workflows/mastracode-e2e.yml
+++ b/.github/workflows/mastracode-e2e.yml
@@ -28,7 +28,7 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         timeout-minutes: 20
         with:
           ref: ${{ inputs.head_sha }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Cache turbo build setup
         if: ${{ env.TURBO_TOKEN == '' }}
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .turbo/cache
           key: turbo-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -85,7 +85,7 @@ jobs:
           ls -R $cache_dir
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v46.1.19
+        uses: renovatebot/github-action@22e0a16091fc706b04affe6ae53d5e3358ac4023 # v46.1.19
         with:
           configurationFile: renovate.json
           docker-user: '${{ steps.id.outputs.user }}:${{ steps.id.outputs.group }}'

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Cache turbo build setup
         if: ${{ env.TURBO_TOKEN == '' }}
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .turbo/cache
           key: turbo-${{ runner.os }}-${{ github.sha }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: vitest-blob-unit-${{ matrix.shard }}
           path: .vitest-reports/
@@ -180,7 +180,7 @@ jobs:
 
       - name: Cache turbo build setup
         if: ${{ env.TURBO_TOKEN == '' }}
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .turbo/cache
           key: turbo-${{ runner.os }}-${{ github.sha }}
@@ -219,7 +219,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: vitest-blob-e2e-${{ steps.normalize.outputs.project_id }}
           path: .vitest-reports/

--- a/.github/workflows/trigger-cloud-tests.yml
+++ b/.github/workflows/trigger-cloud-tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: starsling-ubuntu-24.04
     steps:
       - name: Trigger mastra-cloud integration tests
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ secrets.MASTRA_CLOUD_PAT }}
           repository: mastra-ai/mastra-cloud

--- a/client-sdks/client-js/src/observability/collector.ts
+++ b/client-sdks/client-js/src/observability/collector.ts
@@ -78,17 +78,16 @@ function isValidTraceparentMatch(parsed: RegExpExecArray): boolean {
 }
 
 function randomSpanIdHex(): string {
-  // 16 hex chars = 8 bytes. Use crypto when available; fall back to
-  // Math.random for environments without (older RN, some sandboxes).
-  if (typeof globalThis.crypto !== 'undefined' && globalThis.crypto.getRandomValues) {
-    const bytes = new Uint8Array(8);
-    globalThis.crypto.getRandomValues(bytes);
-    let out = '';
-    for (const b of bytes) out += b.toString(16).padStart(2, '0');
-    return out;
+  // 16 hex chars = 8 bytes. Requires WebCrypto; environments without it
+  // (older RN, some sandboxes) must polyfill globalThis.crypto instead of
+  // falling back to predictable Math.random IDs.
+  if (typeof globalThis.crypto === 'undefined' || !globalThis.crypto.getRandomValues) {
+    throw new Error('randomSpanIdHex requires globalThis.crypto.getRandomValues (add a polyfill)');
   }
+  const bytes = new Uint8Array(8);
+  globalThis.crypto.getRandomValues(bytes);
   let out = '';
-  for (let i = 0; i < 16; i++) out += Math.floor(Math.random() * 16).toString(16);
+  for (const b of bytes) out += b.toString(16).padStart(2, '0');
   return out;
 }
 

--- a/packages/_changeset-cli/src/git/backport.ts
+++ b/packages/_changeset-cli/src/git/backport.ts
@@ -16,6 +16,21 @@ const octokit = new Octokit({
   auth: `token ${process.env.GITHUB_TOKEN}`,
 });
 
+// Run git without a shell: execFileSync passes args directly, so branch
+// names / SHAs derived from PR metadata cannot inject extra commands.
+const SAFE_BRANCH = /^[A-Za-z0-9._/-]+$/;
+const SAFE_SHA = /^[0-9a-f]{4,40}$/;
+
+function assertSafe(value: string, pattern: RegExp, label: string): void {
+  if (!pattern.test(value)) {
+    throw new Error(`Refusing to run git: unsafe ${label} ${JSON.stringify(value)}`);
+  }
+}
+
+function runGit(args: string[]): void {
+  childProcess.execFileSync('git', args, { stdio: 'inherit' });
+}
+
 /**
  * Get the details of the PR, create a new branch, cherry-pick the commit, push the branch, and create a PR.
  */
@@ -50,48 +65,37 @@ async function github({ pull_number, continue: continueAfterCherryPick }: { pull
   const normalizedBranch = branch.replaceAll('/', '-');
   const backportBranchName = `backport/${normalizedBranch}-${pull_number}`;
 
+  assertSafe(baseBranch, SAFE_BRANCH, 'base branch');
+  assertSafe(branch, SAFE_BRANCH, 'head branch');
+  assertSafe(backportBranchName, SAFE_BRANCH, 'backport branch');
+  assertSafe(commitSha, SAFE_SHA, 'commit SHA');
+
   console.log(`Backport branch name: ${backportBranchName}`);
 
-  childProcess.execSync(`git fetch origin ${baseBranch}`, {
-    stdio: `inherit`,
-  });
+  runGit(['fetch', 'origin', baseBranch]);
 
   try {
-    childProcess.execSync(`git switch "${baseBranch}"`, {
-      stdio: `inherit`,
-    });
-    childProcess.execSync(`git pull origin "${baseBranch}"`, {
-      stdio: `inherit`,
-    });
+    runGit(['switch', baseBranch]);
+    runGit(['pull', 'origin', baseBranch]);
   } catch {}
 
   if (!continueAfterCherryPick) {
     try {
-      childProcess.execSync(`git branch -D "${backportBranchName}"`, {
-        stdio: `inherit`,
-      });
+      runGit(['branch', '-D', backportBranchName]);
     } catch {}
   }
 
   if (continueAfterCherryPick) {
-    childProcess.execSync(`git switch "${backportBranchName}"`, {
-      stdio: `inherit`,
-    });
+    runGit(['switch', backportBranchName]);
 
     try {
-      childProcess.execSync(`git cherry-pick --continue`, {
-        stdio: `inherit`,
-      });
+      runGit(['cherry-pick', '--continue']);
     } catch {}
   } else {
-    childProcess.execSync(`git checkout -b "${backportBranchName}"`, {
-      stdio: `inherit`,
-    });
+    runGit(['checkout', '-b', backportBranchName]);
 
     try {
-      childProcess.execSync(`git cherry-pick -x ${commitSha}`, {
-        stdio: `inherit`,
-      });
+      runGit(['cherry-pick', '-x', commitSha]);
     } catch (err) {
       console.error('[ERROR]: cherry-pick failed', err);
 
@@ -108,9 +112,7 @@ cc @${prDetails.data.user.login}
     }
   }
 
-  childProcess.execSync(`git push origin +${backportBranchName} --force`, {
-    stdio: `inherit`,
-  });
+  runGit(['push', 'origin', `+${backportBranchName}`, '--force']);
 
   const pr = await octokit.pulls.create({
     owner,


### PR DESCRIPTION
## Description

- Pins 8 floating action refs to their tag SHAs with version comments (`mastracode-e2e.yml`, `test-suite.yml` x4, `labeler.yml`, `trigger-cloud-tests.yml`, `renovate.yml`), matching the SHA-pinning the rest of the repo already uses.
- `packages/_changeset-cli/src/git/backport.ts`: replaces `execSync` string interpolation of PR-derived branch names/SHAs with `execFileSync('git', [...])` plus `SAFE_BRANCH`/`SAFE_SHA` allowlist validation.
- `.github/scripts/check-deleted-pages.js`: same `execFileSync` + `BASE_REF` allowlist treatment.
- `client-sdks/client-js/.../collector.ts`: `randomSpanIdHex` no longer falls back to predictable `Math.random`; throws with a polyfill message when WebCrypto is unavailable.

## Related issue(s)

Fixes #23750

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable) (not applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (verified by reading + `node --check` on the script; full test run to be confirmed by CI)
- [ ] I have addressed all Coderabbit comments on this PR (none yet — will address on review)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes automated actions safer, prevents unsafe Git commands, and removes a predictable fallback for generating observability IDs. It replaces changeable references and risky command handling with fixed, validated behavior.

## Changes

- Pins eight GitHub Actions to immutable commit SHAs with version comments.
- Replaces interpolated `execSync` Git commands with `execFileSync` and argument arrays.
- Validates branch names, commit SHAs, and `BASE_REF` before Git operations.
- Makes `randomSpanIdHex` require `crypto.getRandomValues`.
- Throws a polyfill error when WebCrypto is unavailable instead of using `Math.random`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->