### PR TITLE
feat(playground-ui): unified Button icon slot and icons on every text button

### DIFF
--- a/.changeset/button-icon-prop.md
+++ b/.changeset/button-icon-prop.md
@@ -1,0 +1,6 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/playground': patch
+---
+
+Button: add an `icon` prop. The icon is always rendered on the left of the label, wrapped in `<Icon>`, with a fixed gap, size, opacity and hover transition defined once in `Button`. All icon+label buttons in `@mastra/playground-ui` and `@mastra/playground` now use `icon={...}` instead of composing the icon inside `children`.

--- a/.changeset/button-icon-prop.md
+++ b/.changeset/button-icon-prop.md
@@ -1,6 +1,5 @@
 ---
 '@mastra/playground-ui': patch
-'@mastra/playground': patch
 ---
 
 Button: add an `icon` prop. The icon is always rendered on the left of the label, wrapped in `<Icon>`, with a fixed gap, size, opacity and hover transition defined once in `Button`. All icon+label buttons in `@mastra/playground-ui` and `@mastra/playground` now use `icon={...}` instead of composing the icon inside `children`.

--- a/.changeset/button-icons-for-text-only.md
+++ b/.changeset/button-icons-for-text-only.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Give every text-only Button an icon via `icon={...}`: entity icons from the sidebar (Agent, Workflow, Dataset, Scorer, Trace, Memory, Tools, …) when the action targets a Mastra entity, lucide icons by action verb otherwise (Cancel → `X`, Save → `Check`, Delete → `Trash2`, Connect → `Plug`, Publish → `Rocket`, …). Buttons whose label is data (ids, values, zoom level) and pass-through wrappers are left unchanged.

