### PR TITLE
feat(playground-ui): share composer slash-command suggestions

### DIFF
--- a/.changeset/kind-things-sip.md
+++ b/.changeset/kind-things-sip.md
@@ -1,0 +1,24 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added reusable slash-command suggestions and keyboard navigation for chat composers.
+
+Use `ComposerSuggestions` and `useComposerCommands` from `@mastra/playground-ui/components/Composer`. Supply the available commands, controlled draft, input ref, and submission callback:
+
+```tsx
+const commands = useComposerCommands({
+  commands: availableCommands,
+  value: draft,
+  onValueChange: setDraft,
+  onSubmit: submitCommand,
+  inputRef,
+});
+
+<ComposerBox>
+  <ComposerSuggestions {...commands.suggestionsProps} />
+  <ComposerInput {...commands.inputProps} ref={inputRef} aria-label="Message" />
+</ComposerBox>;
+```
+
+Compose the input key handler with normal message submission: call `commands.inputProps.onKeyDown(event)` first, then submit only if `event.defaultPrevented` is false. The application continues to own command execution and permissions.

--- a/packages/playground-ui/.storybook/fixtures/chat/commands.ts
+++ b/packages/playground-ui/.storybook/fixtures/chat/commands.ts
@@ -1,0 +1,13 @@
+import type { ComposerCommand } from '@/ds/components/Composer';
+
+export const reviewCommands: ComposerCommand[] = [
+  {
+    name: 'review',
+    description: 'Review part of the conversation UI',
+    options: [
+      { value: 'keyboard', label: 'Keyboard access', description: 'Sending, navigation, and focus' },
+      { value: 'attachments', label: 'Attachment previews', description: 'Adding, removing, and opening files' },
+    ],
+  },
+  { name: 'summarize', description: 'Summarize the conversation' },
+];

