### PR TITLE
fix(core): resume experiment branches with available data

### DIFF
--- a/.changeset/honest-sloths-battle.md
+++ b/.changeset/honest-sloths-battle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workflow experiments skipping a suspended branch with resume data when an earlier branch has none.

--- a/packages/core/src/datasets/experiment/__tests__/workflow-resume-regression.test.ts
+++ b/packages/core/src/datasets/experiment/__tests__/workflow-resume-regression.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { Mastra } from '../../../mastra';
+import { MockStore } from '../../../storage/mock';
+import { createStep, createWorkflow } from '../../../workflows';
+import type { AnyWorkflow } from '../../../workflows';
+import { executeTarget } from '../executor';
+
+function makeBranch(id: string) {
+  return createStep({
+    id,
+    inputSchema: z.object({}),
+    outputSchema: z.object({ from: z.string() }),
+    suspendSchema: z.object({ need: z.string() }),
+    resumeSchema: z.object({ value: z.string() }),
+    execute: async ({ resumeData, suspend }) => {
+      if (!resumeData) {
+        await suspend({ need: id });
+        return { from: id };
+      }
+      return { from: `${id}:${resumeData.value}` };
+    },
+  });
+}
+
+/** Two independent branches that both suspend on start. */
+function makeParallelWorkflow(id: string) {
+  const branchA = makeBranch('branch-a');
+  const branchB = makeBranch('branch-b');
+  const workflow = createWorkflow({ id, inputSchema: z.object({}), outputSchema: z.any() })
+    .parallel([branchA, branchB])
+    .commit();
+  new Mastra({ logger: false, storage: new MockStore(), workflows: { [id]: workflow } });
+  return workflow;
+}
+
+interface ResumeItem {
+  resumeSteps?: Record<string, unknown>;
+  resumeData?: unknown;
+  metadata?: Record<string, unknown>;
+}
+
+function runWorkflow(workflow: AnyWorkflow, item: ResumeItem) {
+  return executeTarget(workflow, 'workflow', { input: {}, ...item });
+}
+
+function stepOutput(result: Awaited<ReturnType<typeof executeTarget>>, stepId: string): unknown {
+  const step = result.stepResults?.[stepId];
+  if (step?.status !== 'success') {
+    throw new Error(`Expected step "${stepId}" to succeed, got "${step?.status}"`);
+  }
+  return step.output;
+}
+
+describe('workflow experiment branch resume', () => {
+  it('resumes both parallel branches when every branch has data', async () => {
+    const workflow = makeParallelWorkflow('multi-branch-control');
+
+    const result = await runWorkflow(workflow, {
+      resumeSteps: { 'branch-a': { value: 'a' }, 'branch-b': { value: 'b' } },
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.output).toEqual({
+      'branch-a': { from: 'branch-a:a' },
+      'branch-b': { from: 'branch-b:b' },
+    });
+    expect(stepOutput(result, 'branch-a')).toEqual({ from: 'branch-a:a' });
+    expect(stepOutput(result, 'branch-b')).toEqual({ from: 'branch-b:b' });
+  });
+
+  it('resumes a later suspended branch when an earlier branch has no data', async () => {
+    const workflow = makeParallelWorkflow('multi-branch-partial');
+
+    const result = await runWorkflow(workflow, {
+      resumeSteps: { 'branch-b': { value: 'b' } },
+    });
+
+    expect(stepOutput(result, 'branch-b')).toEqual({ from: 'branch-b:b' });
+    expect(result.stepResults?.['branch-a']?.status).toBe('suspended');
+    expect(result.error).not.toBeNull();
+    expect(result.error?.message.toLowerCase()).toContain('suspend');
+  });
+
+  it('resumes a later top-level branch when an earlier nested branch has no data', async () => {
+    const inner = makeBranch('inner');
+    const nested = createWorkflow({
+      id: 'nested-branch',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ from: z.string() }),
+    })
+      .then(inner)
+      .commit();
+    const branchB = makeBranch('branch-b');
+    const workflow = createWorkflow({
+      id: 'multi-branch-nested-first',
+      inputSchema: z.object({}),
+      outputSchema: z.any(),
+    })
+      .parallel([nested, branchB])
+      .commit();
+    new Mastra({
+      logger: false,
+      storage: new MockStore(),
+      workflows: { 'multi-branch-nested-first': workflow, 'nested-branch': nested },
+    });
+
+    const result = await runWorkflow(workflow, { resumeSteps: { 'branch-b': { value: 'b' } } });
+
+    expect(stepOutput(result, 'branch-b')).toEqual({ from: 'branch-b:b' });
+    expect(result.error).not.toBeNull();
+    expect(result.error?.message.toLowerCase()).toContain('suspend');
+  });
+
+  it('stays suspended when no resume data matches any suspended branch', async () => {
+    const workflow = makeParallelWorkflow('multi-branch-no-match');
+
+    const result = await runWorkflow(workflow, {
+      resumeSteps: { 'other-step': { value: 'x' } },
+    });
+
+    expect(result.stepResults?.['branch-a']?.status).toBe('suspended');
+    expect(result.stepResults?.['branch-b']?.status).toBe('suspended');
+    expect(result.error).not.toBeNull();
+    expect(result.error?.message.toLowerCase()).toContain('suspend');
+  });
+
+  it('selects a later branch from metadata.resumeSteps', async () => {
+    const workflow = makeParallelWorkflow('multi-branch-metadata');
+
+    const result = await runWorkflow(workflow, {
+      metadata: { resumeSteps: { 'branch-b': { value: 'b' } } },
+    });
+
+    expect(stepOutput(result, 'branch-b')).toEqual({ from: 'branch-b:b' });
+    expect(result.stepResults?.['branch-a']?.status).toBe('suspended');
+  });
+
+  it('forwards a falsy defined per-step payload to a later branch', async () => {
+    const branchA = makeBranch('branch-a');
+    const branchB = createStep({
+      id: 'branch-b',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ from: z.string() }),
+      suspendSchema: z.object({ need: z.string() }),
+      resumeSchema: z.boolean(),
+      execute: async ({ resumeData, suspend }) => {
+        if (resumeData === undefined) {
+          await suspend({ need: 'branch-b' });
+          return { from: 'branch-b:pending' };
+        }
+        return { from: `branch-b:${resumeData}` };
+      },
+    });
+    const workflow = createWorkflow({
+      id: 'multi-branch-falsy',
+      inputSchema: z.object({}),
+      outputSchema: z.any(),
+    })
+      .parallel([branchA, branchB])
+      .commit();
+    new Mastra({ logger: false, storage: new MockStore(), workflows: { 'multi-branch-falsy': workflow } });
+
+    const result = await runWorkflow(workflow, { resumeSteps: { 'branch-b': false } });
+
+    expect(stepOutput(result, 'branch-b')).toEqual({ from: 'branch-b:false' });
+  });
+
+  it('stops at MAX_RESUME_CYCLES when a matching later branch keeps suspending', async () => {
+    let attempts = 0;
+    const branchA = makeBranch('branch-a');
+    const branchB = createStep({
+      id: 'branch-b',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ from: z.string() }),
+      suspendSchema: z.object({ need: z.string() }),
+      resumeSchema: z.object({ value: z.string() }),
+      execute: async ({ suspend }) => {
+        attempts++;
+        await suspend({ need: 'branch-b' });
+        return { from: 'branch-b' };
+      },
+    });
+    const workflow = createWorkflow({
+      id: 'multi-branch-cycle-cap',
+      inputSchema: z.object({}),
+      outputSchema: z.any(),
+    })
+      .parallel([branchA, branchB])
+      .commit();
+    new Mastra({ logger: false, storage: new MockStore(), workflows: { 'multi-branch-cycle-cap': workflow } });
+
+    const result = await runWorkflow(workflow, { resumeSteps: { 'branch-b': { value: 'b' } } });
+
+    // One initial execute plus MAX_RESUME_CYCLES (10) resumed executes, then the cap stops the loop.
+    expect(attempts).toBe(11);
+    expect(result.error).not.toBeNull();
+    expect(result.error?.message.toLowerCase()).toContain('suspend');
+  });
+});

