### PR TITLE
fix(core): declare hono as peer dependency and stop vendoring its types

### DIFF
--- a/.changeset/hono-peer-type-identity.md
+++ b/.changeset/hono-peer-type-identity.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix type identity for Hono types crossing the public API. `hono` is now a peer dependency of `@mastra/core` and its declarations are no longer vendored into `dist/_types`, so published types import from the consumer's own `hono` install. Passing a Hono `Context` or `MiddlewareHandler` to `registerApiRoute` no longer fails typechecking under `"moduleResolution": "bundler"` with TS2322 nominal-mismatch errors. Fixes #22774

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -914,6 +914,7 @@
     "@modelcontextprotocol/server": "2.0.0"
   },
   "peerDependencies": {
+    "hono": "^4.12.8",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -137,7 +137,6 @@ export default defineConfig({
         '@internal/external-types',
         '@internal/core',
         '@internal/voice',
-        'hono',
         'hono-openapi',
         '@internal/auth',
       ]),


### PR DESCRIPTION
## Description

Since the tsdown migration (#19829), the published declarations of `@mastra/core` vendor a copy of Hono's `.d.ts` into `dist/_types/hono/` and point the public server types at that copy. Under `"moduleResolution": "bundler"`, a consumer passing its own hono-typed `Context` / `MiddlewareHandler` to `registerApiRoute` fails typechecking with TS2322: the two hono declarations are structurally identical but nominally distinct (e.g. `[GET_MATCH_RESULT]` originates from different declaration files).

hono crosses the public API boundary of `@mastra/core` (`src/server/index.ts`, `src/server/types.ts`, `src/channels/wait-until.ts`), so its declarations must resolve to the **same** hono the consumer compiles against. This PR:

- declares `hono` as a **peer dependency** of `@mastra/core` (modern package managers auto-install peers, so there is no new install burden, and consumers using hono directly are guaranteed a single copy),
- removes `hono` from the `generateTypes(...)` vendored set in `packages/core/tsdown.config.ts`, so published declarations import from `'hono'` instead of `dist/_types/hono`,
- keeps `hono-openapi` vendored — it is not part of the consumer-facing identity surface, and after this change its vendored declarations import from the consumer's hono anyway.

The build-time declaration validator (`validateDeclarationRuntimeImports`) is satisfied via the peer dependency.

## Related issue(s)

Fixes #22774

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Verification

The eleven-line reproduction from #22774 (`registerApiRoute` + hono `Context`/`MiddlewareHandler`, `moduleResolution: "bundler"`, `skipLibCheck`):

- against `@mastra/core@1.63.2` from npm: reproduces the reported errors — `repro.ts(8,16)` and `repro.ts(10,3)` TS2322, ``Property '[GET_MATCH_RESULT]' is missing``;
- against a `pnpm pack` of this branch's build: `tsc --noEmit` exits 0 with no errors.

`pnpm build:core` completes 14/14 tasks with the declaration validator passing; lockfile is unchanged (pnpm does not record peer dependencies in importer snapshots), so frozen installs are unaffected.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable) — no docs changes needed
- [ ] I have added tests that prove my fix is effective or that my feature works — verified via the packaged-consumer reproduction above; happy to add a consumer-typecheck fixture to CI if maintainers want one in-repo
- [x] I have addressed all Coderabbit comments on this PR

## Notes for reviewers

- `packages/mcp/tsdown.config.ts` vendors `hono` the same way — I left it out of this PR to keep the change scoped to the reported issue, but it likely needs the same treatment; happy to follow up.
- Commit authorship: `245706417+nikolas-sapa@users.noreply.github.com` (GitHub noreply, attributes to my account).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes `@mastra/core` use the app’s installed Hono types instead of shipping a separate copy. This prevents TypeScript type conflicts when consumers use `registerApiRoute` with `moduleResolution: "bundler"`.

## Changes

- Added `hono@^4.12.8` as a peer dependency of `@mastra/core`.
- Stopped vendoring Hono declarations through `generateTypes`.
- Continued vendoring `hono-openapi`.
- Added a patch changeset for `@mastra/core`.

## Validation

- The reported reproduction typechecks successfully against a packed build.
- `pnpm build:core` completes with declaration validation passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->