### PR TITLE
perf(storage): parallelize redis thread fetch, cut fs syscalls

### DIFF
--- a/packages/core/src/storage/filesystem-db.ts
+++ b/packages/core/src/storage/filesystem-db.ts
@@ -111,9 +111,9 @@ export class FilesystemDB {
       throw new Error(`Configured domain path "${directory}" is a file, expected a directory`);
     }
 
-    return readdirSync(baseDir)
-      .filter(file => extname(file) === extension && statSync(join(baseDir, file)).isFile())
-      .map(file => `${directory}/${file}`);
+    return readdirSync(baseDir, { withFileTypes: true })
+      .filter(entry => entry.isFile() && extname(entry.name) === extension)
+      .map(entry => `${directory}/${entry.name}`);
   }
 
   /**
@@ -267,8 +267,12 @@ export class FilesystemDB {
 /**
  * JSON reviver that converts ISO date strings back to Date objects.
  */
+const ISO_DATE_PREFIX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
 function dateReviver(_key: string, value: unknown): unknown {
-  if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(value)) {
+  // Fast path: shortest ISO datetime ('YYYY-MM-DDTHH:MM:SS') is 19 chars
+  // with '-' at index 4. Skips the regex for all other strings.
+  if (typeof value !== 'string' || value.length < 19 || value.charCodeAt(4) !== 45) return value;
+  if (ISO_DATE_PREFIX.test(value)) {
     const d = new Date(value);
     if (!isNaN(d.getTime())) return d;
   }
@@ -280,12 +284,11 @@ function dateReviver(_key: string, value: unknown): unknown {
  */
 function walkDir(dir: string): string[] {
   const results: string[] = [];
-  for (const entry of readdirSync(dir)) {
-    const fullPath = join(dir, entry);
-    const stat = statSync(fullPath);
-    if (stat.isDirectory()) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
       results.push(...walkDir(fullPath));
-    } else {
+    } else if (entry.isFile()) {
       results.push(fullPath);
     }
   }

--- a/stores/redis/src/storage/domains/memory/index.ts
+++ b/stores/redis/src/storage/domains/memory/index.ts
@@ -710,10 +710,13 @@ export class StoreMemoryRedis extends MemoryStorage {
         };
       }
 
+      // Fetch per-thread message IDs concurrently; Promise.all preserves
+      // thread order so downstream results are identical to sequential fetch.
+      const idsPerThread = await Promise.all(
+        threadIds.map(async tid => ({ tid, msgIds: await this.client.zRange(getThreadMessagesKey(tid), 0, -1) })),
+      );
       const allMessageIdsWithThreads: { threadId: string; messageId: string }[] = [];
-      for (const tid of threadIds) {
-        const threadMessagesKey = getThreadMessagesKey(tid);
-        const msgIds = await this.client.zRange(threadMessagesKey, 0, -1);
+      for (const { tid, msgIds } of idsPerThread) {
         for (const mid of msgIds) {
           allMessageIdsWithThreads.push({ threadId: tid, messageId: mid });
         }


### PR DESCRIPTION
## Description

- `stores/redis/.../memory/index.ts`: per-thread `ZRANGE` calls now run concurrently via order-preserving `Promise.all` — identical results, parallel I/O.
- `packages/core/src/storage/filesystem-db.ts`: `listDomainFiles` and `walkDir` use `readdirSync(..., { withFileTypes: true })` instead of `statSync` per entry; `dateReviver` gets a length/char fast-path before the regex (same regex, same semantics).

Behavior note: symlinked entries are no longer followed by the fs scans. No API changes.

## Related issue(s)

Fixes #23752

## Type of change

- [x] Performance improvement

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable) (not applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (no new tests; existing redis/filesystem suites to confirm via CI)
- [ ] I have addressed all Coderabbit comments on this PR (none yet — will address on review)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes message loading and file scanning faster. It performs independent Redis requests at the same time, reduces filesystem checks, and skips unnecessary date parsing. File scans no longer follow symlinks.

## Changes

- Parallelize per-thread Redis `ZRANGE` calls with order-preserving `Promise.all`.
- Use directory entry types in `listDomainFiles` and `walkDir` to remove per-entry `statSync` calls.
- Add a length and character fast path to `dateReviver` before the ISO date regex.
- Preserve existing API behavior and message ordering.
- Do not follow symlinked entries during filesystem scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->