--- a/packages/playground-ui/.storybook/fixtures/chat/composer.tsx
+++ b/packages/playground-ui/.storybook/fixtures/chat/composer.tsx
@@ -1,5 +1,6 @@
 import { ArrowUp, Paperclip, Square, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+import { reviewCommands } from './commands';
 import type { ChatFile, Phase } from './data';
 import { UserFilePartRenderer } from '@/domains/chat/messages/renderers/user-file-part-renderer';
 import { Button } from '@/ds/components/Button';
@@ -10,6 +11,8 @@ import {
   ComposerBox,
   ComposerInput,
   ComposerRing,
+  ComposerSuggestions,
+  useComposerCommands,
 } from '@/ds/components/Composer';
 import { Notice } from '@/ds/components/Notice';
 import { Txt } from '@/ds/components/Txt';
@@ -48,6 +51,14 @@ export function ConversationComposer({ phase, busy, onSend, onStop }: Conversati
   const reading = files.some(file => !file.part && !file.error);
   const readyFiles = files.flatMap(file => (file.part ? [file.part] : []));
   const canSend = !busy && files.every(file => file.part) && (text.trim().length > 0 || readyFiles.length > 0);
+  const commands = useComposerCommands({
+    commands: reviewCommands,
+    value: text,
+    onValueChange: setText,
+    onSubmit: submitMessage,
+    inputRef: messageInput,
+    enabled: !busy,
+  });
 
   useEffect(() => {
     const pending = readers.current;
@@ -93,9 +104,9 @@ export function ConversationComposer({ phase, busy, onSend, onStop }: Conversati
     setFiles(current => current.filter(file => file.id !== id));
   }
 
-  function submitMessage() {
+  function submitMessage(message = text) {
     if (!canSend) return;
-    onSend(text, readyFiles);
+    onSend(message, readyFiles);
     setText('');
     setFiles([]);
     setSentCount(current => current + 1);
@@ -123,6 +134,7 @@ export function ConversationComposer({ phase, busy, onSend, onStop }: Conversati
       />
       <ComposerRing busy={phase === 'streaming'}>
         <ComposerBox sendingPulseKey={sentCount}>
+          <ComposerSuggestions {...commands.suggestionsProps} />
           {files.length > 0 && (
             <ComposerAttachments aria-label="Draft attachments" className="flex flex-wrap gap-2 px-3 pt-3">
               {files.map(file => (
@@ -154,13 +166,15 @@ export function ConversationComposer({ phase, busy, onSend, onStop }: Conversati
             </ComposerAttachments>
           )}
           <ComposerInput
+            {...commands.inputProps}
             ref={messageInput}
             aria-label="Message"
-            placeholder="Ask a follow-up…"
-            value={text}
-            onChange={event => setText(event.target.value)}
+            placeholder="Ask a follow-up, or / for commands…"
             onKeyDown={event => {
-              const shouldSend = event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing;
+              commands.inputProps.onKeyDown(event);
+              if (event.defaultPrevented) return;
+              const composing = event.nativeEvent.isComposing || event.keyCode === 229;
+              const shouldSend = event.key === 'Enter' && !event.shiftKey && !composing;
               if (shouldSend) {
                 event.preventDefault();
                 submitMessage();

--- a/packages/playground-ui/.storybook/fixtures/command-composer.tsx
+++ b/packages/playground-ui/.storybook/fixtures/command-composer.tsx
@@ -1,0 +1,78 @@
+import { useRef, useState } from 'react';
+import { reviewCommands } from './chat/commands';
+import { Button } from '@/ds/components/Button';
+import {
+  Composer,
+  ComposerActions,
+  ComposerBox,
+  ComposerInput,
+  ComposerSuggestions,
+  useComposerCommands,
+} from '@/ds/components/Composer';
+import type { ComposerCommand } from '@/ds/components/Composer';
+import { Txt } from '@/ds/components/Txt';
+
+interface CommandComposerProps {
+  initialValue?: string;
+  commands?: readonly ComposerCommand[];
+  enabled?: boolean;
+}
+
+export function CommandComposer({
+  initialValue = '/',
+  commands = reviewCommands,
+  enabled = true,
+}: CommandComposerProps) {
+  const [value, setValue] = useState(initialValue);
+  const [submitted, setSubmitted] = useState('');
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const commandMenu = useComposerCommands({
+    commands,
+    value,
+    onValueChange: setValue,
+    onSubmit: submit,
+    inputRef,
+    enabled,
+  });
+
+  function submit(text: string) {
+    setSubmitted(text);
+    setValue('');
+  }
+
+  return (
+    <Composer
+      onSubmit={event => {
+        event.preventDefault();
+        if (value.trim()) submit(value);
+      }}
+    >
+      <ComposerBox>
+        <ComposerSuggestions {...commandMenu.suggestionsProps} />
+        <ComposerInput
+          {...commandMenu.inputProps}
+          ref={inputRef}
+          aria-label="Message"
+          placeholder="Type / for commands…"
+          onKeyDown={event => {
+            commandMenu.inputProps.onKeyDown(event);
+            const composing = event.nativeEvent.isComposing || event.keyCode === 229;
+            const shouldSubmit = event.key === 'Enter' && !event.shiftKey && !composing;
+            if (!event.defaultPrevented && shouldSubmit) {
+              event.preventDefault();
+              if (value.trim()) submit(value);
+            }
+          }}
+        />
+        <ComposerActions>
+          <Txt variant="ui-sm" role="status">
+            {submitted ? `Submitted: ${submitted}` : 'Ready'}
+          </Txt>
+          <Button type="submit" disabled={!value.trim()}>
+            Send
+          </Button>
+        </ComposerActions>
+      </ComposerBox>
+    </Composer>
+  );
+}

--- a/packages/playground-ui/src/domains/chat/stories/chat.stories.tsx
+++ b/packages/playground-ui/src/domains/chat/stories/chat.stories.tsx
@@ -17,7 +17,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'A complete conversation assembled from playground-ui components: ChatShell, message renderers, grouped tools, plan, edit, question, approvals, tasks, timeline, attachments, and Composer. Send a message or attach a local file; a deterministic fixture produces incoming chunks, and useRevealedParts paces the displayed text just as in Studio and Factory. Reset restores the selected scenario. This is the shared UI reference; transport, persistence, model selection, and application-specific message wrappers remain owned by Studio and Factory.',
+          'An interactive conversation assembled from playground-ui components: ChatShell, message renderers, grouped tools, plan, edit, question, approvals, tasks, timeline, attachments, and Composer. Type / for fixture commands, send a message, or attach a local file. ComposerSuggestions and useComposerCommands provide the shared command interaction; command selection submits a fixture message. A deterministic fixture produces incoming chunks, and useRevealedParts paces the displayed text. Reset restores the selected scenario. Transport, persistence, model selection, and application-specific message wrappers remain owned by Studio and Factory.',
       },
     },
   },
@@ -35,6 +35,29 @@ export const AwaitingApproval: Story = { args: { scenario: 'approval' } };
 export const Declined: Story = { args: { scenario: 'declined' } };
 export const Error: Story = { args: { scenario: 'error' } };
 export const LongConversation: Story = { args: { scenario: 'long' } };
+
+export const SlashCommands: Story = {
+  args: { scenario: 'empty' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox', { name: 'Message' });
+    await userEvent.type(input, '/');
+    await expect(await canvas.findByRole('listbox', { name: 'Slash commands' })).toBeVisible();
+    await userEvent.type(input, 'rev');
+    await userEvent.keyboard('{Tab}');
+    await expect(input).toHaveValue('/review ');
+    await expect(await canvas.findByRole('listbox', { name: '/review options' })).toBeVisible();
+    await userEvent.keyboard('{Escape}');
+    await expect(input).toHaveValue('/review');
+    await userEvent.keyboard('{Enter}{ArrowDown}{Enter}');
+    await expect(input).toHaveValue('');
+    await expect(input).toHaveFocus();
+    await expect(canvas.getByRole('region', { name: 'Turn 1' })).toHaveTextContent('/review attachments');
+    await expect(canvas.getByRole('button', { name: 'Stop response' })).toBeVisible();
+    await userEvent.click(canvas.getByRole('button', { name: 'Stop response' }));
+    await expect(input).toHaveFocus();
+  },
+};
 
 export const ReviewAndApprove: Story = {
   args: { scenario: 'question' },

--- a/packages/playground-ui/src/ds/components/Composer/commands/command-matches.ts
+++ b/packages/playground-ui/src/ds/components/Composer/commands/command-matches.ts
@@ -1,0 +1,31 @@
+export interface ComposerCommandOption {
+  value: string;
+  label: string;
+  description?: string;
+  active?: boolean;
+}
+
+export interface ComposerCommand {
+  name: string;
+  description: string;
+  options?: readonly ComposerCommandOption[];
+}
+
+export function matchCommands<T extends Pick<ComposerCommand, 'name'>>(commands: readonly T[], draft: string): T[] {
+  if (!draft.startsWith('/')) return [];
+  const query = draft.slice(1).toLowerCase();
+  if (/\s/.test(query)) return [];
+  return commands.filter(command => command.name.toLowerCase().startsWith(query));
+}
+
+export function matchCommandOptions<T extends ComposerCommand>(commands: readonly T[], draft: string) {
+  if (!draft.startsWith('/')) return undefined;
+  const firstWhitespace = draft.search(/\s/);
+  if (firstWhitespace === -1) return undefined;
+  const command = commands.find(candidate => candidate.name === draft.slice(1, firstWhitespace));
+  if (!command?.options) return undefined;
+  const query = draft.slice(firstWhitespace).trim().toLowerCase();
+  if (/\s/.test(query)) return undefined;
+  const options = command.options.filter(option => option.value.toLowerCase().startsWith(query));
+  return options.length > 0 ? { command, options } : undefined;
+}

--- a/packages/playground-ui/src/ds/components/Composer/commands/composer-commands.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Composer/commands/composer-commands.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CommandComposer } from '../../../../../.storybook/fixtures/command-composer';
+
+const meta = {
+  title: 'AI/Composer Commands',
+  component: CommandComposer,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Compose ComposerSuggestions with useComposerCommands. Spread inputProps onto ComposerInput and suggestionsProps onto ComposerSuggestions. The caller owns the draft and onSubmit callback; the hook handles prefix matching, option selection, keyboard navigation, and focus. When composing an onKeyDown handler, call inputProps.onKeyDown first and handle submission only when the event has not been prevented. Enter on an exact command without options falls through to the caller. Command execution and availability belong to the application.',
+      },
+    },
+  },
+} satisfies Meta<typeof CommandComposer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Commands: Story = {};
+export const CommandOptions: Story = { args: { initialValue: '/review ' } };
+export const NoMatch: Story = { args: { initialValue: '/unknown' } };
+export const Disabled: Story = { args: { enabled: false } };
+export const LongList: Story = {
+  args: {
+    commands: Array.from({ length: 500 }, (_, index) => ({
+      name: `command-${index + 1}`,
+      description: 'A command with a long description that should stay within the composer on narrow screens',
+    })),
+  },
+};

--- a/packages/playground-ui/src/ds/components/Composer/commands/composer-commands.test.tsx
+++ b/packages/playground-ui/src/ds/components/Composer/commands/composer-commands.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { CommandComposer } from '../../../../../.storybook/fixtures/command-composer';
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+afterEach(cleanup);
+
+function messageInput() {
+  return screen.getByRole<HTMLTextAreaElement>('textbox', { name: 'Message' });
+}
+
+describe('Composer commands', () => {
+  describe('when the user types a slash prefix', () => {
+    it('filters commands and completes the selection without submitting', () => {
+      render(<CommandComposer initialValue="" />);
+      const input = messageInput();
+      input.focus();
+      fireEvent.change(input, { target: { value: '/rev' } });
+      expect(screen.getAllByRole('option')).toHaveLength(1);
+      fireEvent.keyDown(input, { key: 'Tab' });
+      expect(input.value).toBe('/review ');
+      expect(screen.getByRole('listbox', { name: '/review options' })).toBeTruthy();
+      expect(screen.getByRole('status').textContent).toBe('Ready');
+      expect(document.activeElement).toBe(input);
+    });
+
+    it('wraps arrow navigation and exposes the active option to the textarea', () => {
+      render(<CommandComposer />);
+      const input = messageInput();
+      fireEvent.keyDown(input, { key: 'ArrowUp' });
+      const selected = screen.getByRole('option', { selected: true });
+      expect(selected.textContent).toContain('/summarize');
+      expect(input.getAttribute('aria-activedescendant')).toBe(selected.id);
+      expect(input.getAttribute('aria-controls')).toBe(screen.getByRole('listbox').id);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      expect(screen.getByRole('option', { selected: true }).textContent).toContain('/review');
+    });
+
+    it('resets navigation when the query changes and when the menu is reopened', () => {
+      render(<CommandComposer />);
+      const input = messageInput();
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      fireEvent.change(input, { target: { value: '/r' } });
+      expect(screen.getByRole('option', { selected: true }).textContent).toContain('/review');
+      fireEvent.change(input, { target: { value: '/' } });
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      fireEvent.keyDown(input, { key: 'Escape' });
+      expect(input.value).toBe('');
+      expect(input.getAttribute('aria-activedescendant')).toBeNull();
+      fireEvent.change(input, { target: { value: '/' } });
+      expect(screen.getByRole('option', { selected: true }).textContent).toContain('/review');
+    });
+  });
+
+  describe('when a command has options', () => {
+    it('submits the selected option with the command name', () => {
+      render(<CommandComposer initialValue="/review " />);
+      const input = messageInput();
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(screen.getByRole('status').textContent).toBe('Submitted: /review attachments');
+      expect(input.value).toBe('');
+      expect(document.activeElement).toBe(input);
+    });
+
+    it('returns to commands with Escape and the back button', () => {
+      render(<CommandComposer initialValue="/review " />);
+      const input = messageInput();
+      fireEvent.keyDown(input, { key: 'Escape' });
+      expect(input.value).toBe('/review');
+      fireEvent.keyDown(input, { key: 'Enter' });
+      const back = screen.getByRole('button', { name: 'Back to slash commands' });
+      back.focus();
+      fireEvent.click(back);
+      expect(input.value).toBe('/review');
+      expect(document.activeElement).toBe(input);
+    });
+
+    it('supports pointer selection and filters options by their value', () => {
+      render(<CommandComposer />);
+      fireEvent.click(screen.getByRole('option', { name: /\/review / }));
+      fireEvent.change(messageInput(), { target: { value: '/review att' } });
+      expect(screen.getAllByRole('option')).toHaveLength(1);
+      fireEvent.click(screen.getByRole('option', { name: /Attachment previews/ }));
+      expect(screen.getByRole('status').textContent).toBe('Submitted: /review attachments');
+      expect(document.activeElement).toBe(messageInput());
+    });
+  });
+
+  describe('when the caller owns normal submission', () => {
+    it.each(['/summarize', '/review custom arguments', '/unknown'])('preserves the submitted text %s', value => {
+      render(<CommandComposer initialValue={value} />);
+      fireEvent.keyDown(messageInput(), { key: 'Enter' });
+      expect(screen.getByRole('status').textContent).toBe(`Submitted: ${value}`);
+    });
+
+    it('leaves Shift+Enter and Shift+Tab to the caller', () => {
+      render(<CommandComposer />);
+      expect(fireEvent.keyDown(messageInput(), { key: 'Enter', shiftKey: true })).toBe(true);
+      expect(fireEvent.keyDown(messageInput(), { key: 'Tab', shiftKey: true })).toBe(true);
+      expect(messageInput().value).toBe('/');
+    });
+
+    it.each([{ isComposing: true }, { keyCode: 229 }])('does not select or submit during IME composition %j', flags => {
+      render(<CommandComposer initialValue="/review " />);
+      fireEvent.keyDown(messageInput(), { key: 'Enter', ...flags });
+      expect(messageInput().value).toBe('/review ');
+      expect(screen.getByRole('status').textContent).toBe('Ready');
+    });
+  });
+
+  describe('when command availability changes', () => {
+    it('stops intercepting keys when disabled', () => {
+      const { rerender } = render(<CommandComposer />);
+      rerender(<CommandComposer enabled={false} />);
+      expect(messageInput().getAttribute('aria-controls')).toBeNull();
+      expect(fireEvent.keyDown(messageInput(), { key: 'Tab' })).toBe(true);
+    });
+
+    it('keeps selection valid when the command list shrinks', () => {
+      const { rerender } = render(<CommandComposer />);
+      fireEvent.keyDown(messageInput(), { key: 'ArrowDown' });
+      rerender(<CommandComposer commands={[{ name: 'available', description: 'Available command' }]} />);
+      fireEvent.keyDown(messageInput(), { key: 'Tab' });
+      expect(messageInput().value).toBe('/available ');
+      rerender(<CommandComposer commands={[]} />);
+      expect(messageInput().getAttribute('aria-activedescendant')).toBeNull();
+    });
+  });
+});

--- a/packages/playground-ui/src/ds/components/Composer/commands/composer-commands.test.tsx
+++ b/packages/playground-ui/src/ds/components/Composer/commands/composer-commands.test.tsx
@@ -82,7 +82,7 @@ describe('Composer commands', () => {
 
     it('supports pointer selection and filters options by their value', () => {
       render(<CommandComposer />);
-      fireEvent.click(screen.getByRole('option', { name: /\/review / }));
+      fireEvent.click(screen.getByRole('option', { name: /^\/review/ }));
       fireEvent.change(messageInput(), { target: { value: '/review att' } });
       expect(screen.getAllByRole('option')).toHaveLength(1);
       fireEvent.click(screen.getByRole('option', { name: /Attachment previews/ }));

--- a/packages/playground-ui/src/ds/components/Composer/commands/composer-suggestions.tsx
+++ b/packages/playground-ui/src/ds/components/Composer/commands/composer-suggestions.tsx
@@ -1,0 +1,104 @@
+import { Collapsible } from '@base-ui/react/collapsible';
+import { ArrowLeft, Check } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import { ScrollArea } from '../../ScrollArea';
+import { cn } from '@/lib/utils';
+
+export interface ComposerSuggestionItem {
+  id: string;
+  label: string;
+  description?: string;
+  active?: boolean;
+}
+
+export interface ComposerSuggestionsProps {
+  id: string;
+  items: readonly ComposerSuggestionItem[];
+  activeIndex: number;
+  contextLabel?: string;
+  onBack?: () => void;
+  onSelect: (index: number) => void;
+}
+
+export function ComposerSuggestions({
+  id,
+  items,
+  activeIndex,
+  contextLabel,
+  onBack,
+  onSelect,
+}: ComposerSuggestionsProps) {
+  const activeOption = useRef<HTMLButtonElement>(null);
+  const activeItemId = items[activeIndex]?.id;
+  const label = contextLabel ? `${contextLabel} options` : 'Slash commands';
+
+  useEffect(() => {
+    activeOption.current?.scrollIntoView({ block: 'nearest' });
+  }, [activeItemId]);
+
+  return (
+    <Collapsible.Root open={items.length > 0}>
+      <Collapsible.Panel className="duration-normal ease-out-custom h-[var(--collapsible-panel-height)] overflow-hidden transition-[height] data-[ending-style]:h-0 data-[starting-style]:h-0 motion-reduce:transition-none">
+        <div className="border-border1/60 border-b" role="region" aria-label={label}>
+          {contextLabel && onBack && (
+            <div className="border-border1/60 border-b px-1.5 py-1">
+              <button
+                type="button"
+                className="text-icon3 hover:text-icon6 text-ui-sm duration-normal ease-out-custom hover:bg-neutral6/5 flex items-center gap-1.5 rounded-xl px-2 py-1.5 transition-colors motion-reduce:transition-none"
+                aria-label="Back to slash commands"
+                onMouseDown={event => event.preventDefault()}
+                onClick={onBack}
+              >
+                <ArrowLeft size={14} aria-hidden />
+                <span>{contextLabel}</span>
+              </button>
+            </div>
+          )}
+          <ScrollArea maxHeight="min(22rem, 50dvh)" viewPortClassName="overscroll-contain">
+            <div id={id} role="listbox" aria-label={label} className="flex flex-col gap-px p-1.5">
+              {items.map((item, index) => (
+                <button
+                  ref={index === activeIndex ? activeOption : undefined}
+                  id={item.id}
+                  key={item.id}
+                  type="button"
+                  role="option"
+                  tabIndex={-1}
+                  aria-selected={index === activeIndex}
+                  aria-current={item.active ? 'true' : undefined}
+                  className={cn(
+                    'flex w-full cursor-pointer items-center justify-between gap-4 rounded-2xl px-2 py-1.5 text-left text-ui-sm transition-colors duration-normal ease-out-custom motion-reduce:transition-none',
+                    index === activeIndex
+                      ? 'text-icon6 bg-neutral6/5'
+                      : 'text-icon3 hover:text-icon6 hover:bg-neutral6/5',
+                  )}
+                  onMouseDown={event => event.preventDefault()}
+                  onClick={() => onSelect(index)}
+                >
+                  <span className="max-w-[60%] min-w-0 shrink-0 truncate" title={item.label}>
+                    {item.label}
+                  </span>
+                  {(item.description || item.active) && (
+                    <span className="flex min-w-0 items-center gap-1.5 text-right">
+                      {item.description && (
+                        <span className="truncate" title={item.description}>
+                          {item.description}
+                        </span>
+                      )}
+                      {item.active && (
+                        <span className="flex shrink-0 items-center gap-1">
+                          <Check size={13} aria-hidden />
+                          Current
+                        </span>
+                      )}
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+          </ScrollArea>
+        </div>
+      </Collapsible.Panel>
+    </Collapsible.Root>
+  );
+}

--- a/packages/playground-ui/src/ds/components/Composer/commands/use-composer-commands.ts
+++ b/packages/playground-ui/src/ds/components/Composer/commands/use-composer-commands.ts
@@ -1,0 +1,112 @@
+import type { ChangeEvent, ComponentPropsWithoutRef, KeyboardEvent, RefObject } from 'react';
+import { useId, useState } from 'react';
+import type { ComposerCommand, ComposerCommandOption } from './command-matches';
+import { matchCommandOptions, matchCommands } from './command-matches';
+import type { ComposerSuggestionItem, ComposerSuggestionsProps } from './composer-suggestions';
+
+function createSuggestionItems(
+  listId: string,
+  commands: readonly ComposerCommand[],
+  options?: readonly ComposerCommandOption[],
+): ComposerSuggestionItem[] {
+  if (options)
+    return options.map(option => ({ ...option, id: `${listId}-option-${encodeURIComponent(option.value)}` }));
+  return commands.map(command => ({
+    id: `${listId}-command-${encodeURIComponent(command.name)}`,
+    label: `/${command.name}`,
+    description: command.description,
+  }));
+}
+
+export interface UseComposerCommandsProps {
+  commands: readonly ComposerCommand[];
+  value: string;
+  onValueChange: (value: string) => void;
+  onSubmit: (value: string) => void;
+  inputRef: RefObject<HTMLTextAreaElement | null>;
+  enabled?: boolean;
+}
+
+export function useComposerCommands({
+  commands,
+  value,
+  onValueChange,
+  onSubmit,
+  inputRef,
+  enabled = true,
+}: UseComposerCommandsProps) {
+  const listId = useId();
+  const [navigation, setNavigation] = useState({ value: '', index: 0 });
+  const optionMatch = enabled ? matchCommandOptions(commands, value) : undefined;
+  const matchingCommands = enabled && !optionMatch ? matchCommands(commands, value) : [];
+  const items = createSuggestionItems(listId, matchingCommands, optionMatch?.options);
+  const boundedIndex = Math.min(navigation.index, Math.max(0, items.length - 1));
+  const activeIndex = navigation.value === value ? boundedIndex : 0;
+
+  function updateValue(nextValue: string) {
+    setNavigation({ value: nextValue, index: 0 });
+    onValueChange(nextValue);
+  }
+
+  function returnToCommands() {
+    updateValue(optionMatch ? `/${optionMatch.command.name}` : '');
+    inputRef.current?.focus();
+  }
+
+  function selectSuggestion(index: number) {
+    inputRef.current?.focus();
+    if (optionMatch) {
+      const option = optionMatch.options[index];
+      if (option) onSubmit(`/${optionMatch.command.name} ${option.value}`);
+      return;
+    }
+    const command = matchingCommands[index];
+    if (command) updateValue(`/${command.name} `);
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    const isModified = event.shiftKey || event.ctrlKey || event.metaKey || event.altKey;
+    const isComposing = event.nativeEvent.isComposing || event.keyCode === 229;
+    if (isModified || isComposing || items.length === 0) return;
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      const direction = event.key === 'ArrowDown' ? 1 : -1;
+      setNavigation({ value, index: (activeIndex + direction + items.length) % items.length });
+      return;
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      returnToCommands();
+      return;
+    }
+    if (event.key === 'Tab' || event.key === 'Enter') {
+      const command = matchingCommands[activeIndex];
+      const exactCommand = matchingCommands.length === 1 && value.toLowerCase() === `/${command?.name}`;
+      const submitExactCommand = event.key === 'Enter' && exactCommand && !command?.options?.length;
+      if (submitExactCommand) return;
+      event.preventDefault();
+      selectSuggestion(activeIndex);
+    }
+  }
+
+  const inputProps = {
+    value,
+    onChange: (event: ChangeEvent<HTMLTextAreaElement>) => updateValue(event.target.value),
+    'aria-autocomplete': 'list',
+    'aria-controls': items.length > 0 ? listId : undefined,
+    'aria-activedescendant': items[activeIndex]?.id,
+    onKeyDown,
+  } satisfies ComponentPropsWithoutRef<'textarea'>;
+
+  const suggestionsProps: ComposerSuggestionsProps = {
+    id: listId,
+    items,
+    activeIndex,
+    contextLabel: optionMatch ? `/${optionMatch.command.name}` : undefined,
+    onBack: optionMatch ? returnToCommands : undefined,
+    onSelect: selectSuggestion,
+  };
+
+  return { inputProps, suggestionsProps };
+}

--- a/packages/playground-ui/src/ds/components/Composer/index.ts
+++ b/packages/playground-ui/src/ds/components/Composer/index.ts
@@ -1,2 +1,8 @@
 export { Composer, ComposerActions, ComposerAttachments, ComposerBox, ComposerInput, ComposerRing } from './composer';
 export type { ComposerBoxProps, ComposerInputProps, ComposerProps, ComposerRingProps } from './composer';
+export { ComposerSuggestions } from './commands/composer-suggestions';
+export type { ComposerSuggestionItem, ComposerSuggestionsProps } from './commands/composer-suggestions';
+export { useComposerCommands } from './commands/use-composer-commands';
+export type { UseComposerCommandsProps } from './commands/use-composer-commands';
+export { matchCommands, matchCommandOptions } from './commands/command-matches';
+export type { ComposerCommand, ComposerCommandOption } from './commands/command-matches';


### PR DESCRIPTION
**─────── TLDR ───────**
> Type `/` in the conversation story to select a command through reusable playground-ui components.

Using commands in `AI/Chat / Conversation`
&nbsp;&nbsp;├─ **was** — `/` stayed plain text with no suggestions
&nbsp;&nbsp;└─ **now** — filter commands, open options, and submit a fixture message

Adds `ComposerSuggestions` and `useComposerCommands` to the Composer exports. The hook owns matching, keyboard selection, and focus; the caller supplies commands, the draft, and execution. Exact commands without options and free-form arguments keep the caller's normal submission path.

Includes focused stories for command options, unmatched input, disabled suggestions, and 500 commands. Factory adoption follows in #23768.

Verified 68 targeted tests, the package typecheck, and library and Storybook builds. All five conversation interaction stories pass in the browser; command menus were checked at desktop, tablet, and mobile widths, with 500 commands and reduced motion. React Doctor found no issues in the changed files.

---

> ██████████████████ **shared UI** `+253`
> ████████████ **stories and fixtures** `+166 −7`
> ██████████ **interaction tests** `+134`
> ██ **changeset** `+24`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR lets users type `/` in a chat box to find and run available commands. Users can filter commands, choose options with the keyboard or mouse, and keep normal message submission for regular text.

## Changes

- Added reusable `ComposerSuggestions` and `useComposerCommands` APIs.
- Added command and option matching utilities.
- Added keyboard navigation, selection, focus management, IME handling, and disabled-state support.
- Preserved normal submission for exact commands without options and free-form input.
- Exported the new components, hook, utilities, and types from `Composer`.
- Added Storybook examples for options, unmatched commands, disabled suggestions, and 500-command lists.
- Added interaction tests for filtering, navigation, selection, submission, Escape behavior, IME input, and changing command lists.
- Added a minor changeset.

Targeted tests, typechecking, builds, Storybook interaction stories, responsive checks, reduced-motion testing, and React Doctor validation passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->