### PR TITLE
feat(playground): make whole DataList rows the click/focus target

### DIFF
--- a/.changeset/dark-showers-repair.md
+++ b/.changeset/dark-showers-repair.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Agents list: the whole row now navigates to the agent, not only the Name/Purpose cells. Keyboard focus lands on the row itself.
+Studio lists with cells outside the main link/button (agents, datasets, experiments, workflows, inbox, skills) now activate from anywhere on the row: clicking a trailing cell navigates or selects, and keyboard focus lands on the row itself instead of the inner link. Buttons, popovers and expanders inside those rows keep their own behavior without triggering the row.

--- a/.changeset/dark-showers-repair.md
+++ b/.changeset/dark-showers-repair.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Agents list: the whole row now navigates to the agent, not only the Name/Purpose cells. Keyboard focus lands on the row itself.

--- a/.changeset/gentle-jars-grab.md
+++ b/.changeset/gentle-jars-grab.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added an `onSelectRow` prop to `DataList.RowWrapper` so a whole row (including trailing cells) can be focused, clicked, or activated with Enter. `DataList.RowLink` now forwards its ref.

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-link.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-link.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import type { CSSProperties, ComponentPropsWithoutRef, ReactNode } from 'react';
 import { useDataListRowWrapperContext } from './data-list-row-wrapper-context';
 import { dataListRowInteractiveStyles, dataListRowStyles } from './shared';
@@ -13,31 +14,28 @@ export type DataListRowLinkProps = DataListRowSharedProps & {
   LinkComponent?: LinkComponent;
 } & Omit<ComponentPropsWithoutRef<'a'>, 'href' | 'children' | 'className' | 'style'>;
 
