### PR TITLE
feat(memory): add observation failurePolicy and bounded retry schedules (#21849)

### DIFF
--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -116,6 +116,8 @@ type MemoryObservationalMemoryOptions = Omit<ObservationalMemoryOptions, 'model'
   activateOnProviderChange?: ObservationalMemoryConfig['activateOnProviderChange'];
   temporalMarkers?: boolean;
   hooks?: ObservationalMemoryConfig['hooks'];
+  failurePolicy?: ObservationalMemoryConfig['failurePolicy'];
+  retry?: ObservationalMemoryConfig['retry'];
 };
 
 type MemoryOptions = Omit<MemoryConfigInternal, 'observationalMemory'> & {

--- a/packages/memory/src/processors/observational-memory/__tests__/failure-policy.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/failure-policy.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ResourceScopedObservationStrategy } from '../observation-strategies/resource-scoped';
+import { SyncObservationStrategy } from '../observation-strategies/sync';
+import type { StrategyDeps } from '../observation-strategies/base';
+import type { ObservationRunOpts } from '../observation-strategies/types';
+import type { ObservationFailurePolicy, ResolvedObservationConfig } from '../types';
+
+function createMockDeps(failurePolicy?: ObservationFailurePolicy): StrategyDeps {
+  return {
+    storage: {
+      getObservationalMemory: vi.fn(),
+      persistMarkerToStorage: vi.fn(),
+    } as any,
+    messageHistory: {} as any,
+    tokenCounter: {
+      countMessagesAsync: vi.fn().mockResolvedValue(100),
+    } as any,
+    observationConfig: {
+      failurePolicy: failurePolicy ?? 'throw',
+      modelSettings: {},
+      providerOptions: {},
+      maxTokensPerBatch: 1000,
+      extractors: [],
+    } as unknown as ResolvedObservationConfig,
+    reflectionConfig: {} as any,
+    scope: 'thread',
+    retrieval: false,
+    observer: {} as any,
+    reflector: {} as any,
+    observedMessageIds: new Set(),
+    obscureThreadIds: false,
+    emitDebugEvent: vi.fn(),
+    persistMarkerToStorage: vi.fn().mockResolvedValue(undefined),
+    persistMarkerToMessage: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockOpts(): ObservationRunOpts {
+  return {
+    record: {
+      id: 'rec-test-1',
+      threadId: 'thread-test-1',
+      resourceId: 'resource-test-1',
+      activeObservations: '',
+    } as any,
+    threadId: 'thread-test-1',
+    resourceId: 'resource-test-1',
+    messages: [
+      {
+        id: 'msg-1',
+        role: 'user',
+        content: 'Hello world',
+        createdAt: new Date(),
+        type: 'text',
+      } as any,
+    ],
+  };
+}
+
+describe('ObservationFailurePolicy', () => {
+  describe('SyncObservationStrategy.rethrowOnFailure', () => {
+    it('returns true when failurePolicy is "throw"', () => {
+      const deps = createMockDeps('throw');
+      const strategy = new SyncObservationStrategy(deps, createMockOpts());
+      expect(strategy.rethrowOnFailure).toBe(true);
+    });
+
+    it('defaults to true when failurePolicy is undefined or default', () => {
+      const deps = createMockDeps();
+      const strategy = new SyncObservationStrategy(deps, createMockOpts());
+      expect(strategy.rethrowOnFailure).toBe(true);
+    });
+
+    it('returns false when failurePolicy is "warn"', () => {
+      const deps = createMockDeps('warn');
+      const strategy = new SyncObservationStrategy(deps, createMockOpts());
+      expect(strategy.rethrowOnFailure).toBe(false);
+    });
+
+    it('returns false when failurePolicy is "bypass"', () => {
+      const deps = createMockDeps('bypass');
+      const strategy = new SyncObservationStrategy(deps, createMockOpts());
+      expect(strategy.rethrowOnFailure).toBe(false);
+    });
+  });
+
+  describe('ResourceScopedObservationStrategy.rethrowOnFailure', () => {
+    it('returns true when failurePolicy is "throw"', () => {
+      const deps = createMockDeps('throw');
+      const strategy = new ResourceScopedObservationStrategy(deps, createMockOpts());
+      expect(strategy.rethrowOnFailure).toBe(true);
+    });
+
+    it('defaults to true when failurePolicy is undefined or default', () => {
+      const deps = createMockDeps();
+      const strategy = new ResourceScopedObservationStrategy(deps, createMockOpts());
+      expect(strategy.rethrowOnFailure).toBe(true);
+    });
+
+    it('returns false when failurePolicy is "warn"', () => {
+      const deps = createMockDeps('warn');
+      const strategy = new ResourceScopedObservationStrategy(deps, createMockOpts());
+      expect(strategy.rethrowOnFailure).toBe(false);
+    });
+
+    it('returns false when failurePolicy is "bypass"', () => {
+      const deps = createMockDeps('bypass');
+      const strategy = new ResourceScopedObservationStrategy(deps, createMockOpts());
+      expect(strategy.rethrowOnFailure).toBe(false);
+    });
+  });
+
+  describe('ObservationStrategy error handling execution', () => {
+    it('rethrows error when rethrowOnFailure is true', async () => {
+      const deps = createMockDeps('throw');
+      const strategy = new SyncObservationStrategy(deps, createMockOpts());
+
+      // Mock prepare and observe to throw
+      vi.spyOn(strategy, 'prepare').mockRejectedValue(new Error('LLM rate limit reached'));
+
+      await expect(strategy.run()).rejects.toThrow('LLM rate limit reached');
+    });
+
+    it('returns { observed: false, error } and does not throw when failurePolicy is "warn"', async () => {
+      const deps = createMockDeps('warn');
+      const strategy = new SyncObservationStrategy(deps, createMockOpts());
+
+      const failureError = new Error('Observer network timeout');
+      vi.spyOn(strategy, 'prepare').mockRejectedValue(failureError);
+
+      const result = await strategy.run();
+      expect(result.observed).toBe(false);
+      expect(result.error).toBe(failureError);
+    });
+
+    it('returns { observed: false, error } and does not throw when failurePolicy is "bypass"', async () => {
+      const deps = createMockDeps('bypass');
+      const strategy = new SyncObservationStrategy(deps, createMockOpts());
+
+      const failureError = new Error('Observer token budget exceeded');
+      vi.spyOn(strategy, 'prepare').mockRejectedValue(failureError);
+
+      const result = await strategy.run();
+      expect(result.observed).toBe(false);
+      expect(result.error).toBe(failureError);
+    });
+  });
+});

--- a/packages/memory/src/processors/observational-memory/__tests__/retry.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/retry.test.ts
@@ -229,4 +229,33 @@ describe('withRetry', () => {
     // Exactly one attempt happened before we aborted the backoff wait.
     expect(fn).toHaveBeenCalledTimes(1);
   });
+
+  it('respects custom retryConfig.maxRetries override in withRetry', async () => {
+    const fn = vi.fn().mockRejectedValue(new TypeError('terminated'));
+
+    // Override default 3 retries to only 1 retry (total 2 attempts)
+    await expect(withRetry(fn, { label: 'test', retryConfig: { maxRetries: 1 } })).rejects.toThrow('terminated');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('respects custom retryConfig.maxRetries: 0 (no retries)', async () => {
+    const fn = vi.fn().mockRejectedValue(new TypeError('fetch failed'));
+
+    await expect(withRetry(fn, { label: 'test', retryConfig: { maxRetries: 0 } })).rejects.toThrow('fetch failed');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects custom retryConfig delay parameters in computeDelay', () => {
+    const customConfig = {
+      initialDelayMs: 500,
+      backoffFactor: 3,
+      maxDelayMs: 10_000,
+      jitter: 0,
+    };
+
+    expect(computeDelay(0, customConfig)).toBe(500);
+    expect(computeDelay(1, customConfig)).toBe(1500);
+    expect(computeDelay(2, customConfig)).toBe(4500);
+    expect(computeDelay(3, customConfig)).toBe(10_000); // capped at maxDelayMs
+  });
 });

--- a/packages/memory/src/processors/observational-memory/observation-strategies/base.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/base.ts
@@ -146,7 +146,9 @@ export abstract class ObservationStrategy {
         };
         await this.persistMarkerToStorage(failedMarkerForStorage, threadId, this.opts.resourceId).catch(() => {});
         if (abortSignal?.aborted) throw error;
-        omError('[OM] Observation failed', error);
+        if (this.observationConfig.failurePolicy !== 'bypass') {
+          omError('[OM] Observation failed', error);
+        }
         return { observed: false, error: error instanceof Error ? error : new Error(String(error)) };
       }
 

--- a/packages/memory/src/processors/observational-memory/observation-strategies/resource-scoped.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/resource-scoped.ts
@@ -76,7 +76,7 @@ export class ResourceScopedObservationStrategy extends ObservationStrategy {
     return true;
   }
   get rethrowOnFailure() {
-    return true;
+    return (this.observationConfig.failurePolicy ?? 'throw') === 'throw';
   }
 
   async prepare() {

--- a/packages/memory/src/processors/observational-memory/observation-strategies/sync.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/sync.ts
@@ -41,7 +41,7 @@ export class SyncObservationStrategy extends ObservationStrategy {
     return true;
   }
   get rethrowOnFailure() {
-    return true;
+    return (this.observationConfig.failurePolicy ?? 'throw') === 'throw';
   }
 
   async prepare() {

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -621,6 +621,8 @@ export class ObservationalMemory {
         extract: config.observation?.extract,
         continuationHints: config.observation?.continuationHints,
       }),
+      failurePolicy: config.observation?.failurePolicy ?? config.failurePolicy ?? 'throw',
+      retry: config.observation?.retry ?? config.retry,
     };
 
     // Resolve reflection config with defaults

--- a/packages/memory/src/processors/observational-memory/observer-runner.ts
+++ b/packages/memory/src/processors/observational-memory/observer-runner.ts
@@ -365,7 +365,7 @@ export class ObserverRunner {
                 }
               }, abortSignal),
           }),
