### PR TITLE
feat(playground-ui): add complete chat conversation stories

### DIFF
--- a/packages/playground-ui/.storybook/fixtures/chat/composer.tsx
+++ b/packages/playground-ui/.storybook/fixtures/chat/composer.tsx
@@ -1,0 +1,208 @@
+import { ArrowUp, Paperclip, Square, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import type { ChatFile, Phase } from './data';
+import { UserFilePartRenderer } from '@/domains/chat/messages/renderers/user-file-part-renderer';
+import { Button } from '@/ds/components/Button';
+import {
+  Composer,
+  ComposerActions,
+  ComposerAttachments,
+  ComposerBox,
+  ComposerInput,
+  ComposerRing,
+} from '@/ds/components/Composer';
+import { Notice } from '@/ds/components/Notice';
+import { Txt } from '@/ds/components/Txt';
+
+const composerStatus: Record<Phase, string> = {
+  complete: 'Ready',
+  streaming: 'Responding…',
+  stopped: 'Response stopped',
+  question: 'Waiting for your answer',
+  approval: 'Waiting for approval',
+  declined: 'Ready',
+  error: 'Reply failed',
+};
+
+interface DraftFile {
+  id: string;
+  filename: string;
+  part?: ChatFile;
+  error?: string;
+}
+
+interface ConversationComposerProps {
+  phase?: Phase;
+  busy: boolean;
+  onSend: (text: string, files: ChatFile[]) => void;
+  onStop: () => void;
+}
+
+export function ConversationComposer({ phase, busy, onSend, onStop }: ConversationComposerProps) {
+  const [text, setText] = useState('');
+  const [files, setFiles] = useState<DraftFile[]>([]);
+  const [sentCount, setSentCount] = useState(0);
+  const fileInput = useRef<HTMLInputElement>(null);
+  const messageInput = useRef<HTMLTextAreaElement>(null);
+  const readers = useRef(new Map<string, FileReader>());
+  const reading = files.some(file => !file.part && !file.error);
+  const readyFiles = files.flatMap(file => (file.part ? [file.part] : []));
+  const canSend = !busy && files.every(file => file.part) && (text.trim().length > 0 || readyFiles.length > 0);
+
+  useEffect(() => {
+    const pending = readers.current;
+    return () => {
+      pending.forEach(reader => reader.abort());
+      pending.clear();
+    };
+  }, []);
+
+  function addFiles(selected: FileList | null) {
+    for (const file of Array.from(selected ?? [])) {
+      const id = crypto.randomUUID();
+      const reader = new FileReader();
+      readers.current.set(id, reader);
+      setFiles(current => [...current, { id, filename: file.name }]);
+      reader.onload = () => {
+        readers.current.delete(id);
+        const data = reader.result;
+        if (typeof data !== 'string') return;
+        const part: ChatFile = {
+          type: 'file',
+          filename: file.name,
+          mimeType: file.type || 'application/octet-stream',
+          data,
+        };
+        setFiles(current => current.map(item => (item.id === id ? { ...item, part } : item)));
+      };
+      reader.onerror = () => {
+        readers.current.delete(id);
+        setFiles(current =>
+          current.map(item =>
+            item.id === id ? { ...item, error: 'Could not read this file. Remove it and try again.' } : item,
+          ),
+        );
+      };
+      reader.readAsDataURL(file);
+    }
+  }
+
+  function removeFile(id: string) {
+    readers.current.get(id)?.abort();
+    readers.current.delete(id);
+    setFiles(current => current.filter(file => file.id !== id));
+  }
+
+  function submitMessage() {
+    if (!canSend) return;
+    onSend(text, readyFiles);
+    setText('');
+    setFiles([]);
+    setSentCount(current => current + 1);
+    messageInput.current?.focus();
+  }
+
+  return (
+    <Composer
+      aria-label="Chat composer"
+      onSubmit={event => {
+        event.preventDefault();
+        submitMessage();
+      }}
+    >
+      <input
+        ref={fileInput}
+        type="file"
+        multiple
+        hidden
+        aria-label="Attach files"
+        onChange={event => {
+          addFiles(event.target.files);
+          event.target.value = '';
+        }}
+      />
+      <ComposerRing busy={phase === 'streaming'}>
+        <ComposerBox sendingPulseKey={sentCount}>
+          {files.length > 0 && (
+            <ComposerAttachments aria-label="Draft attachments" className="flex flex-wrap gap-2 px-3 pt-3">
+              {files.map(file => (
+                <div key={file.id} className="flex min-w-0 items-center gap-1">
+                  {file.part ? (
+                    <UserFilePartRenderer part={file.part} />
+                  ) : (
+                    <Txt variant="ui-sm">
+                      {file.filename}
+                      {file.error ? '' : ' — Reading…'}
+                    </Txt>
+                  )}
+                  {file.error && (
+                    <Notice variant="destructive" title={file.filename}>
+                      <Notice.Message>{file.error}</Notice.Message>
+                    </Notice>
+                  )}
+                  <Button
+                    type="button"
+                    size="icon-sm"
+                    variant="ghost"
+                    aria-label={`Remove ${file.filename}`}
+                    onClick={() => removeFile(file.id)}
+                  >
+                    <X />
+                  </Button>
+                </div>
+              ))}
+            </ComposerAttachments>
+          )}
+          <ComposerInput
+            ref={messageInput}
+            aria-label="Message"
+            placeholder="Ask a follow-up…"
+            value={text}
+            onChange={event => setText(event.target.value)}
+            onKeyDown={event => {
+              const shouldSend = event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing;
+              if (shouldSend) {
+                event.preventDefault();
+                submitMessage();
+              }
+            }}
+          />
+          <ComposerActions>
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="ghost"
+              aria-label="Add attachments"
+              tooltip="Add attachments"
+              onClick={() => fileInput.current?.click()}
+            >
+              <Paperclip />
+            </Button>
+            <Txt variant="ui-xs" role="status" aria-live="polite">
+              {reading ? 'Reading attachments…' : composerStatus[phase ?? 'complete']}
+            </Txt>
+            <div className="ml-auto">
+              {phase === 'streaming' ? (
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  aria-label="Stop response"
+                  onClick={() => {
+                    onStop();
+                    messageInput.current?.focus();
+                  }}
+                >
+                  <Square />
+                </Button>
+              ) : (
+                <Button type="submit" size="icon-sm" variant="primary" aria-label="Send message" disabled={!canSend}>
+                  <ArrowUp />
+                </Button>
+              )}
+            </div>
+          </ComposerActions>
+        </ComposerBox>
+      </ComposerRing>
+    </Composer>
+  );
+}

--- a/packages/playground-ui/.storybook/fixtures/chat/conversation.tsx
+++ b/packages/playground-ui/.storybook/fixtures/chat/conversation.tsx
@@ -1,0 +1,149 @@
+import { MessageSquare, RotateCcw } from 'lucide-react';
+import { useState } from 'react';
+import { ConversationComposer } from './composer';
+import type { Scenario } from './data';
+import { ConversationResponse } from './response';
+import { useStoryConversation } from './use-conversation';
+import { UserFilePartRenderer } from '@/domains/chat/messages/renderers/user-file-part-renderer';
+import { UserTextPartRenderer } from '@/domains/chat/messages/renderers/user-text-part-renderer';
+import type { TaskListItem } from '@/ds/components/ai/task-list';
+import { TaskList } from '@/ds/components/ai/task-list';
+import { Avatar } from '@/ds/components/Avatar';
+import { Button } from '@/ds/components/Button';
+import { ChatShell } from '@/ds/components/ChatShell';
+import { EmptyState } from '@/ds/components/EmptyState';
+import { MessageScrollerItem } from '@/ds/components/MessageScroller';
+import { ThreadRail } from '@/ds/components/ThreadRail';
+import { TooltipProvider } from '@/ds/components/Tooltip';
+import { Txt } from '@/ds/components/Txt';
+
+function Conversation({ scenario, onReset }: { scenario: Scenario; onReset: () => void }) {
+  const { turns, phase, busy, sendMessage, transitionTurn } = useStoryConversation(scenario);
+  const activeTurn = turns.at(-1);
+  let verificationStatus: TaskListItem['status'] = 'pending';
+  if (phase === 'complete') verificationStatus = 'completed';
+  if (phase === 'streaming') verificationStatus = 'in_progress';
+  return (
+    <TooltipProvider>
+      <ChatShell className="h-dvh" scroller={{ autoScroll: true, defaultScrollPosition: 'end' }}>
+        <ChatShell.Bar>
+          <ChatShell.Column className="flex-row items-center justify-between gap-3 py-3">
+            <Txt as="h1" variant="header-xs">
+              Composer review
+            </Txt>
+            <Button size="sm" variant="ghost" onClick={onReset}>
+              <RotateCcw />
+              Reset conversation
+            </Button>
+          </ChatShell.Column>
+        </ChatShell.Bar>
+        <ChatShell.Stage>
+          <ChatShell.Viewport>
+            <ChatShell.Content>
+              <ChatShell.Column className="gap-8 py-6">
+                {turns.length === 0 && (
+                  <EmptyState
+                    iconSlot={<MessageSquare />}
+                    titleSlot="Start a conversation"
+                    descriptionSlot="Add a file or send a message to try the composer."
+                  />
+                )}
+                {turns.map((turn, index) => (
+                  <ChatShell.Turn
+                    key={turn.id}
+                    role="region"
+                    aria-label={`Turn ${index + 1}`}
+                    opensTurn
+                    holdsRoom={turn.phase === 'streaming'}
+                    restored={turn.id === 'review'}
+                    className="gap-6"
+                  >
+                    <MessageScrollerItem
+                      messageId={turn.id}
+                      scrollAnchor
+                      className="ml-auto flex max-w-[85%] min-w-0 flex-col items-end gap-2"
+                    >
+                      <div className="flex items-center gap-2">
+                        <Txt variant="ui-sm">You</Txt>
+                        <Avatar name="You" size="sm" />
+                      </div>
+                      {turn.prompt && <UserTextPartRenderer part={{ type: 'text', text: turn.prompt }} />}
+                      <div className="flex max-w-full flex-wrap justify-end gap-2">
+                        {turn.files.map((file, fileIndex) => (
+                          <UserFilePartRenderer key={`${file.filename}-${fileIndex}`} part={file} />
+                        ))}
+                      </div>
+                    </MessageScrollerItem>
+                    <MessageScrollerItem messageId={`${turn.id}-reply`} className="flex min-w-0 flex-col gap-3">
+                      <div className="flex items-center gap-2">
+                        <Avatar name="Assistant" size="sm" />
+                        <Txt variant="ui-sm">Assistant</Txt>
+                      </div>
+                      <ConversationResponse turn={turn} transitionTurn={transitionTurn} />
+                    </MessageScrollerItem>
+                  </ChatShell.Turn>
+                ))}
+              </ChatShell.Column>
+            </ChatShell.Content>
+            <ChatShell.Dock>
+              <ChatShell.ScrollButton aria-label="Jump to latest message" />
+              <ChatShell.Column className="gap-2">
+                {activeTurn?.review && (
+                  <TaskList
+                    defaultOpen={false}
+                    hideWhenComplete={false}
+                    scrollActiveIntoView={false}
+                    tasks={[
+                      {
+                        id: 'inspect',
+                        content: 'Inspect the composer',
+                        activeForm: 'Inspecting the composer',
+                        status: 'completed',
+                      },
+                      { id: 'plan', content: 'Review the plan', activeForm: 'Reviewing the plan', status: 'completed' },
+                      {
+                        id: 'verify',
+                        content: 'Verify the interaction',
+                        activeForm: 'Verifying the interaction',
+                        status: verificationStatus,
+                      },
+                    ]}
+                  />
+                )}
+                <ConversationComposer
+                  phase={phase}
+                  busy={busy}
+                  onSend={sendMessage}
+                  onStop={() => {
+                    if (activeTurn) transitionTurn(activeTurn.id, 'streaming', 'stopped');
+                  }}
+                />
+              </ChatShell.Column>
+            </ChatShell.Dock>
+          </ChatShell.Viewport>
+          <ThreadRail
+            turns={turns.map(turn => ({
+              key: turn.id,
+              messageId: turn.id,
+              prompt: turn.prompt || 'Attachments',
+              reply: turn.text,
+              files: turn.files.map(file => file.filename),
+              hiddenFileCount: 0,
+            }))}
+          />
+        </ChatShell.Stage>
+      </ChatShell>
+    </TooltipProvider>
+  );
+}
+
+export function ChatConversation({ scenario }: { scenario: Scenario }) {
+  const [revision, setRevision] = useState(0);
+  return (
+    <Conversation
+      key={`${scenario}-${revision}`}
+      scenario={scenario}
+      onReset={() => setRevision(current => current + 1)}
+    />
+  );
+}

--- a/packages/playground-ui/.storybook/fixtures/chat/data.ts
+++ b/packages/playground-ui/.storybook/fixtures/chat/data.ts
@@ -1,0 +1,100 @@
+import type { FilePart } from '@mastra/react';
+import type { ToolCallGroupStep } from '@/ds/components/ai/tool-call';
+
+export type ChatFile = FilePart & { filename: string };
+export type Phase = 'complete' | 'streaming' | 'stopped' | 'question' | 'approval' | 'declined' | 'error';
+export type Scenario = Phase | 'empty' | 'long';
+
+export interface Turn {
+  id: string;
+  prompt: string;
+  files: ChatFile[];
+  phase: Phase;
+  text: string;
+  answer?: string;
+  review?: boolean;
+}
+
+export const reply = `The composer now keeps attachments beside the draft and sends them with the message.
+
+- **Keyboard:** Enter sends; Shift + Enter adds a line.
+- **Attachments:** previews stay available in the conversation.
+- **Streaming:** Stop keeps the partial reply, and the next message starts a new turn.
+
+\`\`\`tsx
+<ComposerInput aria-label="Message" placeholder="Ask a follow-up…" />
+\`\`\`
+
+The conversation is ready for another review.`;
+
+export const reviewFiles: ChatFile[] = [
+  {
+    type: 'file',
+    filename: 'review-notes.txt',
+    mimeType: 'text/plain',
+    data: 'Keep attachments with the message.\nSupport keyboard navigation.\nRésumé: café, 日本語, 👋',
+  },
+  {
+    type: 'file',
+    filename: 'composer-layout.svg',
+    mimeType: 'image/svg+xml',
+    data: `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="480" height="240" viewBox="0 0 480 240"><rect width="480" height="240" rx="20" fill="#18181b"/><rect x="24" y="24" width="280" height="16" rx="8" fill="#a1a1aa"/><rect x="24" y="56" width="210" height="16" rx="8" fill="#71717a"/><rect x="24" y="112" width="432" height="104" rx="16" fill="#27272a"/><rect x="40" y="128" width="112" height="24" rx="8" fill="#52525b"/><rect x="40" y="176" width="200" height="12" rx="6" fill="#71717a"/><circle cx="424" cy="184" r="16" fill="#a3e8c0"/></svg>')}`,
+  },
+];
+
+export const reviewTools = [
+  {
+    toolName: 'read_file',
+    args: { path: 'src/chat/composer.tsx' },
+    status: 'idle',
+    output: 'Enter currently adds a newline.',
+  },
+  {
+    toolName: 'grep',
+    args: { pattern: 'onKeyDown', path: 'src/chat' },
+    status: 'idle',
+    output: 'composer.tsx:42: onKeyDown',
+  },
+  { toolName: 'execute_command', args: { command: 'pnpm test composer' }, status: 'idle', output: '6 tests passed.' },
+] satisfies (ToolCallGroupStep & { output: string })[];
+
+export const editArgs = {
+  path: 'src/chat/composer.tsx',
+  old_string: 'if (event.key === "Enter") return;',
+  new_string: 'if (event.key === "Enter" && !event.shiftKey) submit();',
+};
+
+export const plan = `1. Keep file previews next to the draft.
+2. Send text and attachments together.
+3. Verify keyboard, streaming, and narrow layouts.`;
+
+export function createInitialTurns(scenario: Scenario): Turn[] {
+  if (scenario === 'empty') return [];
+  const phase = scenario === 'long' ? 'complete' : scenario;
+  let initialText = '';
+  if (phase === 'complete') initialText = reply;
+  if (phase === 'stopped') initialText = reply.slice(0, 100);
+  const review: Turn = {
+    id: 'review',
+    prompt: 'Review the chat composer using these notes and the attached layout. Show your plan before making changes.',
+    files: reviewFiles,
+    phase,
+    text: initialText,
+    answer: phase === 'question' ? undefined : 'Keyboard access',
+    review: true,
+  };
+  if (scenario !== 'long') return [review];
+  return [
+    ...Array.from(
+      { length: 12 },
+      (_, index): Turn => ({
+        id: `earlier-${index}`,
+        prompt: `Review ${index + 1}: how should the conversation handle a longer history?`,
+        files: [],
+        phase: 'complete',
+        text: 'Keep earlier messages readable while a reply arrives. The timeline can return to this turn, and the jump-to-latest button returns to the composer.',
+      }),
+    ),
+    review,
+  ];
+}

--- a/packages/playground-ui/.storybook/fixtures/chat/response.tsx
+++ b/packages/playground-ui/.storybook/fixtures/chat/response.tsx
@@ -1,0 +1,140 @@
+import { editArgs, plan, reviewTools } from './data';
+import type { Phase, Turn } from './data';
+import { ReviewTool } from './tool';
+import { ToolCallProvider } from '@/domains/chat/context/tool-call-context';
+import { MessageText } from '@/domains/chat/messages/renderers/message-text';
+import { ReasoningPartRenderer } from '@/domains/chat/messages/renderers/reasoning-part-renderer';
+import { SignalBadge } from '@/domains/chat/messages/signal-badge';
+import { ToolApprovalButtons } from '@/domains/chat/tools/badges/tool-approval-buttons';
+import { AskUser } from '@/ds/components/ai/ask-user';
+import {
+  Plan,
+  PlanBody,
+  PlanContent,
+  PlanHeader,
+  PlanHeaderActions,
+  PlanCopyButton,
+  PlanIntro,
+  PlanLabel,
+  PlanMain,
+  PlanTitle,
+} from '@/ds/components/ai/plan';
+import { ToolCallGroup } from '@/ds/components/ai/tool-call';
+import { Button } from '@/ds/components/Button';
+import { CopyButton } from '@/ds/components/CopyButton';
+
+interface ConversationResponseProps {
+  turn: Turn;
+  transitionTurn: (id: string, from: Phase, to: Phase, answer?: string) => void;
+}
+
+export function ConversationResponse({ turn, transitionTurn }: ConversationResponseProps) {
+  const approveEdit = () => transitionTurn(turn.id, 'approval', 'streaming');
+  const declineEdit = () => transitionTurn(turn.id, 'approval', 'declined');
+  return (
+    <div className="flex min-w-0 flex-col gap-4">
+      {turn.review && (
+        <>
+          <ReasoningPartRenderer
+            part={{
+              type: 'reasoning',
+              reasoning:
+                'I’ll compare the existing composer with the notes, check the keyboard behavior, and propose a small change.',
+            }}
+          />
+          <ToolCallGroup steps={reviewTools}>
+            {reviewTools.map(tool => (
+              <ReviewTool key={tool.toolName} {...tool} />
+            ))}
+          </ToolCallGroup>
+          <Plan>
+            <PlanHeader>
+              <PlanLabel />
+              <PlanHeaderActions>
+                <PlanCopyButton content={plan} />
+              </PlanHeaderActions>
+            </PlanHeader>
+            <PlanBody>
+              <PlanIntro>
+                <PlanTitle>Keep the composer predictable</PlanTitle>
+              </PlanIntro>
+              <PlanMain>
+                <PlanContent>{plan}</PlanContent>
+              </PlanMain>
+            </PlanBody>
+          </Plan>
+          <AskUser
+            payload={{
+              question: 'What should we prioritize in this review?',
+              options: [
+                { label: 'Keyboard access', description: 'Sending, new lines, and focus.' },
+                { label: 'Attachment previews', description: 'Adding, removing, and opening files.' },
+              ],
+            }}
+            result={turn.answer ? { content: turn.answer } : undefined}
+            onSubmit={answer =>
+              transitionTurn(turn.id, 'question', 'approval', Array.isArray(answer) ? answer.join(', ') : answer)
+            }
+          />
+          {turn.phase !== 'question' && (
+            <ReviewTool toolName="edit_file" args={editArgs} defaultOpen={turn.phase === 'approval'}>
+              {turn.phase === 'approval' && (
+                <ToolCallProvider
+                  approveToolcall={approveEdit}
+                  declineToolcall={declineEdit}
+                  approveToolcallGenerate={approveEdit}
+                  declineToolcallGenerate={declineEdit}
+                  approveNetworkToolcall={approveEdit}
+                  declineNetworkToolcall={declineEdit}
+                  isRunning={false}
+                  toolCallApprovals={{}}
+                  networkToolCallApprovals={{}}
+                >
+                  <ToolApprovalButtons
+                    toolCallId="composer-edit"
+                    toolName="edit_file"
+                    toolCalled={false}
+                    isNetwork={false}
+                    toolApprovalMetadata={{ toolCallId: 'composer-edit', toolName: 'edit_file', args: editArgs }}
+                  />
+                </ToolCallProvider>
+              )}
+            </ReviewTool>
+          )}
+        </>
+      )}
+      {turn.phase === 'error' && (
+        <>
+          <MessageText
+            text="The connection was interrupted before the reply arrived. Your message and attachments are still here."
+            metadata={{ status: 'error' }}
+          />
+          <div>
+            <Button onClick={() => transitionTurn(turn.id, 'error', 'streaming')}>Retry response</Button>
+          </div>
+        </>
+      )}
+      {turn.phase === 'declined' && (
+        <MessageText
+          text="The edit was declined. No changes were applied. You can send revised instructions below."
+          metadata={{ status: 'warning' }}
+        />
+      )}
+      {turn.text && <MessageText text={turn.text} metadata={undefined} streaming={turn.phase === 'streaming'} />}
+      {turn.phase === 'complete' && turn.review && (
+        <SignalBadge
+          signal={{
+            type: 'notification',
+            attributes: { source: 'review', kind: 'success', status: 'completed' },
+            contents: 'Composer review complete',
+          }}
+        />
+      )}
+      {turn.text && turn.phase !== 'streaming' && (
+        <div>
+          <CopyButton content={turn.text} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/playground-ui/.storybook/fixtures/chat/response.tsx
+++ b/packages/playground-ui/.storybook/fixtures/chat/response.tsx
@@ -1,3 +1,4 @@
+import type { TextPart } from '@mastra/react';
 import { editArgs, plan, reviewTools } from './data';
 import type { Phase, Turn } from './data';
 import { ReviewTool } from './tool';
@@ -7,6 +8,7 @@ import { ReasoningPartRenderer } from '@/domains/chat/messages/renderers/reasoni
 import { SignalBadge } from '@/domains/chat/messages/signal-badge';
 import { ToolApprovalButtons } from '@/domains/chat/tools/badges/tool-approval-buttons';
 import { AskUser } from '@/ds/components/ai/ask-user';
+import { useRevealedParts } from '@/ds/components/ai/message-reveal';
 import {
   Plan,
   PlanBody,
@@ -29,6 +31,11 @@ interface ConversationResponseProps {
 }
 
 export function ConversationResponse({ turn, transitionTurn }: ConversationResponseProps) {
+  const writtenParts = [{ type: 'text', text: turn.text }] satisfies TextPart[];
+  const shownParts = useRevealedParts(writtenParts, turn.phase === 'streaming');
+  const shownPart = shownParts[0];
+  const shownText = shownPart?.type === 'text' ? shownPart.text : '';
+  const isRevealing = shownParts !== writtenParts;
   const approveEdit = () => transitionTurn(turn.id, 'approval', 'streaming');
   const declineEdit = () => transitionTurn(turn.id, 'approval', 'declined');
   return (
@@ -120,7 +127,9 @@ export function ConversationResponse({ turn, transitionTurn }: ConversationRespo
           metadata={{ status: 'warning' }}
         />
       )}
-      {turn.text && <MessageText text={turn.text} metadata={undefined} streaming={turn.phase === 'streaming'} />}
+      {shownText && (
+        <MessageText text={shownText} metadata={undefined} streaming={turn.phase === 'streaming' || isRevealing} />
+      )}
       {turn.phase === 'complete' && turn.review && (
         <SignalBadge
           signal={{

--- a/packages/playground-ui/.storybook/fixtures/chat/tool.tsx
+++ b/packages/playground-ui/.storybook/fixtures/chat/tool.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+import {
+  ToolCall,
+  ToolCallContent,
+  ToolCallEdit,
+  ToolCallMono,
+  ToolCallPresentedHeader,
+  ToolCallTrigger,
+  presentTool,
+  stringifyToolValue,
+  toolEdit,
+} from '@/ds/components/ai/tool-call';
+import type { ToolCallStatus } from '@/ds/components/ai/tool-call';
+
+interface ReviewToolProps {
+  toolName: string;
+  args: unknown;
+  status?: ToolCallStatus;
+  output?: string;
+  children?: ReactNode;
+  defaultOpen?: boolean;
+}
+
+export function ReviewTool({ toolName, args, status = 'idle', output, children, defaultOpen }: ReviewToolProps) {
+  const presentation = presentTool(toolName, args);
+  const edit = toolEdit(toolName, args);
+  const input = stringifyToolValue(args);
+  return (
+    <ToolCall status={status} defaultOpen={defaultOpen} aria-label={`Tool: ${toolName}`}>
+      <ToolCallTrigger>
+        <ToolCallPresentedHeader {...presentation} />
+      </ToolCallTrigger>
+      <ToolCallContent>
+        {edit ? <ToolCallEdit edit={edit} /> : <ToolCallMono copyText={input}>{input}</ToolCallMono>}
+        {output && <ToolCallMono copyText={output}>{output}</ToolCallMono>}
+        {children}
+      </ToolCallContent>
+    </ToolCall>
+  );
+}

--- a/packages/playground-ui/.storybook/fixtures/chat/use-conversation.ts
+++ b/packages/playground-ui/.storybook/fixtures/chat/use-conversation.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { createInitialTurns, reply } from './data';
+import type { ChatFile, Phase, Scenario } from './data';
+
+export function useStoryConversation(scenario: Scenario) {
+  const [turns, setTurns] = useState(() => createInitialTurns(scenario));
+  const activeTurn = turns.at(-1);
+  const activeId = activeTurn?.id;
+  const phase = activeTurn?.phase;
+  const busy = phase === 'streaming' || phase === 'approval' || phase === 'question';
+
+  useEffect(() => {
+    if (phase !== 'streaming') return;
+    const timer = window.setInterval(() => {
+      setTurns(current =>
+        current.map(turn => {
+          if (turn.id !== activeId || turn.phase !== 'streaming') return turn;
+          const text = reply.slice(0, turn.text.length + 12);
+          return { ...turn, text, phase: text === reply ? 'complete' : 'streaming' };
+        }),
+      );
+    }, 80);
+    return () => window.clearInterval(timer);
+  }, [activeId, phase]);
+
+  function transitionTurn(id: string, from: Phase, to: Phase, answer?: string) {
+    setTurns(current =>
+      current.map(turn =>
+        turn.id === id && turn.phase === from ? { ...turn, phase: to, answer: answer ?? turn.answer } : turn,
+      ),
+    );
+  }
+
+  function sendMessage(prompt: string, files: ChatFile[]) {
+    if (busy || (!prompt.trim() && files.length === 0)) return;
+    const messageId = crypto.randomUUID();
+    setTurns(current => {
+      if (current.at(-1)?.phase === 'streaming') return current;
+      return [...current, { id: messageId, prompt: prompt.trim(), files, phase: 'streaming', text: '' }];
+    });
+  }
+
+  return { turns, phase, busy, sendMessage, transitionTurn };
+}

--- a/packages/playground-ui/.storybook/tailwind.css
+++ b/packages/playground-ui/.storybook/tailwind.css
@@ -1,1 +1,3 @@
 @import '../src/index.css';
+
+@source './fixtures';

--- a/packages/playground-ui/src/domains/chat/stories/approvals.stories.tsx
+++ b/packages/playground-ui/src/domains/chat/stories/approvals.stories.tsx
@@ -18,7 +18,7 @@ const contextValue = {
 } satisfies ToolCallContextValue;
 
 const meta = {
-  title: 'Chat/Tool Approvals',
+  title: 'AI/Tool Approvals',
   component: ToolApprovalButtons,
   args: {
     toolCallId: 'write-file-1',

--- a/packages/playground-ui/src/domains/chat/stories/attachments.stories.tsx
+++ b/packages/playground-ui/src/domains/chat/stories/attachments.stories.tsx
@@ -4,7 +4,7 @@ import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { UserFilePartRenderer } from '../messages/renderers/user-file-part-renderer';
 
 const meta = {
-  title: 'Chat/Attachments',
+  title: 'AI/Attachments',
   component: UserFilePartRenderer,
   parameters: {
     docs: {

--- a/packages/playground-ui/src/domains/chat/stories/chat.stories.tsx
+++ b/packages/playground-ui/src/domains/chat/stories/chat.stories.tsx
@@ -17,7 +17,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'A complete conversation assembled from playground-ui components: ChatShell, message renderers, grouped tools, plan, edit, question, approvals, tasks, timeline, attachments, and Composer. Send a message or attach a local file; responses stream from a deterministic fixture. Reset restores the selected scenario. This is the shared UI reference; transport, persistence, model selection, and application-specific message wrappers remain owned by Studio and Factory.',
+          'A complete conversation assembled from playground-ui components: ChatShell, message renderers, grouped tools, plan, edit, question, approvals, tasks, timeline, attachments, and Composer. Send a message or attach a local file; a deterministic fixture produces incoming chunks, and useRevealedParts paces the displayed text just as in Studio and Factory. Reset restores the selected scenario. This is the shared UI reference; transport, persistence, model selection, and application-specific message wrappers remain owned by Studio and Factory.',
       },
     },
   },

--- a/packages/playground-ui/src/domains/chat/stories/chat.stories.tsx
+++ b/packages/playground-ui/src/domains/chat/stories/chat.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { ChatConversation } from '../../../../.storybook/fixtures/chat/conversation';
+
+const meta = {
+  title: 'AI/Chat',
+  component: ChatConversation,
+  args: { scenario: 'complete' },
+  argTypes: {
+    scenario: {
+      control: 'select',
+      options: ['complete', 'empty', 'streaming', 'stopped', 'question', 'approval', 'declined', 'error', 'long'],
+    },
+  },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'A complete conversation assembled from playground-ui components: ChatShell, message renderers, grouped tools, plan, edit, question, approvals, tasks, timeline, attachments, and Composer. Send a message or attach a local file; responses stream from a deterministic fixture. Reset restores the selected scenario. This is the shared UI reference; transport, persistence, model selection, and application-specific message wrappers remain owned by Studio and Factory.',
+      },
+    },
+  },
+} satisfies Meta<typeof ChatConversation>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Conversation: Story = {};
+export const Empty: Story = { args: { scenario: 'empty' } };
+export const Streaming: Story = { args: { scenario: 'streaming' } };
+export const Stopped: Story = { args: { scenario: 'stopped' } };
+export const AwaitingAnswer: Story = { args: { scenario: 'question' } };
+export const AwaitingApproval: Story = { args: { scenario: 'approval' } };
+export const Declined: Story = { args: { scenario: 'declined' } };
+export const Error: Story = { args: { scenario: 'error' } };
+export const LongConversation: Story = { args: { scenario: 'long' } };
+
+export const ReviewAndApprove: Story = {
+  args: { scenario: 'question' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(within(canvas.getByRole('group', { name: 'Tool group: 3 steps' })).getByRole('button'));
+    await userEvent.click(within(await canvas.findByRole('group', { name: 'Tool: read_file' })).getByRole('button'));
+    await waitFor(() => expect(canvas.getByText('Enter currently adds a newline.')).toBeVisible());
+    await userEvent.click(canvas.getByRole('radio', { name: /Keyboard access/ }));
+    await userEvent.click(await canvas.findByRole('button', { name: 'Approve' }));
+    await waitFor(() => expect(canvas.getByText('The conversation is ready for another review.')).toBeVisible(), {
+      timeout: 8000,
+    });
+    await expect(canvas.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument();
+  },
+};
+
+export const DeclineEdit: Story = {
+  args: { scenario: 'approval' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Decline' }));
+    await waitFor(() => expect(canvas.getByText(/The edit was declined/)).toBeVisible());
+    await expect(canvas.queryByRole('button', { name: 'Stop response' })).not.toBeInTheDocument();
+  },
+};
+
+export const SendAttachmentsAndStop: Story = {
+  args: { scenario: 'empty' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.upload(canvas.getByLabelText('Attach files'), [
+      new File(['Review the draft.'], 'draft.txt', { type: 'text/plain' }),
+      new File(['Remove this one.'], 'discard.txt', { type: 'text/plain' }),
+    ]);
+    await canvas.findByRole('button', { name: 'Preview draft.txt' });
+    await userEvent.click(canvas.getByRole('button', { name: 'Remove discard.txt' }));
+    const input = canvas.getByRole('textbox', { name: 'Message' });
+    await userEvent.type(input, 'Review this draft.{shift>}{enter}{/shift}Keep both lines.');
+    await expect(input).toHaveValue('Review this draft.\nKeep both lines.');
+    await userEvent.keyboard('{enter}');
+    await expect(input).toHaveValue('');
+    await expect(canvas.getAllByRole('region', { name: /^Turn / })).toHaveLength(1);
+    await expect(canvas.queryByRole('region', { name: 'Draft attachments' })).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Preview draft.txt' })).toBeInTheDocument();
+    await expect(canvas.queryByText('discard.txt')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(canvas.getByRole('region', { name: 'Turn 1' })).toHaveTextContent(/The composer now keeps attachments/),
+    );
+    await userEvent.click(await canvas.findByRole('button', { name: 'Stop response' }));
+    await expect(input).toHaveFocus();
+    await expect(canvas.getByText('Response stopped')).toBeVisible();
+    await userEvent.type(input, 'Continue.{enter}');
+    await expect(canvas.getAllByRole('region', { name: /^Turn / })).toHaveLength(2);
+    await waitFor(() => expect(canvas.getByText('The conversation is ready for another review.')).toBeVisible(), {
+      timeout: 8000,
+    });
+  },
+};
+
+export const RetryResponse: Story = {
+  args: { scenario: 'error' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Retry response' }));
+    await waitFor(() => expect(canvas.getByText('The conversation is ready for another review.')).toBeVisible(), {
+      timeout: 8000,
+    });
+    await expect(canvas.getAllByRole('region', { name: /^Turn / })).toHaveLength(1);
+    await expect(canvas.queryByRole('button', { name: 'Retry response' })).not.toBeInTheDocument();
+  },
+};

--- a/packages/playground-ui/src/domains/chat/stories/messages.stories.tsx
+++ b/packages/playground-ui/src/domains/chat/stories/messages.stories.tsx
@@ -3,7 +3,7 @@ import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { MessageText } from '../messages/renderers/message-text';
 
 const meta = {
-  title: 'Chat/Message Text',
+  title: 'AI/Message Text',
   component: MessageText,
   args: { metadata: undefined },
   parameters: {

--- a/packages/playground-ui/src/domains/chat/stories/reasoning.stories.tsx
+++ b/packages/playground-ui/src/domains/chat/stories/reasoning.stories.tsx
@@ -4,7 +4,7 @@ import { expect, userEvent, within } from 'storybook/test';
 import { ReasoningPartRenderer } from '../messages/renderers/reasoning-part-renderer';
 
 const meta = {
-  title: 'Chat/Reasoning',
+  title: 'AI/Reasoning',
   component: ReasoningPartRenderer,
   parameters: {
     docs: {

--- a/packages/playground-ui/src/domains/chat/stories/signals.stories.tsx
+++ b/packages/playground-ui/src/domains/chat/stories/signals.stories.tsx
@@ -3,7 +3,7 @@ import { SignalBadge } from '../messages/signal-badge';
 import type { SignalData } from '../messages/signal-data';
 
 const meta = {
-  title: 'Chat/Signals',
+  title: 'AI/Signals',
   component: SignalBadge,
   parameters: {
     docs: {

--- a/packages/playground-ui/src/domains/chat/stories/system-reminders.stories.tsx
+++ b/packages/playground-ui/src/domains/chat/stories/system-reminders.stories.tsx
@@ -3,7 +3,7 @@ import { expect, userEvent, within } from 'storybook/test';
 import { UserTextPartRenderer } from '../messages/renderers/user-text-part-renderer';
 
 const meta = {
-  title: 'Chat/System Reminders',
+  title: 'AI/System Reminders',
   component: UserTextPartRenderer,
   args: {
     part: {


### PR DESCRIPTION
**─────── TLDR ───────**
> Review the whole chat in `AI/Chat`, with the actual playground-ui components and a working composer.

Reviewing chat changes in Storybook
&nbsp;&nbsp;├─ **was** — separate stories for messages, tools, attachments, and input
&nbsp;&nbsp;└─ **now** — one conversation with reasoning, grouped tools, a plan, edit preview, question, approval, tasks, and attachments

Send a message or attach a local file. A fixture generates incoming chunks; the shared `useRevealedParts` hook used by Studio and Factory paces the displayed text. Stop keeps the partial reply. Separate scenarios cover empty history, approval, decline, errors with retry, and a longer conversation with timeline navigation. Reset restores the selected scenario.

All UI components and providers come from playground-ui. The conversation state lives in Storybook fixtures. Studio and Factory still own their transport, persistence, and application-specific wrappers; this gives us the shared UI reference before consolidating those wrappers.

Moves the stories from #23761 into the existing **AI** category.

---

> ██████████████████ **storybook fixtures** `+690`
> ███ **stories and interaction checks** `+115 −6`
> █ **storybook styles** `+2`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds complete chat examples to Storybook. Users can view and test messages, files, approvals, questions, errors, retries, and streaming replies.

## Summary

- Added reusable chat fixtures for:
  - Conversation data and scenarios.
  - Streaming responses with reasoning, plans, grouped tools, questions, and edit approvals.
  - File attachments and message composition.
  - Sending, stopping, retrying, approving, and declining responses.
  - Conversation reset and timeline navigation.
- Added `AI/Chat` stories for complete, empty, streaming, stopped, question, approval, declined, error, and long conversations.
- Added interaction tests for approvals, declines, attachments, stopping responses, continued responses, and retries.
- Moved existing chat stories under the `AI` Storybook category.
- Updated Tailwind source scanning to include Storybook fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->