### PR TITLE
feat(playground-ui): navigate main list pages with arrow keys from anywhere

### DIFF
--- a/.changeset/cold-nights-buy.md
+++ b/.changeset/cold-nights-buy.md
@@ -1,0 +1,11 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added a `global` option to `useDataListKeyboard` / `useTableKeydown`. When enabled, ArrowUp/ArrowDown/PageUp/PageDown move the list selection from anywhere on the page, without first focusing a row. Keys typed into inputs, comboboxes, menus or open dialogs are left untouched. Enable it on the single main list of a page:
+
+```ts
+const { containerRef, getRowProps } = useDataListKeyboard({ count: items.length, global: true });
+```
+
+Studio list pages (agents, tools, workflows, MCP servers, processors, prompts, scorers, datasets, experiments, schedules, inbox, skills, logs, traces) now use it, so pressing ArrowUp/ArrowDown moves the selection right away without having to click or tab into the list first.

--- a/packages/playground-ui/src/domains/logs/components/logs-list-view.tsx
+++ b/packages/playground-ui/src/domains/logs/components/logs-list-view.tsx
@@ -53,6 +53,7 @@ export function LogsListView({
     count: logs.length,
     containerRef: scrollRef,
     onNavigate: index => virtualizer.scrollToIndex(index),
+    global: true,
   });
 
   // Reset scroll to top whenever a fresh query resolves (filter / date range change).

--- a/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
@@ -97,6 +97,7 @@ export function TracesListView({
     count: traces.length,
     containerRef: scrollRef,
     onNavigate: index => virtualizer.scrollToIndex(index),
+    global: true,
   });
 
   // Reset scroll to top whenever a fresh query resolves (filter / date range change).

--- a/packages/playground-ui/src/ds/components/DataList/use-data-list-keyboard.test.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/use-data-list-keyboard.test.tsx
@@ -3,8 +3,8 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { useDataListKeyboard } from './use-data-list-keyboard';
 
