### PR TITLE
fix(mcp): declare hono as peer dependency and stop vendoring its types

### DIFF
--- a/.changeset/mcp-hono-peer-type-identity.md
+++ b/.changeset/mcp-hono-peer-type-identity.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fix type identity for Hono types crossing the `@mastra/mcp` public API. `hono` is now a peer dependency and its declarations are no longer vendored into `dist/_types`, so `MCPServer.connectHonoSSE({ stream })` and `getSseHonoTransport()` now use the consumer's own hono types. Passing a hono `SSEStreamingApi` from the consumer's app no longer fails typechecking with TS2322 nominal-mismatch errors.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -47,7 +47,8 @@
     "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.64.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.64.0-0 <2.0.0-0",
+    "hono": "^4.12.8"
   },
   "devDependencies": {
     "@hono/node-server": "^2.0.0",

--- a/packages/mcp/tsdown.config.ts
+++ b/packages/mcp/tsdown.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
     alwaysBundle: ['@mastra/schema-compat'],
   },
   onSuccess: async () => {
-    await generateTypes(process.cwd(), new Set(['hono', 'hono-mcp-server-sse-transport']));
+    await generateTypes(process.cwd(), new Set(['hono-mcp-server-sse-transport']));
   },
 });


### PR DESCRIPTION
## Description

Same root cause as #22774 (fixed for `@mastra/core` in #23774), now in `@mastra/mcp`: the published package vendors Hono's `.d.ts` into `dist/_types/hono/` and the public `MCPServer` API references the vendored copy:

- `connectHonoSSE({ messagePath, stream })` — takes a **consumer-supplied** hono `SSEStreamingApi`
- `getSseHonoTransport()` — returns the vendored `SSETransport` type

Under `"moduleResolution": "bundler"`, consumers wiring the MCP server into their own Hono app (the documented pattern) fail typechecking because the two hono declarations are structurally identical but nominally distinct.

This PR mirrors the `@mastra/core` fix: `hono` becomes a peer dependency of `@mastra/mcp` (modern package managers auto-install peers, and consumers using hono directly are guaranteed a single copy), and `hono` is dropped from the `generateTypes(...)` vendored set. `hono-mcp-server-sse-transport` stays vendored — after this change its vendored declarations resolve hono from the consumer.

## Related issue(s)

Fixes #23775

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Verification

Consumer repro (`MCPServer` + `connectHonoSSE` with a hono `SSEStreamingApi` from the consumer's install, `moduleResolution: "bundler"`, `skipLibCheck: true`):

- against `@mastra/mcp@1.17.3` from npm: `error TS2322: ... Types have separate declarations of a private property 'writer'.`
- against a `pnpm pack` of this branch's build: `tsc --noEmit` exits 0.

`pnpm build:mcp` completes with the declaration validator passing; no lockfile change required.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable) — no docs changes needed
- [ ] I have added tests that prove my fix is effective or that my feature works — verified via the packaged-consumer reproduction above; can add a consumer-typecheck fixture if maintainers want one in-repo
- [x] I have addressed all Coderabbit comments on this PR

## Notes for reviewers

- Follow-up to #23774 (@mastra/core); independent of that PR — branches off current main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes `@mastra/mcp` use the consumer’s installed Hono types instead of shipping a separate copy. This prevents TypeScript errors when applications pass Hono streams to MCP APIs.

## Changes

- Adds `hono` (`^4.12.8`) as a peer dependency of `@mastra/mcp`.
- Stops vendoring Hono declarations into `dist/_types`.
- Keeps `hono-mcp-server-sse-transport` vendored.
- Fixes type compatibility for `connectHonoSSE()` and `getSseHonoTransport()`.
- Adds a patch changeset for `@mastra/mcp`.

## Verification

- The documented consumer pattern typechecks with `moduleResolution: "bundler"`.
- The packaged build no longer reproduces the TS2322 error caused by separate private `writer` declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->