--- a/packages/core/src/datasets/experiment/executor.ts
+++ b/packages/core/src/datasets/experiment/executor.ts
@@ -533,19 +533,27 @@ async function executeWorkflow(
       const suspendedPaths: string[][] = result.suspended ?? [];
       if (suspendedPaths.length === 0) break;
 
-      // For each suspended step, look up resume data
-      const firstSuspendedStep = suspendedPaths[0]?.[0];
-      if (!firstSuspendedStep) break;
+      // An earlier branch without data must not block a later branch with data.
+      // Prefer per-step data over the flat fallback, preserving falsy payloads.
+      let stepToResume: string | undefined;
+      let stepResumeData: unknown;
+      for (const suspendedPath of suspendedPaths) {
+        const suspendedStep = suspendedPath?.[0];
+        if (!suspendedStep) continue;
 
-      // Resolve resume data: per-step map takes precedence, then flat fallback.
-      // Use explicit undefined check so falsy values (null, false, 0) are forwarded.
-      const perStepValue = perStep?.[firstSuspendedStep];
-      const stepResumeData = perStepValue !== undefined ? perStepValue : flat;
-      if (stepResumeData === undefined) break; // No data for this step, stop resuming
+        const perStepValue = perStep?.[suspendedStep];
+        const candidate = perStepValue !== undefined ? perStepValue : flat;
+        if (candidate === undefined) continue;
+
+        stepToResume = suspendedStep;
+        stepResumeData = candidate;
+        break;
+      }
+      if (stepToResume === undefined) break; // No data for any suspended step, stop resuming
 
       result = await run.resume({
         resumeData: stepResumeData,
-        step: firstSuspendedStep,
+        step: stepToResume,
         ...(reqCtx ? { requestContext: reqCtx } : {}),
         ...observabilityContext,
       });


### PR DESCRIPTION
## Description

When two workflow branches suspend, the experiment stops looking for resume data if the first branch has none. This means data supplied for a later branch is ignored.

This fix skips branches without data and resumes the next matching branch. For example, with branches A and B suspended:

```ts
resumeSteps: { 'branch-b': { value: 'b' } }

// Before: both branches stay suspended.
// After: B resumes; A stays suspended.
```

The existing payload precedence and ten-resume limit stay unchanged. Added regression tests using real workflows and a core patch changeset.

## Related issue(s)

Fixes #23771.

Addresses the branch-selection case in #17380, item 3. This covers part of the issue, not all of it. Related previous work: #17383.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

Tested locally: all 375 dataset tests pass, along with the core build, lint and type checks. Five regression cases fail on the original code and pass with this fix. No API docs changes are needed.
