### PR TITLE
fix(core): validate pagination inputs, guard empty subagents, harden groupBy

### DIFF
--- a/packages/core/src/agent-controller/tools.ts
+++ b/packages/core/src/agent-controller/tools.ts
@@ -117,6 +117,9 @@ export function createSubagentTool(opts: CreateSubagentToolOptions) {
   const { subagents, resolveModel, controllerTools, fallbackModelId, mastra } = opts;
 
   const subagentIds = subagents.map(s => s.id);
+  if (subagentIds.length === 0) {
+    throw new Error('createSubagentTool requires at least one subagent');
+  }
 
   const typeDescriptions = subagents.map(s => `- **${s.id}** (${s.name}): ${s.description}`).join('\n');
 

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -130,8 +130,14 @@ export function normalizePerPage(perPageInput: number | false | undefined, defau
   } else if (perPageInput === 0) {
     return 0; // Return zero results
   } else if (typeof perPageInput === 'number' && perPageInput > 0) {
-    return perPageInput; // Valid positive number
+    if (!Number.isInteger(perPageInput) || !Number.isFinite(perPageInput)) {
+      throw new Error('perPage must be a positive integer');
+    }
+    return perPageInput; // Valid positive integer
   } else if (typeof perPageInput === 'number' && perPageInput < 0) {
+    throw new Error('perPage must be >= 0');
+  } else if (typeof perPageInput === 'number') {
+    // NaN reaches here (all numeric comparisons are false for NaN)
     throw new Error('perPage must be >= 0');
   }
   // For undefined, use default
@@ -152,6 +158,9 @@ export function calculatePagination(
   perPageInput: number | false | undefined,
   normalizedPerPage: number,
 ): { offset: number; perPage: number | false } {
+  if (!Number.isInteger(page) || page < 0) {
+    throw new Error('page must be >= 0');
+  }
   return {
     offset: perPageInput === false ? 0 : page * normalizedPerPage,
     perPage: perPageInput === false ? false : normalizedPerPage,

--- a/packages/core/src/storage/pagination.test.ts
+++ b/packages/core/src/storage/pagination.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+
+import { normalizePerPage, calculatePagination } from './base';
+
+describe('normalizePerPage', () => {
+  it('passes through valid positive integers', () => {
+    expect(normalizePerPage(10, 40)).toBe(10);
+  });
+
+  it('maps false to MAX_SAFE_INTEGER and 0 to 0', () => {
+    expect(normalizePerPage(false, 40)).toBe(Number.MAX_SAFE_INTEGER);
+    expect(normalizePerPage(0, 40)).toBe(0);
+  });
+
+  it('falls back to the default for undefined', () => {
+    expect(normalizePerPage(undefined, 40)).toBe(40);
+  });
+
+  it('rejects negatives, NaN, Infinity, and fractions', () => {
+    expect(() => normalizePerPage(-1, 40)).toThrow();
+    expect(() => normalizePerPage(Number.NaN, 40)).toThrow();
+    expect(() => normalizePerPage(Number.POSITIVE_INFINITY, 40)).toThrow();
+    expect(() => normalizePerPage(2.5, 40)).toThrow();
+  });
+});
+
+describe('calculatePagination', () => {
+  it('computes offset for valid pages', () => {
+    expect(calculatePagination(2, 10, 10)).toEqual({ offset: 20, perPage: 10 });
+  });
+
+  it('forces offset 0 when perPage is false', () => {
+    expect(calculatePagination(3, false, Number.MAX_SAFE_INTEGER)).toEqual({
+      offset: 0,
+      perPage: false,
+    });
+  });
+
+  it('rejects negative, NaN, and fractional pages', () => {
+    expect(() => calculatePagination(-1, 10, 10)).toThrow('page must be >= 0');
+    expect(() => calculatePagination(Number.NaN, 10, 10)).toThrow('page must be >= 0');
+    expect(() => calculatePagination(1.5, 10, 10)).toThrow('page must be >= 0');
+  });
+});

--- a/stores/pg/src/vector/performance.helpers.ts
+++ b/stores/pg/src/vector/performance.helpers.ts
@@ -139,15 +139,20 @@ export const groupBy = <T, K extends keyof T>(
   key: K | ((item: T) => string),
   reducer?: (group: T[]) => any,
 ): Record<string, any> => {
-  const grouped = array.reduce(
-    (acc, item) => {
-      const value = typeof key === 'function' ? key(item) : item[key];
-      if (!acc[value as any]) acc[value as any] = [];
-      acc[value as any]?.push(item);
-      return acc;
-    },
-    {} as Record<string, T[]>,
-  );
+  // Collect into a Map first so keys like '__proto__' can't pollute the
+  // result object; Object.fromEntries defines own properties safely.
+  const groups = new Map<string, T[]>();
+  for (const item of array) {
+    const value = typeof key === 'function' ? key(item) : item[key];
+    const k = String(value);
+    const group = groups.get(k);
+    if (group) {
+      group.push(item);
+    } else {
+      groups.set(k, [item]);
+    }
+  }
+  const grouped = Object.fromEntries(groups) as Record<string, T[]>;
 
   if (reducer) {
     return Object.fromEntries(Object.entries(grouped).map(([key, group]) => [key, reducer(group)]));


### PR DESCRIPTION
## Description

- `packages/core/src/storage/base.ts`: `normalizePerPage` now rejects `NaN`/`Infinity`/fractions; `calculatePagination` rejects non-integer/negative pages. Error messages for previously-throwing cases are unchanged, so existing callers behave identically for valid input.
- `packages/core/src/agent-controller/tools.ts`: `createSubagentTool` throws a clear error on empty `subagents` instead of crashing inside `z.enum` via an unchecked tuple cast.
- `stores/pg/src/vector/performance.helpers.ts`: `groupBy` collects through a `Map` + `Object.fromEntries`, so keys like `__proto__` become safe own-properties; return shape unchanged.
- Adds `packages/core/src/storage/pagination.test.ts` covering valid, default, and rejection cases.

Behavior note: non-integer page/perPage now throws instead of silently slicing the wrong page.

## Related issue(s)

Fixes #23751

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable) (not applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (`pagination.test.ts`; not executed locally — needs CI confirmation)
- [ ] I have addressed all Coderabbit comments on this PR (none yet — will address on review)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR rejects invalid pagination values, prevents empty subagent tools from crashing, and safely groups PostgreSQL vector data. It also adds tests for pagination behavior.

## Changes

- Validate `perPage` and `page` as finite, non-negative integers.
- Preserve existing pagination error messages.
- Throw a clear error when `createSubagentTool` receives no subagents.
- Use `Map` and `Object.fromEntries` in `groupBy` to handle keys such as `__proto__` safely.
- Add tests for valid, default, and invalid pagination inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->