-export function DataListRowLink({
-  children,
-  to,
-  className,
-  style,
-  LinkComponent: Link = 'a',
-  colStart,
-  colEnd,
-  featured,
-  variant,
-  ...rest
-}: DataListRowLinkProps) {
-  const isWrapped = useDataListRowWrapperContext();
-  const hasColumnOverride = colStart !== undefined || colEnd !== undefined;
-  const resolvedStyle = hasColumnOverride ? { ...style, gridColumn: `${colStart ?? 1} / ${colEnd ?? -1}` } : style;
-  return (
-    <Link
-      href={to}
-      className={cn(...(isWrapped ? dataListRowInteractiveStyles : dataListRowStyles), className)}
-      style={resolvedStyle}
-      data-featured={featured || undefined}
-      data-variant={variant ?? 'default'}
-      {...rest}
-    >
-      {children}
-    </Link>
-  );
-}
+export const DataListRowLink = forwardRef<HTMLAnchorElement, DataListRowLinkProps>(
+  (
+    { children, to, className, style, LinkComponent: Link = 'a', colStart, colEnd, featured, variant, ...rest },
+    ref,
+  ) => {
+    const isWrapped = useDataListRowWrapperContext();
+    const hasColumnOverride = colStart !== undefined || colEnd !== undefined;
+    const resolvedStyle = hasColumnOverride ? { ...style, gridColumn: `${colStart ?? 1} / ${colEnd ?? -1}` } : style;
+    return (
+      <Link
+        ref={ref}
+        href={to}
+        className={cn(...(isWrapped ? dataListRowInteractiveStyles : dataListRowStyles), className)}
+        style={resolvedStyle}
+        data-featured={featured || undefined}
+        data-variant={variant ?? 'default'}
+        {...rest}
+      >
+        {children}
+      </Link>
+    );
+  },
+);
+
+DataListRowLink.displayName = 'DataListRowLink';

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-wrapper.test.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-wrapper.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DataListRowWrapper } from './data-list-row-wrapper';
+
+afterEach(cleanup);
+
+describe('DataListRowWrapper', () => {
+  it('is not focusable and ignores clicks without onSelectRow', () => {
+    render(<DataListRowWrapper data-testid="row">content</DataListRowWrapper>);
+    const row = screen.getByTestId('row');
+    expect(row.hasAttribute('tabindex')).toBe(false);
+    expect(() => fireEvent.click(row)).not.toThrow();
+  });
+
+  it('becomes focusable and activates on click / Enter with onSelectRow', () => {
+    const onSelectRow = vi.fn();
+    render(
+      <DataListRowWrapper data-testid="row" onSelectRow={onSelectRow}>
+        content
+      </DataListRowWrapper>,
+    );
+    const row = screen.getByTestId('row');
+    expect(row.getAttribute('tabindex')).toBe('0');
+
+    fireEvent.click(row);
+    expect(onSelectRow).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(row, { key: 'Enter' });
+    expect(onSelectRow).toHaveBeenCalledTimes(2);
+
+    fireEvent.keyDown(row, { key: ' ' });
+    expect(onSelectRow).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not activate when Enter is fired on a focusable child', () => {
+    const onSelectRow = vi.fn();
+    render(
+      <DataListRowWrapper onSelectRow={onSelectRow}>
+        <a href="/somewhere">link</a>
+      </DataListRowWrapper>,
+    );
+    fireEvent.keyDown(screen.getByText('link'), { key: 'Enter' });
+    expect(onSelectRow).not.toHaveBeenCalled();
+  });
+
+  it('does not activate when a child stops click propagation', () => {
+    const onSelectRow = vi.fn();
+    render(
+      <DataListRowWrapper onSelectRow={onSelectRow}>
+        <button type="button" onClick={event => event.stopPropagation()}>
+          action
+        </button>
+      </DataListRowWrapper>,
+    );
+    fireEvent.click(screen.getByText('action'));
+    expect(onSelectRow).not.toHaveBeenCalled();
+  });
+
+  it('lets spread tabIndex override the default and still calls spread onKeyDown', () => {
+    const onSelectRow = vi.fn();
+    const onKeyDown = vi.fn();
+    render(
+      <DataListRowWrapper data-testid="row" onSelectRow={onSelectRow} tabIndex={-1} onKeyDown={onKeyDown}>
+        content
+      </DataListRowWrapper>,
+    );
+    const row = screen.getByTestId('row');
+    expect(row.getAttribute('tabindex')).toBe('-1');
+
+    fireEvent.keyDown(row, { key: 'ArrowDown' });
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(onSelectRow).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(row, { key: 'Enter' });
+    expect(onKeyDown).toHaveBeenCalledTimes(2);
+    expect(onSelectRow).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-wrapper.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-wrapper.tsx
@@ -1,32 +1,69 @@
 import { forwardRef } from 'react';
-import type { ComponentPropsWithoutRef } from 'react';
+import type { ComponentPropsWithoutRef, KeyboardEvent, MouseEvent } from 'react';
 import { DataListRowWrapperContext } from './data-list-row-wrapper-context';
 import { dataListRowOuterStyles, dataListRowStateStyles } from './shared';
 import { cn } from '@/lib/utils';
 
-export type DataListRowWrapperProps = ComponentPropsWithoutRef<'div'>;
+export type DataListRowWrapperProps = ComponentPropsWithoutRef<'div'> & {
+  /**
+   * Makes the whole wrapper the row's activation target: it becomes focusable
+   * (`tabIndex=0` unless overridden, e.g. by `getRowProps`), and a click or
+   * Enter on the wrapper itself calls this. Descendants that must not activate
+   * the row (the inner link, popover triggers, action buttons) should call
+   * `event.stopPropagation()` on their click.
+   */
+  onSelectRow?: () => void;
+};
 
 /**
- * Non-interactive grid wrapper. Used to host a leading or trailing cell (e.g. a
- * selection checkbox or row actions) alongside a `DataList.RowButton` so
- * hover/focus/click only apply to the button portion. For standalone
- * interactive rows, use `DataList.RowButton` directly without this wrapper.
+ * Grid wrapper used to host a leading or trailing cell (e.g. a selection
+ * checkbox or row actions) alongside a `DataList.RowButton` / `RowLink`.
+ *
+ * Without `onSelectRow` it is non-interactive: hover/focus/click only apply to
+ * the nested row primitive. With `onSelectRow` the wrapper itself becomes the
+ * click / Enter target so the entire row (including trailing cells) activates.
+ * For standalone interactive rows, use `DataList.RowButton` directly.
  *
  * Carries the `.data-list-row` marker so root-level row styling behaves the
  * same in wrapped and standalone rows.
  */
 export const DataListRowWrapper = forwardRef<HTMLDivElement, DataListRowWrapperProps>(
-  ({ children, className, ...rest }, ref) => {
+  ({ children, className, onSelectRow, onClick, onKeyDown, tabIndex, ...rest }, ref) => {
+    const isSelectable = onSelectRow !== undefined;
+
+    const handleClick = (event: MouseEvent<HTMLDivElement>) => {
+      onClick?.(event);
+      if (!isSelectable || event.defaultPrevented) return;
+      onSelectRow();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+      onKeyDown?.(event);
+      if (!isSelectable || event.defaultPrevented) return;
+      // Only when the wrapper itself is focused. A focused descendant (the
+      // link) receiving Enter fires its own native click; handling it here too
+      // would activate the row twice.
+      if (event.key === 'Enter' && event.target === event.currentTarget) {
+        event.preventDefault();
+        onSelectRow();
+      }
+    };
+
     return (
       <DataListRowWrapperContext.Provider value>
         <div
           ref={ref}
+          tabIndex={tabIndex ?? (isSelectable ? 0 : undefined)}
           className={cn(
             'grid grid-cols-subgrid gap-0',
             ...dataListRowOuterStyles,
             ...dataListRowStateStyles,
+            isSelectable &&
+              'cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:ring-inset',
             className,
           )}
+          onClick={handleClick}
+          onKeyDown={handleKeyDown}
           {...rest}
         >
           {children}

--- a/packages/playground-ui/src/ds/components/DataList/shared.ts
+++ b/packages/playground-ui/src/ds/components/DataList/shared.ts
@@ -17,6 +17,7 @@ export const dataListRowOuterStyles = [
  */
 export const dataListRowStateStyles = [
   'hover:bg-surface3 active:bg-surface4',
+  'focus-visible:bg-surface3 has-focus-visible:bg-surface3',
   'data-featured:bg-surface3 has-data-featured:bg-surface3 has-data-selected:bg-surface3',
   'data-featured:hover:bg-surface4 has-data-featured:hover:bg-surface4 has-data-selected:hover:bg-surface4',
   'data-[variant=error]:bg-notice-destructive/10 has-data-[variant=error]:bg-notice-destructive/10',

--- a/packages/playground/src/domains/agents/components/agent-list/__tests__/agents-list.keyboard.test.tsx
+++ b/packages/playground/src/domains/agents/components/agent-list/__tests__/agents-list.keyboard.test.tsx
@@ -1,6 +1,6 @@
 import type { GetAgentResponse } from '@mastra/client-js';
-import { fireEvent } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentsList } from '../agents-list';
 import { expectArrowNavigation, expectRovingTabindex, interactiveRows } from '@/test/keyboard';
@@ -28,14 +28,25 @@ const renderList = () =>
     </TestLinkProvider>,
   );
 
+const rowLink = (row: HTMLElement) => {
+  const link = row.querySelector('a');
+  if (!link) throw new Error('Row has no link');
+  return link;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe('AgentsList keyboard navigation', () => {
-  it('applies a roving tabindex to the row link inside each RowWrapper', () => {
+  it('applies a roving tabindex to the RowWrapper, with the inner link removed from the tab order', () => {
     renderList();
 
     const rows = interactiveRows();
     expect(rows).toHaveLength(3);
-    // The focus target is the inner RowLink anchor, not the wrapper.
-    expect(rows.every(row => row.tagName === 'A')).toBe(true);
+    // The focus target is the wrapper so the whole row (trailing cells included) is one tab stop.
+    expect(rows.every(row => row.tagName === 'DIV')).toBe(true);
+    expect(rows.every(row => rowLink(row).getAttribute('tabindex') === '-1')).toBe(true);
     expectRovingTabindex(rows);
   });
 
@@ -56,13 +67,61 @@ describe('AgentsList keyboard navigation', () => {
     expect(document.activeElement).toBe(rows[1]);
   });
 
-  it('keeps row links navigable (href preserved on the focus target)', () => {
+  it('keeps row links navigable (href preserved on the inner link)', () => {
     renderList();
 
-    expect(interactiveRows().map(row => row.getAttribute('href'))).toEqual([
+    expect(interactiveRows().map(row => rowLink(row).getAttribute('href'))).toEqual([
       '/agents/agent-a/threads/new',
       '/agents/agent-b/threads/new',
       '/agents/agent-c/threads/new',
     ]);
+  });
+});
+
+describe('AgentsList row activation', () => {
+  it('activates the link when Enter is pressed on the focused wrapper', () => {
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click');
+    renderList();
+    const [first] = interactiveRows();
+    if (!first) throw new Error('Missing row');
+
+    first.focus();
+    fireEvent.keyDown(first, { key: 'Enter' });
+
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(click.mock.instances[0]).toBe(rowLink(first));
+  });
+
+  it('activates the link when clicking a non-link area of the row', () => {
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click');
+    renderList();
+    const [first] = interactiveRows();
+    if (!first) throw new Error('Missing row');
+
+    fireEvent.click(first);
+
+    expect(click).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-activate the link when the link itself is clicked', () => {
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click');
+    renderList();
+    const [first] = interactiveRows();
+    if (!first) throw new Error('Missing row');
+
+    // fireEvent.click dispatches directly (no programmatic .click()), so any
+    // call recorded here would come from the wrapper's onSelectRow.
+    fireEvent.click(rowLink(first));
+
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it('does not activate the link when clicking inside a trailing cell', () => {
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click');
+    renderList();
+
+    fireEvent.click(screen.getByLabelText('Show model details for Agent A'));
+
+    expect(click).not.toHaveBeenCalled();
   });
 });

--- a/packages/playground/src/domains/agents/components/agent-list/agent-row.tsx
+++ b/packages/playground/src/domains/agents/components/agent-list/agent-row.tsx
@@ -1,0 +1,69 @@
+import type { GetAgentResponse } from '@mastra/client-js';
+import { DataList as EntityList, useDataListKeyboard } from '@mastra/playground-ui/components/DataList';
+import { useRef } from 'react';
+import type { SyntheticEvent } from 'react';
+import { extractPrompt } from '../../utils/extractPrompt';
+import { AgentProviderDetails } from './agent-provider-details';
+import { AgentSubagentDetails } from './agent-subagent-details';
+import { AgentToolsDetails } from './agent-tools-details';
+import { AgentWorkflowDetails } from './agent-workflow-details';
+import { useLinkComponent } from '@/lib/framework';
+
+export interface AgentRowProps {
+  agent: GetAgentResponse;
+  rowProps: ReturnType<ReturnType<typeof useDataListKeyboard>['getRowProps']>;
+}
+
+// Trailing cells host popovers: a click there must open the popover, not
+// activate the row. Same for the link itself, whose native click already
+// navigates — letting it bubble to the wrapper would navigate twice.
+const stopPropagation = (event: SyntheticEvent) => event.stopPropagation();
+
+/**
+ * Reference pattern for "whole row activates" on lists using
+ * `useDataListKeyboard({ global: true })`: the wrapper owns focus/roving and
+ * forwards activation to the inner link via `linkRef.current.click()`.
+ */
+export function AgentRow({ agent, rowProps }: AgentRowProps) {
+  const { paths, Link } = useLinkComponent();
+  const linkRef = useRef<HTMLAnchorElement>(null);
+
+  const instructions = extractPrompt(agent.instructions).replace(/\s+/g, ' ').trim();
+  const purpose = instructions || 'No instructions provided.';
+
+  return (
+    <EntityList.RowWrapper {...rowProps} onSelectRow={() => linkRef.current?.click()}>
+      <EntityList.RowLink
+        ref={linkRef}
+        colEnd={3}
+        to={paths.agentNewThreadLink(agent.id)}
+        LinkComponent={Link}
+        tabIndex={-1}
+        onClick={stopPropagation}
+      >
+        <EntityList.Cell className="text-neutral4 min-w-0 overflow-visible text-left">
+          <span title={agent.name} className="block max-w-full min-w-0 overflow-clip text-ellipsis whitespace-nowrap">
+            {agent.name}
+          </span>
+        </EntityList.Cell>
+        <EntityList.Cell className="min-w-0 overflow-visible">
+          <span title={purpose} className="block max-w-full min-w-0 overflow-clip text-ellipsis whitespace-nowrap">
+            {purpose}
+          </span>
+        </EntityList.Cell>
+      </EntityList.RowLink>
+      <EntityList.Cell className="justify-center overflow-visible" onClick={stopPropagation}>
+        <AgentProviderDetails agentName={agent.name} provider={agent.provider} modelId={agent.modelId} />
+      </EntityList.Cell>
+      <EntityList.Cell className="justify-center overflow-visible" onClick={stopPropagation}>
+        <AgentWorkflowDetails agentName={agent.name} workflows={agent.workflows} />
+      </EntityList.Cell>
+      <EntityList.Cell className="justify-center overflow-visible" onClick={stopPropagation}>
+        <AgentSubagentDetails agentName={agent.name} agents={agent.agents} />
+      </EntityList.Cell>
+      <EntityList.Cell className="justify-center overflow-visible" onClick={stopPropagation}>
+        <AgentToolsDetails agentName={agent.name} tools={agent.tools} />
+      </EntityList.Cell>
+    </EntityList.RowWrapper>
+  );
+}

--- a/packages/playground/src/domains/agents/components/agent-list/agents-list.tsx
+++ b/packages/playground/src/domains/agents/components/agent-list/agents-list.tsx
@@ -8,12 +8,7 @@ import { TextAndIcon } from '@mastra/playground-ui/components/Text';
 import { AgentIcon } from '@mastra/playground-ui/icons/AgentIcon';
 import { ToolsIcon } from '@mastra/playground-ui/icons/ToolsIcon';
 import { WorkflowIcon } from '@mastra/playground-ui/icons/WorkflowIcon';
-import { extractPrompt } from '../../utils/extractPrompt';
-import { AgentProviderDetails } from './agent-provider-details';
-import { AgentSubagentDetails } from './agent-subagent-details';
-import { AgentToolsDetails } from './agent-tools-details';
-import { AgentWorkflowDetails } from './agent-workflow-details';
-import { useLinkComponent } from '@/lib/framework';
+import { AgentRow } from './agent-row';
 
 export interface AgentsListProps {
   agents: GetAgentResponse[];
@@ -24,7 +19,6 @@ export interface AgentsListProps {
 const agentsListColumns = 'minmax(12rem,20rem) minmax(0,1fr) auto auto auto auto';
 
 export function AgentsList({ agents, isLoading, hasSearch }: AgentsListProps) {
-  const { paths, Link } = useLinkComponent();
   const { containerRef, getRowProps } = useDataListKeyboard({ count: agents.length, global: true });
 
   if (isLoading) {
@@ -59,50 +53,9 @@ export function AgentsList({ agents, isLoading, hasSearch }: AgentsListProps) {
 
       {agents.length === 0 && hasSearch ? <EntityList.NoMatch message="No Agents match your search" /> : null}
 
-      {agents.map((agent, index) => {
-        const instructions = extractPrompt(agent.instructions).replace(/\s+/g, ' ').trim();
-        const purpose = instructions || 'No instructions provided.';
-
-        return (
-          <EntityList.RowWrapper key={agent.id}>
-            <EntityList.RowLink
-              colEnd={3}
-              to={paths.agentNewThreadLink(agent.id)}
-              LinkComponent={Link}
-              {...getRowProps(index)}
-            >
-              <EntityList.Cell className="text-neutral4 min-w-0 overflow-visible text-left">
-                <span
-                  title={agent.name}
-                  className="block max-w-full min-w-0 overflow-clip text-ellipsis whitespace-nowrap"
-                >
-                  {agent.name}
-                </span>
-              </EntityList.Cell>
-              <EntityList.Cell className="min-w-0 overflow-visible">
-                <span
-                  title={purpose}
-                  className="block max-w-full min-w-0 overflow-clip text-ellipsis whitespace-nowrap"
-                >
-                  {purpose}
-                </span>
-              </EntityList.Cell>
-            </EntityList.RowLink>
-            <EntityList.Cell className="justify-center overflow-visible">
-              <AgentProviderDetails agentName={agent.name} provider={agent.provider} modelId={agent.modelId} />
-            </EntityList.Cell>
-            <EntityList.Cell className="justify-center overflow-visible">
-              <AgentWorkflowDetails agentName={agent.name} workflows={agent.workflows} />
-            </EntityList.Cell>
-            <EntityList.Cell className="justify-center overflow-visible">
-              <AgentSubagentDetails agentName={agent.name} agents={agent.agents} />
-            </EntityList.Cell>
-            <EntityList.Cell className="justify-center overflow-visible">
-              <AgentToolsDetails agentName={agent.name} tools={agent.tools} />
-            </EntityList.Cell>
-          </EntityList.RowWrapper>
-        );
-      })}
+      {agents.map((agent, index) => (
+        <AgentRow key={agent.id} agent={agent} rowProps={getRowProps(index)} />
+      ))}
     </EntityList>
   );
 }

--- a/packages/playground/src/domains/datasets/components/datasets-list/__tests__/datasets-list.keyboard.test.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/__tests__/datasets-list.keyboard.test.tsx
@@ -29,7 +29,9 @@ describe('DatasetsList keyboard navigation', () => {
 
     const rows = interactiveRows();
     expect(rows).toHaveLength(3);
-    expect(rows.every(row => row.tagName === 'A')).toBe(true);
+    // The RowWrapper is the focus target; the link inside is out of the tab order.
+    expect(rows.every(row => row.tagName === 'DIV')).toBe(true);
+    expect(rows.every(row => row.querySelector('a')?.tabIndex === -1)).toBe(true);
     expectRovingTabindex(rows);
   });
 
@@ -39,10 +41,10 @@ describe('DatasetsList keyboard navigation', () => {
     expectArrowNavigation(interactiveRows());
   });
 
-  it('keeps row links navigable (href preserved on the focus target)', () => {
+  it('keeps row links navigable (href preserved on the inner link)', () => {
     renderList();
 
-    expect(interactiveRows().map(row => row.getAttribute('href'))).toEqual([
+    expect(interactiveRows().map(row => row.querySelector('a')?.getAttribute('href'))).toEqual([
       '/datasets/ds-a',
       '/datasets/ds-b',
       '/datasets/ds-c',

--- a/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
@@ -7,7 +7,8 @@ import {
   DataListSkeleton as EntityListSkeleton,
   useDataListKeyboard,
 } from '@mastra/playground-ui/components/DataList';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
+import type { SyntheticEvent } from 'react';
 import { ComputedTag } from '@/domains/observability/components/computed-tag';
 import { useLinkComponent } from '@/lib/framework';
 
@@ -37,6 +38,75 @@ function formatDate(dateStr: string | Date | undefined | null): string {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
 }
 
+const stopPropagation = (event: SyntheticEvent) => event.stopPropagation();
+
+type EnrichedDataset = DatasetRecord & { experimentCount: number; successPct: number | null };
+
+/**
+ * Wrapper owns focus/roving and activation so the whole row navigates; the
+ * link and the trailing experiments button stop propagation to avoid double
+ * activation.
+ */
+function DatasetRow({
+  dataset: ds,
+  rowProps,
+}: {
+  dataset: EnrichedDataset;
+  rowProps: ReturnType<ReturnType<typeof useDataListKeyboard>['getRowProps']>;
+}) {
+  const { paths, Link } = useLinkComponent();
+  const linkRef = useRef<HTMLAnchorElement>(null);
+  const experimentsBadgeVariant = getExperimentsBadgeVariant(ds.successPct);
+  const tags = Array.isArray(ds.tags) ? ds.tags.filter(tag => typeof tag === 'string') : [];
+  const hasExperimentsAction = ds.experimentCount > 0;
+
+  return (
+    <EntityList.RowWrapper {...rowProps} onSelectRow={() => linkRef.current?.click()}>
+      <EntityList.RowLink
+        ref={linkRef}
+        colEnd={hasExperimentsAction ? -2 : -1}
+        to={paths.datasetLink(ds.id)}
+        LinkComponent={Link}
+        tabIndex={-1}
+        onClick={stopPropagation}
+      >
+        <EntityList.NameCell>{ds.name}</EntityList.NameCell>
+        <EntityList.DescriptionCell>{ds.description}</EntityList.DescriptionCell>
+        <EntityList.Cell>
+          {tags.length > 0 ? (
+            <div className="flex max-w-48 items-center gap-1 overflow-hidden" title={tags.join(', ')}>
+              {tags.slice(0, 2).map(tag => (
+                <ComputedTag key={tag} value={tag} className="shrink-0" />
+              ))}
+              {tags.length > 2 && <span className="text-neutral2 text-ui-xs shrink-0">+{tags.length - 2}</span>}
+            </div>
+          ) : (
+            <span className="text-neutral2">—</span>
+          )}
+        </EntityList.Cell>
+        <EntityList.TextCell>v{ds.version ?? 1}</EntityList.TextCell>
+        <EntityList.TextCell>{formatDate(ds.updatedAt)}</EntityList.TextCell>
+        {hasExperimentsAction ? null : <EntityList.Cell className="justify-center" />}
+      </EntityList.RowLink>
+
+      {hasExperimentsAction ? (
+        <Button
+          as={Link}
+          to={`/experiments?dataset=${ds.id}`}
+          variant="ghost"
+          size="sm"
+          className="h-full w-full rounded-lg p-0!"
+          onClick={stopPropagation}
+        >
+          <Badge variant={experimentsBadgeVariant} size="sm">
+            {ds.experimentCount} ({ds.successPct ?? 0}%)
+          </Badge>
+        </Button>
+      ) : null}
+    </EntityList.RowWrapper>
+  );
+}
+
 export function DatasetsList({
   datasets,
   experiments,
@@ -48,8 +118,6 @@ export function DatasetsList({
   hasNextPage,
   setEndOfListElement,
 }: DatasetsListProps) {
-  const { paths, Link } = useLinkComponent();
-
   const enrichedDatasets = useMemo(() => {
     return datasets.map(ds => {
       const dsExperiments = experiments.filter(e => e.datasetId === ds.id);
@@ -90,54 +158,9 @@ export function DatasetsList({
         <EntityList.TopCell>Experiments</EntityList.TopCell>
       </EntityList.Top>
 
-      {filteredData.map((ds, index) => {
-        const experimentsBadgeVariant = getExperimentsBadgeVariant(ds.successPct);
-        const tags = Array.isArray(ds.tags) ? ds.tags.filter(tag => typeof tag === 'string') : [];
-        const hasExperimentsAction = ds.experimentCount > 0;
-
-        return (
-          <EntityList.RowWrapper key={ds.id}>
-            <EntityList.RowLink
-              colEnd={hasExperimentsAction ? -2 : -1}
-              to={paths.datasetLink(ds.id)}
-              LinkComponent={Link}
-              {...getRowProps(index)}
-            >
-              <EntityList.NameCell>{ds.name}</EntityList.NameCell>
-              <EntityList.DescriptionCell>{ds.description}</EntityList.DescriptionCell>
-              <EntityList.Cell>
-                {tags.length > 0 ? (
-                  <div className="flex max-w-48 items-center gap-1 overflow-hidden" title={tags.join(', ')}>
-                    {tags.slice(0, 2).map(tag => (
-                      <ComputedTag key={tag} value={tag} className="shrink-0" />
-                    ))}
-                    {tags.length > 2 && <span className="text-neutral2 text-ui-xs shrink-0">+{tags.length - 2}</span>}
-                  </div>
-                ) : (
-                  <span className="text-neutral2">—</span>
-                )}
-              </EntityList.Cell>
-              <EntityList.TextCell>v{ds.version ?? 1}</EntityList.TextCell>
-              <EntityList.TextCell>{formatDate(ds.updatedAt)}</EntityList.TextCell>
-              {hasExperimentsAction ? null : <EntityList.Cell className="justify-center" />}
-            </EntityList.RowLink>
-
-            {hasExperimentsAction ? (
-              <Button
-                as={Link}
-                to={`/experiments?dataset=${ds.id}`}
-                variant="ghost"
-                size="sm"
-                className="h-full w-full rounded-lg p-0!"
-              >
-                <Badge variant={experimentsBadgeVariant} size="sm">
-                  {ds.experimentCount} ({ds.successPct ?? 0}%)
-                </Badge>
-              </Button>
-            ) : null}
-          </EntityList.RowWrapper>
-        );
-      })}
+      {filteredData.map((ds, index) => (
+        <DatasetRow key={ds.id} dataset={ds} rowProps={getRowProps(index)} />
+      ))}
 
       <EntityList.NextPageLoading
         isLoading={isFetchingNextPage}

--- a/packages/playground/src/domains/experiments/components/__tests__/experiments-list.keyboard.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiments-list.keyboard.test.tsx
@@ -31,7 +31,9 @@ describe('ExperimentsList keyboard navigation', () => {
 
     const rows = interactiveRows();
     expect(rows.length).toBe(experiments.length);
-    expect(rows.every(row => row.tagName === 'A')).toBe(true);
+    // The RowWrapper is the focus target; the link inside is out of the tab order.
+    expect(rows.every(row => row.tagName === 'DIV')).toBe(true);
+    expect(rows.every(row => row.querySelector('a')?.tabIndex === -1)).toBe(true);
     expectRovingTabindex(rows);
   });
 
@@ -42,11 +44,12 @@ describe('ExperimentsList keyboard navigation', () => {
   });
 
   describe('when selection mode is active', () => {
-    it('keeps keyboard navigation on the inner row buttons', () => {
+    it('keeps keyboard navigation on the row wrappers', () => {
       renderList({ selection: { selectedExperimentIds: [], onToggleSelection: () => {} } });
       const rows = interactiveRows();
       expect(rows.length).toBe(experiments.length);
-      expect(rows.every(row => row.tagName === 'BUTTON')).toBe(true);
+      expect(rows.every(row => row.tagName === 'DIV')).toBe(true);
+      expect(rows.every(row => row.querySelector('button') !== null)).toBe(true);
       expectArrowNavigation(rows);
     });
 

--- a/packages/playground/src/domains/experiments/components/experiments-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiments-list.tsx
@@ -7,8 +7,8 @@ import {
 } from '@mastra/playground-ui/components/DataList';
 import { getShortId } from '@mastra/playground-ui/components/Text';
 import { Trash2 } from 'lucide-react';
-import type { MouseEvent } from 'react';
-import { useMemo, useState } from 'react';
+import type { MouseEvent, ReactNode, SyntheticEvent } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { DeleteExperimentDialog } from './delete-experiment-dialog';
 import {
   EXPERIMENT_DATASET_COLUMN,
@@ -55,6 +55,57 @@ const columnHeaders = [
   { label: experimentColumnLabels.date },
 ];
 
+const stopPropagation = (event: SyntheticEvent) => event.stopPropagation();
+
+/**
+ * Wrapper owns focus/roving and activation so the whole row navigates; the
+ * link and the delete button stop propagation to avoid double activation.
+ */
+function ExperimentLinkRow({
+  experiment: exp,
+  rowProps,
+  onDelete,
+  children,
+}: {
+  experiment: DatasetExperiment;
+  rowProps: ReturnType<ReturnType<typeof useDataListKeyboard>['getRowProps']>;
+  onDelete: () => void;
+  children: ReactNode;
+}) {
+  const { paths, Link } = useLinkComponent();
+  const linkRef = useRef<HTMLAnchorElement>(null);
+
+  return (
+    <EntityList.RowWrapper {...rowProps} onSelectRow={() => linkRef.current?.click()}>
+      <EntityList.RowLink
+        ref={linkRef}
+        colEnd={-2}
+        to={paths.experimentLink(exp.id)}
+        LinkComponent={Link}
+        tabIndex={-1}
+        onClick={stopPropagation}
+      >
+        {children}
+      </EntityList.RowLink>
+      <EntityList.ActionsCell className="pl-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          tooltip="Delete experiment"
+          aria-label={`Delete experiment ${exp.name ?? exp.id}`}
+          onClick={(e: MouseEvent) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+        >
+          <Trash2 className="size-4" />
+        </Button>
+      </EntityList.ActionsCell>
+    </EntityList.RowWrapper>
+  );
+}
+
 export function ExperimentsList({
   experiments,
   datasets,
@@ -66,8 +117,6 @@ export function ExperimentsList({
   selection,
 }: ExperimentsListProps) {
   const isSelectionActive = selection !== undefined;
-  const { paths, Link } = useLinkComponent();
-
   const datasetMap = useMemo(() => {
     const map = new Map<string, string>();
     datasets?.forEach(ds => map.set(ds.id, ds.name));
@@ -139,31 +188,14 @@ export function ExperimentsList({
 
         if (!selection) {
           return (
-            <EntityList.RowWrapper key={exp.id}>
-              <EntityList.RowLink
-                colEnd={-2}
-                to={paths.experimentLink(exp.id)}
-                LinkComponent={Link}
-                {...getRowProps(index)}
-              >
-                {rowCells}
-              </EntityList.RowLink>
-              <EntityList.ActionsCell className="pl-2">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  tooltip="Delete experiment"
-                  aria-label={`Delete experiment ${exp.name ?? exp.id}`}
-                  onClick={(e: MouseEvent) => {
-                    e.stopPropagation();
-                    setExperimentToDelete(exp);
-                  }}
-                >
-                  <Trash2 className="size-4" />
-                </Button>
-              </EntityList.ActionsCell>
-            </EntityList.RowWrapper>
+            <ExperimentLinkRow
+              key={exp.id}
+              experiment={exp}
+              rowProps={getRowProps(index)}
+              onDelete={() => setExperimentToDelete(exp)}
+            >
+              {rowCells}
+            </ExperimentLinkRow>
           );
         }
 
@@ -171,9 +203,9 @@ export function ExperimentsList({
         const toggle = () => selection.onToggleSelection(exp.id);
 
         return (
-          <EntityList.RowWrapper key={exp.id}>
+          <EntityList.RowWrapper key={exp.id} {...getRowProps(index)} onSelectRow={toggle}>
             <EntityList.SelectCell checked={isSelected} onToggle={toggle} aria-label={`Select experiment ${exp.id}`} />
-            <EntityList.RowButton colStart={2} featured={isSelected} onClick={toggle} {...getRowProps(index)}>
+            <EntityList.RowButton colStart={2} featured={isSelected} tabIndex={-1} onClick={stopPropagation}>
               {rowCells}
             </EntityList.RowButton>
           </EntityList.RowWrapper>

--- a/packages/playground/src/domains/inbox/components/inbox-feedback-list.tsx
+++ b/packages/playground/src/domains/inbox/components/inbox-feedback-list.tsx
@@ -8,6 +8,7 @@ import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { useInView } from '@mastra/playground-ui/hooks/use-in-view';
 import { format } from 'date-fns';
 import { useEffect, useState } from 'react';
+import type { SyntheticEvent } from 'react';
 
 const COLUMNS = 'minmax(0, 2fr) minmax(0, 1fr) auto minmax(0, 1fr) auto auto';
 import { feedbackDisplayValue } from '@/domains/inbox/utils/feedback-display-value';
@@ -26,6 +27,8 @@ export interface InboxFeedbackListProps {
   onSelect: (feedback: FeedbackItem) => void;
   selectedFeedbackId?: string;
 }
+
+const stopPropagation = (event: SyntheticEvent) => event.stopPropagation();
 
 export function InboxFeedbackList({
   items,
@@ -98,13 +101,20 @@ export function InboxFeedbackList({
               const author = feedbackAuthorLabel(feedback);
 
               return (
-                <DataList.RowWrapper key={feedbackId ?? `${String(feedback.timestamp)}-${feedback.traceId}`}>
+                <DataList.RowWrapper
+                  key={feedbackId ?? `${String(feedback.timestamp)}-${feedback.traceId}`}
+                  {...getRowProps(index)}
+                  onSelectRow={feedback.traceId ? () => onSelect(feedback) : undefined}
+                >
                   <DataList.RowButton
                     colEnd={-2}
                     disabled={!feedback.traceId}
                     featured={feedbackId !== undefined && feedbackId === selectedFeedbackId}
-                    onClick={() => onSelect(feedback)}
-                    {...getRowProps(index)}
+                    tabIndex={-1}
+                    onClick={event => {
+                      event.stopPropagation();
+                      onSelect(feedback);
+                    }}
                   >
                     <DataList.TextCell className="min-w-0">
                       <span className="block truncate">{feedbackDisplayValue(feedback)}</span>
@@ -125,7 +135,7 @@ export function InboxFeedbackList({
                     </DataList.TextCell>
                     <DataList.TextCell>{format(feedback.timestamp, 'MMM d, h:mm a')}</DataList.TextCell>
                   </DataList.RowButton>
-                  <DataList.ActionsCell className="pl-2">
+                  <DataList.ActionsCell className="pl-2" onClick={stopPropagation}>
                     {feedbackId ? (
                       <Button
                         variant="ghost"

--- a/packages/playground/src/domains/workflows/components/workflows-list/__tests__/workflows-list.test.tsx
+++ b/packages/playground/src/domains/workflows/components/workflows-list/__tests__/workflows-list.test.tsx
@@ -261,7 +261,9 @@ describe('WorkflowsList', () => {
 
       const rowElements = interactiveRows();
       expect(rowElements.length).toBeGreaterThan(1);
-      expect(rowElements.every(row => row.tagName === 'A')).toBe(true);
+      // The RowWrapper is the focus target; the link inside is out of the tab order.
+      expect(rowElements.every(row => row.tagName === 'DIV')).toBe(true);
+      expect(rowElements.every(row => row.querySelector('a')?.tabIndex === -1)).toBe(true);
       expect(rowElements.map(row => row.tabIndex)).toEqual([0, ...rowElements.slice(1).map(() => -1)]);
 
       await waitForMutationsIdle(queryClient);

--- a/packages/playground/src/domains/workflows/components/workflows-list/workflows-list.tsx
+++ b/packages/playground/src/domains/workflows/components/workflows-list/workflows-list.tsx
@@ -8,7 +8,8 @@ import {
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { truncateString } from '@mastra/playground-ui/utils/truncate-string';
 import { ChevronRightIcon, PauseIcon, WorkflowIcon } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
+import type { SyntheticEvent } from 'react';
 import { useWorkflowsRunCounts } from '@/domains/workflows/hooks/use-workflows-run-counts';
 import { flattenWorkflowTree } from '@/domains/workflows/utils/nested-workflows';
 import type { WorkflowTreeRow } from '@/domains/workflows/utils/nested-workflows';
@@ -73,7 +74,10 @@ function TreeToggleCell({
           aria-expanded={isExpanded}
           aria-label={`${isExpanded ? 'Collapse' : 'Expand'} nested workflows of ${workflowName}`}
           className="text-neutral4 hover:text-neutral2 relative grid size-5 shrink-0 place-items-center before:absolute before:-inset-1.5 before:content-['']"
-          onClick={onToggle}
+          onClick={event => {
+            event.stopPropagation();
+            onToggle();
+          }}
         >
           <ChevronRightIcon className={cn('size-4 transition-transform', isExpanded && 'rotate-90')} />
         </button>
@@ -84,8 +88,101 @@ function TreeToggleCell({
   );
 }
 
-export function WorkflowsList({ workflows, isLoading, search = '' }: WorkflowsListProps) {
+const stopPropagation = (event: SyntheticEvent) => event.stopPropagation();
+
+/**
+ * Wrapper owns focus/roving and activation so the expander gutter also
+ * navigates; the link and the toggle stop propagation to avoid double
+ * activation.
+ */
+function WorkflowRow({
+  row,
+  isExpanded,
+  onToggle,
+  runCount,
+  rowProps,
+}: {
+  row: Extract<WorkflowTreeRow, { kind: 'workflow' }>;
+  isExpanded: boolean;
+  onToggle: () => void;
+  runCount: { running?: number; suspended?: number } | undefined;
+  rowProps: ReturnType<ReturnType<typeof useDataListKeyboard>['getRowProps']>;
+}) {
   const { paths, Link } = useLinkComponent();
+  const linkRef = useRef<HTMLAnchorElement>(null);
+  const { workflow: wf, nestedIds } = row;
+  const name = truncateString(wf.name, 50);
+  const description = truncateString(wf.description ?? '', 200);
+  const stepsCount = Object.keys(wf.steps ?? {}).length;
+  const runningCount = runCount?.running ?? 0;
+  const suspendedCount = runCount?.suspended ?? 0;
+  const hasNested = nestedIds.length > 0;
+
+  return (
+    <EntityList.RowWrapper {...rowProps} onSelectRow={() => linkRef.current?.click()}>
+      <TreeToggleCell row={row} isExpanded={isExpanded} onToggle={onToggle} />
+      <EntityList.RowLink
+        ref={linkRef}
+        colStart={2}
+        to={paths.workflowLink(wf.id)}
+        LinkComponent={Link}
+        tabIndex={-1}
+        onClick={stopPropagation}
+      >
+        <EntityList.NameCell>
+          <span className="flex items-center gap-1.5">
+            {row.depth > 0 ? <TreeConnector guides={row.guides} isLastChild={row.isLastChild} /> : null}
+            <span className="truncate">{name}</span>
+            {wf.origin === 'dynamic' ? (
+              <Badge size="xs" variant="blue" title="Registered via the dynamic-workflows API">
+                Dynamic
+              </Badge>
+            ) : null}
+            {hasNested ? (
+              <span
+                title={`Nested workflows: ${nestedIds.join(', ')}`}
+                className="text-ui-smd text-neutral4 inline-flex shrink-0 items-center gap-1"
+              >
+                <WorkflowIcon aria-hidden className="size-3.5" />
+                {nestedIds.length}
+              </span>
+            ) : null}
+          </span>
+        </EntityList.NameCell>
+        <EntityList.DescriptionCell>{description}</EntityList.DescriptionCell>
+        <EntityList.TextCell className="text-center">
+          {runningCount > 0 ? (
+            <span
+              className="text-positive1 inline-flex items-center gap-1.5"
+              aria-label={`${runningCount} run${runningCount === 1 ? '' : 's'} in progress`}
+            >
+              <span aria-hidden className="bg-positive1 size-2 rounded-full motion-safe:animate-pulse" />
+              {runningCount}
+            </span>
+          ) : (
+            ''
+          )}
+        </EntityList.TextCell>
+        <EntityList.TextCell className="text-center">
+          {suspendedCount > 0 ? (
+            <span
+              className="text-warning1 inline-flex items-center gap-1.5"
+              aria-label={`${suspendedCount} run${suspendedCount === 1 ? '' : 's'} awaiting input`}
+            >
+              <PauseIcon aria-hidden className="size-3.5" />
+              {suspendedCount}
+            </span>
+          ) : (
+            ''
+          )}
+        </EntityList.TextCell>
+        <EntityList.TextCell className="text-center">{stepsCount || ''}</EntityList.TextCell>
+      </EntityList.RowLink>
+    </EntityList.RowWrapper>
+  );
+}
+
+export function WorkflowsList({ workflows, isLoading, search = '' }: WorkflowsListProps) {
   const [expandedPaths, setExpandedPaths] = useState<ReadonlySet<string>>(new Set());
 
   const workflowData = useMemo(
@@ -186,73 +283,15 @@ export function WorkflowsList({ workflows, isLoading, search = '' }: WorkflowsLi
           );
         }
 
-        const { workflow: wf, pathKey, nestedIds } = row;
-        const name = truncateString(wf.name, 50);
-        const description = truncateString(wf.description ?? '', 200);
-        const stepsCount = Object.keys(wf.steps ?? {}).length;
-        const runningCount = runCounts[wf.id]?.running ?? 0;
-        const suspendedCount = runCounts[wf.id]?.suspended ?? 0;
-        const hasNested = nestedIds.length > 0;
-
         return (
-          <EntityList.RowWrapper key={`workflow-${pathKey}`}>
-            <TreeToggleCell row={row} isExpanded={isExpanded} onToggle={toggle} />
-            <EntityList.RowLink
-              colStart={2}
-              to={paths.workflowLink(wf.id)}
-              LinkComponent={Link}
-              {...getRowProps(interactiveIndexByPathKey.get(pathKey) ?? -1)}
-            >
-              <EntityList.NameCell>
-                <span className="flex items-center gap-1.5">
-                  {row.depth > 0 ? <TreeConnector guides={row.guides} isLastChild={row.isLastChild} /> : null}
-                  <span className="truncate">{name}</span>
-                  {wf.origin === 'dynamic' ? (
-                    <Badge size="xs" variant="blue" title="Registered via the dynamic-workflows API">
-                      Dynamic
-                    </Badge>
-                  ) : null}
-                  {hasNested ? (
-                    <span
-                      title={`Nested workflows: ${nestedIds.join(', ')}`}
-                      className="text-ui-smd text-neutral4 inline-flex shrink-0 items-center gap-1"
-                    >
-                      <WorkflowIcon aria-hidden className="size-3.5" />
-                      {nestedIds.length}
-                    </span>
-                  ) : null}
-                </span>
-              </EntityList.NameCell>
-              <EntityList.DescriptionCell>{description}</EntityList.DescriptionCell>
-              <EntityList.TextCell className="text-center">
-                {runningCount > 0 ? (
-                  <span
-                    className="text-positive1 inline-flex items-center gap-1.5"
-                    aria-label={`${runningCount} run${runningCount === 1 ? '' : 's'} in progress`}
-                  >
-                    <span aria-hidden className="bg-positive1 size-2 rounded-full motion-safe:animate-pulse" />
-                    {runningCount}
-                  </span>
-                ) : (
-                  ''
-                )}
-              </EntityList.TextCell>
-              <EntityList.TextCell className="text-center">
-                {suspendedCount > 0 ? (
-                  <span
-                    className="text-warning1 inline-flex items-center gap-1.5"
-                    aria-label={`${suspendedCount} run${suspendedCount === 1 ? '' : 's'} awaiting input`}
-                  >
-                    <PauseIcon aria-hidden className="size-3.5" />
-                    {suspendedCount}
-                  </span>
-                ) : (
-                  ''
-                )}
-              </EntityList.TextCell>
-              <EntityList.TextCell className="text-center">{stepsCount || ''}</EntityList.TextCell>
-            </EntityList.RowLink>
-          </EntityList.RowWrapper>
+          <WorkflowRow
+            key={`workflow-${row.pathKey}`}
+            row={row}
+            isExpanded={isExpanded}
+            onToggle={toggle}
+            runCount={runCounts[row.workflow.id]}
+            rowProps={getRowProps(interactiveIndexByPathKey.get(row.pathKey) ?? -1)}
+          />
         );
       })}
     </EntityList>

--- a/packages/playground/src/domains/workspace/components/skills-table.tsx
+++ b/packages/playground/src/domains/workspace/components/skills-table.tsx
@@ -2,6 +2,7 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { DataList, DataListSkeleton, useDataListKeyboard } from '@mastra/playground-ui/components/DataList';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { AlertTriangle, BookOpen, CircleSlashIcon, Plus } from 'lucide-react';
+import type { SyntheticEvent } from 'react';
 import type { SkillMetadata } from '../types';
 import { SkillRemoveButton, SkillUpdateButton } from './skill-actions';
 import { useLinkComponent } from '@/lib/framework';
@@ -36,6 +37,8 @@ const baseColumns = [
 ] as const;
 
 const columnsWithActions = [...baseColumns, { label: '', size: 'auto' }] as const;
+
+const stopPropagation = (event: SyntheticEvent) => event.stopPropagation();
 
 export function SkillsTable({
   skills,
@@ -131,11 +134,18 @@ export function SkillsTable({
             }
 
             return (
-              <DataList.RowWrapper key={skill.path}>
-                <DataList.RowButton colEnd={-2} onClick={onClick} {...getRowProps(index)}>
+              <DataList.RowWrapper key={skill.path} {...getRowProps(index)} onSelectRow={onClick}>
+                <DataList.RowButton
+                  colEnd={-2}
+                  tabIndex={-1}
+                  onClick={event => {
+                    event.stopPropagation();
+                    onClick();
+                  }}
+                >
                   {rowContent}
                 </DataList.RowButton>
-                <DataList.ActionsCell className="pl-2">
+                <DataList.ActionsCell className="pl-2" onClick={stopPropagation}>
                   {isDownloaded(skill) && (
                     <>
                       {onUpdateSkill && (


### PR DESCRIPTION
## Summary

On Studio list pages, rows that have cells outside the main link (e.g. the agents list's Provider/Workflows/Agents/Tools cells, the datasets list's Experiments button gutter, the workflows tree expander) only navigated when clicking the Name/Description part. Keyboard focus also landed on that inner link rather than the visible row.

This PR makes the whole row the activation target:

- `DataList.RowWrapper` gains an `onSelectRow` prop. When set, the wrapper is focusable, clickable, and Enter-activatable, with the standard focus ring. Existing consumers that don't pass it are unchanged.
- `DataList.RowLink` now forwards its ref so a row can trigger the inner link's native navigation.
- Applied to the six global-keyboard lists with wrapped rows: agents, datasets, experiments (link + selection modes), workflows, inbox, skills. Roving tabindex moves to the wrapper; the inner link/button becomes `tabIndex=-1`. Buttons, popovers, checkboxes and the tree expander inside those rows stop propagation so they keep their own behavior without triggering the row.

Known follow-up: the wrapper is a focusable `div` without an ARIA role; adding proper link/button semantics at the wrapper level is left for a later pass.

## Test plan

- [x] New `data-list-row-wrapper.test.tsx` (click/Enter/Space, child Enter ignored, `stopPropagation`, `tabIndex`/`onKeyDown` composition)
- [x] Updated keyboard tests for agents, datasets, experiments, workflows lists (focus target is the wrapper, href on nested `<a>`, trailing-cell clicks don't navigate)
- [x] `tsc --noEmit` + eslint clean for `@mastra/playground-ui` and `@internal/playground`
- [ ] Manual: on each list, click a trailing cell → navigates once; open a popover / click a row action / toggle the workflow tree → no navigation; Tab from search lands on the row with a visible ring; Enter navigates; ArrowUp/Down move between rows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Studio list rows can now open when clicked or focused and activated with Enter. Buttons, links, checkboxes, popovers, and expanders still work independently.

## Changes

- Added optional `onSelectRow` support to `DataList.RowWrapper`.
- Added row click and Enter activation, focus styling, and row-level roving tabindex.
- Added ref forwarding to `DataList.RowLink`.
- Applied row activation to agents, datasets, experiments, workflows, inbox, and skills.
- Prevented nested controls from triggering row activation.
- Added and updated keyboard and interaction tests.
- Added changesets for `@mastra/playground-ui`.

A follow-up is required to add ARIA link or button semantics to focusable row wrappers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->