--- a/packages/playground-ui/src/domains/chat/attachments/attachment-preview-dialog.tsx
+++ b/packages/playground-ui/src/domains/chat/attachments/attachment-preview-dialog.tsx
@@ -169,8 +169,8 @@ export const TxtEntry = ({ data, name }: TxtEntryProps) => {
         type="button"
         aria-label={filename ? `Preview ${filename}` : 'Preview text attachment'}
         title={filename}
+        icon={<FileText />}
       >
-        <FileText className="shrink-0" />
         {filename && <span className="truncate">{filename}</span>}
       </Button>
       <TxtPreviewDialog data={formattedContent} title={filename} open={open} onOpenChange={setOpen} />

--- a/packages/playground-ui/src/domains/chat/tools/badges/tool-approval-buttons.tsx
+++ b/packages/playground-ui/src/domains/chat/tools/badges/tool-approval-buttons.tsx
@@ -2,7 +2,6 @@ import { Check, X } from 'lucide-react';
 import { SectionLabel } from '../../components/section-label';
 import { useToolCall } from '../../context/tool-call-context';
 import { Button } from '@/ds/components/Button';
-import { Icon } from '@/ds/icons/Icon';
 
 export interface ToolApprovalButtonsProps {
   toolCallId: string;
@@ -74,20 +73,16 @@ export const ToolApprovalButtons = ({
             onClick={handleApprove}
             disabled={isRunning || !!toolCallApprovalStatus}
             className={toolCallApprovalStatus === 'approved' ? 'text-accent1!' : ''}
+            icon={<Check />}
           >
-            <Icon>
-              <Check />
-            </Icon>
             Approve
           </Button>
           <Button
             onClick={handleDecline}
             disabled={isRunning || !!toolCallApprovalStatus}
             className={toolCallApprovalStatus === 'declined' ? 'text-accent2!' : ''}
+            icon={<X />}
           >
-            <Icon>
-              <X />
-            </Icon>
             Decline
           </Button>
         </div>

--- a/packages/playground-ui/src/domains/logs/components/log-details-view.tsx
+++ b/packages/playground-ui/src/domains/logs/components/log-details-view.tsx
@@ -80,8 +80,12 @@ export function LogDetailsView({
             <div className={cn('my-8 grid gap-2', '[&>button]:justify-between [&>button]:overflow-hidden')}>
               {traceId && (
                 <ButtonsGroup spacing="close" className="w-full min-w-0">
-                  <Button size="md" className="min-w-0 flex-1 overflow-hidden" onClick={() => onTraceClick?.(traceId)}>
-                    <ArrowRightIcon />
+                  <Button
+                    size="md"
+                    className="min-w-0 flex-1 overflow-hidden"
+                    icon={<ArrowRightIcon />}
+                    onClick={() => onTraceClick?.(traceId)}
+                  >
                     <span>Trace</span>
                     <span className="text-ui-sm text-neutral2 ml-auto min-w-0 truncate"># {traceId}</span>
                   </Button>
@@ -95,8 +99,8 @@ export function LogDetailsView({
                     className="min-w-0 flex-1 overflow-hidden"
                     disabled={!traceId || !onSpanClick}
                     onClick={() => traceId && onSpanClick?.(traceId, spanId)}
+                    icon={<ArrowRightIcon />}
                   >
-                    <ArrowRightIcon />
                     <span>Span</span>
                     <span className="text-ui-sm text-neutral2 ml-auto min-w-0 truncate"># {spanId}</span>
                   </Button>

--- a/packages/playground-ui/src/domains/logs/components/no-logs-info.tsx
+++ b/packages/playground-ui/src/domains/logs/components/no-logs-info.tsx
@@ -62,8 +62,9 @@ export const NoLogsInfo = ({ datePreset, dateFrom, dateTo }: NoLogsInfoProps = {
             href="https://mastra.ai/en/docs/observability/logging"
             target="_blank"
             rel="noopener noreferrer"
+            icon={<ExternalLinkIcon />}
           >
-            Logging Documentation <ExternalLinkIcon />
+            Logging Documentation
           </Button>
         }
       />

--- a/packages/playground-ui/src/domains/traces/components/trace-columns-menu.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-columns-menu.tsx
@@ -77,8 +77,7 @@ export function TraceColumnsMenu({
       <DropdownMenu>
         <DropdownMenu.Trigger
           render={
-            <Button variant="outline" size="md">
-              <Columns3Icon aria-hidden />
+            <Button variant="outline" size="md" icon={<Columns3Icon aria-hidden />}>
               Columns
             </Button>
           }

--- a/packages/playground-ui/src/domains/traces/components/trace-columns-menu.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-columns-menu.tsx
@@ -1,4 +1,4 @@
-import { Columns3Icon, PlusIcon } from 'lucide-react';
+import { Columns3Icon, PlusIcon, Columns3, X } from 'lucide-react';
 import { useState, type FormEvent } from 'react';
 import { TRACE_USAGE_COLUMNS } from '../trace-list-columns';
 import type { TraceColumnPreferences, TraceOptionalColumn } from '../trace-list-columns';
@@ -164,10 +164,10 @@ export function TraceColumnsMenu({
               )}
             </DialogBody>
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => handleDialogOpenChange(false)}>
+              <Button icon={<X />} type="button" variant="outline" onClick={() => handleDialogOpenChange(false)}>
                 Cancel
               </Button>
-              <Button type="submit" variant="primary">
+              <Button icon={<Columns3 />} type="submit" variant="primary">
                 Add column
               </Button>
             </DialogFooter>

--- a/packages/playground-ui/src/domains/traces/components/traces-list-mode-toggle.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-list-mode-toggle.tsx
@@ -23,9 +23,8 @@ export function TracesListModeToggle({ value, onChange, disabled }: TracesListMo
   return (
     <DropdownMenu>
       <DropdownMenu.Trigger asChild>
-        <Button size="md" variant="default" disabled={disabled}>
+        <Button size="md" variant="default" disabled={disabled} icon={<ChevronDownIcon />}>
           {TRACES_LIST_MODE_LABELS[value]}
-          <ChevronDownIcon />
         </Button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content align="start">

--- a/packages/playground-ui/src/ds/components/Button/Button.tsx
+++ b/packages/playground-ui/src/ds/components/Button/Button.tsx
@@ -7,11 +7,19 @@ import { controlHeight, controlSizeClasses } from '@/ds/primitives/control-size'
 import { controlFocusBorderVisible, sharedFormElementDisabledStyle } from '@/ds/primitives/form-element';
 import { cn } from '@/lib/utils';
 
-// Adornments for text-mode buttons: gap between icon+label, larger radius, and SVG sizing for
-// inline `<svg>` children. Excluded from icon-mode because icon-mode wraps children in `<Icon>`
-// (so `[&>svg]` selectors don't match) and uses its own `rounded-full` (circle).
+// Adornments for text-mode buttons: gap between icon+label and larger radius.
+// - `[data-slot=button-icon]` styles the `<Icon>` wrapper rendered by the `icon` prop — the only
+//   supported way to pair an icon with a label (always on the left, fixed gap).
+// - `[&>svg]` only remains for label-less text-mode buttons (e.g. CopyButton) that pass a bare
+//   SVG as children.
+// Excluded from icon-mode because icon-mode wraps children in `<Icon>` and uses its own
+// `rounded-full` (circle).
 const TEXT_MODE_ADORNMENTS = cn(
   'gap-[.75em] rounded-full',
+  '[&>[data-slot=button-icon]]:-ml-[.3em] [&>[data-slot=button-icon]]:opacity-50',
+  '[&:hover>[data-slot=button-icon]]:opacity-100',
+  '[&>[data-slot=button-icon]]:transition-opacity [&>[data-slot=button-icon]]:duration-normal',
+  '[&>[data-slot=button-icon]]:ease-out-custom',
   '[&>svg]:mx-[-.3em] [&>svg]:size-[1.1em]',
   '[&:hover>svg]:opacity-100 [&>svg]:opacity-50',
   '[&>svg]:transition-opacity [&>svg]:duration-normal [&>svg]:ease-out-custom',
@@ -77,6 +85,8 @@ export interface ButtonProps
   to?: string;
   prefetch?: boolean | null;
   children: React.ReactNode;
+  /** Leading icon, always rendered on the left of the label inside `<Icon>`. Ignored in icon-mode sizes. */
+  icon?: React.ReactNode;
   tooltip?: React.ReactNode;
   target?: string;
   type?: 'button' | 'submit' | 'reset';
@@ -89,6 +99,14 @@ const iconChildSizeMap: Record<IconButtonSize, 'sm' | 'default' | 'lg'> = {
   'icon-sm': 'sm',
   'icon-md': 'default',
   'icon-lg': 'lg',
+};
+
+// `<Icon>` size for the `icon` prop in text-mode, keyed by button size.
+const textIconSizeMap: Record<TextButtonSize, 'sm' | 'default'> = {
+  xs: 'sm',
+  sm: 'sm',
+  md: 'default',
+  lg: 'default',
 };
 
 // Walks React children, expanding `<></>` fragments so `isIconOnly` can inspect the real
@@ -120,7 +138,18 @@ function isIconButtonSize(size: ButtonSize | null | undefined): size is IconButt
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
-    { className, as, size, variant = 'default', disabled, children, tooltip, 'aria-label': ariaLabelProp, ...props },
+    {
+      className,
+      as,
+      size,
+      variant = 'default',
+      disabled,
+      children,
+      icon,
+      tooltip,
+      'aria-label': ariaLabelProp,
+      ...props
+    },
     ref,
   ) => {
     const Component = as || 'button';
@@ -131,7 +160,18 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     // Icon-only buttons need an a11y label. If a string tooltip is provided, reuse it.
     const ariaLabel = ariaLabelProp ?? ((iconMode || isLabelless) && typeof tooltip === 'string' ? tooltip : undefined);
 
-    const content = iconMode ? <Icon size={iconChildSizeMap[size as IconButtonSize]}>{children}</Icon> : children;
+    const content = iconMode ? (
+      <Icon size={iconChildSizeMap[size]}>{children}</Icon>
+    ) : (
+      <>
+        {icon ? (
+          <Icon data-slot="button-icon" size={textIconSizeMap[resolvedSize as TextButtonSize]}>
+            {icon}
+          </Icon>
+        ) : null}
+        {children}
+      </>
+    );
 
     const button = (
       <Component

--- a/packages/playground-ui/src/ds/components/Button/button.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Button/button.stories.tsx
@@ -81,13 +81,21 @@ export const Disabled: Story = {
 
 export const WithIcon: Story = {
   args: {
-    children: (
-      <>
-        <Plus />
-        Add Item
-      </>
-    ),
+    icon: <Plus />,
+    children: 'Add Item',
   },
+};
+
+export const WithIconSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      {(['xs', 'sm', 'md', 'lg'] as const).map(size => (
+        <Button key={size} size={size} icon={<Plus />}>
+          Add Item
+        </Button>
+      ))}
+    </div>
+  ),
 };
 
 export const WithTooltip: Story = {

--- a/packages/playground-ui/src/ds/components/Button/button.test.tsx
+++ b/packages/playground-ui/src/ds/components/Button/button.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { TooltipProvider } from '../Tooltip';
+import { Button } from './Button';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Button', () => {
+  describe('icon prop', () => {
+    it('renders the icon inside an <Icon> slot before the label', () => {
+      render(
+        <Button icon={<svg data-testid="icon" />} size="sm">
+          Add item
+        </Button>,
+      );
+
+      const button = screen.getByRole('button', { name: 'Add item' });
+      const slot = button.querySelector('[data-slot="button-icon"]');
+      expect(slot).not.toBeNull();
+      expect(slot?.contains(screen.getByTestId('icon'))).toBe(true);
+      expect(button.firstElementChild).toBe(slot);
+    });
+
+    it('does not render a slot when no icon is provided', () => {
+      render(<Button>Plain</Button>);
+      expect(screen.getByRole('button').querySelector('[data-slot="button-icon"]')).toBeNull();
+    });
+
+    it('is ignored in icon-mode sizes', () => {
+      render(
+        <Button size="icon-md" icon={<svg data-testid="ignored" />} aria-label="Close">
+          <svg data-testid="child" />
+        </Button>,
+      );
+      const button = screen.getByRole('button', { name: 'Close' });
+      expect(button.querySelector('[data-slot="button-icon"]')).toBeNull();
+      expect(screen.queryByTestId('ignored')).toBeNull();
+      expect(screen.getByTestId('child')).toBeTruthy();
+    });
+
+    it('does not derive aria-label from tooltip when a label is present', () => {
+      render(
+        <TooltipProvider>
+          <Button icon={<svg />} tooltip="Add a new item">
+            Add
+          </Button>
+        </TooltipProvider>,
+      );
+      expect(screen.getByRole('button', { name: 'Add' }).getAttribute('aria-label')).toBeNull();
+    });
+  });
+});

--- a/packages/playground-ui/src/ds/components/ClampedText/clamped-text.tsx
+++ b/packages/playground-ui/src/ds/components/ClampedText/clamped-text.tsx
@@ -50,9 +50,9 @@ export function ClampedText({
           className="mt-1 -ml-[.8em] self-start justify-self-start"
           aria-expanded={isExpanded}
           onClick={() => setIsExpanded(v => !v)}
+          icon={<ChevronIcon className={cn('transition-transform', isExpanded && 'rotate-180')} />}
         >
           {isExpanded ? showLessLabel : readMoreLabel}
-          <ChevronIcon className={cn('transition-transform', isExpanded && 'rotate-180')} />
         </Button>
       )}
     </>

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
@@ -190,8 +190,8 @@ export function Combobox(props: ComboboxProps) {
                   size="sm"
                   className="w-full justify-start"
                   onClick={clearSelection}
+                  icon={<X />}
                 >
-                  <X />
                   {clearLabel}
                 </Button>
               </div>

--- a/packages/playground-ui/src/ds/components/Comment/comment-editor.tsx
+++ b/packages/playground-ui/src/ds/components/Comment/comment-editor.tsx
@@ -1,3 +1,4 @@
+import { Check, X } from 'lucide-react';
 import { useState } from 'react';
 import type { KeyboardEvent } from 'react';
 
@@ -63,10 +64,10 @@ export function CommentEditor({
         />
         {/* Opaque, so a scrolled line passes behind the actions instead of under them. */}
         <div className="bg-surface2 absolute inset-x-px bottom-px flex items-center justify-end gap-1 rounded-b-lg px-1.5 pt-1 pb-1.5">
-          <Button type="button" variant="ghost" size="xs" disabled={isPending} onClick={onClose}>
+          <Button icon={<X />} type="button" variant="ghost" size="xs" disabled={isPending} onClick={onClose}>
             Cancel
           </Button>
-          <Button type="button" variant="outline" size="xs" disabled={!canSave} onClick={save}>
+          <Button icon={<Check />} type="button" variant="outline" size="xs" disabled={!canSave} onClick={save}>
             {isPending ? 'Saving…' : 'Save'}
           </Button>
         </div>

--- a/packages/playground-ui/src/ds/components/DataFilter/select-data-filter.tsx
+++ b/packages/playground-ui/src/ds/components/DataFilter/select-data-filter.tsx
@@ -223,8 +223,7 @@ export function SelectDataFilter({
   return (
     <DropdownMenu modal={false}>
       <DropdownMenu.Trigger asChild>
-        <Button variant="outline" disabled={disabled} size="md">
-          <FilterIcon />
+        <Button variant="outline" disabled={disabled} size="md" icon={<FilterIcon />}>
           {label}
           {activeFilterCount > 0 && (
             <span

--- a/packages/playground-ui/src/ds/components/DataList/data-list-pagination.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-pagination.tsx
@@ -19,15 +19,13 @@ export function DataListPagination({ currentPage, hasMore, onNextPage, onPrevPag
       {showNavigation && (
         <div className="flex gap-4">
           {typeof currentPage === 'number' && currentPage > 0 && (
-            <Button type="button" variant="outline" size="sm" onClick={onPrevPage}>
-              <ArrowLeftIcon />
+            <Button type="button" variant="outline" size="sm" onClick={onPrevPage} icon={<ArrowLeftIcon />}>
               Previous
             </Button>
           )}
           {hasMore && (
-            <Button type="button" variant="outline" size="sm" onClick={onNextPage}>
+            <Button type="button" variant="outline" size="sm" onClick={onNextPage} icon={<ArrowRightIcon />}>
               Next
-              <ArrowRightIcon />
             </Button>
           )}
         </div>

--- a/packages/playground-ui/src/ds/components/DateRangeTimeline/DateRangeBoundaryPicker.tsx
+++ b/packages/playground-ui/src/ds/components/DateRangeTimeline/DateRangeBoundaryPicker.tsx
@@ -39,12 +39,12 @@ export function DateRangeBoundaryPicker({ boundary, value, min, max, onSelect }:
             aria-label={`Choose ${boundaryLabel}, ${formattedDate}`}
             aria-expanded={open}
             size="xs"
-            className="h-11 w-full min-w-0 justify-between gap-2 overflow-hidden px-3 sm:h-8"
+            className="h-11 w-full min-w-0 justify-start overflow-hidden px-3 sm:h-8"
+            icon={<CalendarDaysIcon aria-hidden="true" />}
           >
             <Txt as="span" variant="ui-sm" className="text-neutral5 truncate tabular-nums">
               {formattedDate}
             </Txt>
-            <CalendarDaysIcon className="text-neutral3 size-3.5 shrink-0" aria-hidden="true" />
           </Button>
         }
       />

--- a/packages/playground-ui/src/ds/components/DateTimePicker/date-time-picker.tsx
+++ b/packages/playground-ui/src/ds/components/DateTimePicker/date-time-picker.tsx
@@ -268,8 +268,7 @@ type DefaultButtonProps = {
 export const DefaultTrigger = React.forwardRef<HTMLButtonElement, DefaultButtonProps>(
   ({ value, placeholder, className, ...props }, ref) => {
     return (
-      <Button ref={ref} className={cn('justify-start', className)} {...props}>
-        <CalendarIcon className="size-4" />
+      <Button ref={ref} className={cn('justify-start', className)} icon={<CalendarIcon />} {...props}>
         {value ? (
           <span className="text-white">{format(value, 'PP p')}</span>
         ) : (

--- a/packages/playground-ui/src/ds/components/DateTimePicker/date-time-picker.tsx
+++ b/packages/playground-ui/src/ds/components/DateTimePicker/date-time-picker.tsx
@@ -1,5 +1,5 @@
 import { format, formatDate, isValid } from 'date-fns';
-import { CalendarIcon, CircleAlertIcon } from 'lucide-react';
+import { CalendarIcon, CircleAlertIcon, Check, X } from 'lucide-react';
 import * as React from 'react';
 import type { DayPickerSingleProps } from 'react-day-picker';
 import { useDebouncedCallback } from 'use-debounce';
@@ -239,11 +239,12 @@ export const DateTimePickerContent = ({
 
       <div className="m-4 mt-0 grid grid-cols-[1fr_2fr] gap-2">
         {newValueDefined && (
-          <Button tabIndex={0} size="md" onClick={handleClear} type="button">
+          <Button icon={<X />} tabIndex={0} size="md" onClick={handleClear} type="button">
             Clear
           </Button>
         )}
         <Button
+          icon={newValueDefined ? <Check /> : <X />}
           tabIndex={0}
           type="button"
           size="md"

--- a/packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.tsx
+++ b/packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.tsx
@@ -1,5 +1,5 @@
 import { isValid, parse } from 'date-fns';
-import { CalendarIcon } from 'lucide-react';
+import { CalendarIcon, Check } from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/ds/components/Button/Button';
 import type { ButtonProps } from '@/ds/components/Button/Button';
@@ -157,7 +157,7 @@ export function DateTimeRangePicker({
             >
               &larr; Presets
             </button>
-            <Button variant="primary" size="sm" onClick={applyCustomRange} disabled={disabled}>
+            <Button icon={<Check />} variant="primary" size="sm" onClick={applyCustomRange} disabled={disabled}>
               Apply
             </Button>
           </div>

--- a/packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.tsx
+++ b/packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.tsx
@@ -97,8 +97,7 @@ export function DateTimeRangePicker({
     return (
       <Popover open={customRangeOpen} onOpenChange={setCustomRangeOpen}>
         <PopoverTrigger asChild>
-          <Button size={size} disabled={disabled}>
-            <CalendarIcon />
+          <Button size={size} disabled={disabled} icon={<CalendarIcon />}>
             {dateFrom ? dateFrom.toLocaleDateString() : 'Start'} {' \u2013 '}
             {dateTo ? dateTo.toLocaleDateString() : 'End'}
           </Button>
@@ -170,8 +169,7 @@ export function DateTimeRangePicker({
   return (
     <DropdownMenu>
       <DropdownMenu.Trigger asChild>
-        <Button size={size} disabled={disabled}>
-          <CalendarIcon />
+        <Button size={size} disabled={disabled} icon={<CalendarIcon />}>
           {datePresetLabel}
         </Button>
       </DropdownMenu.Trigger>

--- a/packages/playground-ui/src/ds/components/EnvironmentVariablesEditor/environment-variables-editor-add-button.tsx
+++ b/packages/playground-ui/src/ds/components/EnvironmentVariablesEditor/environment-variables-editor-add-button.tsx
@@ -17,8 +17,14 @@ export function EnvironmentVariablesEditorAddButton({
   return (
     <div className={cn('flex items-center gap-2', className)} {...props}>
       <span aria-hidden="true" className="bg-border1 h-px flex-1" />
-      <Button type="button" variant="ghost" size="sm" disabled={disabled} onClick={() => editor.appendRow()}>
-        <PlusIcon />
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        disabled={disabled}
+        onClick={() => editor.appendRow()}
+        icon={<PlusIcon />}
+      >
         {children ?? 'Add Variable'}
       </Button>
       <span aria-hidden="true" className="bg-border1 h-px flex-1" />

--- a/packages/playground-ui/src/ds/components/EnvironmentVariablesEditor/environment-variables-editor-upload-button.tsx
+++ b/packages/playground-ui/src/ds/components/EnvironmentVariablesEditor/environment-variables-editor-upload-button.tsx
@@ -45,9 +45,9 @@ export function EnvironmentVariablesEditorUploadButton({
             editor.fileInputRef.current?.click();
           }
         }}
+        icon={<UploadIcon />}
         {...props}
       >
-        <UploadIcon />
         {children}
       </Button>
     </>

--- a/packages/playground-ui/src/ds/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/playground-ui/src/ds/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Bug, RefreshCw, RotateCcw } from 'lucide-react';
 import * as React from 'react';
 import { Button } from '../Button';
 import { cn } from '@/lib/utils';
@@ -176,13 +176,19 @@ function DefaultErrorFallback({
           {error.message}
         </p>
         <div className={cn('flex flex-wrap items-center justify-center gap-2', isInline ? 'mt-1' : 'mt-2')}>
-          <Button variant="primary" size={isInline ? 'sm' : 'lg'} onClick={reset}>
+          <Button icon={<RotateCcw />} variant="primary" size={isInline ? 'sm' : 'lg'} onClick={reset}>
             Try again
           </Button>
-          <Button variant="default" size={isInline ? 'sm' : 'lg'} onClick={() => window.location.reload()}>
+          <Button
+            icon={<RefreshCw />}
+            variant="default"
+            size={isInline ? 'sm' : 'lg'}
+            onClick={() => window.location.reload()}
+          >
             Reload page
           </Button>
           <Button
+            icon={<Bug />}
             as="a"
             variant="default"
             size={isInline ? 'sm' : 'lg'}

--- a/packages/playground-ui/src/ds/components/JSONSchemaForm/json-schema-form-add-field.tsx
+++ b/packages/playground-ui/src/ds/components/JSONSchemaForm/json-schema-form-add-field.tsx
@@ -1,3 +1,4 @@
+import { Plus } from 'lucide-react';
 import * as React from 'react';
 import { useJSONSchemaForm } from './json-schema-form-context';
 import { useJSONSchemaFormNestedContext } from './json-schema-form-nested-context';
@@ -11,14 +12,14 @@ export function AddField({ children, ...props }: JSONSchemaFormAddFieldProps) {
   const nestedContext = useJSONSchemaFormNestedContext();
 
   // Use nested context parentPath if available, otherwise add to root
-  const parentPath = nestedContext ? nestedContext.parentPath : [];
+  const parentPath = nestedContext?.parentPath;
 
   const handleClick = React.useCallback(() => {
-    addField(parentPath);
+    addField(parentPath ?? []);
   }, [addField, parentPath]);
 
   return (
-    <Button type="button" {...props} onClick={handleClick}>
+    <Button icon={<Plus />} type="button" {...props} onClick={handleClick}>
       {children || 'Add field'}
     </Button>
   );

--- a/packages/playground-ui/src/ds/components/PrevNextNav/prev-next-nav.tsx
+++ b/packages/playground-ui/src/ds/components/PrevNextNav/prev-next-nav.tsx
@@ -17,12 +17,11 @@ export function PrevNextNav({
 }: PrevNextNavProps) {
   return (
     <ButtonsGroup spacing="close">
-      <Button onClick={onPrevious} disabled={!onPrevious} aria-label={previousAriaLabel}>
-        <ArrowUpIcon /> Prev
+      <Button onClick={onPrevious} disabled={!onPrevious} aria-label={previousAriaLabel} icon={<ArrowUpIcon />}>
+        Prev
       </Button>
-      <Button onClick={onNext} disabled={!onNext} aria-label={nextAriaLabel}>
+      <Button onClick={onNext} disabled={!onNext} aria-label={nextAriaLabel} icon={<ArrowDownIcon />}>
         Next
-        <ArrowDownIcon />
       </Button>
     </ButtonsGroup>
   );

--- a/packages/playground-ui/src/ds/components/PropertyFilter/property-filter-actions.tsx
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/property-filter-actions.tsx
@@ -31,8 +31,7 @@ export function PropertyFilterActions({
   return (
     <div className="flex items-center gap-2">
       {onClear && (
-        <Button disabled={disabled} size="md" onClick={onClear}>
-          <XIcon />
+        <Button disabled={disabled} size="md" onClick={onClear} icon={<XIcon />}>
           Clear
         </Button>
       )}

--- a/packages/playground-ui/src/ds/components/PropertyFilter/property-filter-creator.tsx
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/property-filter-creator.tsx
@@ -1,4 +1,12 @@
-import { ArrowLeftIcon, ChevronRightIcon, FilterIcon, ListFilterPlusIcon, PlusIcon } from 'lucide-react';
+import {
+  ArrowLeftIcon,
+  ChevronRightIcon,
+  FilterIcon,
+  ListFilterPlusIcon,
+  PlusIcon,
+  ListFilterPlus,
+  X,
+} from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { PickMultiPanel } from './pick-multi-panel';
 import type { PropertyFilterField, PropertyFilterToken } from './types';
@@ -276,10 +284,10 @@ export function PropertyFilterCreator({
 
           {selectedField && (
             <div className="flex items-center justify-end gap-2">
-              <Button variant="ghost" size="md" onClick={() => setOpen(false)}>
+              <Button icon={<X />} variant="ghost" size="md" onClick={() => setOpen(false)}>
                 Cancel
               </Button>
-              <Button variant="outline" size="md" onClick={commit}>
+              <Button icon={<ListFilterPlus />} variant="outline" size="md" onClick={commit}>
                 Add filter
               </Button>
             </div>

--- a/packages/playground-ui/src/ds/components/PropertyFilter/property-filter-creator.tsx
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/property-filter-creator.tsx
@@ -146,8 +146,7 @@ export function PropertyFilterCreator({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <Button variant="outline" size={size} disabled={disabled}>
-          <ListFilterPlusIcon />
+        <Button variant="outline" size={size} disabled={disabled} icon={<ListFilterPlusIcon />}>
           {label}
         </Button>
       </PopoverTrigger>

--- a/packages/playground-ui/src/ds/components/SessionExpired/SessionExpired.tsx
+++ b/packages/playground-ui/src/ds/components/SessionExpired/SessionExpired.tsx
@@ -53,7 +53,7 @@ export function SessionExpired({ title, description, className }: SessionExpired
       titleSlot={title ?? 'Session Expired'}
       descriptionSlot={description ?? 'Your session has expired. Please log in again to continue.'}
       actionSlot={
-        <Button variant="default" onClick={handleLogin} disabled={isPending}>
+        <Button icon={<LogIn />} variant="default" onClick={handleLogin} disabled={isPending}>
           {isPending ? 'Redirecting...' : 'Log in'}
         </Button>
       }

--- a/packages/playground-ui/src/ds/components/SideDialog/side-dialog-nav.tsx
+++ b/packages/playground-ui/src/ds/components/SideDialog/side-dialog-nav.tsx
@@ -21,13 +21,11 @@ export function SideDialogNav({ onNext, onPrevious, className }: SideDialogNavPr
     <div className={cn('flex items-center gap-3', '[&_svg]:size-[1.1em] [&_svg]:text-neutral3', className)}>
       {(onNext || onPrevious) && (
         <div className={cn('flex items-baseline gap-3')}>
-          <Button onClick={handleOnPrevious} disabled={!onPrevious}>
+          <Button onClick={handleOnPrevious} disabled={!onPrevious} icon={<ArrowUpIcon />}>
             Previous
-            <ArrowUpIcon />
           </Button>
-          <Button onClick={handleOnNext} disabled={!onNext}>
+          <Button onClick={handleOnNext} disabled={!onNext} icon={<ArrowDownIcon />}>
             Next
-            <ArrowDownIcon />
           </Button>
         </div>
       )}

--- a/packages/playground-ui/src/ds/components/ai/ask-user/ask-user.tsx
+++ b/packages/playground-ui/src/ds/components/ai/ask-user/ask-user.tsx
@@ -1,3 +1,4 @@
+import { Check } from 'lucide-react';
 import { useId, useState } from 'react';
 import type { ComponentProps, KeyboardEvent, ReactNode } from 'react';
 import { Badge } from '@/ds/components/Badge';
@@ -58,7 +59,7 @@ export const AskUserOptionControl = ({ type, label, description, className, ...p
 );
 
 export const AskUserSubmit = ({ children = 'Submit answer', ...props }: ComponentProps<typeof Button>) => (
-  <Button type="button" size="sm" variant="primary" {...props}>
+  <Button icon={<Check />} type="button" size="sm" variant="primary" {...props}>
     {children}
   </Button>
 );

--- a/packages/playground-ui/src/ds/components/ai/plan/plan.tsx
+++ b/packages/playground-ui/src/ds/components/ai/plan/plan.tsx
@@ -325,8 +325,8 @@ export function PlanExpandButton({ className, ...props }: PlanExpandButtonProps)
       size="sm"
       aria-label={isExpanded ? 'Collapse plan' : 'Expand plan'}
       onClick={toggleExpanded}
+      icon={isExpanded ? <Minimize2 /> : <Maximize2 />}
     >
-      {isExpanded ? <Minimize2 /> : <Maximize2 />}
       {isExpanded ? 'Collapse plan' : 'Expand plan'}
     </Button>
   );

--- a/packages/playground-ui/src/ee/signals/components/signals-empty-state.tsx
+++ b/packages/playground-ui/src/ee/signals/components/signals-empty-state.tsx
@@ -1,5 +1,5 @@
 import type { EntityLearningProgressResponse, SignalCatalogEntry } from '@mastra/client-js';
-import { CpuIcon } from 'lucide-react';
+import { CpuIcon, ExternalLink } from 'lucide-react';
 import type { CSSProperties, ReactNode } from 'react';
 
 import './signals-empty-state.css';
@@ -9,6 +9,7 @@ import { nodeColor } from '../../../ds/components/SankeyChart/sankeyColor';
 import type { LinkComponent } from '../../../ds/types/link-component';
 import { getSignalHue } from '../signal-colors';
 import { BUILT_IN_SIGNAL_CATALOG, orderedSignals, signalDescription, signalLabel } from '../signal-formatting';
+import { TraceIcon } from '@/ds/icons/TraceIcon';
 
 const traceRows = [
   ['chat.completion', '1.2s'],
@@ -73,18 +74,18 @@ function ProgressSummary({ progress }: { progress: TraceIntelligenceProgress }) 
   return (
     <dl className="mt-4 grid gap-2 sm:grid-cols-3">
       <div className="border-border1 bg-surface3 rounded-md border px-3 py-2">
-        <dt className="text-neutral3 text-ui-sm">Traces analyzed</dt>
-        <dd className="text-neutral6 text-header-sm mt-1 font-semibold">{formatNumber(progress.traceCount)}</dd>
+        <dt className="text-ui-sm text-neutral3">Traces analyzed</dt>
+        <dd className="text-header-sm text-neutral6 mt-1 font-semibold">{formatNumber(progress.traceCount)}</dd>
       </div>
       <div className="border-border1 bg-surface3 rounded-md border px-3 py-2">
-        <dt className="text-neutral3 text-ui-sm">Trace signal types ready</dt>
-        <dd className="text-neutral6 text-header-sm mt-1 font-semibold">
+        <dt className="text-ui-sm text-neutral3">Trace signal types ready</dt>
+        <dd className="text-header-sm text-neutral6 mt-1 font-semibold">
           {progress.signalCatalog ? readySignalCount : progress.availableSignals.length} of {enabledSignalCount}
         </dd>
       </div>
       <div className="border-border1 bg-surface3 rounded-md border px-3 py-2">
-        <dt className="text-neutral3 text-ui-sm">Status</dt>
-        <dd className="text-neutral6 text-header-sm mt-1 font-semibold capitalize">{progress.status}</dd>
+        <dt className="text-ui-sm text-neutral3">Status</dt>
+        <dd className="text-header-sm text-neutral6 mt-1 font-semibold capitalize">{progress.status}</dd>
       </div>
     </dl>
   );
@@ -110,9 +111,9 @@ function SignalProgressList({ progress }: { progress?: TraceIntelligenceProgress
               <span className="text-ui-md font-semibold" style={signalStyle(signalName)}>
                 {label}
               </span>
-              <span className="text-neutral4 text-ui-sm">{isReady ? 'Themes ready' : 'Processing'}</span>
+              <span className="text-ui-sm text-neutral4">{isReady ? 'Themes ready' : 'Processing'}</span>
             </div>
-            <p className="text-neutral3 text-ui-sm mt-1">
+            <p className="text-ui-sm text-neutral3 mt-1">
               {formatNumber(value.generated)} generated · {formatNumber(value.embedded)} embedded
             </p>
           </li>
@@ -135,10 +136,10 @@ export function PendingSignalProgress({
 
   return (
     <section className="border-border1 bg-surface2 rounded-lg border p-4" aria-labelledby="pending-signals-heading">
-      <h2 id="pending-signals-heading" className="text-neutral6 text-ui-md font-semibold">
+      <h2 id="pending-signals-heading" className="text-ui-md text-neutral6 font-semibold">
         Signals building themes
       </h2>
-      <p className="text-neutral3 text-ui-sm mt-1">
+      <p className="text-ui-sm text-neutral3 mt-1">
         Themes appear once enough new traces are analyzed, embedded, and clustered.
       </p>
       <ul aria-label="Pending trace signals" className="mt-3 grid gap-2 sm:grid-cols-2">
@@ -150,12 +151,12 @@ export function PendingSignalProgress({
                 <span className="text-ui-md font-semibold" style={signalStyle(signal.name)}>
                   {signalLabel(catalog, signal.name)}
                 </span>
-                <span className="text-neutral4 text-ui-sm capitalize">{signal.status}</span>
+                <span className="text-ui-sm text-neutral4 capitalize">{signal.status}</span>
               </div>
               {signalDescription(catalog, signal.name) ? (
-                <p className="text-neutral3 text-ui-sm mt-1">{signalDescription(catalog, signal.name)}</p>
+                <p className="text-ui-sm text-neutral3 mt-1">{signalDescription(catalog, signal.name)}</p>
               ) : null}
-              <p className="text-neutral3 text-ui-sm mt-1">
+              <p className="text-ui-sm text-neutral3 mt-1">
                 {formatNumber(value.generated)} generated · {formatNumber(value.embedded)} embedded
               </p>
             </li>
@@ -189,14 +190,14 @@ export const SignalsEmptyState = ({
     <section className="bg-surface1 min-h-full w-full p-6 md:px-10 lg:px-12 xl:px-[4.375rem]">
       <div className="mx-auto w-full max-w-260">
         <header>
-          <p className="text-neutral4 text-ui-sm flex items-center gap-2 font-mono tracking-wider uppercase">
+          <p className="text-ui-sm text-neutral4 flex items-center gap-2 font-mono tracking-wider uppercase">
             <span aria-hidden="true" className="bg-accent1 size-2 rounded-full" />
             Trace Intelligence
           </p>
           <h1 className="text-header-xl text-neutral6 mt-2 font-medium tracking-tight">
             Understand what drives every agent interaction
           </h1>
-          <p className="text-neutral3 text-ui-md mt-2 max-w-180">
+          <p className="text-ui-md text-neutral3 mt-2 max-w-180">
             Trace Intelligence groups recurring goals, outcomes, behaviors, and sentiment across completed traces.
           </p>
         </header>
@@ -207,9 +208,9 @@ export const SignalsEmptyState = ({
           className="mt-14 grid gap-4 lg:grid-cols-[17.5rem_4.5rem_17.5rem_4.5rem_minmax(0,1fr)] lg:gap-0"
         >
           <div role="listitem" className="min-h-50 p-5">
-            <h2 className="text-neutral6 text-header-sm font-semibold">Traces</h2>
-            <p className="text-neutral3 text-ui-sm mt-0.5">Every agent interaction</p>
-            <p className="text-neutral3 text-ui-sm mt-5 font-mono tracking-[0.18em] uppercase">Input</p>
+            <h2 className="text-header-sm text-neutral6 font-semibold">Traces</h2>
+            <p className="text-ui-sm text-neutral3 mt-0.5">Every agent interaction</p>
+            <p className="text-ui-sm text-neutral3 mt-5 font-mono tracking-[0.18em] uppercase">Input</p>
             <div className="mt-2.5 space-y-2">
               {traceRows.map(([name, duration]) => (
                 <div
@@ -231,8 +232,8 @@ export const SignalsEmptyState = ({
             className="flex min-h-50 flex-col items-center p-5 text-center"
             elevation="elevated"
           >
-            <h2 className="text-neutral6 text-header-sm font-semibold">Trace Intelligence</h2>
-            <p className="text-neutral3 text-ui-sm mt-0.5">Finds recurring themes</p>
+            <h2 className="text-header-sm text-neutral6 font-semibold">Trace Intelligence</h2>
+            <p className="text-ui-sm text-neutral3 mt-0.5">Finds recurring themes</p>
             <div aria-hidden="true" className="relative mt-5 flex size-20 items-center justify-center">
               <span className="signals-engine-pulse border-positive1/15 absolute size-20 rounded-full border" />
               <span className="border-positive1/25 absolute size-14 rounded-full border" />
@@ -247,9 +248,9 @@ export const SignalsEmptyState = ({
           <PipelineConnector />
 
           <div role="listitem" className="min-h-50 p-5">
-            <h2 className="text-neutral6 text-header-sm font-semibold">Theme analysis</h2>
-            <p className="text-neutral3 text-ui-sm mt-0.5">How recurring patterns connect</p>
-            <p className="text-neutral3 text-ui-sm mt-5 font-mono tracking-[0.18em] uppercase">Output</p>
+            <h2 className="text-header-sm text-neutral6 font-semibold">Theme analysis</h2>
+            <p className="text-ui-sm text-neutral3 mt-0.5">How recurring patterns connect</p>
+            <p className="text-ui-sm text-neutral3 mt-5 font-mono tracking-[0.18em] uppercase">Output</p>
             <div className="mt-3 flex flex-wrap gap-2">
               {signalDefinitions.map(signal => (
                 <span
@@ -266,7 +267,7 @@ export const SignalsEmptyState = ({
         </div>
 
         <section className="mt-10" aria-labelledby="signal-definitions-heading">
-          <h2 id="signal-definitions-heading" className="text-neutral6 text-header-sm font-semibold">
+          <h2 id="signal-definitions-heading" className="text-header-sm text-neutral6 font-semibold">
             What each trace signal means
           </h2>
           <ul aria-label="Trace signal definitions" className="mt-4 grid gap-3 sm:grid-cols-2">
@@ -275,7 +276,7 @@ export const SignalsEmptyState = ({
                 <h3 className="text-ui-md font-semibold" style={signalStyle(signal.key)}>
                   {signal.label}
                 </h3>
-                {signal.description ? <p className="text-neutral3 text-ui-sm mt-1.5">{signal.description}</p> : null}
+                {signal.description ? <p className="text-ui-sm text-neutral3 mt-1.5">{signal.description}</p> : null}
               </li>
             ))}
           </ul>
@@ -288,7 +289,7 @@ export const SignalsEmptyState = ({
               className="bg-warning1 mt-1.5 size-2 shrink-0 rounded-full shadow-[0_0_9px_currentColor]"
             />
             <div className="min-w-0 flex-1">
-              <p className="text-neutral3 text-ui-sm">
+              <p className="text-ui-sm text-neutral3">
                 <strong className="text-neutral5 font-semibold">{copy.title}</strong> {copy.body}
               </p>
               {progress ? <ProgressSummary progress={progress} /> : null}
@@ -298,6 +299,7 @@ export const SignalsEmptyState = ({
           <div className="mt-4 flex shrink-0 flex-wrap items-center gap-2 sm:justify-end">
             {actionSlot}
             <Button
+              icon={<ExternalLink />}
               as="a"
               href="https://mastra.ai/en/docs/mastra-platform/trace-intelligence"
               target="_blank"
@@ -307,7 +309,7 @@ export const SignalsEmptyState = ({
             >
               Read the docs<span className="sr-only"> (opens in new tab)</span>
             </Button>
-            <Button as={LinkComponent} href="/traces" variant="primary" size="sm">
+            <Button icon={<TraceIcon />} as={LinkComponent} href="/traces" variant="primary" size="sm">
               View incoming traces
             </Button>
           </div>

--- a/packages/playground-ui/src/ee/signals/examples-pager.tsx
+++ b/packages/playground-ui/src/ee/signals/examples-pager.tsx
@@ -1,3 +1,4 @@
+import { ChevronRight, ChevronLeft } from 'lucide-react';
 import { Button } from '@/ds/components/Button';
 
 export const EXAMPLES_PAGE_SIZE = 5;
@@ -19,6 +20,7 @@ export function ExamplesPager({
   return (
     <nav aria-label="Example pages" className="mt-3 flex items-center gap-3">
       <Button
+        icon={<ChevronLeft />}
         variant="outline"
         size="sm"
         disabled={page <= 1}
@@ -26,10 +28,11 @@ export function ExamplesPager({
       >
         Previous
       </Button>
-      <span className="text-neutral3 text-ui-sm font-mono tabular-nums">
+      <span className="text-ui-sm text-neutral3 font-mono tabular-nums">
         Page {page} of {totalPages}
       </span>
       <Button
+        icon={<ChevronRight />}
         variant="outline"
         size="sm"
         disabled={page >= totalPages}

--- a/packages/playground-ui/src/ee/signals/settings/signal-definition-form-dialog.tsx
+++ b/packages/playground-ui/src/ee/signals/settings/signal-definition-form-dialog.tsx
@@ -182,8 +182,13 @@ export function SignalDefinitionFormDialog({
           <Button type="button" variant="ghost" disabled={pending} onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button type="submit" form={formId} variant="primary" disabled={pending}>
-            {pending ? <Spinner className="size-4" /> : null}
+          <Button
+            type="submit"
+            form={formId}
+            variant="primary"
+            disabled={pending}
+            icon={pending ? <Spinner /> : undefined}
+          >
             {editing ? 'Save signal' : 'Create signal'}
           </Button>
         </DialogFooter>

--- a/packages/playground-ui/src/ee/signals/settings/signal-definition-form-dialog.tsx
+++ b/packages/playground-ui/src/ee/signals/settings/signal-definition-form-dialog.tsx
@@ -3,6 +3,7 @@ import type {
   TraceSignalDefinition,
   UpdateTraceSignalDefinitionInput,
 } from '@mastra/client-js';
+import { X } from 'lucide-react';
 import { useId, useState } from 'react';
 
 import { Button } from '@/ds/components/Button';
@@ -179,7 +180,7 @@ export function SignalDefinitionFormDialog({
           </form>
         </DialogBody>
         <DialogFooter>
-          <Button type="button" variant="ghost" disabled={pending} onClick={() => onOpenChange(false)}>
+          <Button icon={<X />} type="button" variant="ghost" disabled={pending} onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
           <Button

--- a/packages/playground-ui/src/ee/signals/settings/trace-signal-settings.tsx
+++ b/packages/playground-ui/src/ee/signals/settings/trace-signal-settings.tsx
@@ -1,5 +1,5 @@
 import type { TraceSignalDefinition } from '@mastra/client-js';
-import { Settings } from 'lucide-react';
+import { Settings, ArchiveRestore, Archive, Pencil, LayoutGrid } from 'lucide-react';
 import { useState } from 'react';
 
 import { useTraceIntelligence } from '../use-trace-intelligence';
@@ -131,7 +131,13 @@ function TraceSignalSettingsContent() {
               {active.length} of {limit} active organization definitions
             </p>
           </div>
-          <Button size="sm" variant="primary" disabled={!canManage || atLimit} onClick={openCreateForm}>
+          <Button
+            icon={<LayoutGrid />}
+            size="sm"
+            variant="primary"
+            disabled={!canManage || atLimit}
+            onClick={openCreateForm}
+          >
             Create signal
           </Button>
         </div>
@@ -153,10 +159,17 @@ function TraceSignalSettingsContent() {
                 <p className="text-ui-xs text-neutral3 truncate">{definition.description || definition.name}</p>
               </div>
               <div className="flex shrink-0 items-center gap-2">
-                <Button size="sm" variant="ghost" disabled={!canManage} onClick={() => openEditForm(definition)}>
+                <Button
+                  icon={<Pencil />}
+                  size="sm"
+                  variant="ghost"
+                  disabled={!canManage}
+                  onClick={() => openEditForm(definition)}
+                >
                   Edit
                 </Button>
                 <Button
+                  icon={<Archive />}
                   size="sm"
                   variant="ghost"
                   disabled={
@@ -195,6 +208,7 @@ function TraceSignalSettingsContent() {
               <div key={definition.id} className="flex min-h-12 items-center justify-between gap-3 py-2">
                 <span className="text-ui-sm text-neutral3">{definition.displayLabel}</span>
                 <Button
+                  icon={<ArchiveRestore />}
                   size="sm"
                   variant="ghost"
                   disabled={

--- a/packages/playground-ui/src/ee/signals/signals-error-state.tsx
+++ b/packages/playground-ui/src/ee/signals/signals-error-state.tsx
@@ -1,4 +1,4 @@
-import { TriangleAlert } from 'lucide-react';
+import { TriangleAlert, X, RotateCcw } from 'lucide-react';
 import { Button } from '@/ds/components/Button';
 
 export function SignalsErrorState({
@@ -15,14 +15,14 @@ export function SignalsErrorState({
       <div className="flex items-start gap-3">
         <TriangleAlert aria-hidden="true" className="mt-0.5 size-5 shrink-0 text-red-500" />
         <div>
-          <h1 className="text-neutral6 text-ui-md font-semibold">{message}</h1>
-          <p className="text-neutral3 text-ui-sm mt-1">Check the connection and try again.</p>
+          <h1 className="text-ui-md text-neutral6 font-semibold">{message}</h1>
+          <p className="text-ui-sm text-neutral3 mt-1">Check the connection and try again.</p>
           <div className="mt-4 flex flex-wrap gap-2">
-            <Button onClick={onRetry} size="sm" type="button" variant="outline">
+            <Button icon={<RotateCcw />} onClick={onRetry} size="sm" type="button" variant="outline">
               Retry
             </Button>
             {onClear ? (
-              <Button onClick={onClear} size="sm" type="button" variant="ghost">
+              <Button icon={<X />} onClick={onClear} size="sm" type="button" variant="ghost">
                 Clear filter
               </Button>
             ) : null}

--- a/packages/playground-ui/src/ee/signals/snapshot-timeline.tsx
+++ b/packages/playground-ui/src/ee/signals/snapshot-timeline.tsx
@@ -62,7 +62,7 @@ export function TimelineTrack({
           <span
             key={`day-${snapshot.snapshotId}`}
             aria-hidden="true"
-            className="text-neutral3 text-ui-xs absolute top-7 -translate-x-1/2 font-mono tabular-nums"
+            className="text-ui-xs text-neutral3 absolute top-7 -translate-x-1/2 font-mono tabular-nums"
             style={{ left: `${positions[index]}%` }}
           >
             {dayLabels[index]}
@@ -126,12 +126,12 @@ export function SnapshotTimeline({
             size="sm"
             type="button"
             variant="outline"
+            icon={isPlaying ? <Pause aria-hidden="true" /> : <Play aria-hidden="true" />}
           >
-            {isPlaying ? <Pause aria-hidden="true" /> : <Play aria-hidden="true" />}
             {isPlaying ? 'Pause' : 'Play'}
           </Button>
         ) : null}
-        <p className="text-neutral4 text-ui-sm font-mono tabular-nums" data-testid="snapshot-summary">
+        <p className="text-ui-sm text-neutral4 font-mono tabular-nums" data-testid="snapshot-summary">
           {summary}
         </p>
       </div>

--- a/packages/playground-ui/src/ee/signals/theme-filter-banner.tsx
+++ b/packages/playground-ui/src/ee/signals/theme-filter-banner.tsx
@@ -1,5 +1,5 @@
 import type { SignalCatalogEntry } from '@mastra/client-js';
-import { X } from 'lucide-react';
+import { X, Eye } from 'lucide-react';
 import { getSignalHue } from './signal-colors';
 import { signalLabel } from './signal-formatting';
 import type { ThemeSelection } from './theme-drilldown-data';
@@ -77,7 +77,7 @@ export function ThemeFilterBanner({
                 ? `Clear ${selection.kind} filter`
                 : `Clear filter ${selectionLabel(signalCatalog, selection)}`
             }
-            className="border-border1 bg-surface2 text-neutral6 hover:bg-surface4 text-ui-sm flex items-center gap-1.5 rounded-full border py-1 pr-2 pl-2.5 font-medium transition-colors"
+            className="border-border1 bg-surface2 text-ui-sm text-neutral6 hover:bg-surface4 flex items-center gap-1.5 rounded-full border py-1 pr-2 pl-2.5 font-medium transition-colors"
             onClick={() => onRemove(selection.signalName)}
             type="button"
           >
@@ -87,11 +87,12 @@ export function ThemeFilterBanner({
           </button>
         );
       })}
-      <span className="text-neutral4 text-ui-sm">
+      <span className="text-ui-sm text-neutral4">
         {filterSummary({ selections, filteredTraceCount, totalTraceCount, isUnavailable })}
       </span>
       {!isUnavailable && filteredTraceCount !== undefined && latestSelection ? (
         <Button
+          icon={<Eye />}
           aria-label={
             latestSelection.kind === 'theme'
               ? `View theme details for ${latestSelection.label}`
@@ -106,7 +107,7 @@ export function ThemeFilterBanner({
         </Button>
       ) : null}
       {selections.length > 1 ? (
-        <Button onClick={onClear} size="sm" type="button" variant="ghost">
+        <Button icon={<X />} onClick={onClear} size="sm" type="button" variant="ghost">
           Clear all
         </Button>
       ) : null}

--- a/packages/playground-ui/src/ee/signals/trace-insight-view.tsx
+++ b/packages/playground-ui/src/ee/signals/trace-insight-view.tsx
@@ -1,8 +1,10 @@
+import { ChevronLeft } from 'lucide-react';
 import { useTraceInsight } from './hooks';
 import { signalLabel } from './signal-formatting';
 import type { TraceInsightResponse } from './types';
 import { useTraceIntelligence } from './use-trace-intelligence';
 import { Button } from '@/ds/components/Button';
+import { TraceIcon } from '@/ds/icons/TraceIcon';
 
 interface TraceInsightViewProps {
   traceId: string;
@@ -16,14 +18,14 @@ export function TraceInsightView({ traceId, onBack }: TraceInsightViewProps) {
   return (
     <div className="grid content-start gap-6">
       <div className="flex items-center justify-between gap-3">
-        <Button variant="outline" size="sm" onClick={onBack}>
+        <Button icon={<ChevronLeft />} variant="outline" size="sm" onClick={onBack}>
           Back to examples
         </Button>
-        <Button as={LinkComponent} href={getTraceHref(traceId)} variant="outline" size="sm">
+        <Button icon={<TraceIcon />} as={LinkComponent} href={getTraceHref(traceId)} variant="outline" size="sm">
           Open full trace
         </Button>
       </div>
-      {insightQuery.isPending && <p className="text-neutral3 text-ui-md">Loading trace insight…</p>}
+      {insightQuery.isPending && <p className="text-ui-md text-neutral3">Loading trace insight…</p>}
       {insightQuery.isError && <p className="text-ui-md text-red-500">Unable to load the trace insight.</p>}
       {insightQuery.data && <TraceInsightBody insight={insightQuery.data} />}
     </div>
@@ -72,7 +74,7 @@ function ObservationItem({ observation }: { observation: string }) {
   return (
     <li className={`text-ui-md rounded-md border p-3 ${OBSERVATION_SEVERITY_CARD[severity ?? 'info']}`}>
       {kind !== undefined && (
-        <p className="text-neutral3 text-ui-xs font-mono tracking-wider uppercase">
+        <p className="text-ui-xs text-neutral3 font-mono tracking-wider uppercase">
           {severity === 'problem' && (
             <>
               <span className="text-red-400">problem</span>
@@ -92,16 +94,16 @@ function TraceInsightBody({ insight }: { insight: TraceInsightResponse }) {
   return (
     <>
       {insight.summary === undefined ? (
-        <p className="text-neutral3 text-ui-md">No insight available yet for this trace.</p>
+        <p className="text-ui-md text-neutral3">No insight available yet for this trace.</p>
       ) : (
         <section aria-labelledby="trace-insight-summary-heading">
           <h2
             id="trace-insight-summary-heading"
-            className="text-neutral3 text-ui-sm font-mono tracking-wider uppercase"
+            className="text-ui-sm text-neutral3 font-mono tracking-wider uppercase"
           >
             Trace summary
           </h2>
-          <p className="text-neutral5 text-ui-md mt-3">{insight.summary.summary}</p>
+          <p className="text-ui-md text-neutral5 mt-3">{insight.summary.summary}</p>
           {insight.summary.currentTask !== undefined && (
             <dl className="text-ui-md mt-4">
               <dt className="text-neutral3">Current task</dt>
@@ -115,7 +117,7 @@ function TraceInsightBody({ insight }: { insight: TraceInsightResponse }) {
             <>
               <h3
                 id="trace-insight-observations-heading"
-                className="text-neutral3 text-ui-sm mt-4 font-mono tracking-wider uppercase"
+                className="text-ui-sm text-neutral3 mt-4 font-mono tracking-wider uppercase"
               >
                 Observations
               </h3>
@@ -132,7 +134,7 @@ function TraceInsightBody({ insight }: { insight: TraceInsightResponse }) {
         <section aria-labelledby="trace-insight-signals-heading">
           <h2
             id="trace-insight-signals-heading"
-            className="text-neutral3 text-ui-sm font-mono tracking-wider uppercase"
+            className="text-ui-sm text-neutral3 font-mono tracking-wider uppercase"
           >
             Trace signal summaries
           </h2>

--- a/packages/playground-ui/src/ee/topics/components/topic-trace-summary-list.tsx
+++ b/packages/playground-ui/src/ee/topics/components/topic-trace-summary-list.tsx
@@ -1,4 +1,4 @@
-import { SearchIcon } from 'lucide-react';
+import { SearchIcon, ChevronDown } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import type { TopicTraceSummary } from '../types';
 import { getVisibleTraceSummaries } from '../utils';
@@ -72,7 +72,12 @@ export function TopicTraceSummaryList({
       </DataList>
 
       {visible.hasMore ? (
-        <Button variant="outline" size="sm" onClick={() => setPage(currentPage => currentPage + 1)}>
+        <Button
+          icon={<ChevronDown />}
+          variant="outline"
+          size="sm"
+          onClick={() => setPage(currentPage => currentPage + 1)}
+        >
           Load more traces ({visible.traces.length} of {visible.total})
         </Button>
       ) : null}

--- a/packages/playground-ui/src/lib/rule-engine/components/rule-builder.tsx
+++ b/packages/playground-ui/src/lib/rule-engine/components/rule-builder.tsx
@@ -106,17 +106,11 @@ const RuleGroupView: React.FC<RuleGroupViewProps> = ({ schema, group, onChange, 
       ))}
 
       <div className="flex gap-1 p-2">
-        <Button type="button" onClick={handleAddRule} variant="ghost" size="sm">
-          <Icon>
-            <Plus />
-          </Icon>
+        <Button type="button" onClick={handleAddRule} variant="ghost" size="sm" icon={<Plus />}>
           Add rule
         </Button>
         {depth < maxDepth - 1 && (
-          <Button type="button" onClick={handleAddGroup} variant="ghost" size="sm">
-            <Icon>
-              <Component />
-            </Icon>
+          <Button type="button" onClick={handleAddGroup} variant="ghost" size="sm" icon={<Component />}>
             Add group
           </Button>
         )}

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-library-step.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-library-step.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
-import { ArrowRightIcon, CheckIcon, LibraryIcon } from 'lucide-react';
+import { ArrowRightIcon, CheckIcon, LibraryIcon, Plus } from 'lucide-react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { AgentStepContainer } from './agent-step-container';
 import { useStreamRunning } from '@/domains/agent-builder/contexts/stream-chat-context';
@@ -56,6 +56,7 @@ export const AgentProfileLibraryStep = ({ agentId }: AgentProfileLibraryStepProp
           </p>
         ) : (
           <Button
+            icon={<Plus />}
             variant="primary"
             onClick={() => requestChange('public')}
             disabled={isStreaming}

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-ready-step.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-ready-step.tsx
@@ -1,4 +1,6 @@
 import { Button } from '@mastra/playground-ui/components/Button';
+import { AgentIcon } from '@mastra/playground-ui/icons/AgentIcon';
+import { Eye } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { AgentStepContainer } from './agent-step-container';
@@ -46,10 +48,10 @@ export const AgentProfileReadyStep = () => {
       panelOverlay={<span ref={sweepRef} className="ready-stage-sweep" aria-hidden="true" />}
       cta={
         <div className="relative z-[2] flex items-center justify-center gap-3">
-          <Button variant="outline" onClick={handleReview} data-testid="agent-builder-ready-review">
+          <Button icon={<Eye />} variant="outline" onClick={handleReview} data-testid="agent-builder-ready-review">
             Review my agent
           </Button>
-          <Button variant="primary" onClick={handleTry} data-testid="agent-builder-ready-try">
+          <Button icon={<AgentIcon />} variant="primary" onClick={handleTry} data-testid="agent-builder-ready-try">
             Try my agent
           </Button>
         </div>

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-step-container.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-step-container.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
+import { AgentIcon } from '@mastra/playground-ui/icons/AgentIcon';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { ArrowLeftIcon } from 'lucide-react';
+import { ArrowLeftIcon, Settings2 } from 'lucide-react';
 import type { CSSProperties, ReactNode } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { useAgentColor } from '@/domains/agent-builder/contexts/agent-color-context';
@@ -93,10 +94,16 @@ export const AgentStepContainer = ({
             data-testid="agent-step-footer"
           >
             {backButton}
-            <Button variant="outline" onClick={() => startViewTransition(() => next())} disabled={isStreaming}>
+            <Button
+              icon={<Settings2 />}
+              variant="outline"
+              onClick={() => startViewTransition(() => next())}
+              disabled={isStreaming}
+            >
               See agent configuration
             </Button>
             <Button
+              icon={<AgentIcon />}
               variant="primary"
               onClick={() => navigate(`/agent-builder/agents/${agentId}/view`, { viewTransition: true })}
               disabled={isStreaming}

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-step-container.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-step-container.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@mastra/playground-ui/components/Button';
-import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { ArrowLeftIcon } from 'lucide-react';
 import type { CSSProperties, ReactNode } from 'react';
@@ -57,10 +56,9 @@ export const AgentStepContainer = ({
       onClick={() => startViewTransition(() => prev())}
       disabled={isStreaming}
       data-testid="agent-builder-step-back"
+      icon={<ArrowLeftIcon />}
     >
-      <Icon>
-        <ArrowLeftIcon />
-      </Icon>{' '}
+      {' '}
       Back
     </Button>
   ) : null;

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/toolkit-connection-control.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/toolkit-connection-control.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { useQueryClient } from '@tanstack/react-query';
-import { Settings } from 'lucide-react';
+import { Settings, Plug } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import type { UseFormSetValue } from 'react-hook-form';
@@ -223,6 +223,7 @@ export const ToolkitConnectionControl = ({
   if (activeConnections.length === 0) {
     return (
       <Button
+        icon={<Plug />}
         type="button"
         variant="outline"
         size="sm"

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/connect-channel-message.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/connect-channel-message.tsx
@@ -1,6 +1,7 @@
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { Plug, Settings2 } from 'lucide-react';
 import { useState } from 'react';
 import { ChannelDialog } from './publish-channel-dialogs/channel-dialog';
 import { PlatformIcon } from '@/domains/agents/components/agent-channels/platform-icons';
@@ -53,6 +54,7 @@ export function ConnectChannelMessage({ platformId, agentId }: ConnectChannelMes
 
         {!platform.isConfigured ? (
           <Button
+            icon={<Settings2 />}
             size="sm"
             variant="ghost"
             disabled
@@ -62,6 +64,7 @@ export function ConnectChannelMessage({ platformId, agentId }: ConnectChannelMes
           </Button>
         ) : installation ? (
           <Button
+            icon={<Settings2 />}
             size="sm"
             variant="default"
             onClick={() => setDialogOpen(true)}
@@ -71,6 +74,7 @@ export function ConnectChannelMessage({ platformId, agentId }: ConnectChannelMes
           </Button>
         ) : (
           <Button
+            icon={<Plug />}
             size="sm"
             variant="default"
             onClick={handleConnect}

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/delete-agent-action.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/delete-agent-action.tsx
@@ -74,6 +74,7 @@ const DeleteAgentDialog = ({
             Cancel
           </AlertDialog.Cancel>
           <Button
+            icon={<Trash2 />}
             variant="primary"
             data-testid="agent-builder-delete-agent-confirm"
             disabled={isPending || isDependentsLoading}
@@ -103,6 +104,7 @@ export const DeleteAgentPanelButton = ({ agentId, agentName, disabled = false }:
   return (
     <>
       <Button
+        icon={<Trash2 />}
         onClick={() => setOpen(true)}
         disabled={disabled || isPending}
         data-testid="agent-builder-delete-agent"

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/edit-top-bar.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/edit-top-bar.tsx
@@ -58,8 +58,8 @@ export const EditTopBar = ({
             className="hidden shrink-0 lg:inline-flex"
             data-testid="agent-builder-mode-toggle"
             aria-label={toggleLabel}
+            icon={<RefreshCwIcon />}
           >
-            <RefreshCwIcon />
             {toggleLabel}
           </Button>
         )}

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/publish-channel-dialogs/disconnect-channel-content.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/publish-channel-dialogs/disconnect-channel-content.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@mastra/playground-ui/components/Dialog';
 import { toast } from '@mastra/playground-ui/utils/toast';
+import { Check, X } from 'lucide-react';
 import { useDisconnectChannel } from '@/domains/agents/hooks/use-channels';
 import type { ChannelPlatformInfo } from '@/domains/agents/hooks/use-channels';
 
@@ -34,10 +35,11 @@ export function DisconnectChannelContent({ platform, agentId, onCancel, onClose 
         </DialogDescription>
       </DialogHeader>
       <DialogFooter>
-        <Button variant="ghost" onClick={onCancel} disabled={isPending}>
+        <Button icon={<X />} variant="ghost" onClick={onCancel} disabled={isPending}>
           Cancel
         </Button>
         <Button
+          icon={<Check />}
           variant="default"
           onClick={handleConfirm}
           disabled={isPending}

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/publish-channel-dialogs/publish-channel-content.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/publish-channel-dialogs/publish-channel-content.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
 } from '@mastra/playground-ui/components/Dialog';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { X, Plug, Unplug } from 'lucide-react';
 import { PlatformIcon } from '@/domains/agents/components/agent-channels/platform-icons';
 import { useConnectChannelAction } from '@/domains/agents/hooks/use-channels';
 import type { ChannelInstallationInfo, ChannelPlatformInfo } from '@/domains/agents/hooks/use-channels';
@@ -94,6 +95,7 @@ export function PublishChannelContent({
       <DialogFooter>
         {platform.isConfigured && activeInstallation ? (
           <Button
+            icon={<Unplug />}
             variant="default"
             onClick={onDisconnectRequest}
             data-testid={`publish-channel-dialog-${platform.id}-disconnect`}
@@ -102,6 +104,7 @@ export function PublishChannelContent({
           </Button>
         ) : platform.isConfigured ? (
           <Button
+            icon={<Plug />}
             variant="default"
             onClick={handleConnect}
             disabled={isConnecting}
@@ -110,7 +113,7 @@ export function PublishChannelContent({
             {isConnecting ? 'Connecting…' : copy.connectLabel}
           </Button>
         ) : (
-          <Button variant="default" onClick={onClose}>
+          <Button icon={<X />} variant="default" onClick={onClose}>
             Close
           </Button>
         )}

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/visibility-select.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/visibility-select.tsx
@@ -25,8 +25,8 @@ export function VisibilitySelect({ agentId }: VisibilitySelectProps) {
           variant="default"
           onClick={() => requestChange('public')}
           data-testid="agent-builder-visibility-add"
+          icon={<Globe />}
         >
-          <Globe className="h-3.5 w-3.5" />
           Add to library
         </Button>
       ) : (
@@ -35,8 +35,8 @@ export function VisibilitySelect({ agentId }: VisibilitySelectProps) {
           variant="ghost"
           onClick={() => requestChange('private')}
           data-testid="agent-builder-visibility-remove"
+          icon={<LockIcon />}
         >
-          <LockIcon className="h-3.5 w-3.5" />
           Remove from library
         </Button>
       )}

--- a/packages/playground/src/domains/agent-builder/components/agent-view/view-top-bar.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-view/view-top-bar.tsx
@@ -56,8 +56,8 @@ export const ViewTopBar = ({
             className="hidden shrink-0 lg:inline-flex"
             data-testid="agent-builder-mode-toggle"
             aria-label={toggleLabel}
+            icon={<RefreshCwIcon />}
           >
-            <RefreshCwIcon />
             {toggleLabel}
           </Button>
         )}

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
@@ -328,10 +328,9 @@ export const ErrorMessage = ({ error, onRetry }: { error: ParsedStreamError; onR
               <Button
                 variant="default"
                 onClick={onRetry}
-                className="gap-1.5"
                 data-testid="agent-builder-chat-error-retry"
+                icon={<RefreshCw aria-hidden />}
               >
-                <RefreshCw className="size-3.5" aria-hidden />
                 Try again
               </Button>
             )}
@@ -357,10 +356,9 @@ export const ErrorMessage = ({ error, onRetry }: { error: ParsedStreamError; onR
             <Button
               variant="default"
               onClick={onRetry}
-              className="gap-1.5"
               data-testid="agent-builder-chat-error-retry"
+              icon={<RefreshCw aria-hidden />}
             >
-              <RefreshCw className="size-3.5" aria-hidden />
               Try again
             </Button>
           </div>

--- a/packages/playground/src/domains/agent-builder/components/skill-edit/delete-skill-action.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-edit/delete-skill-action.tsx
@@ -57,6 +57,7 @@ const DeleteSkillDialog = ({ open, onOpenChange, skillName, isPending, onConfirm
           Cancel
         </AlertDialog.Cancel>
         <Button
+          icon={<Trash2 />}
           variant="primary"
           data-testid="skill-builder-delete-skill-confirm"
           disabled={isPending}

--- a/packages/playground/src/domains/agent-builder/components/skill-edit/delete-skill-action.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-edit/delete-skill-action.tsx
@@ -91,8 +91,8 @@ export const DeleteSkillPanelButton = ({ skillId, skillName, disabled = false }:
         disabled={disabled || isPending}
         className="w-full"
         data-testid="skill-builder-delete-skill"
+        icon={<Trash2 />}
       >
-        <Trash2 />
         <span>Delete skill</span>
       </Button>
       <DeleteSkillDialog

--- a/packages/playground/src/domains/agent-builder/components/skill-edit/visibility-select.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-edit/visibility-select.tsx
@@ -24,8 +24,8 @@ export function VisibilitySelect({ skillId }: VisibilitySelectProps) {
           variant="default"
           onClick={() => requestChange('public')}
           data-testid="skill-builder-visibility-add"
+          icon={<Globe />}
         >
-          <Globe className="h-3.5 w-3.5" />
           Add to library
         </Button>
       ) : (
@@ -34,8 +34,8 @@ export function VisibilitySelect({ skillId }: VisibilitySelectProps) {
           variant="ghost"
           onClick={() => requestChange('private')}
           data-testid="skill-builder-visibility-remove"
+          icon={<LockIcon />}
         >
-          <LockIcon className="h-3.5 w-3.5" />
           Remove from library
         </Button>
       )}

--- a/packages/playground/src/domains/agent-builder/components/skill-list/builder-add-skill-dialog.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-list/builder-add-skill-dialog.tsx
@@ -14,7 +14,7 @@ import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { GithubIcon } from '@mastra/playground-ui/icons/GithubIcon';
 import { SkillIcon } from '@mastra/playground-ui/icons/SkillIcon';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { Check, Download, ExternalLink, Loader2, Package, Search } from 'lucide-react';
+import { Check, Download, ExternalLink, Loader2, Package, Search, X } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -324,7 +324,7 @@ export function BuilderAddSkillDialog({
                 </div>
               )}
               <div className="flex items-center justify-end gap-2">
-                <Button variant="default" onClick={() => handleOpenChange(false)}>
+                <Button icon={<X />} variant="default" onClick={() => handleOpenChange(false)}>
                   Cancel
                 </Button>
                 <Button

--- a/packages/playground/src/domains/agent-builder/hooks/use-publish-and-connect-channel.tsx
+++ b/packages/playground/src/domains/agent-builder/hooks/use-publish-and-connect-channel.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from '@mastra/playground-ui/components/Dialog';
 import { toast } from '@mastra/playground-ui/utils/toast';
+import { ChevronRight, X } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useFormContext } from 'react-hook-form';
@@ -123,6 +124,7 @@ export function usePublishAndConnectChannel(agentId: string): UsePublishAndConne
           </DialogHeader>
           <DialogFooter>
             <Button
+              icon={<X />}
               variant="ghost"
               onClick={handleCancel}
               disabled={updateStoredAgent.isPending}
@@ -131,6 +133,7 @@ export function usePublishAndConnectChannel(agentId: string): UsePublishAndConne
               Cancel
             </Button>
             <Button
+              icon={<ChevronRight />}
               variant="default"
               onClick={handleConfirm}
               disabled={updateStoredAgent.isPending}

--- a/packages/playground/src/domains/agent-builder/hooks/use-visibility-change-dialog.tsx
+++ b/packages/playground/src/domains/agent-builder/hooks/use-visibility-change-dialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from '@mastra/playground-ui/components/Dialog';
 import { toast } from '@mastra/playground-ui/utils/toast';
+import { Check, X } from 'lucide-react';
 import { useState } from 'react';
 import type { ReactNode } from 'react';
 
@@ -81,10 +82,17 @@ export function useVisibilityChangeDialog<V extends string>({
             </DialogHeader>
             {renderExtraContent?.(pending)}
             <DialogFooter>
-              <Button variant="ghost" onClick={handleCancel} disabled={isPending} data-testid={testIds.cancel}>
+              <Button
+                icon={<X />}
+                variant="ghost"
+                onClick={handleCancel}
+                disabled={isPending}
+                data-testid={testIds.cancel}
+              >
                 Cancel
               </Button>
               <Button
+                icon={<Check />}
                 variant="default"
                 onClick={confirmFor(pending)}
                 disabled={isPending || (confirmDisabled?.(pending) ?? false)}

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-root-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-root-layout.tsx
@@ -113,13 +113,11 @@ function AccessDeniedScreen() {
           descriptionSlot="You don't have permission to access the Agent Builder."
         />
         <div className="flex items-center gap-2">
-          <Button as={Link} href="/agents" variant="outline" size="sm">
-            <ArrowLeft className="h-3.5 w-3.5" />
+          <Button as={Link} href="/agents" variant="outline" size="sm" icon={<ArrowLeft />}>
             Back to Studio
           </Button>
           {isImpersonating && (
-            <Button variant="default" size="sm" onClick={stopImpersonation}>
-              <Eye className="h-3.5 w-3.5" />
+            <Button variant="default" size="sm" onClick={stopImpersonation} icon={<Eye />}>
               Exit {impersonatedRole?.name} preview
             </Button>
           )}

--- a/packages/playground/src/domains/agents/agent-header.tsx
+++ b/packages/playground/src/domains/agents/agent-header.tsx
@@ -23,8 +23,14 @@ export function AgentHeader({ agentId }: { agentId: string }) {
       </Breadcrumb>
 
       <HeaderAction>
-        <Button as={Link} to="https://mastra.ai/en/docs/agents/overview" target="_blank" variant="ghost" size="md">
-          <DocsIcon />
+        <Button
+          as={Link}
+          to="https://mastra.ai/en/docs/agents/overview"
+          target="_blank"
+          variant="ghost"
+          size="md"
+          icon={<DocsIcon />}
+        >
           Agents documentation
         </Button>
       </HeaderAction>

--- a/packages/playground/src/domains/agents/components/agent-channels/agent-channels.tsx
+++ b/packages/playground/src/domains/agents/components/agent-channels/agent-channels.tsx
@@ -3,6 +3,7 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { toast } from '@mastra/playground-ui/utils/toast';
+import { Plug, Unplug } from 'lucide-react';
 import {
   useChannelPlatforms,
   useChannelInstallations,
@@ -94,11 +95,18 @@ function ChannelRow({ platform, agentId }: ChannelRowProps) {
       ) : null}
 
       {isLoading ? null : activeInstallation ? (
-        <Button size="sm" variant="ghost" onClick={handleDisconnect} disabled={isDisconnecting} className="shrink-0">
+        <Button
+          icon={<Unplug />}
+          size="sm"
+          variant="ghost"
+          onClick={handleDisconnect}
+          disabled={isDisconnecting}
+          className="shrink-0"
+        >
           {isDisconnecting ? 'Removing...' : 'Remove'}
         </Button>
       ) : platform.isConfigured ? (
-        <Button size="sm" variant="default" onClick={handleConnect} disabled={isConnecting}>
+        <Button icon={<Plug />} size="sm" variant="default" onClick={handleConnect} disabled={isConnecting}>
           {isConnecting ? 'Connecting...' : 'Connect'}
         </Button>
       ) : null}

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
@@ -20,7 +20,7 @@ import { cn } from '@mastra/playground-ui/utils/cn';
 import type { JsonSchema } from '@mastra/playground-ui/utils/json-schema';
 import type { RuleGroup } from '@mastra/playground-ui/utils/rule-engine';
 import type { ReactCodeMirrorRef } from '@uiw/react-codemirror';
-import { GripVertical, X, BookmarkPlus } from 'lucide-react';
+import { GripVertical, X, BookmarkPlus, Check } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { InstructionBlock, InlineInstructionBlock } from '../agent-edit-page/utils/form-validation';
@@ -123,10 +123,10 @@ const SaveAsPromptBlockDialog = ({
             )}
           </DialogBody>
           <DialogFooter className="px-4 pt-4">
-            <Button type="button" variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+            <Button icon={<X />} type="button" variant="outline" size="sm" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button type="submit" variant="primary" size="sm" disabled={!name.trim() || isPending}>
+            <Button icon={<Check />} type="submit" variant="primary" size="sm" disabled={!name.trim() || isPending}>
               {isPending ? 'Saving...' : 'Save'}
             </Button>
           </DialogFooter>

--- a/packages/playground/src/domains/agents/components/agent-cms-layout/agent-cms-bottom-bar.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-layout/agent-cms-bottom-bar.tsx
@@ -29,17 +29,21 @@ export function AgentCmsBottomBar({ basePath, currentPath }: AgentCmsBottomBarPr
     <div className="border-border1 flex items-center justify-between border-t px-5 py-4">
       <div>
         {previous && (
-          <Button type="button" variant="outline" onClick={() => navigate(previous.href)}>
-            <ArrowLeft />
+          <Button type="button" variant="outline" onClick={() => navigate(previous.href)} icon={<ArrowLeft />}>
             {previous.name}
           </Button>
         )}
       </div>
       <div>
         {next && (
-          <Button type="button" variant="default" disabled={isNextDisabled} onClick={() => navigate(next.href)}>
+          <Button
+            type="button"
+            variant="default"
+            disabled={isNextDisabled}
+            onClick={() => navigate(next.href)}
+            icon={<ArrowRight />}
+          >
             {next.name}
-            <ArrowRight />
           </Button>
         )}
       </div>

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/memory-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/memory-page.tsx
@@ -49,7 +49,7 @@ export function MemoryPage() {
                     name="memory.enabled"
                     control={control}
                     render={({ field }) => (
-                      <Button variant="default" size="sm" onClick={() => field.onChange(true)}>
+                      <Button icon={<MemoryIcon />} variant="default" size="sm" onClick={() => field.onChange(true)}>
                         Enable Memory
                       </Button>
                     )}

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
@@ -4,8 +4,19 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { SideDialog } from '@mastra/playground-ui/components/SideDialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
+import { SkillIcon } from '@mastra/playground-ui/icons/SkillIcon';
 import { toast } from '@mastra/playground-ui/utils/toast';
-import { AlertTriangle, ChevronDown, ChevronRight, CopyIcon, Globe, LockIcon, Pencil, Settings2 } from 'lucide-react';
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  CopyIcon,
+  Globe,
+  LockIcon,
+  Pencil,
+  Settings2,
+  Check,
+} from 'lucide-react';
 import { nanoid } from 'nanoid';
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 
@@ -308,7 +319,13 @@ export function SkillEditDialog({
                   </SelectContent>
                 </Select>
               )}
-              <Button variant="primary" size="sm" onClick={handleSave} disabled={!name.trim() || isPending}>
+              <Button
+                icon={isExistingSkill ? <Check /> : <SkillIcon />}
+                variant="primary"
+                size="sm"
+                onClick={handleSave}
+                disabled={!name.trim() || isPending}
+              >
                 {isPending ? 'Saving...' : isExistingSkill ? 'Save' : 'Create'}
               </Button>
             </>

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
@@ -271,15 +271,15 @@ export function SkillEditDialog({
         </span>
         <div className="mr-6 flex items-center gap-2">
           {isViewMode && isOwner && (
-            <Button variant="outline" size="sm" onClick={() => setIsEditing(true)}>
-              <Pencil className="h-3.5 w-3.5" /> Edit
+            <Button variant="outline" size="sm" onClick={() => setIsEditing(true)} icon={<Pencil />}>
+              Edit
             </Button>
           )}
           {isViewMode && !isOwner && onCopy && skill && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="outline" size="sm" onClick={() => onCopy(skill)}>
-                  <CopyIcon className="h-3.5 w-3.5" /> Copy
+                <Button variant="outline" size="sm" onClick={() => onCopy(skill)} icon={<CopyIcon />}>
+                  Copy
                 </Button>
               </TooltipTrigger>
               <TooltipContent>Make your own private copy you can edit</TooltipContent>

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skills-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skills-page.tsx
@@ -70,8 +70,7 @@ export function SkillsPage() {
           />
 
           {!readOnly && (
-            <Button variant="outline" size="sm" onClick={() => setDialogOpen(true)}>
-              <Plus className="size-3" />
+            <Button variant="outline" size="sm" onClick={() => setDialogOpen(true)} icon={<Plus />}>
               Add a skill
             </Button>
           )}
@@ -117,8 +116,7 @@ export function SkillsPage() {
               descriptionSlot="Create a skill to give your agent specialized knowledge."
               actionSlot={
                 !readOnly ? (
-                  <Button onClick={() => setDialogOpen(true)}>
-                    <Plus />
+                  <Button onClick={() => setDialogOpen(true)} icon={<Plus />}>
                     Add a skill
                   </Button>
                 ) : undefined

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/tools-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/tools-page.tsx
@@ -218,10 +218,7 @@ export function ToolsPage() {
             {canEditToolMembership && unselectedOptions.length > 0 && (
               <Popover>
                 <PopoverTrigger asChild>
-                  <Button variant="ghost" size="sm">
-                    <Icon size="sm">
-                      <PlusIcon />
-                    </Icon>
+                  <Button variant="ghost" size="sm" icon={<PlusIcon />}>
                     Add Tools
                   </Button>
                 </PopoverTrigger>

--- a/packages/playground/src/domains/agents/components/agent-list/agent-subagent-details.tsx
+++ b/packages/playground/src/domains/agents/components/agent-list/agent-subagent-details.tsx
@@ -34,8 +34,8 @@ export function AgentSubagentDetails({ agentName, agents }: AgentSubagentDetails
             size="sm"
             className="pointer-events-auto"
             aria-label={`Show ${agentCount} for ${agentName}`}
+            icon={<AgentIcon aria-hidden="true" />}
           >
-            <AgentIcon aria-hidden="true" />
             <span>{agentEntries.length}</span>
           </Button>
         }

--- a/packages/playground/src/domains/agents/components/agent-list/agent-tools-details.tsx
+++ b/packages/playground/src/domains/agents/components/agent-list/agent-tools-details.tsx
@@ -34,8 +34,8 @@ export function AgentToolsDetails({ agentName, tools }: AgentToolsDetailsProps) 
             size="sm"
             className="pointer-events-auto"
             aria-label={`Show ${toolCount} for ${agentName}`}
+            icon={<ToolsIcon aria-hidden="true" />}
           >
-            <ToolsIcon aria-hidden="true" />
             <span>{toolEntries.length}</span>
           </Button>
         }

--- a/packages/playground/src/domains/agents/components/agent-list/agent-workflow-details.tsx
+++ b/packages/playground/src/domains/agents/components/agent-list/agent-workflow-details.tsx
@@ -34,8 +34,8 @@ export function AgentWorkflowDetails({ agentName, workflows }: AgentWorkflowDeta
             size="sm"
             className="pointer-events-auto"
             aria-label={`Show ${workflowCount} for ${agentName}`}
+            icon={<WorkflowIcon aria-hidden="true" />}
           >
-            <WorkflowIcon aria-hidden="true" />
             <span>{workflowEntries.length}</span>
           </Button>
         }

--- a/packages/playground/src/domains/agents/components/agent-list/no-agents-info.tsx
+++ b/packages/playground/src/domains/agents/components/agent-list/no-agents-info.tsx
@@ -15,8 +15,9 @@ export const NoAgentsInfo = () => (
           href="https://mastra.ai/docs/agents/overview"
           target="_blank"
           rel="noopener noreferrer"
+          icon={<ExternalLinkIcon />}
         >
-          Agents Documentation <ExternalLinkIcon />
+          Agents Documentation
         </Button>
       }
     />

--- a/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata.tsx
+++ b/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata.tsx
@@ -415,7 +415,7 @@ export const AgentMetadataWorkspaceToolsList = ({ tools }: AgentMetadataWorkspac
     <AgentMetadataList>
       {tools.map(tool => (
         <AgentMetadataListItem key={tool}>
-          <Badge icon={<Folder className="text-accent1 h-3 w-3" />}>{formatWorkspaceToolName(tool)}</Badge>
+          <Badge icon={<Folder className="text-accent1" />}>{formatWorkspaceToolName(tool)}</Badge>
         </AgentMetadataListItem>
       ))}
     </AgentMetadataList>
@@ -435,7 +435,7 @@ export const AgentMetadataBrowserToolsList = ({ tools }: AgentMetadataBrowserToo
     <AgentMetadataList>
       {tools.map(tool => (
         <AgentMetadataListItem key={tool}>
-          <Badge icon={<Globe className="h-3 w-3 text-cyan-500" />}>{tool}</Badge>
+          <Badge icon={<Globe className="text-cyan-500" />}>{tool}</Badge>
         </AgentMetadataListItem>
       ))}
     </AgentMetadataList>

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-datasets.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-datasets.tsx
@@ -45,8 +45,8 @@ export function AgentPlaygroundDatasets({ agentId }: AgentPlaygroundDatasetsProp
           variant="primary"
           size="sm"
           onClick={() => void navigate(`/datasets/new?targetType=agent&targetIds=${encodeURIComponent(agentId)}`)}
+          icon={<Plus />}
         >
-          <Plus className="mr-1 h-3.5 w-3.5" />
           Create
         </Button>
       </div>

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-eval.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-eval.tsx
@@ -20,6 +20,8 @@ import {
   ClipboardCheck,
   Award,
   ExternalLink,
+  ListChecks,
+  X,
 } from 'lucide-react';
 import { useState } from 'react';
 
@@ -475,7 +477,7 @@ export function ExperimentResultsPanel({
               Send to Review
             </Button>
           )}
-          <Button variant="ghost" size="sm" onClick={clearSelection}>
+          <Button icon={<X />} variant="ghost" size="sm" onClick={clearSelection}>
             Clear
           </Button>
         </div>
@@ -483,7 +485,7 @@ export function ExperimentResultsPanel({
 
       {results && results.length > 0 && selectedIds.size === 0 && (
         <div className="border-border1 flex items-center gap-2 border-b px-4 py-2">
-          <Button variant="ghost" size="sm" onClick={selectAllFailed}>
+          <Button icon={<ListChecks />} variant="ghost" size="sm" onClick={selectAllFailed}>
             Select all failures
           </Button>
         </div>

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
@@ -356,8 +356,7 @@ export function AgentPlaygroundEvaluate({
 
     const backButton = (label: string, onClick: () => void) => (
       <div className="border-border1 flex items-center gap-2 border-b px-4 py-2">
-        <Button variant="ghost" size="sm" onClick={onClick}>
-          <ChevronLeft className="size-4" />
+        <Button variant="ghost" size="sm" onClick={onClick} icon={<ChevronLeft />}>
           {label}
         </Button>
       </div>
@@ -878,8 +877,7 @@ export function AgentPlaygroundEvaluate({
             {activeTab === 'datasets' && (
               <>
                 {unattachedDatasets.length > 0 && (
-                  <Button variant="ghost" size="sm" onClick={() => setShowAttachDialog(true)}>
-                    <Paperclip className="mr-1 size-3.5" />
+                  <Button variant="ghost" size="sm" onClick={() => setShowAttachDialog(true)} icon={<Paperclip />}>
                     Attach
                   </Button>
                 )}
@@ -889,8 +887,8 @@ export function AgentPlaygroundEvaluate({
                   onClick={() =>
                     void navigate(`/datasets/new?targetType=agent&targetIds=${encodeURIComponent(agentId)}`)
                   }
+                  icon={<Plus />}
                 >
-                  <Plus className="mr-1 size-3.5" />
                   Create
                 </Button>
               </>
@@ -898,13 +896,16 @@ export function AgentPlaygroundEvaluate({
             {activeTab === 'scorers' && (
               <>
                 {unattachedScorers.length > 0 && (
-                  <Button variant="ghost" size="sm" onClick={() => setShowAttachScorerDialog(true)}>
-                    <Paperclip className="mr-1 size-3.5" />
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowAttachScorerDialog(true)}
+                    icon={<Paperclip />}
+                  >
                     Attach
                   </Button>
                 )}
-                <Button variant="ghost" size="sm" onClick={() => setDetailView({ type: 'new-scorer' })}>
-                  <Plus className="mr-1 size-3.5" />
+                <Button variant="ghost" size="sm" onClick={() => setDetailView({ type: 'new-scorer' })} icon={<Plus />}>
                   New
                 </Button>
               </>

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
@@ -512,8 +512,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
             <div className="flex items-center gap-3">
               <DropdownMenu>
                 <DropdownMenu.Trigger asChild>
-                  <Button variant="outline" size="md">
-                    <FilterIcon />
+                  <Button variant="outline" size="md" icon={<FilterIcon />}>
                     Filter
                     {activeFilterCount > 0 && (
                       <span
@@ -622,8 +621,8 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                     setShowCompleted(false);
                     setFeaturedItemId(null);
                   }}
+                  icon={<XIcon />}
                 >
-                  <XIcon />
                   Reset
                 </Button>
               )}

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
@@ -18,7 +18,7 @@ import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { useMastraClient } from '@mastra/react';
-import { CheckCircle, ChevronDown, FilterIcon, GaugeIcon, Sparkles, Trash2, XIcon } from 'lucide-react';
+import { CheckCircle, ChevronDown, FilterIcon, GaugeIcon, Sparkles, Trash2, XIcon, Check, X } from 'lucide-react';
 import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
 import { usePlaygroundModel } from '../../context/playground-model-context';
 import { useReviewQueue } from '../../context/review-queue-context';
@@ -399,7 +399,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
             </div>
           </DialogBody>
           <DialogFooter className="px-4">
-            <Button variant="ghost" onClick={() => setShowAnalyzeDialog(false)} disabled={isAnalyzing}>
+            <Button icon={<X />} variant="ghost" onClick={() => setShowAnalyzeDialog(false)} disabled={isAnalyzing}>
               Cancel
             </Button>
             <Button
@@ -490,10 +490,11 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
             })}
           </DialogBody>
           <DialogFooter>
-            <Button variant="ghost" onClick={() => setShowProposalDialog(false)}>
+            <Button icon={<X />} variant="ghost" onClick={() => setShowProposalDialog(false)}>
               Cancel
             </Button>
             <Button
+              icon={<Check />}
               variant="default"
               onClick={handleAcceptProposals}
               disabled={proposedAssignments.filter(p => p.accepted).length === 0}

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-test-chat.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-test-chat.tsx
@@ -47,8 +47,14 @@ function UnsavedChangesBanner({ ctx }: { ctx: NonNullable<ReturnType<typeof useO
       className="mx-4 mt-3 mb-0"
       action={
         handleSaveDraft && (
-          <Button type="button" variant="default" size="sm" onClick={() => handleSaveDraft()} disabled={isSavingDraft}>
-            <Save className="h-3.5 w-3.5" />
+          <Button
+            type="button"
+            variant="default"
+            size="sm"
+            onClick={() => handleSaveDraft()}
+            disabled={isSavingDraft}
+            icon={<Save />}
+          >
             {isSavingDraft ? 'Saving...' : saveLabel}
           </Button>
         )

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-version-bar.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-version-bar.tsx
@@ -172,17 +172,17 @@ export function AgentPlaygroundVersionBar({
       <div className="border-border1 bg-surface3 flex items-center justify-end border-t px-3 py-2">
         {showCodeModeActions ? (
           <ButtonsGroup className="flex-wrap justify-end">
-            <Button variant="default" size="md" onClick={() => void onDownloadJson?.()}>
-              <Icon size="sm">
-                <Download />
-              </Icon>
+            <Button variant="default" size="md" onClick={() => void onDownloadJson?.()} icon={<Download />}>
               Download JSON
             </Button>
             {canOpenPr ? (
-              <Button variant="primary" size="md" onClick={() => void onOpenPr?.()} title={openPrTitle}>
-                <Icon size="sm">
-                  <GitPullRequest />
-                </Icon>
+              <Button
+                variant="primary"
+                size="md"
+                onClick={() => void onOpenPr?.()}
+                title={openPrTitle}
+                icon={<GitPullRequest />}
+              >
                 Open PR
               </Button>
             ) : (
@@ -295,10 +295,13 @@ export function AgentPlaygroundVersionBar({
               <Button variant="default" size="sm" onClick={() => setShowMessageDialog(false)}>
                 Cancel
               </Button>
-              <Button variant="primary" size="sm" onClick={handleSaveWithMessage} disabled={isSavingDraft}>
-                <Icon size="sm">
-                  <Save />
-                </Icon>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleSaveWithMessage}
+                disabled={isSavingDraft}
+                icon={<Save />}
+              >
                 Save Version
               </Button>
             </DialogFooter>

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-version-bar.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-version-bar.tsx
@@ -19,7 +19,7 @@ import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
-import { Check, ChevronDown, Download, GitPullRequest, Info, MessageSquare, Save } from 'lucide-react';
+import { Check, ChevronDown, Download, GitPullRequest, Info, MessageSquare, Save, X } from 'lucide-react';
 import { useMemo, useState, useCallback } from 'react';
 
 import { useAgentVersions } from '../../hooks/use-agent-versions';
@@ -292,7 +292,7 @@ export function AgentPlaygroundVersionBar({
               </div>
             </DialogBody>
             <DialogFooter className="px-4">
-              <Button variant="default" size="sm" onClick={() => setShowMessageDialog(false)}>
+              <Button icon={<X />} variant="default" size="sm" onClick={() => setShowMessageDialog(false)}>
                 Cancel
               </Button>
               <Button

--- a/packages/playground/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
@@ -9,10 +9,11 @@ import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
+import { ScorersIcon } from '@mastra/playground-ui/icons/ScorersIcon';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { useQueryClient } from '@tanstack/react-query';
-import { Play, Sparkles, Clock, ChevronRight, ChevronDown, Pencil, Save, X, Trash2 } from 'lucide-react';
+import { Play, Sparkles, Clock, ChevronRight, ChevronDown, Pencil, Save, X, Trash2, Paperclip } from 'lucide-react';
 import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { formatVersionLabel } from './format-version-label';
 import { useAgentVersions } from '@/domains/agents/hooks/use-agent-versions';
@@ -347,7 +348,12 @@ export function DatasetDetailView({
               </button>
               {unattachedScorerEntries.length > 0 && (
                 <div className="pr-2">
-                  <Button variant="ghost" size="sm" onClick={() => setShowAttachScorerDialog(true)}>
+                  <Button
+                    icon={<Paperclip />}
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowAttachScorerDialog(true)}
+                  >
                     Attach
                   </Button>
                 </div>
@@ -361,7 +367,12 @@ export function DatasetDetailView({
                   </Txt>
                   {unattachedScorerEntries.length > 0 && (
                     <div className="mt-2">
-                      <Button variant="outline" size="sm" onClick={() => setShowAttachScorerDialog(true)}>
+                      <Button
+                        icon={<ScorersIcon />}
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setShowAttachScorerDialog(true)}
+                      >
                         Attach a scorer
                       </Button>
                     </div>
@@ -767,7 +778,7 @@ function ExpandedItemEditor({
             >
               {deleteItem.isPending ? <Spinner className="h-3 w-3" /> : 'Yes'}
             </Button>
-            <Button variant="ghost" size="sm" onClick={() => setIsConfirmingDelete(false)}>
+            <Button icon={<X />} variant="ghost" size="sm" onClick={() => setIsConfirmingDelete(false)}>
               No
             </Button>
           </>

--- a/packages/playground/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
@@ -249,10 +249,7 @@ export function DatasetDetailView({
             )}
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            <Button variant="ghost" size="sm" onClick={onGenerate}>
-              <Icon size="sm">
-                <Sparkles />
-              </Icon>
+            <Button variant="ghost" size="sm" onClick={onGenerate} icon={<Sparkles />}>
               Generate
             </Button>
             <Button
@@ -714,10 +711,7 @@ function ExpandedItemEditor({
             )}
             Save
           </Button>
-          <Button variant="ghost" size="sm" onClick={cancelEditing}>
-            <Icon size="sm">
-              <X />
-            </Icon>
+          <Button variant="ghost" size="sm" onClick={cancelEditing} icon={<X />}>
             Cancel
           </Button>
         </div>
@@ -756,10 +750,7 @@ function ExpandedItemEditor({
         </div>
       )}
       <div className="flex items-center gap-2 pt-1">
-        <Button variant="ghost" size="sm" onClick={startEditing}>
-          <Icon size="sm">
-            <Pencil />
-          </Icon>
+        <Button variant="ghost" size="sm" onClick={startEditing} icon={<Pencil />}>
           Edit
         </Button>
         {isConfirmingDelete ? (
@@ -786,10 +777,8 @@ function ExpandedItemEditor({
             size="sm"
             onClick={() => setIsConfirmingDelete(true)}
             className="text-neutral2 hover:text-negative1"
+            icon={<Trash2 />}
           >
-            <Icon size="sm">
-              <Trash2 />
-            </Icon>
             Delete
           </Button>
         )}

--- a/packages/playground/src/domains/agents/components/agent-playground/scorer-detail-view.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/scorer-detail-view.tsx
@@ -3,7 +3,6 @@ import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Switch } from '@mastra/playground-ui/components/Switch';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { Pencil } from 'lucide-react';
 
 interface LinkedDataset {
@@ -74,10 +73,7 @@ export function ScorerDetailView({
           </div>
           <div className="flex shrink-0 items-center gap-3">
             {!isCode && (
-              <Button variant="ghost" size="sm" onClick={onEdit}>
-                <Icon size="sm">
-                  <Pencil />
-                </Icon>
+              <Button variant="ghost" size="sm" onClick={onEdit} icon={<Pencil />}>
                 Edit
               </Button>
             )}

--- a/packages/playground/src/domains/agents/components/agent-playground/scorer-mini-editor.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/scorer-mini-editor.tsx
@@ -374,10 +374,7 @@ export function ScorerMiniEditor({
     <div className="flex h-full flex-col">
       {/* Header */}
       <div className="border-border1 flex items-center gap-2 border-b px-4 py-3">
-        <Button variant="ghost" size="sm" onClick={onBack}>
-          <Icon>
-            <ArrowLeft />
-          </Icon>
+        <Button variant="ghost" size="sm" onClick={onBack} icon={<ArrowLeft />}>
           Back
         </Button>
         <Txt as="h3" variant="header-sm" className="ml-2">
@@ -473,10 +470,7 @@ export function ScorerMiniEditor({
                     </Txt>
                   )}
                 </div>
-                <Button variant="outline" size="sm" onClick={addTestItem}>
-                  <Icon>
-                    <Plus />
-                  </Icon>
+                <Button variant="outline" size="sm" onClick={addTestItem} icon={<Plus />}>
                   Add Item
                 </Button>
               </div>

--- a/packages/playground/src/domains/agents/components/agent-playground/scorer-mini-editor.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/scorer-mini-editor.tsx
@@ -10,7 +10,7 @@ import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { useMastraClient } from '@mastra/react';
-import { ArrowLeft, Play, Save, Plus, Trash2, CheckCircle2, XCircle, AlertCircle } from 'lucide-react';
+import { ArrowLeft, Play, Save, Plus, Trash2, CheckCircle2, XCircle, AlertCircle, Check, X } from 'lucide-react';
 import { useState, useCallback, useEffect } from 'react';
 
 import { useAgentEditFormContext } from '../../context/agent-edit-form-context';
@@ -716,7 +716,13 @@ export function ScorerMiniEditor({
             </Button>
           </>
         )}
-        <Button variant="ghost" size="sm" onClick={onBack} className="ml-auto">
+        <Button
+          icon={isEditing || savedScorerId ? <Check /> : <X />}
+          variant="ghost"
+          size="sm"
+          onClick={onBack}
+          className="ml-auto"
+        >
           {isEditing || savedScorerId ? 'Done' : 'Cancel'}
         </Button>
       </div>

--- a/packages/playground/src/domains/agents/components/agent-top-bar-controls.tsx
+++ b/packages/playground/src/domains/agents/components/agent-top-bar-controls.tsx
@@ -18,8 +18,8 @@ export function AgentTopBarRunOptions({ requestContextSchema }: AgentTopBarRunOp
           type="button"
           tooltip="Run options"
           data-testid="agent-top-bar-run-options-trigger"
+          icon={<Settings2 />}
         >
-          <Settings2 />
           Run options
         </Button>
       </PopoverTrigger>

--- a/packages/playground/src/domains/agents/components/agent-view-header.tsx
+++ b/packages/playground/src/domains/agents/components/agent-view-header.tsx
@@ -40,10 +40,7 @@ export function AgentViewHeader({ agentId }: AgentViewHeaderProps) {
         </div>
         <div className="ml-auto flex shrink-0 items-center gap-2 py-2">
           {showEditButton && (
-            <Button variant="outline" size="sm" as={FrameworkLink} to={editPath}>
-              <Icon size="sm">
-                <Pencil />
-              </Icon>
+            <Button variant="outline" size="sm" as={FrameworkLink} to={editPath} icon={<Pencil />}>
               Edit
             </Button>
           )}

--- a/packages/playground/src/domains/agents/components/composer-model-settings.tsx
+++ b/packages/playground/src/domains/agents/components/composer-model-settings.tsx
@@ -10,7 +10,7 @@ import { Slider } from '@mastra/playground-ui/components/Slider';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { Info, Sliders } from 'lucide-react';
+import { Info, Sliders, Settings2, RotateCcw } from 'lucide-react';
 import { useState } from 'react';
 
 import { useAgentSettings } from '../context/agent-context';
@@ -345,6 +345,7 @@ export const ComposerModelSettings = ({ agentId }: ComposerModelSettingsProps) =
 
               <div className="flex items-center justify-between gap-2 pt-1">
                 <Button
+                  icon={<RotateCcw />}
                   variant="ghost"
                   size="sm"
                   type="button"
@@ -354,6 +355,7 @@ export const ComposerModelSettings = ({ agentId }: ComposerModelSettingsProps) =
                   Reset
                 </Button>
                 <Button
+                  icon={<Settings2 />}
                   variant="default"
                   size="sm"
                   type="button"

--- a/packages/playground/src/domains/agents/components/memory-sidebar/agent-memory.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/agent-memory.tsx
@@ -121,8 +121,7 @@ export function AgentMemory({ agentId, threadId, memoryType }: AgentMemoryProps)
               <h3 className="text-neutral5 text-ui-md font-medium">Clone Thread</h3>
               <p className="text-neutral3 text-ui-sm mt-1">Create a copy of this conversation</p>
             </div>
-            <Button onClick={handleCloneThread} disabled={isCloning}>
-              <GitFork className="mr-2 h-4 w-4" />
+            <Button onClick={handleCloneThread} disabled={isCloning} icon={<GitFork />}>
               {isCloning ? 'Cloning...' : 'Clone'}
             </Button>
           </div>

--- a/packages/playground/src/domains/agents/components/memory-sidebar/agent-observational-memory.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/agent-observational-memory.tsx
@@ -490,10 +490,10 @@ export const AgentObservationalMemory = ({ agentId, resourceId, threadId }: Agen
       />
       <Button
         size="sm"
-        className="w-full justify-center gap-2"
+        className="w-full justify-center"
         onClick={() => (isDetailViewOpen ? closeDetailView() : openDetailView())}
+        icon={<Brain />}
       >
-        <Brain className="h-3.5 w-3.5" />
         Analyze Observations
       </Button>
     </div>

--- a/packages/playground/src/domains/agents/components/memory-sidebar/agent-working-memory.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/agent-working-memory.tsx
@@ -6,7 +6,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/c
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { toast } from '@mastra/playground-ui/utils/toast';
-import { RefreshCcwIcon, ExternalLink } from 'lucide-react';
+import { RefreshCcwIcon, ExternalLink, X, Pencil } from 'lucide-react';
 import { useState } from 'react';
 import { useWorkingMemory } from '../../context/agent-working-memory-context';
 import { CodeDisplay } from './code-display';
@@ -139,6 +139,7 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button
+                        icon={<Pencil />}
                         type="button"
                         aria-disabled="true"
                         onClick={event => event.preventDefault()}
@@ -152,7 +153,12 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
                     </TooltipContent>
                   </Tooltip>
                 ) : (
-                  <Button onClick={() => setIsEditing(true)} disabled={isUpdating} className="text-ui-sm">
+                  <Button
+                    icon={<Pencil />}
+                    onClick={() => setIsEditing(true)}
+                    disabled={isUpdating}
+                    className="text-ui-sm"
+                  >
                     Edit Working Memory
                   </Button>
                 )}
@@ -175,6 +181,7 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
                   {isUpdating ? <RefreshCcwIcon className="h-3 w-3 animate-spin" /> : 'Save Changes'}
                 </Button>
                 <Button
+                  icon={<X />}
                   onClick={() => {
                     setEditState({ source: workingMemoryData, value: workingMemoryData ?? '' });
                     setIsEditing(false);

--- a/packages/playground/src/domains/agents/components/memory-sidebar/memory-sidebar.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/memory-sidebar.tsx
@@ -7,7 +7,7 @@ import { Txt } from '@mastra/playground-ui/components/Txt';
 import { useObservationalMemory } from '@mastra/playground-ui/domains/memory/hooks/use-observational-memory';
 import { MemoryIcon } from '@mastra/playground-ui/icons/MemoryIcon';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { ChevronDown, ChevronUp, Eye, MessageSquare, NotebookPen, Search } from 'lucide-react';
+import { ChevronDown, ChevronUp, Eye, MessageSquare, NotebookPen, Search, ExternalLink } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useLayoutEffect, useRef, useState } from 'react';
 import { AgentCapabilitiesFooter } from './agent-capabilities-footer';
@@ -239,6 +239,7 @@ export function MemorySidebarBody({
                 descriptionSlot="Conversations are only saved as threads when the agent has memory configured."
                 actionSlot={
                   <Button
+                    icon={<ExternalLink />}
                     as="a"
                     href="https://mastra.ai/docs/memory/overview"
                     target="_blank"

--- a/packages/playground/src/domains/agents/components/request-context.tsx
+++ b/packages/playground/src/domains/agents/components/request-context.tsx
@@ -10,7 +10,7 @@ import { cn } from '@mastra/playground-ui/utils/cn';
 import { formatJSON, isValidJson } from '@mastra/playground-ui/utils/formatting';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import CodeMirror from '@uiw/react-codemirror';
-import { Braces, CopyIcon, ExternalLink, X } from 'lucide-react';
+import { Braces, CopyIcon, ExternalLink, X, Check } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { RequestContextLabel } from '@/domains/request-context/components/request-context-label';
@@ -206,7 +206,7 @@ export const RequestContext = ({ editorClassName = 'h-[400px]', labelTooltip }: 
               <X />
             </Button>
           )}
-          <Button type="button" onClick={handleSaveRequestContext} disabled={!isRequestContextDirty}>
+          <Button icon={<Check />} type="button" onClick={handleSaveRequestContext} disabled={!isRequestContextDirty}>
             Save
           </Button>
         </div>

--- a/packages/playground/src/domains/auth/components/login-button.tsx
+++ b/packages/playground/src/domains/auth/components/login-button.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@mastra/playground-ui/components/Button';
+import { LogIn } from 'lucide-react';
 import { useSSOLogin } from '../hooks';
 import type { LoginConfig, SSOConfig } from '../types';
 import { withStudioBasePath } from '@/lib/studio-base-path';
@@ -22,6 +23,7 @@ export type LoginButtonProps = {
  * ```tsx
  * import { LoginButton } from '@/domains/auth/components/login-button';
 import { useAuthCapabilities } from '@/domains/auth/hooks/use-auth-capabilities';
+import { LogIn } from 'lucide-react';
  *
  * function LoginPage() {
  *   const { data: capabilities } = useAuthCapabilities();
@@ -75,7 +77,7 @@ export function LoginButton({ config, redirectUri, className, loginUrl = '/login
   };
 
   return (
-    <Button onClick={handleCredentialsLogin} className={className}>
+    <Button icon={<LogIn />} onClick={handleCredentialsLogin} className={className}>
       Sign in
     </Button>
   );

--- a/packages/playground/src/domains/auth/components/login-page.tsx
+++ b/packages/playground/src/domains/auth/components/login-page.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Input } from '@mastra/playground-ui/components/Input';
-import { Lock } from 'lucide-react';
+import { Lock, LogIn } from 'lucide-react';
 import { useState } from 'react';
 import { useSSOLogin } from '../hooks/use-auth-actions';
 import { useAuthCapabilities } from '../hooks/use-auth-capabilities';
@@ -185,7 +185,7 @@ export function LoginPage({ redirectUri, onSuccess, initialMode = 'signin', erro
 
           {error && <div className="text-ui-md rounded-md bg-red-500/10 p-3 text-red-400">{error.message}</div>}
 
-          <Button type="submit" disabled={isPending} className="w-full" size="lg">
+          <Button icon={<LogIn />} type="submit" disabled={isPending} className="w-full" size="lg">
             {isPending ? (isSignIn ? 'Signing in...' : 'Creating account...') : isSignIn ? 'Sign in' : 'Create account'}
           </Button>
 

--- a/packages/playground/src/domains/auth/components/route-permissions-gate.tsx
+++ b/packages/playground/src/domains/auth/components/route-permissions-gate.tsx
@@ -2,6 +2,7 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 
+import { RotateCcw } from 'lucide-react';
 import { usePermissionPatterns } from '../hooks/use-permission-patterns';
 import { ALL_SIDEBAR_PERMISSIONS } from '../route-permissions';
 import { MASTRA_STUDIO_CONFIG_LOCAL_STORAGE_KEY } from '@/domains/configuration/context/studio-config-context';
@@ -90,7 +91,11 @@ const GateInvalidBaseUrl = ({ error, baseUrl }: GateInvalidBaseUrlProps) => {
       <ErrorState
         title="Failed to load studio"
         message={messages.join('\n\n')}
-        action={<Button onClick={handleReset}>Reset Studio Configuration</Button>}
+        action={
+          <Button icon={<RotateCcw />} onClick={handleReset}>
+            Reset Studio Configuration
+          </Button>
+        }
       />
     </div>
   );

--- a/packages/playground/src/domains/auth/components/user-menu.tsx
+++ b/packages/playground/src/domains/auth/components/user-menu.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Popover, PopoverContent, PopoverTrigger } from '@mastra/playground-ui/components/Popover';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { Loader2, Settings, X } from 'lucide-react';
+import { Loader2, Settings, X, LogOut } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router';
 
@@ -115,7 +115,13 @@ export function UserMenu({ user }: UserMenuProps) {
           >
             Settings
           </Button>
-          <Button variant="ghost" onClick={handleLogout} disabled={isPending} className="w-full justify-start">
+          <Button
+            icon={<LogOut />}
+            variant="ghost"
+            onClick={handleLogout}
+            disabled={isPending}
+            className="w-full justify-start"
+          >
             {isPending ? 'Signing out...' : 'Sign out'}
           </Button>
         </div>

--- a/packages/playground/src/domains/auth/components/user-menu.tsx
+++ b/packages/playground/src/domains/auth/components/user-menu.tsx
@@ -111,8 +111,8 @@ export function UserMenu({ user }: UserMenuProps) {
             variant="ghost"
             className="w-full justify-start"
             onClick={() => setOpen(false)}
+            icon={<Settings />}
           >
-            <Settings className="h-4 w-4" />
             Settings
           </Button>
           <Button variant="ghost" onClick={handleLogout} disabled={isPending} className="w-full justify-start">

--- a/packages/playground/src/domains/configuration/components/header-list-form.tsx
+++ b/packages/playground/src/domains/configuration/components/header-list-form.tsx
@@ -40,8 +40,8 @@ export const HeaderListForm = ({ headers, onAddHeader, onRemoveHeader }: HeaderL
             onClick={() => onAddHeader({ name: '', value: '' })}
             size={headers.length === 0 ? 'md' : 'sm'}
             className=""
+            icon={<Plus />}
           >
-            <Plus />
             {headers.length === 0 ? 'Add Header' : 'Add Another Header'}
           </Button>
         </div>

--- a/packages/playground/src/domains/configuration/components/studio-config-form.tsx
+++ b/packages/playground/src/domains/configuration/components/studio-config-form.tsx
@@ -70,8 +70,7 @@ export const StudioConfigForm = ({ initialConfig, onSave }: StudioConfigFormProp
 
         <HeaderListForm headers={headers} onAddHeader={handleAddHeader} onRemoveHeader={handleRemoveHeader} />
 
-        <Button type="submit" className="mt-10! ml-auto">
-          <SaveIcon />
+        <Button type="submit" className="mt-10! ml-auto" icon={<SaveIcon />}>
           Save Configuration
         </Button>
       </form>

--- a/packages/playground/src/domains/datasets/components/add-item-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/add-item-dialog.tsx
@@ -6,6 +6,7 @@ import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { Label } from '@mastra/playground-ui/components/Label';
 import { SideDialog } from '@mastra/playground-ui/components/SideDialog';
 import { toast } from '@mastra/playground-ui/utils/toast';
+import { Plus, X } from 'lucide-react';
 import { useState } from 'react';
 import { useDatasetMutations } from '../hooks/use-dataset-mutations';
 import { DatasetItemScorerSelector } from './dataset-detail/dataset-item-scorer-selector';
@@ -280,10 +281,10 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
           </div>
 
           <div className="flex justify-end gap-2 pt-4">
-            <Button type="button" onClick={handleCancel}>
+            <Button icon={<X />} type="button" onClick={handleCancel}>
               Cancel
             </Button>
-            <Button type="submit" variant="primary" disabled={addItem.isPending}>
+            <Button icon={<Plus />} type="submit" variant="primary" disabled={addItem.isPending}>
               {addItem.isPending ? 'Adding...' : 'Add Item'}
             </Button>
           </div>

--- a/packages/playground/src/domains/datasets/components/add-items-to-dataset-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/add-items-to-dataset-dialog.tsx
@@ -6,6 +6,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody } from '@m
 import { Label } from '@mastra/playground-ui/components/Label';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@mastra/playground-ui/components/Select';
 import { toast } from '@mastra/playground-ui/utils/toast';
+import { Plus, X } from 'lucide-react';
 import { useState } from 'react';
 import { useDatasetMutations } from '../hooks/use-dataset-mutations';
 import { useDatasets } from '../hooks/use-datasets';
@@ -134,10 +135,11 @@ export function AddItemsToDatasetDialog({
             )}
 
             <div className="flex justify-end gap-2 pt-4">
-              <Button type="button" onClick={handleCancel} disabled={isAdding}>
+              <Button icon={<X />} type="button" onClick={handleCancel} disabled={isAdding}>
                 Cancel
               </Button>
               <Button
+                icon={<Plus />}
                 type="submit"
                 variant="primary"
                 disabled={isAdding || !selectedDatasetId || availableDatasets.length === 0}

--- a/packages/playground/src/domains/datasets/components/bulk-trace-review-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/bulk-trace-review-dialog.tsx
@@ -6,7 +6,7 @@ import { Label } from '@mastra/playground-ui/components/Label';
 import { SideDialog } from '@mastra/playground-ui/components/SideDialog';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { toast } from '@mastra/playground-ui/utils/toast';
-import { ChevronLeftIcon, ChevronRightIcon, DatabaseIcon, Loader2Icon, TrashIcon } from 'lucide-react';
+import { ChevronLeftIcon, ChevronRightIcon, DatabaseIcon, Loader2Icon, TrashIcon, X } from 'lucide-react';
 import { useState, useCallback, useEffect } from 'react';
 import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
 
@@ -195,7 +195,7 @@ export function BulkTraceReviewDialog({
           </div>
 
           <div className="flex justify-end gap-2 pt-4">
-            <Button type="button" variant="outline" onClick={onClose}>
+            <Button icon={<X />} type="button" variant="outline" onClick={onClose}>
               Cancel
             </Button>
             <Button variant="default" disabled={batchInsertItems.isPending} onClick={handleSubmit}>

--- a/packages/playground/src/domains/datasets/components/create-dataset-form.tsx
+++ b/packages/playground/src/domains/datasets/components/create-dataset-form.tsx
@@ -1,7 +1,9 @@
 'use client';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { TextFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
+import { DatasetsIcon } from '@mastra/playground-ui/icons/DatasetsIcon';
 import { toast } from '@mastra/playground-ui/utils/toast';
+import { X } from 'lucide-react';
 import { useState } from 'react';
 import { useDatasetMutations } from '../hooks/use-dataset-mutations';
 import { DEFAULT_SCORERS_HELPER_TEXT, DEFAULT_SCORERS_LABEL } from './default-scorers-copy';
@@ -111,10 +113,15 @@ export function CreateDatasetForm({ onSuccess, onCancel, targetType, targetIds }
       )}
 
       <div className="flex justify-end gap-2 pt-4">
-        <Button type="button" onClick={onCancel}>
+        <Button icon={<X />} type="button" onClick={onCancel}>
           Cancel
         </Button>
-        <Button type="submit" variant="primary" disabled={createDataset.isPending || !name.trim()}>
+        <Button
+          icon={<DatasetsIcon />}
+          type="submit"
+          variant="primary"
+          disabled={createDataset.isPending || !name.trim()}
+        >
           {createDataset.isPending ? 'Creating...' : 'Create Dataset'}
         </Button>
       </div>

--- a/packages/playground/src/domains/datasets/components/create-dataset-from-items-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/create-dataset-from-items-dialog.tsx
@@ -5,7 +5,9 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody } from '@mastra/playground-ui/components/Dialog';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
+import { DatasetsIcon } from '@mastra/playground-ui/icons/DatasetsIcon';
 import { toast } from '@mastra/playground-ui/utils/toast';
+import { X } from 'lucide-react';
 import { useState } from 'react';
 import { useDatasetMutations } from '../hooks/use-dataset-mutations';
 
@@ -134,10 +136,10 @@ export function CreateDatasetFromItemsDialog({
             )}
 
             <div className="flex justify-end gap-2 pt-4">
-              <Button type="button" onClick={handleCancel} disabled={isCreating}>
+              <Button icon={<X />} type="button" onClick={handleCancel} disabled={isCreating}>
                 Cancel
               </Button>
-              <Button type="submit" variant="primary" disabled={isCreating || !name.trim()}>
+              <Button icon={<DatasetsIcon />} type="submit" variant="primary" disabled={isCreating || !name.trim()}>
                 {isCreating ? `Creating... (${progress}/${items.length})` : 'Create Dataset'}
               </Button>
             </div>

--- a/packages/playground/src/domains/datasets/components/csv-import/csv-import-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/csv-import/csv-import-dialog.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mastra/playground-ui/components/Dialog';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { toast } from '@mastra/playground-ui/utils/toast';
+import { Check, Upload, ChevronLeft, ChevronRight, X } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import type { ColumnMapping, FieldType } from '../../hooks/use-column-mapping';
 import { useColumnMapping } from '../../hooks/use-column-mapping';
@@ -438,13 +439,19 @@ export function CSVImportDialog({ datasetId, open, onOpenChange, onSuccess }: CS
   const renderFooter = () => {
     switch (step) {
       case 'upload':
-        return <Button onClick={handleClose}>Cancel</Button>;
+        return (
+          <Button icon={<X />} onClick={handleClose}>
+            Cancel
+          </Button>
+        );
 
       case 'preview':
         return (
           <>
-            <Button onClick={() => setStep('upload')}>Back</Button>
-            <Button variant="primary" onClick={() => setStep('mapping')}>
+            <Button icon={<ChevronLeft />} onClick={() => setStep('upload')}>
+              Back
+            </Button>
+            <Button icon={<ChevronRight />} variant="primary" onClick={() => setStep('mapping')}>
               Next
             </Button>
           </>
@@ -453,8 +460,15 @@ export function CSVImportDialog({ datasetId, open, onOpenChange, onSuccess }: CS
       case 'mapping':
         return (
           <>
-            <Button onClick={() => setStep('preview')}>Back</Button>
-            <Button variant="primary" onClick={handleValidateMapping} disabled={!columnMapping.isInputMapped}>
+            <Button icon={<ChevronLeft />} onClick={() => setStep('preview')}>
+              Back
+            </Button>
+            <Button
+              icon={<ChevronRight />}
+              variant="primary"
+              onClick={handleValidateMapping}
+              disabled={!columnMapping.isInputMapped}
+            >
               {dataset?.inputSchema || dataset?.groundTruthSchema ? 'Validate' : 'Next'}
             </Button>
           </>
@@ -463,8 +477,11 @@ export function CSVImportDialog({ datasetId, open, onOpenChange, onSuccess }: CS
       case 'validation':
         return (
           <>
-            <Button onClick={() => setStep('mapping')}>Back</Button>
+            <Button icon={<ChevronLeft />} onClick={() => setStep('mapping')}>
+              Back
+            </Button>
             <Button
+              icon={<Upload />}
               variant="primary"
               onClick={handleImport}
               disabled={!schemaValidation || schemaValidation.validCount === 0}
@@ -481,7 +498,7 @@ export function CSVImportDialog({ datasetId, open, onOpenChange, onSuccess }: CS
 
       case 'complete':
         return (
-          <Button variant="primary" onClick={handleDone}>
+          <Button icon={<Check />} variant="primary" onClick={handleDone}>
             Done
           </Button>
         );

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-header.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-header.tsx
@@ -74,8 +74,7 @@ export function DatasetHeader({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span className="cursor-not-allowed">
-                    <Button disabled tabIndex={-1}>
-                      <Play />
+                    <Button disabled tabIndex={-1} icon={<Play />}>
                       Run Experiment
                     </Button>
                   </span>
@@ -83,8 +82,7 @@ export function DatasetHeader({
                 <TooltipContent>Add items to the dataset before running an experiment</TooltipContent>
               </Tooltip>
             ) : (
-              <Button onClick={onExperimentClick}>
-                <Play />
+              <Button onClick={onExperimentClick} icon={<Play />}>
                 Run Experiment
               </Button>
             )

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-item-form.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-item-form.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { Label } from '@mastra/playground-ui/components/Label';
-import { Pencil } from 'lucide-react';
+import { Pencil, X, Check } from 'lucide-react';
 import { DatasetItemScorerSelector } from './dataset-item-scorer-selector';
 
 /** Schema validation error from API */
@@ -164,10 +164,10 @@ export function EditModeContent({
         </div>
 
         <div className="flex gap-2 pt-4">
-          <Button variant="primary" onClick={onSave} disabled={isSaving}>
+          <Button icon={<Check />} variant="primary" onClick={onSave} disabled={isSaving}>
             {isSaving ? 'Saving...' : 'Save Changes'}
           </Button>
-          <Button onClick={onCancel} disabled={isSaving}>
+          <Button icon={<X />} onClick={onCancel} disabled={isSaving}>
             Cancel
           </Button>
         </div>

--- a/packages/playground/src/domains/datasets/components/dataset-detail/item-detail-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/item-detail-dialog.tsx
@@ -20,6 +20,8 @@ import {
   Pencil,
   Trash2,
   Eraser,
+  Check,
+  X,
 } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { useDatasetMutations } from '../../hooks/use-dataset-mutations';
@@ -293,6 +295,7 @@ export function ItemDetailDialog({
                 preventDefault, which would hide the pending state and a failed
                 purge behind a toast. */}
             <Button
+              icon={<Trash2 />}
               variant="primary"
               size="lg"
               onClick={() => void handlePurgeConfirm()}
@@ -459,10 +462,10 @@ function EditModeContent({
         </div>
 
         <div className="flex justify-end gap-2 pt-4">
-          <Button onClick={onCancel} disabled={isSaving}>
+          <Button icon={<X />} onClick={onCancel} disabled={isSaving}>
             Cancel
           </Button>
-          <Button variant="primary" onClick={onSave} disabled={isSaving}>
+          <Button icon={<Check />} variant="primary" onClick={onSave} disabled={isSaving}>
             {isSaving ? 'Saving...' : 'Save Changes'}
           </Button>
         </div>

--- a/packages/playground/src/domains/datasets/components/dataset-detail/item-detail-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/item-detail-dialog.tsx
@@ -8,7 +8,6 @@ import { Sections } from '@mastra/playground-ui/components/Sections';
 import { SideDialog } from '@mastra/playground-ui/components/SideDialog';
 import type { SideDialogRootProps } from '@mastra/playground-ui/components/SideDialog';
 import { TextAndIcon, getShortId } from '@mastra/playground-ui/components/Text';
-import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { format } from 'date-fns/format';
 import {
@@ -225,22 +224,13 @@ export function ItemDetailDialog({
         <SideDialog.Nav onNext={toNextItem()} onPrevious={toPreviousItem()} />
         {!isEditing && (
           <div className="ml-auto flex items-center gap-2">
-            <Button variant="outline" size="sm" onClick={handleEdit}>
-              <Icon>
-                <Pencil />
-              </Icon>
+            <Button variant="outline" size="sm" onClick={handleEdit} icon={<Pencil />}>
               Edit
             </Button>
-            <Button variant="outline" size="sm" onClick={handleDelete}>
-              <Icon>
-                <Trash2 />
-              </Icon>
+            <Button variant="outline" size="sm" onClick={handleDelete} icon={<Trash2 />}>
               Delete
             </Button>
-            <Button variant="destructive" size="sm" onClick={() => setShowPurgeConfirm(true)}>
-              <Icon>
-                <Eraser />
-              </Icon>
+            <Button variant="destructive" size="sm" onClick={() => setShowPurgeConfirm(true)} icon={<Eraser />}>
               Purge Data
             </Button>
           </div>

--- a/packages/playground/src/domains/datasets/components/dataset-detail/item-page-toolbar.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/item-page-toolbar.tsx
@@ -18,8 +18,8 @@ export function ItemPageToolbar({ onBack, onEdit, onDelete, isEditing = false }:
     <div className="flex items-center justify-between">
       {/* Left side: Back button */}
       <div className="flex items-center gap-2">
-        <Button variant="outline" size="md" onClick={onBack} aria-label="Back to dataset">
-          <ArrowLeft /> Back
+        <Button variant="outline" size="md" onClick={onBack} aria-label="Back to dataset" icon={<ArrowLeft />}>
+          Back
         </Button>
       </div>
 
@@ -27,8 +27,7 @@ export function ItemPageToolbar({ onBack, onEdit, onDelete, isEditing = false }:
       <div className="flex items-center gap-2">
         {!isEditing && (
           <div className="flex items-center gap-[2px]">
-            <Button variant="outline" size="md" onClick={onEdit}>
-              <Pencil />
+            <Button variant="outline" size="md" onClick={onEdit} icon={<Pencil />}>
               Edit
             </Button>
 
@@ -44,14 +43,13 @@ export function ItemPageToolbar({ onBack, onEdit, onDelete, isEditing = false }:
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="w-full justify-start gap-2 text-red-500 hover:text-red-400"
+                    className="w-full justify-start text-red-500 hover:text-red-400"
                     onClick={onDelete}
+                    icon={<Trash2 />}
                   >
-                    <Trash2 />
                     Delete Item
                   </Button>
-                  <Button variant="ghost" size="sm" className="w-full justify-start gap-2" disabled>
-                    <Copy />
+                  <Button variant="ghost" size="sm" className="w-full justify-start" disabled icon={<Copy />}>
                     Duplicate Item (Coming Soon)
                   </Button>
                 </div>

--- a/packages/playground/src/domains/datasets/components/dataset-detail/items-list-actions.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/items-list-actions.tsx
@@ -44,34 +44,28 @@ export function ActionsMenu({
           <Button
             variant="ghost"
             size="sm"
-            className="w-full justify-start gap-2"
+            className="w-full justify-start"
             onClick={() => handleAction(onExportClick)}
+            icon={<Download />}
           >
-            <Icon>
-              <Download className="h-4 w-4" />
-            </Icon>
             Export
           </Button>
           <Button
             variant="ghost"
             size="sm"
-            className="w-full justify-start gap-2"
+            className="w-full justify-start"
             onClick={() => handleAction(onCreateDatasetClick)}
+            icon={<FolderPlus />}
           >
-            <Icon>
-              <FolderPlus className="h-4 w-4" />
-            </Icon>
             Create Dataset
           </Button>
           <Button
             variant="ghost"
             size="sm"
-            className="w-full justify-start gap-2 text-red-500 hover:text-red-400"
+            className="w-full justify-start text-red-500 hover:text-red-400"
             onClick={() => handleAction(onDeleteClick)}
+            icon={<Trash2 />}
           >
-            <Icon>
-              <Trash2 className="h-4 w-4" />
-            </Icon>
             Delete
           </Button>
         </div>

--- a/packages/playground/src/domains/datasets/components/datasets-list/no-datasets-info.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/no-datasets-info.tsx
@@ -20,8 +20,7 @@ export const NoDatasetsInfo = ({ onCreateClick }: NoDatasetsInfoProps = {}) => (
       actionSlot={
         <div className="flex flex-col items-center gap-2">
           {onCreateClick && (
-            <Button variant="primary" onClick={onCreateClick}>
-              <Plus />
+            <Button variant="primary" onClick={onCreateClick} icon={<Plus />}>
               Create Dataset
             </Button>
           )}
@@ -31,8 +30,9 @@ export const NoDatasetsInfo = ({ onCreateClick }: NoDatasetsInfoProps = {}) => (
             href="https://mastra.ai/docs/evals/datasets"
             target="_blank"
             rel="noopener noreferrer"
+            icon={<ExternalLinkIcon />}
           >
-            Datasets Documentation <ExternalLinkIcon />
+            Datasets Documentation
           </Button>
         </div>
       }

--- a/packages/playground/src/domains/datasets/components/datasets-toolbar.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-toolbar.tsx
@@ -67,14 +67,13 @@ export function DatasetsToolbar({
           />
         )}
         {onReset && hasActiveFilters && (
-          <Button onClick={onReset} size="sm" variant="default">
-            <XIcon className="size-3" /> Reset
+          <Button onClick={onReset} size="sm" variant="default" icon={<XIcon />}>
+            Reset
           </Button>
         )}
       </ButtonsGroup>
       {onCreateClick && (
-        <Button onClick={onCreateClick} variant="primary" className="ml-auto shrink-0">
-          <Plus />
+        <Button onClick={onCreateClick} variant="primary" className="ml-auto shrink-0" icon={<Plus />}>
           Create Dataset
         </Button>
       )}

--- a/packages/playground/src/domains/datasets/components/duplicate-dataset-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/duplicate-dataset-dialog.tsx
@@ -5,6 +5,7 @@ import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { useMastraClient } from '@mastra/react';
+import { Copy, X } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { useDatasetMutations } from '../hooks/use-dataset-mutations';
 
@@ -196,10 +197,10 @@ export function DuplicateDatasetDialog({
             )}
 
             <div className="flex justify-end gap-2 pt-4">
-              <Button type="button" onClick={handleCancel} disabled={isDuplicating}>
+              <Button icon={<X />} type="button" onClick={handleCancel} disabled={isDuplicating}>
                 Cancel
               </Button>
-              <Button type="submit" variant="primary" disabled={isDuplicating || !name.trim()}>
+              <Button icon={<Copy />} type="submit" variant="primary" disabled={isDuplicating || !name.trim()}>
                 {isDuplicating ? 'Duplicating...' : 'Duplicate Dataset'}
               </Button>
             </div>

--- a/packages/playground/src/domains/datasets/components/edit-dataset-form.tsx
+++ b/packages/playground/src/domains/datasets/components/edit-dataset-form.tsx
@@ -2,6 +2,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { TextFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
 import { toast } from '@mastra/playground-ui/utils/toast';
+import { Check, X } from 'lucide-react';
 import { useReducer } from 'react';
 import { useDatasetMutations } from '../hooks/use-dataset-mutations';
 import { DEFAULT_SCORERS_HELPER_TEXT, DEFAULT_SCORERS_LABEL } from './default-scorers-copy';
@@ -174,10 +175,15 @@ export function EditDatasetForm({ dataset, onSuccess, onCancel }: EditDatasetFor
       )}
 
       <div className="flex justify-end gap-2 pt-4">
-        <Button type="button" onClick={onCancel}>
+        <Button icon={<X />} type="button" onClick={onCancel}>
           Cancel
         </Button>
-        <Button type="submit" variant="primary" disabled={updateDataset.isPending || !formState.name.trim()}>
+        <Button
+          icon={<Check />}
+          type="submit"
+          variant="primary"
+          disabled={updateDataset.isPending || !formState.name.trim()}
+        >
           {updateDataset.isPending ? 'Saving...' : 'Save Changes'}
         </Button>
       </div>

--- a/packages/playground/src/domains/datasets/components/empty-datasets-table.tsx
+++ b/packages/playground/src/domains/datasets/components/empty-datasets-table.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
-import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { Plus, CircleSlashIcon, BookOpen } from 'lucide-react';
 
 export interface EmptyDatasetsTableProps {
@@ -17,10 +16,7 @@ export function EmptyDatasetsTable({ onCreateClick }: EmptyDatasetsTableProps) {
         actionSlot={
           <div className="flex flex-col gap-2 sm:flex-row">
             {onCreateClick && (
-              <Button size="lg" variant="default" onClick={onCreateClick}>
-                <Icon>
-                  <Plus />
-                </Icon>
+              <Button size="lg" variant="default" onClick={onCreateClick} icon={<Plus />}>
                 Create Dataset
               </Button>
             )}
@@ -31,10 +27,8 @@ export function EmptyDatasetsTable({ onCreateClick }: EmptyDatasetsTableProps) {
               href="https://mastra.ai/docs/evals/datasets"
               target="_blank"
               rel="noopener noreferrer"
+              icon={<BookOpen />}
             >
-              <Icon>
-                <BookOpen />
-              </Icon>
               Documentation
             </Button>
           </div>

--- a/packages/playground/src/domains/datasets/components/experiment-trigger/experiment-trigger-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/experiment-trigger/experiment-trigger-dialog.tsx
@@ -17,7 +17,7 @@ import { Label } from '@mastra/playground-ui/components/Label';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, X } from 'lucide-react';
 import { useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useDatasetItems } from '../../hooks/use-dataset-items';
@@ -380,7 +380,7 @@ export function ExperimentTriggerDialog({
             )}
           </p>
           <div className="flex items-center gap-2">
-            <Button onClick={handleClose} disabled={isRunning}>
+            <Button icon={<X />} onClick={handleClose} disabled={isRunning}>
               Cancel
             </Button>
             <Button variant="primary" onClick={handleRun} disabled={!canRun || isRunning}>

--- a/packages/playground/src/domains/datasets/components/generate-items-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/generate-items-dialog.tsx
@@ -163,10 +163,7 @@ export function GenerateConfigDialog({ datasetId, agentContext, onDismiss }: Gen
         <DialogFooter className="px-4">
           <div className="flex justify-end gap-2">
             <Button onClick={() => handleClose(false)}>Cancel</Button>
-            <Button variant="primary" onClick={handleGenerate} disabled={!modelId}>
-              <Icon>
-                <Sparkles />
-              </Icon>
+            <Button variant="primary" onClick={handleGenerate} disabled={!modelId} icon={<Sparkles />}>
               Generate
             </Button>
           </div>

--- a/packages/playground/src/domains/datasets/components/generate-items-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/generate-items-dialog.tsx
@@ -17,7 +17,7 @@ import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { toast } from '@mastra/playground-ui/utils/toast';
-import { Sparkles, Trash2, Plus } from 'lucide-react';
+import { Sparkles, Trash2, Plus, X, RotateCcw } from 'lucide-react';
 import { useState, useCallback, useRef } from 'react';
 
 import { useGenerationTasks } from '../context/generation-context';
@@ -162,7 +162,9 @@ export function GenerateConfigDialog({ datasetId, agentContext, onDismiss }: Gen
         </DialogBody>
         <DialogFooter className="px-4">
           <div className="flex justify-end gap-2">
-            <Button onClick={() => handleClose(false)}>Cancel</Button>
+            <Button icon={<X />} onClick={() => handleClose(false)}>
+              Cancel
+            </Button>
             <Button variant="primary" onClick={handleGenerate} disabled={!modelId} icon={<Sparkles />}>
               Generate
             </Button>
@@ -285,7 +287,7 @@ export function GenerateReviewDialog({
                 </Txt>
               </div>
               {onStartOver && (
-                <Button variant="ghost" size="sm" onClick={onStartOver}>
+                <Button icon={<RotateCcw />} variant="ghost" size="sm" onClick={onStartOver}>
                   Start over
                 </Button>
               )}
@@ -339,7 +341,9 @@ export function GenerateReviewDialog({
         </DialogBody>
         <DialogFooter className="px-4">
           <div className="flex justify-end gap-2">
-            <Button onClick={() => handleClose(false)}>Cancel</Button>
+            <Button icon={<X />} onClick={() => handleClose(false)}>
+              Cancel
+            </Button>
             <Button
               variant="primary"
               onClick={handleAddSelected}

--- a/packages/playground/src/domains/datasets/components/items/dataset-items-list.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-items-list.tsx
@@ -230,19 +230,16 @@ function EmptyDatasetItemList({ onAddClick, onImportClick, onImportJsonClick }: 
         actionSlot={
           <div className="flex flex-col items-center gap-2">
             <ButtonsGroup>
-              <Button variant="primary" onClick={onAddClick}>
-                <Plus />
+              <Button variant="primary" onClick={onAddClick} icon={<Plus />}>
                 Add Item
               </Button>
               {onImportClick && (
-                <Button onClick={onImportClick}>
-                  <Upload />
+                <Button onClick={onImportClick} icon={<Upload />}>
                   Import CSV
                 </Button>
               )}
               {onImportJsonClick && (
-                <Button onClick={onImportJsonClick}>
-                  <FileJson />
+                <Button onClick={onImportJsonClick} icon={<FileJson />}>
                   Import JSON
                 </Button>
               )}
@@ -253,8 +250,9 @@ function EmptyDatasetItemList({ onAddClick, onImportClick, onImportJsonClick }: 
               href="https://mastra.ai/docs/evals/datasets"
               target="_blank"
               rel="noopener noreferrer"
+              icon={<ExternalLinkIcon />}
             >
-              Datasets Documentation <ExternalLinkIcon />
+              Datasets Documentation
             </Button>
           </div>
         }

--- a/packages/playground/src/domains/datasets/components/items/dataset-items-toolbar.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-items-toolbar.tsx
@@ -143,8 +143,8 @@ export function DatasetItemsToolbar({
         {selectionDropdown}
         {showItemActions && !isItemPanelOpen && !isViewingOldVersion && (
           <ButtonsGroup spacing="close">
-            <Button onClick={onAddClick}>
-              <Plus /> Add Item
+            <Button onClick={onAddClick} icon={<Plus />}>
+              Add Item
             </Button>
             <DropdownMenu>
               <DropdownMenu.Trigger asChild>

--- a/packages/playground/src/domains/datasets/components/items/dataset-versions-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-versions-panel.tsx
@@ -86,13 +86,14 @@ export function DatasetVersionsPanel({
               disabled={selectedKeys.size !== 2}
               onClick={handleExecuteCompare}
               tooltip={selectedKeys.size !== 2 ? 'Select two versions to enable comparison' : undefined}
+              icon={<ArrowRightIcon />}
             >
-              <ArrowRightIcon /> Compare
+              Compare
             </Button>
           </div>
         ) : (
-          <Button variant="ghost" size="sm" onClick={() => setIsSelectionActive(true)}>
-            <GitCompareIcon /> Compare
+          <Button variant="ghost" size="sm" onClick={() => setIsSelectionActive(true)} icon={<GitCompareIcon />}>
+            Compare
           </Button>
         )}
       </div>

--- a/packages/playground/src/domains/datasets/components/items/dataset-versions-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-versions-panel.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mastra/playground-ui/components/ThreadList';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { format } from 'date-fns';
-import { GitCompareIcon, ArrowRightIcon } from 'lucide-react';
+import { GitCompareIcon, ArrowRightIcon, ChevronDown, X } from 'lucide-react';
 import { useState } from 'react';
 import { useDatasetVersions } from '../../hooks/use-dataset-versions';
 import type { DatasetVersion } from '../../hooks/use-dataset-versions';
@@ -77,7 +77,7 @@ export function DatasetVersionsPanel({
         </Txt>
         {isSelectionActive ? (
           <div className="flex items-center gap-1">
-            <Button variant="ghost" size="sm" onClick={handleCancelSelection}>
+            <Button icon={<X />} variant="ghost" size="sm" onClick={handleCancelSelection}>
               Cancel
             </Button>
             <Button
@@ -151,6 +151,7 @@ export function DatasetVersionsPanel({
               {hasNextPage && (
                 <li>
                   <Button
+                    icon={<ChevronDown />}
                     variant="ghost"
                     size="sm"
                     onClick={() => fetchNextPage()}

--- a/packages/playground/src/domains/datasets/components/json-import/json-format-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/json-import/json-format-panel.tsx
@@ -65,8 +65,16 @@ export function JSONFormatPanel() {
         />
       </div>
 
-      <Button variant="ghost" as="a" href={DOCS_URL} target="_blank" rel="noopener noreferrer" className="self-start">
-        Datasets documentation <ExternalLinkIcon />
+      <Button
+        variant="ghost"
+        as="a"
+        href={DOCS_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="self-start"
+        icon={<ExternalLinkIcon />}
+      >
+        Datasets documentation
       </Button>
     </div>
   );

--- a/packages/playground/src/domains/datasets/components/json-import/json-format-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/json-import/json-format-panel.tsx
@@ -2,7 +2,7 @@ import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
-import { ExternalLinkIcon } from 'lucide-react';
+import { ExternalLinkIcon, Check, Copy } from 'lucide-react';
 
 const DOCS_URL = 'https://mastra.ai/docs/evals/datasets';
 
@@ -50,7 +50,7 @@ export function JSONFormatPanel() {
       <div className="border-border1 overflow-hidden rounded-lg border">
         <div className="border-border1 bg-surface3 flex items-center justify-between border-b py-1.5 pr-1.5 pl-3">
           <span className="text-ui-xs text-neutral4 font-mono">example.json</span>
-          <Button variant="ghost" size="xs" onClick={handleCopy}>
+          <Button icon={isCopied ? <Check /> : <Copy />} variant="ghost" size="xs" onClick={handleCopy}>
             {isCopied ? 'Copied' : 'Copy'}
           </Button>
         </div>

--- a/packages/playground/src/domains/datasets/components/json-import/json-import-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/json-import/json-import-dialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { toast } from '@mastra/playground-ui/utils/toast';
+import { X } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { useDatasetMutations } from '../../hooks/use-dataset-mutations';
@@ -160,7 +161,7 @@ export function JSONImportDialog({ datasetId, datasetName, open, onOpenChange, o
         <DialogFooter className="border-border1 items-center border-t px-4 py-3 sm:justify-between">
           <JSONImportStatus validation={validation} />
           <div className="flex gap-2">
-            <Button onClick={handleClose} disabled={isImporting}>
+            <Button icon={<X />} onClick={handleClose} disabled={isImporting}>
               Cancel
             </Button>
             <Button variant="primary" onClick={handleImport} disabled={validation.status !== 'ready' || isImporting}>

--- a/packages/playground/src/domains/datasets/components/json-import/json-source-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/json-import/json-source-panel.tsx
@@ -3,7 +3,7 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { Tab, TabContent, TabList, Tabs } from '@mastra/playground-ui/components/Tabs';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { FileJson, Upload } from 'lucide-react';
+import { FileJson, Upload, RefreshCw } from 'lucide-react';
 import { useCallback, useState } from 'react';
 
 import { MAX_IMPORT_LABEL } from '../../utils/json-validation';
@@ -183,7 +183,7 @@ function FileCard({
         <FileJson className="text-neutral4 size-4 shrink-0" />
         <span className="text-ui-sm text-neutral6 min-w-0 flex-1 truncate font-mono">{file.name}</span>
         <span className="text-ui-xs text-neutral3 shrink-0">{formatFileSize(file.size)}</span>
-        <Button variant="ghost" size="xs" onClick={onReplace} disabled={isImporting}>
+        <Button icon={<RefreshCw />} variant="ghost" size="xs" onClick={onReplace} disabled={isImporting}>
           Replace
         </Button>
       </div>

--- a/packages/playground/src/domains/datasets/components/save-as-dataset-item-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/save-as-dataset-item-dialog.tsx
@@ -9,7 +9,7 @@ import { SideDialog } from '@mastra/playground-ui/components/SideDialog';
 import type { SideDialogRootProps } from '@mastra/playground-ui/components/SideDialog';
 import { TextAndIcon } from '@mastra/playground-ui/components/Text';
 import { toast } from '@mastra/playground-ui/utils/toast';
-import { DatabaseIcon } from 'lucide-react';
+import { DatabaseIcon, Check, X } from 'lucide-react';
 import { useState, useEffect, useRef } from 'react';
 import type { ReactNode } from 'react';
 import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
@@ -287,10 +287,11 @@ export function SaveAsDatasetItemDialog({
           </div>
 
           <div className="flex justify-end gap-2 pt-4">
-            <Button type="button" variant="outline" onClick={handleCancel}>
+            <Button icon={<X />} type="button" variant="outline" onClick={handleCancel}>
               Cancel
             </Button>
             <Button
+              icon={<Check />}
               type="submit"
               variant="default"
               disabled={addItem.isPending || trajectoryLoading || !selectedDatasetId || datasets.length === 0}

--- a/packages/playground/src/domains/datasets/components/schema-settings/schema-import.tsx
+++ b/packages/playground/src/domains/datasets/components/schema-settings/schema-import.tsx
@@ -157,8 +157,7 @@ export function SchemaImport({ schemaType, onImport }: SchemaImportProps) {
         </Select>
       )}
 
-      <Button size="sm" variant="outline" onClick={handleImport} disabled={!canImport()}>
-        <Download className="h-4 w-4" />
+      <Button size="sm" variant="outline" onClick={handleImport} disabled={!canImport()} icon={<Download />}>
         Import
       </Button>
 

--- a/packages/playground/src/domains/experimental-ui/experimental-ui-manager.tsx
+++ b/packages/playground/src/domains/experimental-ui/experimental-ui-manager.tsx
@@ -19,8 +19,13 @@ export function ExperimentalUIManager({ pathname }: { pathname?: string }) {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button aria-label="Experimental UI" size="sm" className="mr-auto ml-3 bg-blue-600 text-white">
-          <FlaskConicalIcon /> UI
+        <Button
+          aria-label="Experimental UI"
+          size="sm"
+          className="mr-auto ml-3 bg-blue-600 text-white"
+          icon={<FlaskConicalIcon />}
+        >
+          UI
         </Button>
       </PopoverTrigger>
 

--- a/packages/playground/src/domains/experiments/components/delete-experiment-dialog.tsx
+++ b/packages/playground/src/domains/experiments/components/delete-experiment-dialog.tsx
@@ -3,6 +3,7 @@
 import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { toast } from '@mastra/playground-ui/utils/toast';
+import { Trash2 } from 'lucide-react';
 import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
 
 export interface DeleteExperimentDialogProps {
@@ -50,7 +51,13 @@ export function DeleteExperimentDialog({
           {/* Deliberately a Button rather than AlertDialog.Action: Action is a
               Close, which would dismiss the dialog before the request settles
               and hide a failed deletion behind a toast. */}
-          <Button variant="primary" size="lg" onClick={handleDelete} disabled={deleteExperiment.isPending}>
+          <Button
+            icon={<Trash2 />}
+            variant="primary"
+            size="lg"
+            onClick={handleDelete}
+            disabled={deleteExperiment.isPending}
+          >
             {deleteExperiment.isPending ? 'Deleting...' : 'Delete'}
           </Button>
           <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>

--- a/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
@@ -245,26 +245,22 @@ export function ExperimentResultPanel({
             nextLabel="Next result"
           />
           {experimentLink && (
-            <Button size="md" as={Link} to={experimentLink}>
-              <FlaskConical />
+            <Button size="md" as={Link} to={experimentLink} icon={<FlaskConical />}>
               See experiment
             </Button>
           )}
           {result.traceId && onShowTrace && (
-            <Button size="md" onClick={onShowTrace}>
-              <TraceIcon />
+            <Button size="md" onClick={onShowTrace} icon={<TraceIcon />}>
               Trace
             </Button>
           )}
           {canFlag && (
-            <Button size="md" variant="primary" onClick={() => onFlagForReview!(result.id)}>
-              <ClipboardCheck />
+            <Button size="md" variant="primary" onClick={() => onFlagForReview!(result.id)} icon={<ClipboardCheck />}>
               Flag for Review
             </Button>
           )}
           {onComplete && result.status === 'needs-review' && (
-            <Button size="md" variant="primary" onClick={onComplete}>
-              <CheckCircle />
+            <Button size="md" variant="primary" onClick={onComplete} icon={<CheckCircle />}>
               Mark as reviewed
             </Button>
           )}

--- a/packages/playground/src/domains/experiments/components/experiment-results-bulk-actions.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-results-bulk-actions.tsx
@@ -18,8 +18,7 @@ export function ExperimentResultsBulkActions({ selection }: ExperimentResultsBul
 
   return (
     <ButtonsGroup className="whitespace-nowrap">
-      <Button variant="outline" disabled={busy} onClick={selection.flagSelectedForReview}>
-        <ClipboardCheck />
+      <Button variant="outline" disabled={busy} onClick={selection.flagSelectedForReview} icon={<ClipboardCheck />}>
         Flag {selectedIds.size} to review
       </Button>
       <ExperimentResultsTagPicker

--- a/packages/playground/src/domains/experiments/components/experiment-results-bulk-actions.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-results-bulk-actions.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
-import { ClipboardCheck } from 'lucide-react';
+import { ClipboardCheck, X } from 'lucide-react';
 
 import type { ExperimentResultsSelection } from '../hooks/use-experiment-results-selection';
 import { ExperimentResultsTagPicker } from './experiment-results-tag-picker';
@@ -27,7 +27,7 @@ export function ExperimentResultsBulkActions({ selection }: ExperimentResultsBul
         onAddTag={selection.addTagToSelected}
         disabled={busy}
       />
-      <Button variant="ghost" onClick={selection.clearSelection}>
+      <Button icon={<X />} variant="ghost" onClick={selection.clearSelection}>
         Clear
       </Button>
     </ButtonsGroup>

--- a/packages/playground/src/domains/experiments/components/experiment-score-panel.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-score-panel.tsx
@@ -72,8 +72,7 @@ export function ExperimentScorePanel({
             />
           )}
           {onShowTrace && score.traceId && (
-            <Button size="md" onClick={onShowTrace}>
-              <TraceIcon />
+            <Button size="md" onClick={onShowTrace} icon={<TraceIcon />}>
               Trace
             </Button>
           )}

--- a/packages/playground/src/domains/experiments/components/experiment-top-area.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-top-area.tsx
@@ -36,8 +36,7 @@ export function ExperimentTopArea({ experiment, onDeleteClick, children }: Exper
       <PageLayout.Row className="items-center justify-start gap-2">
         <ButtonsGroup className="whitespace-nowrap">
           <RerunExperimentButton experiment={experiment} />
-          <Button as={LinkComponent} to={experimentReviewQueueLink(experiment.id)}>
-            <ClipboardCheck />
+          <Button as={LinkComponent} to={experimentReviewQueueLink(experiment.id)} icon={<ClipboardCheck />}>
             Review queue
           </Button>
           {hasMenu && (

--- a/packages/playground/src/domains/experiments/components/experiment-trace-timeline-tools.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-trace-timeline-tools.tsx
@@ -91,10 +91,8 @@ export function ExperimentTraceTimelineTools({
           <Button
             onClick={() => handleToggle('other' as ExperimentUISpanType)}
             className={fadedTypes?.includes('other') ? 'opacity-40' : ''}
+            icon={<CircleDashedIcon />}
           >
-            <Icon>
-              <CircleDashedIcon />
-            </Icon>
             Other
           </Button>
         )}

--- a/packages/playground/src/domains/experiments/components/experiments-toolbar.tsx
+++ b/packages/playground/src/domains/experiments/components/experiments-toolbar.tsx
@@ -3,7 +3,7 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup, ButtonsGroupText } from '@mastra/playground-ui/components/ButtonsGroup';
 import { SelectFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
-import { GitCompare, Play, XIcon } from 'lucide-react';
+import { GitCompare, Play, XIcon, X } from 'lucide-react';
 import { EXPERIMENT_STATUS_OPTIONS } from './experiments-list-options';
 
 export interface ExperimentsToolbarDatasetOption {
@@ -103,7 +103,9 @@ export function ExperimentsToolbar({
           <Button variant="primary" disabled={!canCompare} onClick={selection.onExecuteCompare} icon={<GitCompare />}>
             Compare Experiments
           </Button>
-          <Button onClick={selection.onCancelSelection}>Cancel</Button>
+          <Button icon={<X />} onClick={selection.onCancelSelection}>
+            Cancel
+          </Button>
         </ButtonsGroup>
       ) : (
         <ButtonsGroup className="ml-auto shrink-0">

--- a/packages/playground/src/domains/experiments/components/experiments-toolbar.tsx
+++ b/packages/playground/src/domains/experiments/components/experiments-toolbar.tsx
@@ -84,8 +84,8 @@ export function ExperimentsToolbar({
           className="whitespace-nowrap"
         />
         {onReset && hasActiveFilters && (
-          <Button onClick={onReset} size="sm" variant="default">
-            <XIcon className="size-3" /> Reset
+          <Button onClick={onReset} size="sm" variant="default" icon={<XIcon />}>
+            Reset
           </Button>
         )}
       </ButtonsGroup>
@@ -100,8 +100,7 @@ export function ExperimentsToolbar({
               <span className="text-accent2">· {selection.compareDisabledReason}</span>
             )}
           </ButtonsGroupText>
-          <Button variant="primary" disabled={!canCompare} onClick={selection.onExecuteCompare}>
-            <GitCompare />
+          <Button variant="primary" disabled={!canCompare} onClick={selection.onExecuteCompare} icon={<GitCompare />}>
             Compare Experiments
           </Button>
           <Button onClick={selection.onCancelSelection}>Cancel</Button>
@@ -109,14 +108,16 @@ export function ExperimentsToolbar({
       ) : (
         <ButtonsGroup className="ml-auto shrink-0">
           {onCompareClick && (
-            <Button onClick={onCompareClick} tooltip="Select two experiments of the same dataset to compare">
-              <GitCompare />
+            <Button
+              onClick={onCompareClick}
+              tooltip="Select two experiments of the same dataset to compare"
+              icon={<GitCompare />}
+            >
               Compare
             </Button>
           )}
           {onRunClick && (
-            <Button onClick={onRunClick} tooltip={runTooltip} variant="primary">
-              <Play />
+            <Button onClick={onRunClick} tooltip={runTooltip} variant="primary" icon={<Play />}>
               Run Experiment
             </Button>
           )}

--- a/packages/playground/src/domains/experiments/components/no-experiments-info.tsx
+++ b/packages/playground/src/domains/experiments/components/no-experiments-info.tsx
@@ -16,8 +16,7 @@ export const NoExperimentsInfo = ({ onRunExperiment }: { onRunExperiment?: () =>
       actionSlot={
         <div className="flex flex-col items-center gap-2">
           {onRunExperiment && (
-            <Button variant="primary" onClick={onRunExperiment}>
-              <Play />
+            <Button variant="primary" onClick={onRunExperiment} icon={<Play />}>
               Run Experiment
             </Button>
           )}
@@ -27,8 +26,9 @@ export const NoExperimentsInfo = ({ onRunExperiment }: { onRunExperiment?: () =>
             href="https://mastra.ai/docs/evals/experiments"
             target="_blank"
             rel="noopener noreferrer"
+            icon={<ExternalLinkIcon />}
           >
-            Experiments Documentation <ExternalLinkIcon />
+            Experiments Documentation
           </Button>
         </div>
       }

--- a/packages/playground/src/domains/experiments/components/rename-experiment-dialog.tsx
+++ b/packages/playground/src/domains/experiments/components/rename-experiment-dialog.tsx
@@ -4,6 +4,7 @@ import { Dialog, DialogBody, DialogContent, DialogHeader, DialogTitle } from '@m
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
 import { toast } from '@mastra/playground-ui/utils/toast';
+import { Check, X } from 'lucide-react';
 import { useState } from 'react';
 import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
 
@@ -72,10 +73,15 @@ export function RenameExperimentDialog({ experiment, open, onOpenChange }: Renam
             </div>
 
             <div className="flex justify-end gap-2 pt-4">
-              <Button type="button" onClick={() => onOpenChange(false)} disabled={updateExperiment.isPending}>
+              <Button
+                icon={<X />}
+                type="button"
+                onClick={() => onOpenChange(false)}
+                disabled={updateExperiment.isPending}
+              >
                 Cancel
               </Button>
-              <Button type="submit" variant="primary" disabled={!canSave}>
+              <Button icon={<Check />} type="submit" variant="primary" disabled={!canSave}>
                 {updateExperiment.isPending ? 'Saving...' : 'Save'}
               </Button>
             </div>

--- a/packages/playground/src/domains/experiments/components/rerun-experiment-button.tsx
+++ b/packages/playground/src/domains/experiments/components/rerun-experiment-button.tsx
@@ -37,8 +37,8 @@ export function RerunExperimentButton({ experiment }: RerunExperimentButtonProps
         variant="primary"
         onClick={() => setOpen(true)}
         tooltip="Run this experiment again with the same configuration"
+        icon={<Play />}
       >
-        <Play />
         Rerun
       </Button>
       {/* Mounted on demand and keyed on the resolved scorers so the dialog seeds its state

--- a/packages/playground/src/domains/inbox/components/inbox-empty-state.tsx
+++ b/packages/playground/src/domains/inbox/components/inbox-empty-state.tsx
@@ -1,5 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
+import { ExperimentsIcon } from '@mastra/playground-ui/icons/ExperimentsIcon';
+import { TraceIcon } from '@mastra/playground-ui/icons/TraceIcon';
 import { CircleSlashIcon } from 'lucide-react';
 import { Link } from 'react-router';
 
@@ -18,10 +20,10 @@ export function InboxEmptyState() {
         }
         actionSlot={
           <div className="flex items-center gap-2">
-            <Button as={Link} to="/experiments" variant="outline">
+            <Button icon={<ExperimentsIcon />} as={Link} to="/experiments" variant="outline">
               Go to experiments
             </Button>
-            <Button as={Link} to="/traces" variant="outline">
+            <Button icon={<TraceIcon />} as={Link} to="/traces" variant="outline">
               Go to traces
             </Button>
           </div>

--- a/packages/playground/src/domains/inbox/components/inbox-feedback-list.tsx
+++ b/packages/playground/src/domains/inbox/components/inbox-feedback-list.tsx
@@ -7,6 +7,7 @@ import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { useInView } from '@mastra/playground-ui/hooks/use-in-view';
 import { format } from 'date-fns';
+import { ClipboardCheck } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 const COLUMNS = 'minmax(0, 2fr) minmax(0, 1fr) auto minmax(0, 1fr) auto auto';
@@ -128,6 +129,7 @@ export function InboxFeedbackList({
                   <DataList.ActionsCell className="pl-2">
                     {feedbackId ? (
                       <Button
+                        icon={<ClipboardCheck />}
                         variant="ghost"
                         size="sm"
                         onClick={() => onMarkReviewed(feedbackId)}

--- a/packages/playground/src/domains/inbox/components/inbox-trace-panel.tsx
+++ b/packages/playground/src/domains/inbox/components/inbox-trace-panel.tsx
@@ -6,7 +6,6 @@ import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { DataPanel } from '@mastra/playground-ui/components/DataPanel';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { useTraceOrBranchSpans } from '@mastra/playground-ui/domains/traces/hooks/use-trace-or-branch-spans';
-import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { format } from 'date-fns/format';
 import { Check } from 'lucide-react';
 import { useState } from 'react';
@@ -84,10 +83,13 @@ export function InboxTracePanel({
               </div>
             </div>
             <ButtonsGroup className="ml-auto shrink-0">
-              <Button variant="primary" size="sm" onClick={onMarkReviewed} disabled={isMarkingReviewed}>
-                <Icon>
-                  <Check />
-                </Icon>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={onMarkReviewed}
+                disabled={isMarkingReviewed}
+                icon={<Check />}
+              >
                 Mark as reviewed
               </Button>
             </ButtonsGroup>

--- a/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-form-sidebar.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-form-sidebar.tsx
@@ -246,8 +246,7 @@ export function MCPClientFormSidebar({
                     </div>
                   ))}
                   {!readOnly && (
-                    <Button variant="outline" size="sm" onClick={addEnvVar} className="w-fit">
-                      <PlusIcon className="mr-1 h-3 w-3" />
+                    <Button variant="outline" size="sm" onClick={addEnvVar} className="w-fit" icon={<PlusIcon />}>
                       Add variable
                     </Button>
                   )}

--- a/packages/playground/src/domains/mcps/components/mcp-client-list/mcp-client-list.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-client-list/mcp-client-list.tsx
@@ -135,10 +135,7 @@ export function MCPClientList() {
           <SubSectionHeader title="MCP Clients" icon={<LaptopMinimal />} />
 
           {!readOnly && (
-            <Button variant="ghost" size="sm" onClick={() => setIsCreateOpen(true)}>
-              <Icon size="sm">
-                <PlusIcon />
-              </Icon>
+            <Button variant="ghost" size="sm" onClick={() => setIsCreateOpen(true)} icon={<PlusIcon />}>
               Add MCP Client
             </Button>
           )}
@@ -156,10 +153,7 @@ export function MCPClientList() {
               titleSlot="No MCP clients configured yet."
               descriptionSlot="Add one to get started."
               actionSlot={
-                <Button variant="outline" size="sm" onClick={() => setIsCreateOpen(true)}>
-                  <Icon size="sm">
-                    <PlusIcon />
-                  </Icon>
+                <Button variant="outline" size="sm" onClick={() => setIsCreateOpen(true)} icon={<PlusIcon />}>
                   Add MCP Client
                 </Button>
               }
@@ -204,10 +198,8 @@ export function MCPClientList() {
                         e.stopPropagation();
                         handleRemove(index);
                       }}
+                      icon={<XIcon />}
                     >
-                      <Icon>
-                        <XIcon />
-                      </Icon>
                       Remove
                     </Button>
                   )}

--- a/packages/playground/src/domains/mcps/components/mcps-list/no-mcp-servers-info.tsx
+++ b/packages/playground/src/domains/mcps/components/mcps-list/no-mcp-servers-info.tsx
@@ -20,8 +20,9 @@ export const NoMCPServersInfo = () => (
           href="https://mastra.ai/docs/tools-mcp/mcp-overview"
           target="_blank"
           rel="noopener noreferrer"
+          icon={<ExternalLinkIcon />}
         >
-          MCP Documentation <ExternalLinkIcon />
+          MCP Documentation
         </Button>
       }
     />

--- a/packages/playground/src/domains/observability/components/add-trace-mocks-to-item-dialog.tsx
+++ b/packages/playground/src/domains/observability/components/add-trace-mocks-to-item-dialog.tsx
@@ -11,7 +11,7 @@ import { TextAndIcon, getShortId } from '@mastra/playground-ui/components/Text';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
-import { EyeIcon, WrenchIcon } from 'lucide-react';
+import { EyeIcon, WrenchIcon, Plus, X } from 'lucide-react';
 import { useState } from 'react';
 import { useDatasetItem, useDatasetItems } from '@/domains/datasets/hooks/use-dataset-items';
 import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
@@ -228,10 +228,11 @@ function AddTraceMocksForm({ initialMocksJson, onClose }: AddTraceMocksFormProps
       </div>
 
       <div className="flex justify-end gap-2 pt-4">
-        <Button type="button" variant="outline" onClick={onClose}>
+        <Button icon={<X />} type="button" variant="outline" onClick={onClose}>
           Cancel
         </Button>
         <Button
+          icon={<Plus />}
           type="submit"
           variant="default"
           disabled={

--- a/packages/playground/src/domains/processors/components/processor-panel.tsx
+++ b/packages/playground/src/domains/processors/components/processor-panel.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import CodeMirror from '@uiw/react-codemirror';
+import { Play } from 'lucide-react';
 import { useState, useId, useEffect } from 'react';
 import type {
   ProcessorDetail,
@@ -181,6 +182,7 @@ function ProcessorDetailPanel({ processor }: ProcessorDetailPanelProps) {
           </div>
 
           <Button
+            icon={<Play />}
             onClick={handleExecute}
             disabled={executeProcessor.isPending || selectedPhase === 'outputStream'}
             className="w-full"

--- a/packages/playground/src/domains/processors/components/processors-list/no-processors-info.tsx
+++ b/packages/playground/src/domains/processors/components/processors-list/no-processors-info.tsx
@@ -15,8 +15,9 @@ export const NoProcessorsInfo = () => (
           href="https://mastra.ai/docs/agents/processors"
           target="_blank"
           rel="noopener noreferrer"
+          icon={<ExternalLinkIcon />}
         >
-          Processors Documentation <ExternalLinkIcon />
+          Processors Documentation
         </Button>
       }
     />

--- a/packages/playground/src/domains/prompt-blocks/components/prompts-list/no-prompt-blocks-info.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/prompts-list/no-prompt-blocks-info.tsx
@@ -30,8 +30,7 @@ export const NoPromptBlocksInfo = () => {
         actionSlot={
           <div className="flex flex-col items-center gap-2">
             {canCreate && (
-              <Button as={Link} to={paths.cmsPromptBlockCreateLink()} variant="primary">
-                <Plus />
+              <Button as={Link} to={paths.cmsPromptBlockCreateLink()} variant="primary" icon={<Plus />}>
                 Create Prompt
               </Button>
             )}
@@ -41,8 +40,9 @@ export const NoPromptBlocksInfo = () => {
               href="https://mastra.ai/docs/editor/overview#prompt-blocks"
               target="_blank"
               rel="noopener noreferrer"
+              icon={<ExternalLinkIcon />}
             >
-              Prompts Documentation <ExternalLinkIcon />
+              Prompts Documentation
             </Button>
           </div>
         }

--- a/packages/playground/src/domains/review/components/dataset-review.tsx
+++ b/packages/playground/src/domains/review/components/dataset-review.tsx
@@ -20,7 +20,7 @@ import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { useMastraClient } from '@mastra/react';
-import { CheckCircle, CircleSlashIcon, EllipsisIcon, Sparkles, Trash2, XIcon } from 'lucide-react';
+import { CheckCircle, CircleSlashIcon, EllipsisIcon, Sparkles, Trash2, XIcon, Check, X } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useState, useMemo, useCallback, useEffect } from 'react';
 import { useReviewItems, useCompletedItems } from '../hooks/use-dataset-review-items';
@@ -536,7 +536,7 @@ export function DatasetReview({
             </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setShowAnalyzeDialog(false)}>
+            <Button icon={<X />} variant="outline" onClick={() => setShowAnalyzeDialog(false)}>
               Cancel
             </Button>
             <Button onClick={handleAnalyze} disabled={!analyzeProvider || !analyzeModel || isAnalyzing}>
@@ -610,10 +610,14 @@ export function DatasetReview({
             })}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setShowProposalDialog(false)}>
+            <Button icon={<X />} variant="outline" onClick={() => setShowProposalDialog(false)}>
               Cancel
             </Button>
-            <Button onClick={handleAcceptProposals} disabled={proposedAssignments.filter(p => p.accepted).length === 0}>
+            <Button
+              icon={<Check />}
+              onClick={handleAcceptProposals}
+              disabled={proposedAssignments.filter(p => p.accepted).length === 0}
+            >
               Accept {proposedAssignments.filter(p => p.accepted).length} proposals
             </Button>
           </DialogFooter>

--- a/packages/playground/src/domains/review/components/dataset-review.tsx
+++ b/packages/playground/src/domains/review/components/dataset-review.tsx
@@ -409,8 +409,8 @@ export function DatasetReview({
           />
         )}
         {hasActiveFilters && (
-          <Button onClick={resetFilters} size="sm" variant="default">
-            <XIcon className="size-3" /> Reset
+          <Button onClick={resetFilters} size="sm" variant="default" icon={<XIcon />}>
+            Reset
           </Button>
         )}
       </ButtonsGroup>
@@ -428,8 +428,7 @@ export function DatasetReview({
                 onRemoveTag={handleBulkRemoveTag}
                 onNewTag={tag => handleBulkTag(tag)}
               />
-              <Button variant="primary" onClick={handleBulkComplete}>
-                <CheckCircle />
+              <Button variant="primary" onClick={handleBulkComplete} icon={<CheckCircle />}>
                 Mark as reviewed
               </Button>
               <DropdownMenu>

--- a/packages/playground/src/domains/scores/components/no-scores-info.tsx
+++ b/packages/playground/src/domains/scores/components/no-scores-info.tsx
@@ -11,8 +11,7 @@ export const NoScoresInfo = ({ onRunExperiment }: { onRunExperiment?: () => void
       actionSlot={
         <div className="flex flex-col items-center gap-2">
           {onRunExperiment && (
-            <Button variant="primary" onClick={onRunExperiment}>
-              <Play />
+            <Button variant="primary" onClick={onRunExperiment} icon={<Play />}>
               Run Experiment
             </Button>
           )}
@@ -22,8 +21,9 @@ export const NoScoresInfo = ({ onRunExperiment }: { onRunExperiment?: () => void
             href="https://mastra.ai/en/docs/evals/overview"
             target="_blank"
             rel="noopener noreferrer"
+            icon={<ExternalLinkIcon />}
           >
-            Scorers Documentation <ExternalLinkIcon />
+            Scorers Documentation
           </Button>
         </div>
       }

--- a/packages/playground/src/domains/scores/components/score-dialog.tsx
+++ b/packages/playground/src/domains/scores/components/score-dialog.tsx
@@ -5,7 +5,6 @@ import { Sections } from '@mastra/playground-ui/components/Sections';
 import { SideDialog } from '@mastra/playground-ui/components/SideDialog';
 import type { SideDialogRootProps } from '@mastra/playground-ui/components/SideDialog';
 import { TextAndIcon, getShortId } from '@mastra/playground-ui/components/Text';
-import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { format } from 'date-fns/format';
 import {
   HashIcon,
@@ -101,10 +100,13 @@ export function ScoreDialog({
           </TextAndIcon>
           |
           <SideDialog.Nav onNext={onNext} onPrevious={onPrevious} />
-          <Button size="lg" className="mr-8 ml-auto" disabled={!score} onClick={() => setDatasetDialogOpen(true)}>
-            <Icon>
-              <SaveIcon />
-            </Icon>
+          <Button
+            size="lg"
+            className="mr-8 ml-auto"
+            disabled={!score}
+            onClick={() => setDatasetDialogOpen(true)}
+            icon={<SaveIcon />}
+          >
             Save as Dataset Item
           </Button>
         </SideDialog.Top>

--- a/packages/playground/src/domains/scores/components/scorers-list/no-scorers-info.tsx
+++ b/packages/playground/src/domains/scores/components/scorers-list/no-scorers-info.tsx
@@ -15,8 +15,9 @@ export const NoScorersInfo = () => (
           href="https://mastra.ai/docs/evals/overview"
           target="_blank"
           rel="noopener noreferrer"
+          icon={<ExternalLinkIcon />}
         >
-          Scorers Documentation <ExternalLinkIcon />
+          Scorers Documentation
         </Button>
       }
     />

--- a/packages/playground/src/domains/scores/components/scorers-list/scorers-toolbar.tsx
+++ b/packages/playground/src/domains/scores/components/scorers-list/scorers-toolbar.tsx
@@ -54,8 +54,8 @@ export function ScorersToolbar({
           className="whitespace-nowrap"
         />
         {onReset && hasActiveFilters && (
-          <Button onClick={handleReset} size="sm" variant="default">
-            <XIcon className="size-3" /> Reset
+          <Button onClick={handleReset} size="sm" variant="default" icon={<XIcon />}>
+            Reset
           </Button>
         )}
       </ButtonsGroup>

--- a/packages/playground/src/domains/scores/components/scores-columns.tsx
+++ b/packages/playground/src/domains/scores/components/scores-columns.tsx
@@ -8,10 +8,7 @@ export function ScoresColumnsMenu({ visibleColumns, toggleColumn }: Omit<ScoresC
   return (
     <DropdownMenu>
       <DropdownMenu.Trigger asChild>
-        <Button>
-          <Columns3Icon />
-          Columns
-        </Button>
+        <Button icon={<Columns3Icon />}>Columns</Button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content align="end">
         <DropdownMenu.Label>Toggle columns</DropdownMenu.Label>

--- a/packages/playground/src/domains/scores/components/scores-tools.tsx
+++ b/packages/playground/src/domains/scores/components/scores-tools.tsx
@@ -34,8 +34,8 @@ export function ScoresTools({ onEntityChange, onReset, selectedEntity, entityOpt
       />
 
       {selectedEntity && selectedEntity.value !== 'all' && (
-        <Button onClick={onReset} disabled={isLoading} size="sm" variant="default">
-          <XIcon className="size-3" /> Reset
+        <Button onClick={onReset} disabled={isLoading} size="sm" variant="default" icon={<XIcon />}>
+          Reset
         </Button>
       )}
     </ButtonsGroup>

--- a/packages/playground/src/domains/shared/components/bulk-tag-picker.tsx
+++ b/packages/playground/src/domains/shared/components/bulk-tag-picker.tsx
@@ -2,7 +2,6 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import type { ButtonProps } from '@mastra/playground-ui/components/Button';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Popover, PopoverTrigger, PopoverContent } from '@mastra/playground-ui/components/Popover';
-import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { Tag, X } from 'lucide-react';
 import { useState } from 'react';
 
@@ -30,10 +29,7 @@ export function BulkTagPicker({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <Button variant="outline" size={size}>
-          <Icon size="sm">
-            <Tag />
-          </Icon>
+        <Button variant="outline" size={size} icon={<Tag />}>
           Tag {selectedCount} items
         </Button>
       </PopoverTrigger>

--- a/packages/playground/src/domains/templates/templates-tools.tsx
+++ b/packages/playground/src/domains/templates/templates-tools.tsx
@@ -71,8 +71,8 @@ export function TemplatesTools({
         options={providerOptions}
       />
       {onReset && (
-        <Button onClick={onReset}>
-          Reset <XIcon />
+        <Button onClick={onReset} icon={<XIcon />}>
+          Reset
         </Button>
       )}
     </div>

--- a/packages/playground/src/domains/tool-providers/components/manage-connection-form.tsx
+++ b/packages/playground/src/domains/tool-providers/components/manage-connection-form.tsx
@@ -66,10 +66,8 @@ export const ManageConnectionForm = ({
             aria-label="Back to connections"
             data-testid={`${testIdPrefix}-back`}
             className="text-neutral3 -mt-1 -ml-1.5 w-fit"
+            icon={<ChevronLeft />}
           >
-            <Icon>
-              <ChevronLeft />
-            </Icon>
             Connections
           </Button>
         )}

--- a/packages/playground/src/domains/tool-providers/components/manage-connection-form.tsx
+++ b/packages/playground/src/domains/tool-providers/components/manage-connection-form.tsx
@@ -6,7 +6,7 @@ import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { toast } from '@mastra/playground-ui/utils/toast';
-import { ChevronLeft, Link2 } from 'lucide-react';
+import { ChevronLeft, Link2, Unplug } from 'lucide-react';
 import { useState } from 'react';
 
 import { useDisconnectConnection } from '../hooks/use-disconnect-connection';
@@ -117,6 +117,7 @@ export const ManageConnectionForm = ({
           </div>
 
           <Button
+            icon={<Unplug />}
             type="button"
             variant="ghost"
             onClick={() => setConfirmDisconnectOpen(true)}
@@ -150,6 +151,7 @@ export const ManageConnectionForm = ({
               Cancel
             </AlertDialog.Cancel>
             <Button
+              icon={<Unplug />}
               type="button"
               variant="primary"
               onClick={disconnect}

--- a/packages/playground/src/domains/tool-providers/components/tool-provider-dialog.tsx
+++ b/packages/playground/src/domains/tool-providers/components/tool-provider-dialog.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { SideDialog } from '@mastra/playground-ui/components/SideDialog';
+import { ToolsIcon } from '@mastra/playground-ui/icons/ToolsIcon';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { SelectedToolList } from './selected-tool-list';
@@ -71,7 +72,7 @@ export function ToolProviderDialog({ provider, onClose, selectedToolIds, onSubmi
       <SideDialog.Header className="px-9 pt-4">
         <SideDialog.Heading>{provider?.name}</SideDialog.Heading>
         {onSubmit && (
-          <Button variant="primary" size="sm" onClick={handleSubmit}>
+          <Button icon={<ToolsIcon />} variant="primary" size="sm" onClick={handleSubmit}>
             {selectionCount > 0 ? `Add ${selectionCount} tool${selectionCount !== 1 ? 's' : ''}` : 'Add tools'}
           </Button>
         )}

--- a/packages/playground/src/domains/tools/components/tools-list/no-tools-info.tsx
+++ b/packages/playground/src/domains/tools/components/tools-list/no-tools-info.tsx
@@ -20,8 +20,9 @@ export const NoToolsInfo = () => (
           href="https://mastra.ai/docs/agents/using-tools-and-mcp"
           target="_blank"
           rel="noopener noreferrer"
+          icon={<ExternalLinkIcon />}
         >
-          Tools Documentation <ExternalLinkIcon />
+          Tools Documentation
         </Button>
       }
     />

--- a/packages/playground/src/domains/traces/components/feedback-thread.tsx
+++ b/packages/playground/src/domains/traces/components/feedback-thread.tsx
@@ -20,7 +20,7 @@ import {
 } from '@mastra/playground-ui/components/Comment';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { format } from 'date-fns';
-import { Trash2Icon } from 'lucide-react';
+import { Trash2Icon, Trash2, ChevronRight, ChevronLeft, ClipboardCheck } from 'lucide-react';
 import { useState } from 'react';
 
 import { ReviewStatusBadge } from '@/domains/review/components/review-status-badge';
@@ -91,6 +91,7 @@ function FeedbackItems({
     const status = <FeedbackReviewStatusBadge status={fb.reviewStatus} />;
     const markReviewed = onMarkReviewed && feedbackId && fb.reviewStatus !== 'reviewed' && (
       <Button
+        icon={<ClipboardCheck />}
         variant="ghost"
         size="sm"
         disabled={pendingFeedbackId === feedbackId}
@@ -241,6 +242,7 @@ export function FeedbackThread({
       {(hasMore || currentPage > 0) && (
         <div className="flex items-center gap-2">
           <Button
+            icon={<ChevronLeft />}
             size="sm"
             variant="ghost"
             disabled={currentPage === 0}
@@ -248,7 +250,13 @@ export function FeedbackThread({
           >
             Previous
           </Button>
-          <Button size="sm" variant="ghost" disabled={!hasMore} onClick={() => onPageChange?.(currentPage + 1)}>
+          <Button
+            icon={<ChevronRight />}
+            size="sm"
+            variant="ghost"
+            disabled={!hasMore}
+            onClick={() => onPageChange?.(currentPage + 1)}
+          >
             Next
           </Button>
         </div>
@@ -269,7 +277,7 @@ export function FeedbackThread({
           </AlertDialog.Header>
           <AlertDialog.Footer>
             <AlertDialog.Cancel disabled={isDeleting}>Cancel</AlertDialog.Cancel>
-            <Button variant="primary" disabled={isDeleting} onClick={handleDeleteConfirm}>
+            <Button icon={<Trash2 />} variant="primary" disabled={isDeleting} onClick={handleDeleteConfirm}>
               {isDeleting ? 'Deleting…' : 'Delete'}
             </Button>
           </AlertDialog.Footer>

--- a/packages/playground/src/domains/traces/components/score-data-panel.tsx
+++ b/packages/playground/src/domains/traces/components/score-data-panel.tsx
@@ -3,7 +3,6 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { DataKeysAndValues } from '@mastra/playground-ui/components/DataKeysAndValues';
 import { DataPanel } from '@mastra/playground-ui/components/DataPanel';
-import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { format } from 'date-fns/format';
 import { FileInputIcon, FileOutputIcon, GaugeIcon, ReceiptText, SaveIcon } from 'lucide-react';
@@ -102,10 +101,7 @@ export function ScoreDataPanel({ score, onClose, onPrevious, onNext }: ScoreData
           </DataKeysAndValues>
 
           <div className="mt-6 mb-6 flex justify-end">
-            <Button size="sm" onClick={() => setDatasetDialogOpen(true)}>
-              <Icon>
-                <SaveIcon />
-              </Icon>
+            <Button size="sm" onClick={() => setDatasetDialogOpen(true)} icon={<SaveIcon />}>
               Save as Dataset Item
             </Button>
           </div>

--- a/packages/playground/src/domains/traces/components/span-scoring.tsx
+++ b/packages/playground/src/domains/traces/components/span-scoring.tsx
@@ -3,6 +3,7 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { SelectFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { TextAndIcon } from '@mastra/playground-ui/components/Text';
+import { ScorersIcon } from '@mastra/playground-ui/icons/ScorersIcon';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { InfoIcon } from 'lucide-react';
 import { useState } from 'react';
@@ -93,7 +94,7 @@ export function SpanScoring({
         )}
       </div>
 
-      <Button disabled={!selectedScorer || isWaiting} onClick={handleStartScoring}>
+      <Button icon={<ScorersIcon />} disabled={!selectedScorer || isWaiting} onClick={handleStartScoring}>
         {isPending ? 'Starting...' : 'Start Scoring'}
       </Button>
     </div>

--- a/packages/playground/src/domains/traces/components/thread-view-by-trace.tsx
+++ b/packages/playground/src/domains/traces/components/thread-view-by-trace.tsx
@@ -323,8 +323,8 @@ function TraceThreadRow({
               variant="ghost"
               size="md"
               className="shrink-0"
+              icon={<ExternalLinkIcon />}
             >
-              <ExternalLinkIcon />
               Go to trace
             </Button>
           </DataPanel.Header>

--- a/packages/playground/src/domains/traces/components/thread-view-by-trace.tsx
+++ b/packages/playground/src/domains/traces/components/thread-view-by-trace.tsx
@@ -15,7 +15,7 @@ import { useTraceSpans } from '@mastra/playground-ui/domains/traces/hooks/use-tr
 import { useTraces } from '@mastra/playground-ui/domains/traces/hooks/use-traces';
 import { useMeasuredAutoHeight } from '@mastra/playground-ui/hooks/use-measured-auto-height';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { ExternalLinkIcon } from 'lucide-react';
+import { ExternalLinkIcon, ChevronUp, ChevronDown } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router';
 
@@ -352,7 +352,7 @@ function TraceThreadRow({
             </div>
             {overflows && isClamped && (
               <div className="from-surface1 via-surface1/80 absolute inset-x-0 bottom-0 flex h-20 items-end justify-center bg-linear-to-t to-transparent pb-2">
-                <Button variant="ghost" size="sm" onClick={() => onExpandedChange(true)}>
+                <Button icon={<ChevronDown />} variant="ghost" size="sm" onClick={() => onExpandedChange(true)}>
                   Show more
                 </Button>
               </div>
@@ -361,7 +361,7 @@ function TraceThreadRow({
           {/* Collapsing would hide the selected span, so the control waits until the panel closes. */}
           {overflows && !isClamped && !isActive && (
             <div className="flex justify-center py-2">
-              <Button variant="ghost" size="sm" onClick={() => onExpandedChange(false)}>
+              <Button icon={<ChevronUp />} variant="ghost" size="sm" onClick={() => onExpandedChange(false)}>
                 Show less
               </Button>
             </div>

--- a/packages/playground/src/domains/traces/components/trace-messages-panel.tsx
+++ b/packages/playground/src/domains/traces/components/trace-messages-panel.tsx
@@ -3,6 +3,7 @@ import { DataPanel } from '@mastra/playground-ui/components/DataPanel';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { cn } from '@mastra/playground-ui/utils/cn';
 
+import { Eye } from 'lucide-react';
 import { TraceThreadItemView } from '@/domains/traces/components/trace-thread-item-view';
 import { Link } from '@/lib/link';
 
@@ -27,7 +28,7 @@ export function TraceMessagesPanel({ traceId, className, fullThreadHref, onHighl
         <div className="flex h-full min-h-0 flex-col">
           {fullThreadHref && (
             <div className="flex justify-center px-3 pt-2">
-              <Button as={Link} href={fullThreadHref} variant="default" size="xs">
+              <Button icon={<Eye />} as={Link} href={fullThreadHref} variant="default" size="xs">
                 View full thread
               </Button>
             </div>

--- a/packages/playground/src/domains/workflows/components/workflow-information.tsx
+++ b/packages/playground/src/domains/workflows/components/workflow-information.tsx
@@ -1,7 +1,6 @@
 import type { GetWorkflowResponse } from '@mastra/client-js';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
-import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { Plus } from 'lucide-react';
 import type { ContextType, ReactNode } from 'react';
@@ -64,10 +63,8 @@ function NewWorkflowRunButton({ workflowId, onClick }: { workflowId: string; onC
         variant="primary"
         className="w-full"
         onClick={onClick}
+        icon={<Plus />}
       >
-        <Icon>
-          <Plus />
-        </Icon>
         New workflow run
       </Button>
     </div>

--- a/packages/playground/src/domains/workflows/components/workflow-tracing-run-options.tsx
+++ b/packages/playground/src/domains/workflows/components/workflow-tracing-run-options.tsx
@@ -4,6 +4,7 @@ import { useCodemirrorTheme } from '@mastra/playground-ui/components/CodeEditor'
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import CodeMirror from '@uiw/react-codemirror';
+import { Check } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTracingSettings } from '@/domains/observability/context/tracing-settings-context';
 
@@ -91,7 +92,7 @@ export const WorkflowTracingRunOptions = ({
       />
 
       <div className="flex items-center justify-end">
-        <Button type="button" onClick={handleSave}>
+        <Button icon={<Check />} type="button" onClick={handleSave}>
           Save
         </Button>
       </div>

--- a/packages/playground/src/domains/workflows/components/workflows-list/no-workflows-info.tsx
+++ b/packages/playground/src/domains/workflows/components/workflows-list/no-workflows-info.tsx
@@ -20,8 +20,9 @@ export const NoWorkflowsInfo = () => (
           href="https://mastra.ai/docs/workflows/overview"
           target="_blank"
           rel="noopener noreferrer"
+          icon={<ExternalLinkIcon />}
         >
-          Workflows Documentation <ExternalLinkIcon />
+          Workflows Documentation
         </Button>
       }
     />

--- a/packages/playground/src/domains/workflows/workflow-header.tsx
+++ b/packages/playground/src/domains/workflows/workflow-header.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ApiIcon } from '@mastra/playground-ui/icons/ApiIcon';
-import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { CalendarClockIcon, EyeIcon } from 'lucide-react';
 import { Link } from 'react-router';
 import { useSchedules } from '@/domains/schedules/hooks/use-schedules';
@@ -18,21 +17,22 @@ export function WorkflowHeader({ workflowName, workflowId }: { workflowName: str
     <RouteHeaderActions owner="workflow-detail">
       <div className="flex items-center gap-2">
         {scheduleCount > 0 && (
-          <Button as={Link} to={schedulesHref} size="sm">
-            <Icon>
-              <CalendarClockIcon />
-            </Icon>
+          <Button as={Link} to={schedulesHref} size="sm" icon={<CalendarClockIcon />}>
             Schedules ({scheduleCount})
           </Button>
         )}
-        <Button as={Link} to={`/traces?entity=${encodeURIComponent(workflowName)}`} size="sm">
-          <Icon>
-            <EyeIcon />
-          </Icon>
+        <Button as={Link} to={`/traces?entity=${encodeURIComponent(workflowName)}`} size="sm" icon={<EyeIcon />}>
           Traces
         </Button>
-        <Button as="a" target="_blank" rel="noopener noreferrer" href="/swagger-ui" variant="ghost" size="sm">
-          <ApiIcon />
+        <Button
+          as="a"
+          target="_blank"
+          rel="noopener noreferrer"
+          href="/swagger-ui"
+          variant="ghost"
+          size="sm"
+          icon={<ApiIcon />}
+        >
           API endpoints
         </Button>
       </div>

--- a/packages/playground/src/domains/workflows/workflow/components/workflow-edge-data-button.tsx
+++ b/packages/playground/src/domains/workflows/workflow/components/workflow-edge-data-button.tsx
@@ -28,9 +28,9 @@ export const WorkflowEdgeDataButton = ({ previousStepId, output, label }: Workfl
       <Button
         size="sm"
         onClick={() => setIsOpen(true)}
-        className="border-border1 bg-surface3/95 text-neutral5 hover:bg-surface4 h-7 gap-1 rounded-full border px-2 shadow-lg"
+        className="border-border1 bg-surface3/95 text-neutral5 hover:bg-surface4 h-7 rounded-full border px-2 shadow-lg"
+        icon={<Database className="text-accent1" />}
       >
-        <Database className="h-icon-sm w-icon-sm text-accent1" />
         Data
       </Button>
 

--- a/packages/playground/src/domains/workflows/workflow/workflow-debug-step-controls.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-debug-step-controls.tsx
@@ -42,10 +42,14 @@ export function WorkflowDebugStepControls({ isStreaming }: WorkflowDebugStepCont
         Run next step
       </Button>
 
-      <Button type="button" variant="ghost" className="w-full" onClick={continueFullRun} disabled={isStreaming}>
-        <Icon>
-          <StepForwardIcon />
-        </Icon>
+      <Button
+        type="button"
+        variant="ghost"
+        className="w-full"
+        onClick={continueFullRun}
+        disabled={isStreaming}
+        icon={<StepForwardIcon />}
+      >
         Continue full run
       </Button>
     </div>

--- a/packages/playground/src/domains/workflows/workflow/workflow-map-config-dialog.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-map-config-dialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@mastra/playground-ui/components/Dialog';
+import { Eye } from 'lucide-react';
 import { useState } from 'react';
 
 import { CodeDialogContent } from './workflow-code-dialog-content';
@@ -21,7 +22,7 @@ export function WorkflowMapConfigDialog({ stepName, mapConfig }: WorkflowMapConf
 
   return (
     <>
-      <Button type="button" size="sm" onClick={() => setOpen(true)}>
+      <Button icon={<Eye />} type="button" size="sm" onClick={() => setOpen(true)}>
         Map config
       </Button>
 

--- a/packages/playground/src/domains/workflows/workflow/workflow-nested-graph-dialog.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-nested-graph-dialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@mastra/playground-ui/components/Dialog';
+import { WorkflowIcon } from '@mastra/playground-ui/icons/WorkflowIcon';
 import { ReactFlowProvider } from '@xyflow/react';
 import { useState } from 'react';
 
@@ -24,7 +25,7 @@ export function WorkflowNestedGraphDialog({ stepName, fullStep, stepGraph }: Wor
 
   return (
     <>
-      <Button type="button" size="sm" onClick={() => setOpen(true)}>
+      <Button icon={<WorkflowIcon />} type="button" size="sm" onClick={() => setOpen(true)}>
         View nested graph
       </Button>
 

--- a/packages/playground/src/domains/workflows/workflow/workflow-trigger-form.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-trigger-form.tsx
@@ -52,8 +52,8 @@ export function WorkflowTriggerForm({
             size="sm"
             className="w-full justify-start"
             onClick={() => setIsInputDialogOpen(true)}
+            icon={<FormInput className="text-neutral3" />}
           >
-            <FormInput className="text-neutral3 shrink-0" />
             <span className="truncate">Run input</span>
           </Button>
         </div>

--- a/packages/playground/src/domains/workspace/components/add-skill-dialog.tsx
+++ b/packages/playground/src/domains/workspace/components/add-skill-dialog.tsx
@@ -13,7 +13,7 @@ import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { GithubIcon } from '@mastra/playground-ui/icons/GithubIcon';
 import { SkillIcon } from '@mastra/playground-ui/icons/SkillIcon';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { Search, Download, ExternalLink, Loader2, CircleSlashIcon, Package, Check, Folder } from 'lucide-react';
+import { Search, Download, ExternalLink, Loader2, CircleSlashIcon, Package, Check, Folder, X } from 'lucide-react';
 import { useState, useCallback, useMemo } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 import { useSearchSkillsSh, usePopularSkillsSh, useSkillPreview, parseSkillSource } from '../hooks/use-skills-sh';
@@ -393,7 +393,7 @@ export function AddSkillDialog({
                     const mount = writableMounts.find(m => skillPath.startsWith(m.path + '/') || skillPath === m.path);
                     return mount ? <span className="text-icon4 text-ui-sm">Installed at {mount.path}</span> : null;
                   })()}
-                <Button variant="default" onClick={() => handleOpenChange(false)}>
+                <Button icon={<X />} variant="default" onClick={() => handleOpenChange(false)}>
                   Cancel
                 </Button>
                 <Button

--- a/packages/playground/src/domains/workspace/components/file-browser.tsx
+++ b/packages/playground/src/domains/workspace/components/file-browser.tsx
@@ -24,6 +24,7 @@ import {
   Cloud,
   Database,
   HardDrive,
+  X,
 } from 'lucide-react';
 import { useState } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
@@ -545,7 +546,7 @@ export function FileViewer({ path, content, isLoading, mimeType, onClose }: File
         <div className="flex items-center gap-2">
           <CopyButton content={content} copyMessage="Copied file content" />
           {onClose && (
-            <Button variant="ghost" size="md" onClick={onClose}>
+            <Button icon={<X />} variant="ghost" size="md" onClick={onClose}>
               Close
             </Button>
           )}

--- a/packages/playground/src/domains/workspace/components/no-workspaces-info.tsx
+++ b/packages/playground/src/domains/workspace/components/no-workspaces-info.tsx
@@ -20,8 +20,9 @@ export const NoWorkspacesInfo = () => (
           href="https://mastra.ai/en/docs/workspace/overview"
           target="_blank"
           rel="noopener noreferrer"
+          icon={<ExternalLinkIcon />}
         >
-          Workspaces Documentation <ExternalLinkIcon />
+          Workspaces Documentation
         </Button>
       }
     />

--- a/packages/playground/src/domains/workspace/components/skill-detail.tsx
+++ b/packages/playground/src/domains/workspace/components/skill-detail.tsx
@@ -81,14 +81,10 @@ export function SkillDetail({ skill, rawSkillMd, onReferenceClick }: SkillDetail
       {/* Metadata */}
       <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
         <MetadataCard label="Source" value={sourceInfo.label} icon={sourceInfo.icon} />
-        <MetadataCard label="Path" value={skill.path} icon={<FolderOpen className="h-3.5 w-3.5" />} />
+        <MetadataCard label="Path" value={skill.path} icon={<FolderOpen />} />
         {skill.license && <MetadataCard label="License" value={skill.license} />}
         {skill.compatibility != null && <MetadataCard label="Compatibility" value={skill.compatibility} />}
-        <MetadataCard
-          label="References"
-          value={`${skill.references.length} files`}
-          icon={<FileText className="h-3.5 w-3.5" />}
-        />
+        <MetadataCard label="References" value={`${skill.references.length} files`} icon={<FileText />} />
       </div>
 
       {/* Instructions */}

--- a/packages/playground/src/domains/workspace/components/skills-table.tsx
+++ b/packages/playground/src/domains/workspace/components/skills-table.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { DataList, DataListSkeleton, useDataListKeyboard } from '@mastra/playground-ui/components/DataList';
-import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { AlertTriangle, BookOpen, CircleSlashIcon, Plus } from 'lucide-react';
 import type { SkillMetadata } from '../types';
 import { SkillRemoveButton, SkillUpdateButton } from './skill-actions';
@@ -69,10 +68,7 @@ export function SkillsTable({
     <div className="space-y-4">
       {onAddSkill && (
         <div className="flex items-center gap-4">
-          <Button variant="default" size="sm" onClick={onAddSkill}>
-            <Icon>
-              <Plus className="h-4 w-4" />
-            </Icon>
+          <Button variant="default" size="sm" onClick={onAddSkill} icon={<Plus />}>
             Add Skill
           </Button>
         </div>
@@ -182,17 +178,18 @@ function SkillsNotConfigured({ onAddSkill }: SkillsNotConfiguredProps) {
         </p>
         <div className="flex gap-3">
           {onAddSkill && (
-            <Button size="lg" variant="default" onClick={onAddSkill}>
-              <Icon>
-                <Plus className="h-4 w-4" />
-              </Icon>
+            <Button size="lg" variant="default" onClick={onAddSkill} icon={<Plus />}>
               Add Skill from skills.sh
             </Button>
           )}
-          <Button size="lg" variant="default" as="a" href="https://mastra.ai/en/docs/workspace/skills" target="_blank">
-            <Icon>
-              <BookOpen className="h-4 w-4" />
-            </Icon>
+          <Button
+            size="lg"
+            variant="default"
+            as="a"
+            href="https://mastra.ai/en/docs/workspace/skills"
+            target="_blank"
+            icon={<BookOpen />}
+          >
             Learn about Skills
           </Button>
         </div>

--- a/packages/playground/src/domains/workspace/components/workspace-not-configured.tsx
+++ b/packages/playground/src/domains/workspace/components/workspace-not-configured.tsx
@@ -20,8 +20,9 @@ export const WorkspaceNotConfigured = () => (
           href="https://mastra.ai/en/docs/workspace/overview"
           target="_blank"
           rel="noopener noreferrer"
+          icon={<ExternalLinkIcon />}
         >
-          Workspaces Documentation <ExternalLinkIcon />
+          Workspaces Documentation
         </Button>
       }
     />

--- a/packages/playground/src/domains/workspace/components/workspace-not-supported.tsx
+++ b/packages/playground/src/domains/workspace/components/workspace-not-supported.tsx
@@ -21,8 +21,9 @@ export const WorkspaceNotSupported = () => (
           href="https://mastra.ai/en/docs/workspace/overview"
           target="_blank"
           rel="noopener noreferrer"
+          icon={<ExternalLinkIcon />}
         >
-          Workspaces Documentation <ExternalLinkIcon />
+          Workspaces Documentation
         </Button>
       }
     />

--- a/packages/playground/src/lib/ai-ui/attachments/attach-file-popover.tsx
+++ b/packages/playground/src/lib/ai-ui/attachments/attach-file-popover.tsx
@@ -3,7 +3,6 @@ import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
 import { Popover, PopoverContent, PopoverTrigger } from '@mastra/playground-ui/components/Popover';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { Icon } from '@mastra/playground-ui/icons/Icon';
 
 import { CloudUpload, Link, PlusIcon } from 'lucide-react';
 import { useState } from 'react';
@@ -103,10 +102,7 @@ export const AttachFilePopover = () => {
               placeholder="https://placehold.co/600x400/png"
             />
           </div>
-          <Button type="submit" className="h-8!" variant="default">
-            <Icon>
-              <Link />
-            </Icon>
+          <Button type="submit" className="h-8!" variant="default" icon={<Link />}>
             Add
           </Button>
         </form>

--- a/packages/playground/src/lib/ai-ui/messages/dataset-save-action.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/dataset-save-action.tsx
@@ -14,7 +14,7 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { useMastraClient } from '@mastra/react';
-import { DatabaseIcon, Save } from 'lucide-react';
+import { DatabaseIcon, Save, X } from 'lucide-react';
 import { useState, useCallback, useEffect, useMemo } from 'react';
 
 import { useDatasetSaveContext } from '../context/dataset-save-context';
@@ -146,7 +146,7 @@ function DatasetSaveDialog({
           </div>
         </DialogBody>
         <DialogFooter className="px-4">
-          <Button variant="default" size="sm" onClick={() => onOpenChange(false)}>
+          <Button icon={<X />} variant="default" size="sm" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
           <Button

--- a/packages/playground/src/lib/ai-ui/messages/dataset-save-action.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/dataset-save-action.tsx
@@ -12,7 +12,6 @@ import {
 import { Label } from '@mastra/playground-ui/components/Label';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@mastra/playground-ui/components/Select';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
-import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { useMastraClient } from '@mastra/react';
 import { DatabaseIcon, Save } from 'lucide-react';
@@ -155,10 +154,8 @@ function DatasetSaveDialog({
             size="sm"
             onClick={handleSubmit}
             disabled={addItem.isPending || !selectedDatasetId || datasets.length === 0}
+            icon={<Save />}
           >
-            <Icon size="sm">
-              <Save />
-            </Icon>
             {addItem.isPending ? 'Saving...' : 'Save Item'}
           </Button>
         </DialogFooter>

--- a/packages/playground/src/lib/ai-ui/tools/badges/workflow-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/workflow-badge.tsx
@@ -11,6 +11,7 @@ import { SectionLabel } from '@mastra/playground-ui/domains/chat/components/sect
 import type { ToolApprovalButtonsProps } from '@mastra/playground-ui/domains/chat/tools/badges/tool-approval-buttons';
 import { ToolApprovalButtons } from '@mastra/playground-ui/domains/chat/tools/badges/tool-approval-buttons';
 import { WorkflowIcon } from '@mastra/playground-ui/icons/WorkflowIcon';
+import { Eye } from 'lucide-react';
 import { useContext, useEffect } from 'react';
 import { BackgroundTaskMetadataDialogTrigger } from './background-task-metadata-dialog';
 import {
@@ -133,11 +134,11 @@ const WorkflowBadgeExtended = ({ workflowId, workflow, runId }: WorkflowBadgeExt
   return (
     <>
       <div className="flex items-center gap-2 pb-2">
-        <Button as={Link} href={`/workflows/${workflowId}/graph`}>
+        <Button icon={<WorkflowIcon />} as={Link} href={`/workflows/${workflowId}/graph`}>
           Go to workflow
         </Button>
         {runId && (
-          <Button as={Link} href={`/workflows/${workflowId}/graph/${runId}`}>
+          <Button icon={<Eye />} as={Link} href={`/workflows/${workflowId}/graph/${runId}`}>
             See run
           </Button>
         )}

--- a/packages/playground/src/lib/ai-ui/tools/submit-plan-tool.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/submit-plan-tool.tsx
@@ -19,6 +19,7 @@ import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import type { MessageMetadata } from '@mastra/playground-ui/domains/chat';
 import { useToolCall } from '@mastra/playground-ui/domains/chat/context/tool-call-context';
+import { X, Check } from 'lucide-react';
 import { useAgentPlan } from '@/domains/agents/hooks/use-agent-plan';
 
 export interface SubmitPlanToolProps {
@@ -167,6 +168,7 @@ function PendingPlanCard({ agentId, agentVersionId, requestContext, toolCallId, 
           <PlanControls>
             <PlanActionGroup>
               <Button
+                icon={<Check />}
                 type="button"
                 size="sm"
                 variant="primary"
@@ -183,6 +185,7 @@ function PendingPlanCard({ agentId, agentVersionId, requestContext, toolCallId, 
             </span>
             <PlanActionGroup>
               <Button
+                icon={<X />}
                 type="button"
                 size="sm"
                 aria-label="Reject the plan"

--- a/packages/playground/src/lib/form/components/array-element-wrapper.tsx
+++ b/packages/playground/src/lib/form/components/array-element-wrapper.tsx
@@ -1,6 +1,5 @@
 import type { ArrayElementWrapperProps } from '@autoform/react';
 import { Button } from '@mastra/playground-ui/components/Button';
-import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { TrashIcon } from 'lucide-react';
 import React from 'react';
 
@@ -8,10 +7,7 @@ export const ArrayElementWrapper: React.FC<ArrayElementWrapperProps> = ({ childr
   return (
     <div className="border-border1 border-l pl-4">
       {children}
-      <Button onClick={onRemove} type="button">
-        <Icon size="sm">
-          <TrashIcon />
-        </Icon>
+      <Button onClick={onRemove} type="button" icon={<TrashIcon />}>
         Delete
       </Button>
     </div>

--- a/packages/playground/src/lib/form/components/date-field.tsx
+++ b/packages/playground/src/lib/form/components/date-field.tsx
@@ -42,8 +42,13 @@ export const DateField: React.FC<AutoFormFieldProps> = ({ inputProps, field, err
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <Button id={id} variant="default" size="lg" className={cn('w-full', error ? 'border-accent2' : '')}>
-          <CalendarIcon className="h-4 w-4" />
+        <Button
+          id={id}
+          variant="default"
+          size="lg"
+          className={cn('w-full', error ? 'border-accent2' : '')}
+          icon={<CalendarIcon />}
+        >
           {value ? (
             <span className="text-white">{format(value, 'PPP')}</span>
           ) : (

--- a/packages/playground/src/lib/form/components/date-field.tsx
+++ b/packages/playground/src/lib/form/components/date-field.tsx
@@ -4,7 +4,7 @@ import { DatePicker } from '@mastra/playground-ui/components/DateTimePicker';
 import { Popover, PopoverContent, PopoverTrigger } from '@mastra/playground-ui/components/Popover';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { format, isValid } from 'date-fns';
-import { CalendarIcon } from 'lucide-react';
+import { CalendarIcon, X } from 'lucide-react';
 import React, { useState, useEffect } from 'react';
 
 export const DateField: React.FC<AutoFormFieldProps> = ({ inputProps, field, error, id }) => {
@@ -60,7 +60,7 @@ export const DateField: React.FC<AutoFormFieldProps> = ({ inputProps, field, err
         <DatePicker mode="single" selected={value} onSelect={handleSelect} month={value} onMonthChange={setValue} />
         {value && (
           <div className="p-3 pt-0">
-            <Button variant="default" size="lg" className="w-full" onClick={handleClear}>
+            <Button icon={<X />} variant="default" size="lg" className="w-full" onClick={handleClear}>
               Clear
             </Button>
           </div>

--- a/packages/playground/src/lib/form/components/record-field.tsx
+++ b/packages/playground/src/lib/form/components/record-field.tsx
@@ -93,8 +93,7 @@ export const RecordField: React.FC<AutoFormFieldProps> = ({ inputProps, field })
           </div>
         </div>
       ))}
-      <Button type="button" className="w-full" onClick={addPair}>
-        <Plus className="mr-2 h-4 w-4" />
+      <Button type="button" className="w-full" onClick={addPair} icon={<Plus />}>
         Add Key-Value Pair
       </Button>
     </div>

--- a/packages/playground/src/lib/route-header/route-header.tsx
+++ b/packages/playground/src/lib/route-header/route-header.tsx
@@ -68,8 +68,8 @@ export function RouteHeader() {
             size="sm"
             aria-label={docs.label ?? 'Documentation'}
             className="max-w-[14rem] min-w-0"
+            icon={<DocsIcon />}
           >
-            <DocsIcon />
             <span className="min-w-0 truncate">{docs.label ?? 'Documentation'}</span>
           </Button>
         )}

--- a/packages/playground/src/pages/agent-builder/agents/edit.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/edit.tsx
@@ -1,5 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { AgentIcon } from '@mastra/playground-ui/icons/AgentIcon';
+import { Settings2 } from 'lucide-react';
 import { useState } from 'react';
 import { FormProvider, useForm, useFormContext, useFormState, useWatch } from 'react-hook-form';
 import { Navigate, useNavigate, useParams } from 'react-router';
@@ -183,6 +185,7 @@ const MobileInitialCtas = () => {
   return (
     <div className="flex flex-col gap-2 lg:hidden" data-testid="agent-builder-mobile-initial-ctas">
       <Button
+        icon={<AgentIcon />}
         variant="primary"
         onClick={() => navigate(`/agent-builder/agents/${agentId}/view`, { viewTransition: true })}
         data-testid="agent-builder-mobile-initial-cta-chat"
@@ -190,6 +193,7 @@ const MobileInitialCtas = () => {
         Chat with my agent
       </Button>
       <Button
+        icon={<Settings2 />}
         variant="outline"
         onClick={() => startViewTransition(() => next())}
         data-testid="agent-builder-mobile-initial-cta-config"

--- a/packages/playground/src/pages/agent-builder/agents/index.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/index.tsx
@@ -80,8 +80,8 @@ export default function AgentBuilderAgentsPage() {
             descriptionSlot="Start building your first agent with the Agent Builder."
             actionSlot={
               canWrite ? (
-                <Button as={FrameworkLink} to="/agent-builder/agents/create" variant="primary">
-                  <PlusIcon /> Create an agent
+                <Button as={FrameworkLink} to="/agent-builder/agents/create" variant="primary" icon={<PlusIcon />}>
+                  Create an agent
                 </Button>
               ) : undefined
             }
@@ -110,8 +110,9 @@ export default function AgentBuilderAgentsPage() {
                 to="/agent-builder/agents/create"
                 variant="primary"
                 className="w-full justify-center md:w-auto"
+                icon={<PlusIcon />}
               >
-                <PlusIcon /> New agent
+                New agent
               </Button>
             </div>
           )}

--- a/packages/playground/src/pages/agent-builder/skills/index.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/index.tsx
@@ -86,15 +86,16 @@ export default function AgentBuilderSkillsPage() {
             actionSlot={
               canWriteSkills ? (
                 <div className="flex items-center gap-2">
-                  <Button variant="primary" onClick={goToCreate}>
-                    <PlusIcon /> New skill
+                  <Button variant="primary" onClick={goToCreate} icon={<PlusIcon />}>
+                    New skill
                   </Button>
                   {enabledRegistry && (
                     <Button
                       variant="default"
                       onClick={() => setRegistryDialog({ id: enabledRegistry.id, label: enabledRegistry.label })}
+                      icon={<DownloadIcon />}
                     >
-                      <DownloadIcon /> Browse registry
+                      Browse registry
                     </Button>
                   )}
                 </div>
@@ -126,12 +127,18 @@ export default function AgentBuilderSkillsPage() {
                     variant="default"
                     className="w-full justify-center md:w-auto"
                     onClick={() => setRegistryDialog({ id: enabledRegistry.id, label: enabledRegistry.label })}
+                    icon={<DownloadIcon />}
                   >
-                    <DownloadIcon /> Browse registry
+                    Browse registry
                   </Button>
                 )}
-                <Button variant="primary" className="w-full justify-center md:w-auto" onClick={goToCreate}>
-                  <PlusIcon /> New skill
+                <Button
+                  variant="primary"
+                  className="w-full justify-center md:w-auto"
+                  onClick={goToCreate}
+                  icon={<PlusIcon />}
+                >
+                  New skill
                 </Button>
               </div>
             )}

--- a/packages/playground/src/pages/agent-builder/skills/view.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/view.tsx
@@ -90,8 +90,8 @@ const AgentBuilderSkillViewPage = ({ skill }: PageProps) => {
               size="md"
               onClick={() => setCopyOpen(true)}
               data-testid="skill-view-copy-button"
+              icon={<PlusIcon />}
             >
-              <PlusIcon />
               Copy to my skills
             </Button>
           )}

--- a/packages/playground/src/pages/cms/agents/edit-layout.tsx
+++ b/packages/playground/src/pages/cms/agents/edit-layout.tsx
@@ -3,7 +3,7 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { MainContentLayout } from '@mastra/playground-ui/components/MainContent';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
-import { Check, Download, GitPullRequest, Save } from 'lucide-react';
+import { Check, Download, GitPullRequest, Save, Rocket, Eye } from 'lucide-react';
 import { useCallback, useEffect, useMemo } from 'react';
 import { Outlet, useLocation, useNavigate, useParams, useSearchParams } from 'react-router';
 import { AgentCmsFormShell } from '@/domains/agents/components/agent-cms-form-shell';
@@ -66,10 +66,11 @@ function EditFormContent({
     <Notice variant="info" title="This is a previous version" className="mb-4">
       <Notice.Message>You are seeing a specific version of the agent.</Notice.Message>
       <div className="flex items-center gap-2">
-        <Button type="button" variant="default" size="sm" onClick={() => setSearchParams({})}>
+        <Button icon={<Eye />} type="button" variant="default" size="sm" onClick={() => setSearchParams({})}>
           View latest version
         </Button>
         <Button
+          icon={<Rocket />}
           type="button"
           variant="default"
           size="sm"

--- a/packages/playground/src/pages/cms/agents/edit-layout.tsx
+++ b/packages/playground/src/pages/cms/agents/edit-layout.tsx
@@ -256,8 +256,11 @@ function EditLayoutWrapper() {
             {showCodeModeActions ? (
               isCodeAgentEditable ? (
                 <>
-                  <Button onClick={() => void handleDownloadJson()} disabled={isSavingDraft || isSubmitting}>
-                    <Download />
+                  <Button
+                    onClick={() => void handleDownloadJson()}
+                    disabled={isSavingDraft || isSubmitting}
+                    icon={<Download />}
+                  >
                     Download JSON
                   </Button>
                   <Button

--- a/packages/playground/src/pages/cms/prompt-blocks/edit/index.tsx
+++ b/packages/playground/src/pages/cms/prompt-blocks/edit/index.tsx
@@ -7,6 +7,7 @@ import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { useMastraClient } from '@mastra/react';
 import { useQueryClient } from '@tanstack/react-query';
+import { Rocket, Eye } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router';
 import { AgentEditLayout } from '@/domains/agents/components/agent-edit-page/agent-edit-layout';
@@ -187,10 +188,11 @@ function CmsPromptBlocksEditForm({
         <Notice variant="info" title="This is a previous version" className="m-4 mb-0">
           <Notice.Message>You are seeing a specific version of the prompt block.</Notice.Message>
           <div className="flex gap-2">
-            <Button type="button" variant="default" size="sm" onClick={onClearVersion}>
+            <Button icon={<Eye />} type="button" variant="default" size="sm" onClick={onClearVersion}>
               View latest version
             </Button>
             <Button
+              icon={<Rocket />}
               type="button"
               variant="default"
               size="sm"

--- a/packages/playground/src/pages/cms/scorers/edit/index.tsx
+++ b/packages/playground/src/pages/cms/scorers/edit/index.tsx
@@ -7,6 +7,7 @@ import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { useMastraClient } from '@mastra/react';
 import { useQueryClient } from '@tanstack/react-query';
+import { Rocket, Eye } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router';
 import { AgentEditLayout } from '@/domains/agents/components/agent-edit-page/agent-edit-layout';
@@ -187,10 +188,11 @@ function CmsScorersEditForm({
         <Notice variant="info" title="This is a previous version" className="m-4 mb-0">
           <Notice.Message>You are seeing a specific version of the scorer.</Notice.Message>
           <div className="flex gap-2">
-            <Button type="button" variant="default" size="sm" onClick={onClearVersion}>
+            <Button icon={<Eye />} type="button" variant="default" size="sm" onClick={onClearVersion}>
               View latest version
             </Button>
             <Button
+              icon={<Rocket />}
               type="button"
               variant="default"
               size="sm"

--- a/packages/playground/src/pages/datasets/dataset/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/index.tsx
@@ -87,8 +87,7 @@ function DatasetPage() {
           titleSlot="Dataset not found"
           descriptionSlot={`No dataset with id "${datasetId}".`}
           actionSlot={
-            <Button as={Link} to="/datasets">
-              <ArrowLeft />
+            <Button as={Link} to="/datasets" icon={<ArrowLeft />}>
               Back to Datasets
             </Button>
           }
@@ -133,8 +132,7 @@ function DatasetPage() {
               }
               rightSlot={
                 <ButtonsGroup>
-                  <Button as={Link} to={`/experiments?dataset=${datasetId}`}>
-                    <FlaskConical />
+                  <Button as={Link} to={`/experiments?dataset=${datasetId}`} icon={<FlaskConical />}>
                     View experiments
                   </Button>
                   <DatasetVersions
@@ -149,8 +147,7 @@ function DatasetPage() {
                       <TooltipTrigger asChild>
                         <span className="cursor-not-allowed">
                           <div className="pointer-events-none opacity-50" inert aria-disabled="true">
-                            <Button variant="primary">
-                              <Play />
+                            <Button variant="primary" icon={<Play />}>
                               Run Experiment
                             </Button>
                           </div>
@@ -159,8 +156,7 @@ function DatasetPage() {
                       <TooltipContent>Add items to the dataset before running an experiment</TooltipContent>
                     </Tooltip>
                   ) : (
-                    <Button variant="primary" onClick={() => setExperimentDialogOpen(true)}>
-                      <Play />
+                    <Button variant="primary" onClick={() => setExperimentDialogOpen(true)} icon={<Play />}>
                       Run Experiment
                     </Button>
                   )}

--- a/packages/playground/src/pages/datasets/dataset/item/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
-import { DatabaseIcon } from 'lucide-react';
+import { DatabaseIcon, X } from 'lucide-react';
 import { useMemo } from 'react';
 import { useParams } from 'react-router';
 
@@ -45,7 +45,11 @@ function DatasetItemPage() {
               iconSlot={<DatabaseIcon />}
               titleSlot="Item not found"
               descriptionSlot={`No loaded item "${itemId}".`}
-              actionSlot={<Button onClick={close}>Close</Button>}
+              actionSlot={
+                <Button icon={<X />} onClick={close}>
+                  Close
+                </Button>
+              }
             />
           </div>
         </div>

--- a/packages/playground/src/pages/datasets/dataset/versions/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/versions/index.tsx
@@ -101,8 +101,7 @@ function DatasetCompareVersionsPage() {
               </MainHeader.Description>
             </MainHeader.Column>
             <MainHeader.Column>
-              <Button as={Link} to={`/datasets/${datasetId}`}>
-                <ArrowLeft />
+              <Button as={Link} to={`/datasets/${datasetId}`} icon={<ArrowLeft />}>
                 Back to Dataset
               </Button>
             </MainHeader.Column>

--- a/packages/playground/src/pages/experiments/compare/index.tsx
+++ b/packages/playground/src/pages/experiments/compare/index.tsx
@@ -131,8 +131,8 @@ function CompareExperimentsPage() {
                   onClick={() =>
                     setSearchParams({ dataset: datasetId, baseline: experimentIdB, contender: experimentIdA })
                   }
+                  icon={<ArrowLeftRightIcon />}
                 >
-                  <ArrowLeftRightIcon />
                   Swap sides
                 </Button>
               </TooltipTrigger>

--- a/packages/playground/src/pages/experiments/experiment/index.tsx
+++ b/packages/playground/src/pages/experiments/experiment/index.tsx
@@ -94,8 +94,7 @@ function ExperimentPage() {
         titleSlot="Experiment not found"
         descriptionSlot={`No experiment with id "${experimentId}".`}
         actionSlot={
-          <Button as={Link} to="/experiments">
-            <ArrowLeft />
+          <Button as={Link} to="/experiments" icon={<ArrowLeft />}>
             Back to Experiments
           </Button>
         }

--- a/packages/playground/src/pages/experiments/experiment/item/index.tsx
+++ b/packages/playground/src/pages/experiments/experiment/item/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { toast } from '@mastra/playground-ui/utils/toast';
-import { PlayCircle } from 'lucide-react';
+import { PlayCircle, X } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useParams } from 'react-router';
 
@@ -110,7 +110,11 @@ function ExperimentItemPageContent({ itemId }: { itemId: string }) {
               iconSlot={<PlayCircle />}
               titleSlot="Item not found"
               descriptionSlot={`No loaded result for item "${itemId}".`}
-              actionSlot={<Button onClick={close}>Close</Button>}
+              actionSlot={
+                <Button icon={<X />} onClick={close}>
+                  Close
+                </Button>
+              }
             />
           </div>
         </div>

--- a/packages/playground/src/pages/experiments/review-queue/index.tsx
+++ b/packages/playground/src/pages/experiments/review-queue/index.tsx
@@ -71,9 +71,8 @@ function ReviewQueuePage() {
         }
         toolbarEnd={
           selectedId ? (
-            <Button as={Link} href={paths.experimentLink(selectedId)}>
+            <Button as={Link} href={paths.experimentLink(selectedId)} icon={<ArrowUpRight />}>
               See experiment
-              <ArrowUpRight />
             </Button>
           ) : undefined
         }

--- a/packages/playground/src/pages/metrics/index.tsx
+++ b/packages/playground/src/pages/metrics/index.tsx
@@ -313,8 +313,9 @@ function MetricsContent() {
                 href="https://mastra.ai/docs/observability/metrics/overview"
                 target="_blank"
                 rel="noopener noreferrer"
+                icon={<ExternalLinkIcon />}
               >
-                Metrics Documentation <ExternalLinkIcon />
+                Metrics Documentation
               </Button>
             }
           />

--- a/packages/playground/src/pages/prompt-blocks/index.tsx
+++ b/packages/playground/src/pages/prompt-blocks/index.tsx
@@ -82,8 +82,13 @@ export default function PromptBlocks() {
             />
           </div>
           {isCmsAvailable && (
-            <Button as={Link} to={paths.cmsPromptBlockCreateLink()} variant="primary" className="shrink-0">
-              <Plus />
+            <Button
+              as={Link}
+              to={paths.cmsPromptBlockCreateLink()}
+              variant="primary"
+              className="shrink-0"
+              icon={<Plus />}
+            >
               Create Prompt
             </Button>
           )}

--- a/packages/playground/src/pages/scorers/scorer/index.tsx
+++ b/packages/playground/src/pages/scorers/scorer/index.tsx
@@ -241,8 +241,7 @@ export default function Scorer() {
           />
           <ButtonsGroup>
             <ScoresColumnsMenu visibleColumns={columnsState.visibleColumns} toggleColumn={columnsState.toggleColumn} />
-            <Button variant="primary" onClick={() => setRunDialogOpen(true)}>
-              <Play />
+            <Button variant="primary" onClick={() => setRunDialogOpen(true)} icon={<Play />}>
               Run Experiment
             </Button>
             {scorerActionsMenu}

--- a/packages/playground/src/pages/workflows/index.tsx
+++ b/packages/playground/src/pages/workflows/index.tsx
@@ -55,8 +55,13 @@ function Workflows() {
           <div className="max-w-120 flex-1">
             <ListSearch onSearch={setSearch} label="Filter workflows" placeholder="Filter by name or description" />
           </div>
-          <Button as={Link} to="/workflows/schedules" variant="primary" className="shrink-0">
-            <CalendarClockIcon />
+          <Button
+            as={Link}
+            to="/workflows/schedules"
+            variant="primary"
+            className="shrink-0"
+            icon={<CalendarClockIcon />}
+          >
             Schedules
           </Button>
         </PageLayout.Row>

--- a/packages/playground/src/pages/workflows/schedule.tsx
+++ b/packages/playground/src/pages/workflows/schedule.tsx
@@ -72,8 +72,7 @@ export default function SchedulePage() {
       <PageLayout.TopArea>
         <PageLayout.Row className="justify-end">
           <PageLayout.Column className="flex justify-end gap-2">
-            <Button as={Link} to={paths.schedulesLink()} variant="ghost">
-              <ArrowLeftIcon />
+            <Button as={Link} to={paths.schedulesLink()} variant="ghost" icon={<ArrowLeftIcon />}>
               Back to schedules
             </Button>
             {workflowId ? (

--- a/packages/playground/src/pages/workflows/schedule.tsx
+++ b/packages/playground/src/pages/workflows/schedule.tsx
@@ -4,6 +4,7 @@ import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/P
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { WorkflowIcon } from '@mastra/playground-ui/icons/WorkflowIcon';
 import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { ArrowLeftIcon, PauseIcon, PlayIcon } from 'lucide-react';
 import { Link, useParams } from 'react-router';
@@ -76,7 +77,7 @@ export default function SchedulePage() {
               Back to schedules
             </Button>
             {workflowId ? (
-              <Button as={Link} to={paths.workflowLink(workflowId)} variant="ghost">
+              <Button icon={<WorkflowIcon />} as={Link} to={paths.workflowLink(workflowId)} variant="ghost">
                 Open workflow
               </Button>
             ) : null}


### PR DESCRIPTION
## Summary

Studio buttons previously mixed three patterns: raw SVG children before the label, SVG after the label, and plain text. This PR unifies them.

- **`Button` gets an `icon` prop.** The icon always renders on the left, wrapped in `<Icon>` with a fixed gap, sized from the button size token (xs/sm → 12px, md/lg → 16px), and dimmed at rest / full opacity on hover. Icon-only buttons (`size="icon-*"`) are unchanged.
- **All icon+label buttons migrated** to `icon={…}` across `@mastra/playground-ui` and `packages/playground` (right-side icons such as "Next" chevrons now sit on the left).
- **Every text-only button gets an icon**: the sidebar entity icon when the label refers to a Mastra entity (Agents, Workflows, Traces, Datasets, Memory…), otherwise a lucide icon chosen by action verb (Cancel → `X`, Save → `Check`, Edit → `Pencil`, Delete → `Trash2`, Retry → `RotateCcw`, Previous/Next → chevrons, …). Full mapping in `.mastracode/plans/button-icons-inventory.md`.
- Deliberately left without icons: buttons whose label is data (trace IDs, token values, zoom %), pass-through wrappers (`DialogAction`, `NoticeButton`, `ThreadList`…) where the consumer supplies the icon, and buttons that already render an icon another way (SSO).

## Test plan

- [x] `typecheck` + `lint` on both packages
- [x] `@mastra/playground-ui` tests (3427) and `playground` tests (2372) pass — role/name queries unaffected since `Icon` renders no text
- [x] New `button.test.tsx` covers icon slot rendering/sizing
- [ ] Visual pass in Studio: dialog footers (Cancel/Save side by side), `PropertyFilter` `ButtonsGroup`, empty states with entity icons, Storybook `Button/WithIcon` & `WithIconSizes`