-const Subject = ({ count }: { count: number }) => {
-  const { containerRef, getRowProps } = useDataListKeyboard({ count });
+const Subject = ({ count, global }: { count: number; global?: boolean }) => {
+  const { containerRef, getRowProps } = useDataListKeyboard({ count, global });
 
   return (
     <div ref={containerRef} data-testid="container">
@@ -54,5 +54,13 @@ describe('useDataListKeyboard', () => {
 
     fireEvent.keyDown(row(2), { key: 'ArrowUp' });
     expect(document.activeElement).toBe(row(1));
+  });
+
+  it('forwards global so ArrowDown from body focuses the first row', () => {
+    render(<Subject count={3} global />);
+
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+
+    expect(document.activeElement).toBe(row(0));
   });
 });

--- a/packages/playground-ui/src/ds/components/DataList/use-data-list-keyboard.ts
+++ b/packages/playground-ui/src/ds/components/DataList/use-data-list-keyboard.ts
@@ -16,6 +16,10 @@ export type UseDataListKeyboardArgs<T extends HTMLElement = HTMLDivElement> = Om
  * container ref, so callsites only need to attach `containerRef` to the element
  * wrapping the `<DataList>` (or pass an existing scroll ref) and spread
  * `getRowProps(index)` on each interactive row (RowButton / RowLink).
+ *
+ * Pass `global: true` on the page's main list so ArrowUp/ArrowDown work from
+ * anywhere on the page (before any row has focus). Only one list per page
+ * should be global; sub-lists in panels keep the default row-level behavior.
  */
 export const useDataListKeyboard = <T extends HTMLElement = HTMLDivElement>({
   containerRef: externalRef,

--- a/packages/playground-ui/src/lib/keyboard/use-keydown.test.tsx
+++ b/packages/playground-ui/src/lib/keyboard/use-keydown.test.tsx
@@ -151,6 +151,56 @@ describe('useKeydown', () => {
 
     expect(onArrowUp).not.toHaveBeenCalled();
   });
+
+  it('does not attach a listener when enabled is false', () => {
+    const onArrowUp = vi.fn();
+    renderHook(() => useKeydown({ ArrowUp: onArrowUp }, { enabled: false }));
+
+    pressKey('ArrowUp');
+
+    expect(onArrowUp).not.toHaveBeenCalled();
+  });
+
+  it('attaches and detaches the listener when enabled toggles', () => {
+    const onArrowUp = vi.fn();
+    const { rerender } = renderHook(({ enabled }) => useKeydown({ ArrowUp: onArrowUp }, { enabled }), {
+      initialProps: { enabled: false },
+    });
+
+    pressKey('ArrowUp');
+    expect(onArrowUp).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+    pressKey('ArrowUp');
+    expect(onArrowUp).toHaveBeenCalledTimes(1);
+
+    rerender({ enabled: false });
+    pressKey('ArrowUp');
+    expect(onArrowUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the event untouched when shouldHandle returns false', () => {
+    const onArrowUp = vi.fn();
+    renderHook(() => useKeydown({ ArrowUp: onArrowUp }, { shouldHandle: () => false }));
+
+    const event = new KeyboardEvent('keydown', { key: 'ArrowUp', cancelable: true });
+    window.dispatchEvent(event);
+
+    expect(onArrowUp).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('passes the event to shouldHandle', () => {
+    const onArrowUp = vi.fn();
+    const shouldHandle = vi.fn((event: KeyboardEvent) => !event.repeat);
+    renderHook(() => useKeydown({ ArrowUp: onArrowUp }, { shouldHandle }));
+
+    pressKey('ArrowUp', { repeat: true });
+    expect(onArrowUp).not.toHaveBeenCalled();
+
+    pressKey('ArrowUp');
+    expect(onArrowUp).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('useKeydown with a scoped target', () => {
@@ -199,9 +249,10 @@ type TableHarnessProps = {
   pageSize?: number;
   onActivate?: (index: number) => void;
   onNavigate?: (index: number) => void;
+  global?: boolean;
 };
 
-const TableHarness = ({ count, pageSize, onActivate, onNavigate }: TableHarnessProps) => {
+const TableHarness = ({ count, pageSize, onActivate, onNavigate, global }: TableHarnessProps) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const { activeIndex, getRowProps, getContainerProps } = useTableKeydown({
     count,
@@ -209,6 +260,7 @@ const TableHarness = ({ count, pageSize, onActivate, onNavigate }: TableHarnessP
     pageSize,
     onActivate,
     onNavigate,
+    global,
   });
 
   return (
@@ -372,5 +424,92 @@ describe('useTableKeydown', () => {
     rerender(<TableHarness count={2} />);
 
     expect(activeIndexOf()).toBe(1);
+  });
+});
+
+describe('useTableKeydown global', () => {
+  it('focuses the current row on the first ArrowDown from body, then moves', () => {
+    render(<TableHarness count={3} global />);
+    expect(document.activeElement).toBe(document.body);
+
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(row(0));
+    expect(activeIndexOf()).toBe(0);
+
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(row(1));
+    expect(activeIndexOf()).toBe(1);
+  });
+
+  it('ignores arrows typed into an input outside the list', () => {
+    render(
+      <div>
+        <TableHarness count={3} global />
+        <input data-testid="search" />
+      </div>,
+    );
+    const search = screen.getByTestId('search');
+    search.focus();
+
+    const prevented = !fireEvent.keyDown(search, { key: 'ArrowDown' });
+
+    expect(prevented).toBe(false);
+    expect(document.activeElement).toBe(search);
+    expect(activeIndexOf()).toBe(0);
+  });
+
+  it('ignores arrows from inside a dialog', () => {
+    render(
+      <div>
+        <TableHarness count={3} global />
+        <div role="dialog">
+          <button data-testid="in-dialog">ok</button>
+        </div>
+      </div>,
+    );
+
+    fireEvent.keyDown(screen.getByTestId('in-dialog'), { key: 'ArrowDown' });
+
+    expect(activeIndexOf()).toBe(0);
+  });
+
+  it('moves only once when the key is pressed on a focused row', () => {
+    render(<TableHarness count={3} global />);
+    row(0).focus();
+
+    pressOnRow(0, 'ArrowDown');
+
+    expect(activeIndexOf()).toBe(1);
+    expect(document.activeElement).toBe(row(1));
+  });
+
+  it('does not handle Home/End from body but still does from a row', () => {
+    render(<TableHarness count={3} global />);
+
+    fireEvent.keyDown(document.body, { key: 'End' });
+    expect(activeIndexOf()).toBe(0);
+
+    row(0).focus();
+    pressOnRow(0, 'End');
+    expect(activeIndexOf()).toBe(2);
+  });
+
+  it('does nothing from body when global is not set', () => {
+    render(<TableHarness count={3} />);
+
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+
+    expect(activeIndexOf()).toBe(0);
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it('stops handling global keys after unmount', () => {
+    const { unmount } = render(<TableHarness count={3} global />);
+
+    unmount();
+    const event = new KeyboardEvent('keydown', { key: 'ArrowDown', cancelable: true, bubbles: true });
+    document.body.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
   });
 });

--- a/packages/playground-ui/src/lib/keyboard/use-keydown.ts
+++ b/packages/playground-ui/src/lib/keyboard/use-keydown.ts
@@ -57,10 +57,20 @@ export const matchesCombo = (event: KeyboardEvent, combo: ParsedKeyCombo): boole
 export type UseKeydownOptions = {
   /** Attach the listener to this element instead of `window`. */
   target?: RefObject<HTMLElement | null>;
+  /** When `false`, no listener is attached. Defaults to `true`. */
+  enabled?: boolean;
+  /**
+   * Called before any combo is matched. Return `false` to leave the event
+   * untouched (no `preventDefault`, no handler).
+   */
+  shouldHandle?: (event: KeyboardEvent) => boolean;
 };
 
 export const useKeydown = (opts: UseKeydownArgs, options: UseKeydownOptions = {}) => {
+  const { enabled = true } = options;
+
   const handlers = useEffectEvent((event: KeyboardEvent) => {
+    if (options.shouldHandle && !options.shouldHandle(event)) return;
     for (const [combo, handler] of Object.entries(opts)) {
       if (matchesCombo(event, parseKeyCombo(combo))) {
         event.preventDefault();
@@ -74,6 +84,7 @@ export const useKeydown = (opts: UseKeydownArgs, options: UseKeydownOptions = {}
   targetRef.current = options.target;
 
   useEffect(() => {
+    if (!enabled) return;
     const target = targetRef.current;
     const element: HTMLElement | Window | null = target ? (target.current ?? null) : window;
     if (!element) return;
@@ -84,7 +95,7 @@ export const useKeydown = (opts: UseKeydownArgs, options: UseKeydownOptions = {}
 
     element.addEventListener('keydown', handleKeyDown);
     return () => element.removeEventListener('keydown', handleKeyDown);
-  }, []);
+  }, [enabled]);
 };
 
 export type UseTableKeydownArgs = {
@@ -100,7 +111,32 @@ export type UseTableKeydownArgs = {
   onActivate?: (index: number) => void;
   /** Called with the next index before focus moves (e.g. virtualizer.scrollToIndex). */
   onNavigate?: (index: number) => void;
+  /**
+   * Also listen for ArrowUp/ArrowDown/PageUp/PageDown on `document`, so the
+   * list can be navigated before any row has focus. Keys are ignored when the
+   * event originates from an editable field, a keyboard widget (combobox, menu,
+   * listbox…) or an open dialog/popover. Enable on at most one list per page.
+   */
+  global?: boolean;
 };
+
+const KEYBOARD_CONSUMER_SELECTOR = [
+  'input',
+  'textarea',
+  'select',
+  '[contenteditable="true"]',
+  '[role="combobox"]',
+  '[role="listbox"]',
+  '[role="menu"]',
+  '[role="menuitem"]',
+  '[role="option"]',
+  '[role="dialog"]',
+  '[role="alertdialog"]',
+  '[data-radix-popper-content-wrapper]',
+].join(', ');
+
+const isKeyboardConsumer = (target: EventTarget | null): boolean =>
+  target instanceof Element && target.closest(KEYBOARD_CONSUMER_SELECTOR) !== null;
 
 export const useTableKeydown = ({
   count,
@@ -109,6 +145,7 @@ export const useTableKeydown = ({
   initialIndex = 0,
   onActivate,
   onNavigate,
+  global = false,
 }: UseTableKeydownArgs) => {
   const [activeIndex, setActiveIndex] = useState(initialIndex);
 
@@ -148,6 +185,24 @@ export const useTableKeydown = ({
       }
     }
   };
+
+  // When focus is outside the list, the first ArrowUp/ArrowDown press lands on
+  // the current row instead of skipping past it.
+  const focusIsInList = () => containerRef.current?.contains(document.activeElement) ?? false;
+  const step = (delta: number) => navigateTo(focusIsInList() ? activeIndex + delta : activeIndex);
+
+  useKeydown(
+    {
+      ArrowUp: () => step(-1),
+      ArrowDown: () => step(1),
+      PageUp: () => navigateTo(activeIndex - pageSize),
+      PageDown: () => navigateTo(activeIndex + pageSize),
+    },
+    {
+      enabled: global,
+      shouldHandle: event => !event.defaultPrevented && count > 0 && !isKeyboardConsumer(event.target),
+    },
+  );
 
   useEffect(() => {
     if (activeIndex >= count) {

--- a/packages/playground/src/domains/agents/components/agent-list/__tests__/agents-list.keyboard.test.tsx
+++ b/packages/playground/src/domains/agents/components/agent-list/__tests__/agents-list.keyboard.test.tsx
@@ -1,4 +1,5 @@
 import type { GetAgentResponse } from '@mastra/client-js';
+import { fireEvent } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { AgentsList } from '../agents-list';
@@ -42,6 +43,17 @@ describe('AgentsList keyboard navigation', () => {
     renderList();
 
     expectArrowNavigation(interactiveRows());
+  });
+
+  it('focuses the first row on ArrowDown from the page body, then moves down', () => {
+    renderList();
+    const rows = interactiveRows();
+
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(rows[0]);
+
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(rows[1]);
   });
 
   it('keeps row links navigable (href preserved on the focus target)', () => {

--- a/packages/playground/src/domains/agents/components/agent-list/agents-list.tsx
+++ b/packages/playground/src/domains/agents/components/agent-list/agents-list.tsx
@@ -25,7 +25,7 @@ const agentsListColumns = 'minmax(12rem,20rem) minmax(0,1fr) auto auto auto auto
 
 export function AgentsList({ agents, isLoading, hasSearch }: AgentsListProps) {
   const { paths, Link } = useLinkComponent();
-  const { containerRef, getRowProps } = useDataListKeyboard({ count: agents.length });
+  const { containerRef, getRowProps } = useDataListKeyboard({ count: agents.length, global: true });
 
   if (isLoading) {
     return <EntityListSkeleton columns={agentsListColumns} fit="container" />;

--- a/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
@@ -73,7 +73,7 @@ export function DatasetsList({
     });
   }, [enrichedDatasets, search, experimentFilter, tagFilter]);
 
-  const { containerRef, getRowProps } = useDataListKeyboard({ count: filteredData.length });
+  const { containerRef, getRowProps } = useDataListKeyboard({ count: filteredData.length, global: true });
 
   if (isLoading) {
     return <EntityListSkeleton columns={COLUMNS} />;

--- a/packages/playground/src/domains/experiments/components/experiments-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiments-list.tsx
@@ -98,7 +98,7 @@ export function ExperimentsList({
     });
   }, [sortedExperiments, search, datasetMap, statusFilter, datasetFilter]);
 
-  const { containerRef, getRowProps } = useDataListKeyboard({ count: filteredData.length });
+  const { containerRef, getRowProps } = useDataListKeyboard({ count: filteredData.length, global: true });
 
   const [experimentToDelete, setExperimentToDelete] = useState<DatasetExperiment | null>(null);
 

--- a/packages/playground/src/domains/inbox/components/inbox-feedback-list.tsx
+++ b/packages/playground/src/domains/inbox/components/inbox-feedback-list.tsx
@@ -51,7 +51,7 @@ export function InboxFeedbackList({
       )
     : items;
 
-  const { containerRef, getRowProps } = useDataListKeyboard({ count: filtered.length });
+  const { containerRef, getRowProps } = useDataListKeyboard({ count: filtered.length, global: true });
   // The sentinel observes the list's own scroll viewport, not the window.
   const { inView, setRef: setEndOfListElement } = useInView({ root: containerRef });
 

--- a/packages/playground/src/domains/mcps/components/mcps-list/mcps-list.tsx
+++ b/packages/playground/src/domains/mcps/components/mcps-list/mcps-list.tsx
@@ -54,7 +54,7 @@ export function McpServersList({ mcpServers, isLoading, search = '' }: McpServer
     );
   }, [mcpServers, search]);
 
-  const { containerRef, getRowProps } = useDataListKeyboard({ count: filteredData.length });
+  const { containerRef, getRowProps } = useDataListKeyboard({ count: filteredData.length, global: true });
 
   if (isLoading) {
     return <EntityListSkeleton columns="auto 1fr auto auto auto" />;

--- a/packages/playground/src/domains/processors/components/processors-list/processors-list.tsx
+++ b/packages/playground/src/domains/processors/components/processors-list/processors-list.tsx
@@ -30,7 +30,7 @@ export function ProcessorsList({ processors, isLoading, search = '' }: Processor
     return processorData.filter(p => p.id.toLowerCase().includes(term) || (p.name || '').toLowerCase().includes(term));
   }, [processorData, search]);
 
-  const { containerRef, getRowProps } = useDataListKeyboard({ count: filteredData.length });
+  const { containerRef, getRowProps } = useDataListKeyboard({ count: filteredData.length, global: true });
 
   if (isLoading) {
     return <EntityListSkeleton columns="auto 1fr auto auto auto auto auto auto" />;

--- a/packages/playground/src/domains/prompt-blocks/components/prompts-list/prompts-list.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/prompts-list/prompts-list.tsx
@@ -37,7 +37,7 @@ export function PromptsList({
     );
   }, [promptBlocks, search]);
 
-  const { containerRef, getRowProps } = useDataListKeyboard({ count: filteredData.length });
+  const { containerRef, getRowProps } = useDataListKeyboard({ count: filteredData.length, global: true });
 
   if (isLoading) {
     return <EntityListSkeleton columns="auto 1fr auto auto" />;

--- a/packages/playground/src/domains/schedules/components/schedules-list.tsx
+++ b/packages/playground/src/domains/schedules/components/schedules-list.tsx
@@ -25,7 +25,7 @@ export function SchedulesList({ schedules, isLoading, search = '' }: SchedulesLi
     );
   }, [schedules, search]);
 
-  const { containerRef, getRowProps } = useDataListKeyboard({ count: filtered.length });
+  const { containerRef, getRowProps } = useDataListKeyboard({ count: filtered.length, global: true });
 
   if (isLoading) {
     return <DataListSkeleton columns={COLUMNS} />;

--- a/packages/playground/src/domains/scores/components/scorers-list/scorers-list.tsx
+++ b/packages/playground/src/domains/scores/components/scorers-list/scorers-list.tsx
@@ -43,7 +43,7 @@ export function ScorersList({ scorers, isLoading, search = '', sourceFilter = 'a
     });
   }, [scorerData, search, sourceFilter]);
 
-  const { containerRef, getRowProps } = useDataListKeyboard({ count: filteredData.length });
+  const { containerRef, getRowProps } = useDataListKeyboard({ count: filteredData.length, global: true });
 
   if (isLoading) {
     return <EntityListSkeleton columns={COLUMNS} />;

--- a/packages/playground/src/domains/tools/components/tools-list/tools-list.tsx
+++ b/packages/playground/src/domains/tools/components/tools-list/tools-list.tsx
@@ -27,7 +27,7 @@ export function ToolsList({ tools, agents, isLoading, search = '' }: ToolsListPr
     [toolData, search],
   );
 
-  const { containerRef, getRowProps } = useDataListKeyboard({ count: filteredData.length });
+  const { containerRef, getRowProps } = useDataListKeyboard({ count: filteredData.length, global: true });
 
   if (isLoading) {
     return <EntityListSkeleton columns="auto 1fr auto" />;

--- a/packages/playground/src/domains/workflows/components/workflows-list/workflows-list.tsx
+++ b/packages/playground/src/domains/workflows/components/workflows-list/workflows-list.tsx
@@ -120,7 +120,7 @@ export function WorkflowsList({ workflows, isLoading, search = '' }: WorkflowsLi
     return map;
   }, [rows]);
 
-  const { containerRef, getRowProps } = useDataListKeyboard({ count: interactiveIndexByPathKey.size });
+  const { containerRef, getRowProps } = useDataListKeyboard({ count: interactiveIndexByPathKey.size, global: true });
 
   const toggleExpanded = (pathKey: string) => {
     setExpandedPaths(previous => {

--- a/packages/playground/src/domains/workspace/components/skills-table.tsx
+++ b/packages/playground/src/domains/workspace/components/skills-table.tsx
@@ -50,7 +50,7 @@ export function SkillsTable({
   removingSkillName,
 }: SkillsTableProps) {
   const { navigate } = useLinkComponent();
-  const { containerRef, getRowProps } = useDataListKeyboard({ count: skills.length });
+  const { containerRef, getRowProps } = useDataListKeyboard({ count: skills.length, global: true });
 
   const isDownloaded = (skill: SkillMetadata) => skill.path?.includes(DOWNLOADED_SKILLS_PATH) ?? false;
   const hasActionCallbacks = !!onRemoveSkill || !!onUpdateSkill;


### PR DESCRIPTION
On Studio list pages you had to click or tab into a row before ArrowUp/ArrowDown would move the selection. This adds a `global` option to `useDataListKeyboard` / `useTableKeydown` that listens on the document, so the page's main list can be navigated straight away. Keys typed into inputs, comboboxes, menus or open dialogs are left alone, and the first press lands on the current row instead of skipping past it.

```ts
const { containerRef, getRowProps } = useDataListKeyboard({ count: items.length, global: true });
```

All Studio main lists (agents, tools, workflows, MCP servers, processors, prompts, scorers, datasets, experiments, schedules, inbox, skills, logs, traces) opt in. `useKeydown` also gains `enabled` and `shouldHandle` options to support this.

Test plan: unit tests added for `useKeydown` (`enabled`/`shouldHandle`), `useDataListKeyboard` and the agents list keyboard test cover global navigation and consumer-element skipping. Manually verified on the agents page that ArrowDown works on load and does nothing while typing in the search input.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

You can now use ArrowUp and ArrowDown to move through Studio lists from anywhere on the page. The feature avoids interfering with text fields, menus, comboboxes, and dialogs.

## Changes

- Added global navigation support to `useDataListKeyboard` and `useTableKeydown`.
- Added `enabled` and `shouldHandle` options to `useKeydown`.
- Selected the current row on the first key press when focus is outside the list.
- Added safeguards for interactive controls, dialogs, and already-handled events.
- Enabled global navigation for Studio lists, including agents, tools, workflows, MCP servers, processors, prompts, scorers, datasets, experiments, schedules, inbox, skills, logs, and traces.
- Added unit tests for global navigation, exclusions, duplicate handling, disabled listeners, cleanup, and agent-list behavior.
- Added a patch changeset for `@mastra/playground-ui`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->