### PR TITLE
ci(tests): discover integrations/channels/browser/workspaces/agent-sdks, add turbo test task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,11 @@
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
       "outputLogs": "new-only"
     },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": [".vitest-reports/**"],
+      "outputLogs": "errors-only"
+    },
     "lint": {
       "dependsOn": []
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ const EXCLUDED_DIRS = new Set([
   'packages/_types-builder',
   'packages/_vendored',
   'server-adapters/_test-utils',
+  'browser/_test-utils',
   'observability/_examples',
 ]);
 
@@ -27,6 +28,11 @@ const PROJECT_GLOBS = [
   'signals/*/vitest.config.ts',
   'workflows/*/vitest.config.ts',
   'code-mode/*/vitest.config.ts',
+  'integrations/*/vitest.config.ts',
+  'channels/*/vitest.config.ts',
+  'browser/*/vitest.config.ts',
+  'workspaces/*/vitest.config.ts',
+  'agent-sdks/*/vitest.config.ts',
   'mastracode/vitest.config.ts',
 ];
 


### PR DESCRIPTION
## Description

- Root `vitest.config.ts` now discovers `integrations/*`, `channels/*`, `browser/*`, `workspaces/*`, and `agent-sdks/*` configs, which all ship `vitest.config.*` files that `pnpm test` previously never ran.
- Excludes `browser/_test-utils` (e2e project, mirrors the existing `server-adapters/_test-utils` exclusion). `e2e-tests/` stays out intentionally (needs separate infra).
- `turbo.json` gains a `test` task (`dependsOn: ^build`, `outputs: .vitest-reports/**`) so test runs cache and parallelize.

Note: this newly discovers ~40 test projects, so CI will run more tests than before — that is the point.

## Related issue(s)

Fixes #23753

## Type of change

- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable) (not applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (config-only; discovery expansion to be confirmed by CI)
- [ ] I have addressed all Coderabbit comments on this PR (none yet — will address on review)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes CI find more test projects and run them automatically. It also helps Turbo reuse test results and run tests efficiently.

## Changes

- Added Vitest discovery for:
  - `integrations/*`
  - `channels/*`
  - `browser/*`
  - `workspaces/*`
  - `agent-sdks/*`
- Excluded `browser/_test-utils` from discovery.
- Added a Turbo `test` task that:
  - Depends on `^build`.
  - Caches `.vitest-reports/**`.
  - Logs only errors.

This expands CI coverage by approximately 40 test projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->