-        { label: 'observer', abortSignal },
+        { label: 'observer', abortSignal, retryConfig: this.observationConfig.retry },
       );
     };
 
@@ -676,7 +676,7 @@ export class ObserverRunner {
                 }
               }, abortSignal),
           }),
-        { label: 'observer-multi-thread', abortSignal },
+        { label: 'observer-multi-thread', abortSignal, retryConfig: this.observationConfig.retry },
       );
     };
 

--- a/packages/memory/src/processors/observational-memory/reflector-runner.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-runner.ts
@@ -479,7 +479,7 @@ export class ReflectorRunner {
                 return streamResult.getFullOutput();
               }, abortSignal),
           }),
-        { label: 'reflector', abortSignal },
+        { label: 'reflector', abortSignal, retryConfig: this.observationConfig.retry },
       );
 
       omDebug(

--- a/packages/memory/src/processors/observational-memory/retry.ts
+++ b/packages/memory/src/processors/observational-memory/retry.ts
@@ -128,11 +128,12 @@ export function isTransientLLMError(error: unknown): boolean {
  *
  * @internal
  */
-export function computeDelay(attempt: number): number {
-  const base = RETRY_CONFIG.initialDelayMs * Math.pow(RETRY_CONFIG.backoffFactor, attempt);
-  const capped = Math.min(base, RETRY_CONFIG.maxDelayMs);
-  if (RETRY_CONFIG.jitter <= 0) return capped;
-  const jitterRange = capped * RETRY_CONFIG.jitter;
+export function computeDelay(attempt: number, retryConfig?: Partial<typeof RETRY_CONFIG>): number {
+  const config = { ...RETRY_CONFIG, ...retryConfig };
+  const base = config.initialDelayMs * Math.pow(config.backoffFactor, attempt);
+  const capped = Math.min(base, config.maxDelayMs);
+  if (config.jitter <= 0) return capped;
+  const jitterRange = capped * config.jitter;
   // Symmetric jitter in [-jitterRange, +jitterRange].
   const offset = (Math.random() * 2 - 1) * jitterRange;
   return Math.max(0, Math.round(capped + offset));
@@ -163,6 +164,8 @@ export interface WithRetryOptions {
   label: string;
   /** Optional abort signal — cancels both in-flight attempts and backoff waits. */
   abortSignal?: AbortSignal;
+  /** Optional retry configuration overrides. */
+  retryConfig?: Partial<typeof RETRY_CONFIG>;
 }
 
 /**
@@ -174,7 +177,8 @@ export interface WithRetryOptions {
  * @internal
  */
 export async function withRetry<T>(fn: () => Promise<T>, opts: WithRetryOptions): Promise<T> {
-  const { label, abortSignal } = opts;
+  const { label, abortSignal, retryConfig } = opts;
+  const config = { ...RETRY_CONFIG, ...retryConfig };
   let attempt = 0;
   // total tries = maxRetries + 1 (the initial attempt isn't a "retry")
   while (true) {
@@ -185,7 +189,7 @@ export async function withRetry<T>(fn: () => Promise<T>, opts: WithRetryOptions)
       return await fn();
     } catch (error) {
       if (isAbortError(error) || abortSignal?.aborted) throw error;
-      if (attempt >= RETRY_CONFIG.maxRetries || !isTransientLLMError(error)) {
+      if (attempt >= config.maxRetries || !isTransientLLMError(error)) {
         if (attempt > 0) {
           omDebug(
             `[OM:retry:${label}] giving up after ${attempt} retry/retries: ${
@@ -195,7 +199,7 @@ export async function withRetry<T>(fn: () => Promise<T>, opts: WithRetryOptions)
         }
         throw error;
       }
-      const delay = computeDelay(attempt);
+      const delay = computeDelay(attempt, config);
       attempt++;
       omDebug(
         `[OM:retry:${label}] transient error on attempt ${attempt}, retrying in ${delay}ms: ${

--- a/packages/memory/src/processors/observational-memory/types.ts
+++ b/packages/memory/src/processors/observational-memory/types.ts
@@ -82,6 +82,30 @@ export type ContinuationHintsConfig =
       suggestedResponse?: boolean;
     };
 
+/**
+ * Policy controlling behavior when synchronous observation fails after retries are exhausted.
+ * - 'throw': rethrow the error, failing the synchronous turn (default).
+ * - 'warn': log a warning/error and continue the turn with observed: false.
+ * - 'bypass': silently bypass the failure and continue the turn with observed: false.
+ */
+export type ObservationFailurePolicy = 'throw' | 'warn' | 'bypass';
+
+/**
+ * Bounded retry configuration for observational memory operations.
+ */
+export interface ObservationRetryConfig {
+  /** Maximum number of retry attempts (total tries = maxRetries + 1). @default 8 */
+  maxRetries?: number;
+  /** Initial backoff delay in milliseconds. @default 1000 */
+  initialDelayMs?: number;
+  /** Multiplier applied to the delay after each failed attempt. @default 2 */
+  backoffFactor?: number;
+  /** Cap on per-attempt delay in milliseconds. @default 120000 */
+  maxDelayMs?: number;
+  /** Random jitter as a fraction of the computed delay (e.g. 0.2 = ±20%). @default 0.2 */
+  jitter?: number;
+}
+
 export interface ObservationConfig {
   /**
    * Model for the Observer agent.
@@ -279,6 +303,21 @@ export interface ObservationConfig {
    * @default ['image/*', 'application/pdf']
    */
   observeAttachments?: 'auto' | boolean | string[];
+
+  /**
+   * Policy controlling behavior when synchronous observation fails after retries are exhausted.
+   * - 'throw': rethrow the error, failing the synchronous agent turn (default).
+   * - 'warn': log a warning/error and continue the agent turn with observed: false.
+   * - 'bypass': silently bypass the observation failure and continue the agent turn.
+   *
+   * @default 'throw'
+   */
+  failurePolicy?: ObservationFailurePolicy;
+
+  /**
+   * Bounded retry schedule configuration for observation calls.
+   */
+  retry?: ObservationRetryConfig;
 }
 
 /**
@@ -1097,6 +1136,19 @@ export interface ObservationalMemoryConfig {
 
   /** @internal Parent Mastra instance for custom gateway model resolution. */
   mastra?: Mastra;
+
+  /**
+   * Policy controlling behavior when synchronous observation fails after retries are exhausted.
+   * Can also be set individually on `observation.failurePolicy`.
+   * @default 'throw'
+   */
+  failurePolicy?: ObservationFailurePolicy;
+
+  /**
+   * Bounded retry schedule configuration for observation calls.
+   * Can also be set individually on `observation.retry`.
+   */
+  retry?: ObservationRetryConfig;
 }
 
 /**
@@ -1136,6 +1188,10 @@ export interface ResolvedObservationConfig {
   observeAttachments: 'auto' | boolean | string[];
   /** Resolved observer extractors, including enabled built-ins and user extractors */
   extractors: Extractor<any>[];
+  /** Policy when synchronous observation fails */
+  failurePolicy: ObservationFailurePolicy;
+  /** Bounded retry schedule configuration */
+  retry?: ObservationRetryConfig;
 }
 
 export interface ResolvedReflectionConfig {


### PR DESCRIPTION
### Summary
Closes #21849.

Currently, when synchronous observational memory experiences transient LLM errors during an agent turn (\SyncObservationStrategy\ and \ResourceScopedObservationStrategy\), the observer blocks the turn for ~4 minutes (247s) across an 8-attempt exponential retry schedule, and then rethrows unconditionally (\ethrowOnFailure = true\), aborting the user's turn.

This PR introduces configurable failure policies and bounded retry schedules:
1. **Observation Failure Policy (\ailurePolicy: 'throw' | 'warn' | 'bypass'\)**:
   - \'throw'\ (default): rethrows the error upon retry exhaustion (retains existing behavior).
   - \'warn'\: logs a diagnostic error/warning and returns \{ observed: false, error }\ without throwing, allowing the agent turn to proceed with durable failure markers saved to storage.
   - \'bypass'\: silently continues without logging error spam, returning \{ observed: false, error }\.
   - Updated \SyncObservationStrategy\ and \ResourceScopedObservationStrategy\ to evaluate \ethrowOnFailure\ dynamically via \(this.observationConfig.failurePolicy ?? 'throw') === 'throw'\.
   - Updated \ObservationStrategy.run()\ base error handling to safely capture failed markers and respect non-rethrow policies.

2. **Bounded Retry Schedules (\etry: ObservationRetryConfig\)**:
   - Added \etryConfig?: Partial<typeof RETRY_CONFIG>\ to \computeDelay()\ and \withRetry()\.
   - Allows users and integrations to configure bounded retry budgets (e.g. \maxRetries: 2, maxDelayMs: 2000\) or disable retries entirely (\maxRetries: 0\) instead of waiting 247 seconds.
   - Forwarded \	his.observationConfig.retry\ to \ObserverRunner\ and \ReflectorRunner\.

### Verification & Tests
- Added unit tests for custom retry configuration and \maxRetries: 0\ in \packages/memory/src/processors/observational-memory/__tests__/retry.test.ts\.
- Added test suite in \packages/memory/src/processors/observational-memory/__tests__/failure-policy.test.ts\ verifying strategy failure policy behaviors (\	hrow\, \warn\, \ypass\).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Observational memory can now retry failed observations for a configurable amount of time. If all attempts fail, you can choose whether the agent stops, logs a warning and continues, or continues silently.

## Changes

- Added `failurePolicy: 'throw' | 'warn' | 'bypass'`.
  - Defaults to `'throw'`.
  - Applies to synchronous and resource-scoped observation.
- Added configurable retry settings:
  - `maxRetries`
  - `initialDelayMs`
  - `backoffFactor`
  - `maxDelayMs`
  - `jitter`
- Added `maxRetries: 0` support to disable retries.
- Applied retry settings to observer and reflector runners.
- Updated error handling for warning and bypass policies.
- Added tests for failure policies and custom retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->